### PR TITLE
Fix mobile viewport clipping and Android export

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta
       name="viewport"
-      content="width=device-width, initial-scale=1.0, viewport-fit=cover, maximum-scale=1.0, user-scalable=no"
+      content="width=device-width, initial-scale=1.0, viewport-fit=cover, maximum-scale=1.0, user-scalable=no, interactive-widget=resizes-content"
     />
     <meta name="theme-color" content="#2F3E46" />
     <meta

--- a/scripts/manual-smoke.mjs
+++ b/scripts/manual-smoke.mjs
@@ -111,8 +111,27 @@ try {
   if (await editorBtn.count()) {
     await editorBtn.click()
     const okBtn = page.getByRole('button', { name: /^ok$/i }).first()
+    const trimBtn = page.getByRole('button', { name: /^trim$/i }).first()
+    const deleteBtn = page.getByRole('button', { name: /^delete$/i }).first()
     if (await okBtn.count()) pass('editor mode + OK CTA')
     else fail('editor mode + OK CTA', 'OK button missing')
+
+    // On short mobile viewports, editor actions must remain reachable via scroll.
+    await page.setViewportSize({ width: 390, height: 640 })
+    const screen = page.locator('.camera-screen')
+    const before = await screen.evaluate((el) => el.scrollTop)
+    await screen.evaluate((el) => {
+      el.scrollTop = el.scrollHeight
+    })
+    const after = await screen.evaluate((el) => el.scrollTop)
+    const deleteBox = await deleteBtn.boundingBox()
+    const trimVisible = await trimBtn.isVisible()
+    if (trimVisible && (after >= before || (deleteBox && deleteBox.y > 0))) {
+      pass('editor scroll reaches actions', `scroll ${before}->${after}`)
+    } else {
+      fail('editor scroll reaches actions', `scroll ${before}->${after}, trim=${trimVisible}`)
+    }
+    await page.setViewportSize({ width: 390, height: 844 })
   } else {
     fail('editor mode toggle')
   }

--- a/src/components/export-sheet.tsx
+++ b/src/components/export-sheet.tsx
@@ -3,6 +3,7 @@ interface ExportSheetProps {
   progress: number | null
   busy: boolean
   message: string | null
+  messageTone?: 'info' | 'error'
   onExport: () => void
   onDownloadClips: () => void
   onClose: () => void
@@ -13,6 +14,7 @@ export function ExportSheet({
   progress,
   busy,
   message,
+  messageTone = 'info',
   onExport,
   onDownloadClips,
   onClose,
@@ -21,15 +23,17 @@ export function ExportSheet({
     <div className="sheet" role="dialog" aria-label="Share project">
       <h3>OK, share {projectName}</h3>
       <p className="muted" style={{ margin: 0, lineHeight: 1.45 }}>
-        Kody stitches clips into one local WebM on this device. If stitching fails, save the
-        original clip files instead.
+        Make one local video on this device (no upload). On phones, Android usually opens the system
+        share sheet — that is the reliable save path. If stitching fails, use Files.
       </p>
       {progress !== null ? (
         <div className="progress-bar" aria-label="Export progress">
           <span style={{ width: `${Math.round(progress * 100)}%` }} />
         </div>
       ) : null}
-      {message ? <p style={{ margin: '12px 0 0' }}>{message}</p> : null}
+      {message ? (
+        <p className={`sheet-message${messageTone === 'error' ? ' is-error' : ''}`}>{message}</p>
+      ) : null}
       <div className="sheet-actions">
         <button type="button" className="btn btn-ghost" onClick={onClose} disabled={busy}>
           Close

--- a/src/lib/media.ts
+++ b/src/lib/media.ts
@@ -101,7 +101,6 @@ export function measureBlobDuration(blob: Blob): Promise<number> {
     }
 
     video.onloadedmetadata = () => {
-      // Some browsers report Infinity until a seek.
       if (!Number.isFinite(video.duration) || video.duration === Infinity) {
         video.currentTime = Number.MAX_SAFE_INTEGER
         video.ontimeupdate = () => {
@@ -134,6 +133,10 @@ export async function canFlipCamera(): Promise<boolean> {
   }
 }
 
+function isMobileBrowser(): boolean {
+  return /Android|iPhone|iPad|iPod|Mobile/i.test(navigator.userAgent)
+}
+
 /**
  * Stitch clips into a single WebM using canvas captureStream + MediaRecorder.
  * Applies trim in/out by seeking each source clip.
@@ -147,27 +150,53 @@ export async function exportProjectAsWebm(
     throw new Error('Nothing to export')
   }
 
-  const width = 720
-  const height = 1280
+  // Portrait output matches phone capture; keep moderate for mobile encoders.
+  const width = isMobileBrowser() ? 540 : 720
+  const height = isMobileBrowser() ? 960 : 1280
   const canvas = document.createElement('canvas')
   canvas.width = width
   canvas.height = height
-  const ctx = canvas.getContext('2d')
+  const ctx = canvas.getContext('2d', { alpha: false })
   if (!ctx) throw new Error('Canvas not available')
 
+  // Warm the canvas so captureStream has a first frame on Chromium Android.
+  ctx.fillStyle = '#000'
+  ctx.fillRect(0, 0, width, height)
+
   const canvasStream = canvas.captureStream(30)
-  const audioContext = new AudioContext()
-  const dest = audioContext.createMediaStreamDestination()
+  if (canvasStream.getVideoTracks().length === 0) {
+    throw new Error('This browser cannot capture canvas video for export')
+  }
+
+  let audioContext: AudioContext | null = null
+  let dest: MediaStreamAudioDestinationNode | null = null
+  try {
+    audioContext = new AudioContext()
+    if (audioContext.state === 'suspended') {
+      await audioContext.resume().catch(() => undefined)
+    }
+    dest = audioContext.createMediaStreamDestination()
+  } catch {
+    // Video-only export if AudioContext is unavailable.
+  }
+
   const mixedStream = new MediaStream([
     ...canvasStream.getVideoTracks(),
-    ...dest.stream.getAudioTracks(),
+    ...(dest?.stream.getAudioTracks() ?? []),
   ])
 
-  const mimeType = pickRecorderMimeType() || 'video/webm'
-  const recorder = new MediaRecorder(mixedStream, {
-    mimeType: mimeType.includes('webm') ? mimeType : undefined,
-    videoBitsPerSecond: 2_500_000,
-  })
+  const mimeType = pickRecorderMimeType()
+  let recorder: MediaRecorder
+  try {
+    recorder = mimeType
+      ? new MediaRecorder(mixedStream, {
+          mimeType: mimeType.includes('webm') || mimeType.includes('mp4') ? mimeType : undefined,
+          videoBitsPerSecond: isMobileBrowser() ? 1_500_000 : 2_500_000,
+        })
+      : new MediaRecorder(mixedStream)
+  } catch {
+    recorder = new MediaRecorder(mixedStream)
+  }
 
   const chunks: BlobPart[] = []
   recorder.ondataavailable = (event) => {
@@ -181,13 +210,18 @@ export async function exportProjectAsWebm(
     recorder.onerror = () => reject(new Error('Export recording failed'))
   })
 
-  recorder.start(250)
+  recorder.start(200)
+
+  // Give the recorder a moment to latch onto the canvas track.
+  await wait(120)
 
   const totalMs = clips.reduce((sum, clip) => sum + effectiveDurationMs(clip), 0)
   let elapsed = 0
 
   try {
     for (const clip of clips) {
+      const clipMs = effectiveDurationMs(clip)
+      if (clipMs < 40) continue
       await paintClipToCanvas({
         clip,
         canvas,
@@ -198,24 +232,36 @@ export async function exportProjectAsWebm(
           if (totalMs > 0) onProgress?.((elapsed + clipElapsed) / totalMs)
         },
       })
-      elapsed += effectiveDurationMs(clip)
+      elapsed += clipMs
       onProgress?.(totalMs > 0 ? elapsed / totalMs : 1)
     }
+
+    // Hold the last frame briefly so the final GOP isn't truncated.
+    await wait(180)
   } finally {
     if (recorder.state !== 'inactive') recorder.stop()
     canvasStream.getTracks().forEach((t) => t.stop())
-    await audioContext.close().catch(() => undefined)
+    if (audioContext) {
+      await audioContext.close().catch(() => undefined)
+    }
   }
 
-  return stopped
+  const blob = await stopped
+  const minBytes = Math.max(8_000, Math.floor(totalMs * 4))
+  if (blob.size < minBytes) {
+    throw new Error(
+      `Export produced an unusable file (${Math.round(blob.size / 1024)}KB). Try “Files” instead.`,
+    )
+  }
+  return blob
 }
 
 interface PaintArgs {
   clip: ClipRecord
   canvas: HTMLCanvasElement
   ctx: CanvasRenderingContext2D
-  audioContext: AudioContext
-  dest: MediaStreamAudioDestinationNode
+  audioContext: AudioContext | null
+  dest: MediaStreamAudioDestinationNode | null
   onFrameProgress?: (clipElapsedMs: number) => void
 }
 
@@ -231,52 +277,82 @@ async function paintClipToCanvas({
   const video = document.createElement('video')
   video.src = url
   video.playsInline = true
-  video.muted = false
+  // Must be muted for autoplay policies on Android Chrome/Brave during export.
+  video.muted = true
   video.preload = 'auto'
+  video.setAttribute('playsinline', 'true')
+  video.setAttribute('webkit-playsinline', 'true')
 
-  await waitForEvent(video, 'loadeddata')
-
-  const startSec = clip.trimStartMs / 1000
-  const endSec = Math.min(clip.trimEndMs, clip.durationMs) / 1000
-  video.currentTime = startSec
-  await waitForEvent(video, 'seeked')
-
-  let sourceNode: MediaElementAudioSourceNode | null = null
   try {
-    sourceNode = audioContext.createMediaElementSource(video)
-    sourceNode.connect(dest)
-  } catch {
-    // Element may already be connected in rare cases; continue video-only.
-  }
+    await waitForEvent(video, 'loadeddata')
+    await waitForVideoDimensions(video)
 
-  await video.play()
+    const startSec = clip.trimStartMs / 1000
+    const endSec = Math.min(clip.trimEndMs, clip.durationMs) / 1000
+    if (!(endSec > startSec)) return
 
-  await new Promise<void>((resolve, reject) => {
-    let raf = 0
-    const draw = () => {
-      if (video.ended || video.currentTime >= endSec - 0.02) {
-        cancelAnimationFrame(raf)
-        video.pause()
-        resolve()
-        return
+    video.currentTime = startSec
+    await waitForEvent(video, 'seeked')
+
+    // Keep the element muted for Android autoplay policies. We still tap the
+    // MediaElementSource graph when available; some browsers deliver silent
+    // frames only, which is preferable to a failed stitch.
+    let sourceNode: MediaElementAudioSourceNode | null = null
+    if (audioContext && dest) {
+      try {
+        if (audioContext.state === 'suspended') {
+          await audioContext.resume().catch(() => undefined)
+        }
+        sourceNode = audioContext.createMediaElementSource(video)
+        sourceNode.connect(dest)
+      } catch {
+        sourceNode = null
+      }
+    }
+
+    await video.play()
+
+    await new Promise<void>((resolve, reject) => {
+      let raf = 0
+      let lastFrameAt = performance.now()
+      const draw = () => {
+        const now = performance.now()
+        if (video.ended || video.currentTime >= endSec - 0.04) {
+          cancelAnimationFrame(raf)
+          video.pause()
+          resolve()
+          return
+        }
+
+        // Stall watchdog: if playback never advances, abort this clip.
+        if (now - lastFrameAt > 8000) {
+          cancelAnimationFrame(raf)
+          video.pause()
+          reject(new Error('Clip playback stalled during export'))
+          return
+        }
+
+        if (video.videoWidth > 0) {
+          drawCover(ctx, video, canvas.width, canvas.height)
+          lastFrameAt = now
+        }
+        onFrameProgress?.(Math.max(0, (video.currentTime - startSec) * 1000))
+        raf = requestAnimationFrame(draw)
       }
 
-      drawCover(ctx, video, canvas.width, canvas.height)
-      onFrameProgress?.(Math.max(0, (video.currentTime - startSec) * 1000))
+      video.onerror = () => {
+        cancelAnimationFrame(raf)
+        reject(new Error('Failed while exporting a clip'))
+      }
       raf = requestAnimationFrame(draw)
-    }
+    })
 
-    video.onerror = () => {
-      cancelAnimationFrame(raf)
-      reject(new Error('Failed while exporting a clip'))
-    }
-    raf = requestAnimationFrame(draw)
-  })
-
-  sourceNode?.disconnect()
-  URL.revokeObjectURL(url)
-  video.removeAttribute('src')
-  video.load()
+    sourceNode?.disconnect()
+  } finally {
+    URL.revokeObjectURL(url)
+    video.removeAttribute('src')
+    video.load()
+  }
 }
 
 function drawCover(
@@ -316,6 +392,31 @@ function waitForEvent(target: HTMLMediaElement, event: string): Promise<void> {
   })
 }
 
+async function waitForVideoDimensions(video: HTMLVideoElement): Promise<void> {
+  if (video.videoWidth > 0 && video.videoHeight > 0) return
+  await new Promise<void>((resolve, reject) => {
+    const started = performance.now()
+    const tick = () => {
+      if (video.videoWidth > 0 && video.videoHeight > 0) {
+        resolve()
+        return
+      }
+      if (performance.now() - started > 4000) {
+        reject(new Error('Clip never produced video frames'))
+        return
+      }
+      requestAnimationFrame(tick)
+    }
+    tick()
+  })
+}
+
+function wait(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    window.setTimeout(resolve, ms)
+  })
+}
+
 export async function downloadBlob(blob: Blob, filename: string): Promise<void> {
   const url = URL.createObjectURL(blob)
   const anchor = document.createElement('a')
@@ -325,14 +426,18 @@ export async function downloadBlob(blob: Blob, filename: string): Promise<void> 
   document.body.appendChild(anchor)
   anchor.click()
   anchor.remove()
-  setTimeout(() => URL.revokeObjectURL(url), 1000)
+  // Android often needs the URL alive a bit longer than desktop.
+  setTimeout(() => URL.revokeObjectURL(url), 60_000)
 }
 
 export async function shareOrDownload(
   blob: Blob,
   filename: string,
 ): Promise<'shared' | 'downloaded' | 'cancelled'> {
-  const file = new File([blob], filename, { type: blob.type || 'video/webm' })
+  const type = blob.type || 'video/webm'
+  const file = new File([blob], filename, { type })
+
+  // On Android, Web Share with files is far more reliable than <a download>.
   if (navigator.canShare?.({ files: [file] })) {
     try {
       await navigator.share({
@@ -344,9 +449,23 @@ export async function shareOrDownload(
       if (error instanceof DOMException && error.name === 'AbortError') {
         return 'cancelled'
       }
-      // Fall through to download.
+      // Fall through to download attempt.
     }
   }
+
+  if (isMobileBrowser()) {
+    // Last-resort mobile path: open the blob URL so the browser can hand off to the viewer/share sheet.
+    const url = URL.createObjectURL(blob)
+    const opened = window.open(url, '_blank', 'noopener')
+    if (!opened) {
+      await downloadBlob(blob, filename)
+      setTimeout(() => URL.revokeObjectURL(url), 60_000)
+      return 'downloaded'
+    }
+    setTimeout(() => URL.revokeObjectURL(url), 60_000)
+    return 'downloaded'
+  }
+
   await downloadBlob(blob, filename)
   return 'downloaded'
 }
@@ -359,12 +478,25 @@ export function downloadClipsAsSeparateFiles(clips: ClipRecord[], projectName: s
   })
 }
 
+/** Share/download a single original clip — most reliable path on mobile. */
+export async function shareClipFile(
+  clip: ClipRecord,
+  projectName: string,
+  index: number,
+): Promise<'shared' | 'downloaded' | 'cancelled'> {
+  const ext = clip.mimeType.includes('mp4') ? 'mp4' : 'webm'
+  const filename = `${slugify(projectName)}-clip-${String(index + 1).padStart(2, '0')}.${ext}`
+  return shareOrDownload(clip.blob, filename)
+}
+
 function slugify(value: string): string {
-  return value
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/(^-|-$)/g, '')
-    .slice(0, 40) || 'project'
+  return (
+    value
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/(^-|-$)/g, '')
+      .slice(0, 40) || 'project'
+  )
 }
 
 export function projectFilename(projectName: string, ext = 'webm'): string {

--- a/src/pages/project-page.tsx
+++ b/src/pages/project-page.tsx
@@ -7,6 +7,7 @@ import {
   useRevalidator,
   type LoaderFunctionArgs,
 } from 'react-router-dom'
+import { BlobVideo } from '../components/blob-video'
 import { ExportSheet } from '../components/export-sheet'
 import { OnboardingOverlay } from '../components/onboarding-overlay'
 import { PlaybackOverlay } from '../components/playback-overlay'
@@ -27,6 +28,7 @@ import {
   downloadClipsAsSeparateFiles,
   exportProjectAsWebm,
   projectFilename,
+  shareClipFile,
   shareOrDownload,
 } from '../lib/media'
 import { HoldRecorder } from '../lib/recorder'
@@ -85,6 +87,7 @@ export function ProjectPage() {
   const [exportProgress, setExportProgress] = useState<number | null>(null)
   const [exportBusy, setExportBusy] = useState(false)
   const [exportMessage, setExportMessage] = useState<string | null>(null)
+  const [exportMessageTone, setExportMessageTone] = useState<'info' | 'error'>('info')
 
   const totalDurationMs = data.clips.reduce((sum, clip) => sum + effectiveDurationMs(clip), 0)
 
@@ -314,6 +317,7 @@ export function ProjectPage() {
       <div
         className="camera-stage"
         onPointerDown={(event) => {
+          if (mode !== 'record') return
           if (event.button !== 0) return
           if (countdown !== null) {
             clearCountdown()
@@ -328,24 +332,43 @@ export function ProjectPage() {
           beginRecord(event.pointerId, 'hold')
         }}
         onPointerUp={(event) => {
+          if (mode !== 'record') return
           if (recordingMode !== 'hands-free') {
             void endRecord(event.pointerId)
           }
         }}
         onPointerCancel={(event) => {
+          if (mode !== 'record') return
           if (recordingMode !== 'hands-free') {
             void endRecord(event.pointerId)
           }
         }}
         onContextMenu={(event) => event.preventDefault()}
       >
-        <video
-          ref={bindCameraVideo}
-          className={`camera-video${camera.facing === 'user' ? ' mirror' : ''}`}
-          muted
-          playsInline
-          autoPlay
-        />
+        {mode === 'record' ? (
+          <video
+            ref={bindCameraVideo}
+            className={`camera-video${camera.facing === 'user' ? ' mirror' : ''}`}
+            muted
+            playsInline
+            autoPlay
+          />
+        ) : selected ? (
+          <BlobVideo
+            key={selected.id}
+            blob={selected.blob}
+            className="editor-clip-preview"
+            muted
+            playsInline
+            preload="metadata"
+            onLoadedData={(event) => {
+              const video = event.currentTarget
+              video.currentTime = selected.trimStartMs / 1000
+            }}
+          />
+        ) : (
+          <div className="editor-empty-preview">Select a clip in the timeline</div>
+        )}
 
         {recording ? (
           <div className="record-overlay">
@@ -369,7 +392,7 @@ export function ProjectPage() {
           </div>
         ) : null}
 
-        {needsPermission ? (
+        {mode === 'record' && needsPermission ? (
           <div className="permission-panel">
             <div>
               <h2>Camera access</h2>
@@ -596,17 +619,56 @@ export function ProjectPage() {
           progress={exportProgress}
           busy={exportBusy}
           message={exportMessage}
+          messageTone={exportMessageTone}
           onClose={() => {
             if (!exportBusy) setSheet('none')
           }}
           onDownloadClips={() => {
-            downloadClipsAsSeparateFiles(data.clips, data.project!.name)
-            setExportMessage('Started clip downloads (no upload).')
+            void (async () => {
+              setExportBusy(true)
+              setExportMessageTone('info')
+              try {
+                // Prefer sharing the latest clip on mobile; also kick off individual downloads.
+                const last = data.clips.at(-1)
+                if (last) {
+                  const mode = await shareClipFile(
+                    last,
+                    data.project!.name,
+                    data.clips.length - 1,
+                  )
+                  if (mode === 'cancelled') {
+                    setExportMessage('Share canceled.')
+                  } else if (data.clips.length === 1) {
+                    setExportMessage(
+                      mode === 'shared'
+                        ? 'Shared the clip from this device.'
+                        : 'Opened/saved the clip file.',
+                    )
+                  } else {
+                    downloadClipsAsSeparateFiles(data.clips, data.project!.name)
+                    setExportMessage(
+                      mode === 'shared'
+                        ? 'Shared the latest clip. Also started downloads for all clips.'
+                        : 'Started clip file saves (no upload).',
+                    )
+                  }
+                } else {
+                  downloadClipsAsSeparateFiles(data.clips, data.project!.name)
+                  setExportMessage('Started clip file saves (no upload).')
+                }
+              } catch (err) {
+                setExportMessageTone('error')
+                setExportMessage(err instanceof Error ? err.message : 'Could not save clip files')
+              } finally {
+                setExportBusy(false)
+              }
+            })()
           }}
           onExport={() => {
             void (async () => {
               setExportBusy(true)
               setExportMessage(null)
+              setExportMessageTone('info')
               setExportProgress(0)
               try {
                 const blob = await exportProjectAsWebm(data.clips, setExportProgress)
@@ -614,13 +676,15 @@ export function ProjectPage() {
                 const shareMode = await shareOrDownload(blob, filename)
                 switch (shareMode) {
                   case 'shared':
-                    setExportMessage('Shared from this device.')
+                    setExportMessage('Shared the stitched video from this device.')
                     break
                   case 'downloaded':
-                    setExportMessage('Downloaded. Nothing was uploaded.')
+                    setExportMessage(
+                      'Saved/opened the stitched video locally. On Android, use the share sheet if the file did not appear in Downloads.',
+                    )
                     break
                   case 'cancelled':
-                    setExportMessage('Share canceled — export stayed on this device.')
+                    setExportMessage('Share canceled — video stayed on this device.')
                     break
                   default: {
                     const _exhaustive: never = shareMode
@@ -628,10 +692,11 @@ export function ProjectPage() {
                   }
                 }
               } catch (err) {
+                setExportMessageTone('error')
                 setExportMessage(
                   err instanceof Error
-                    ? `${err.message} Try “Files” for separate downloads.`
-                    : 'Export failed. Try downloading clips separately.',
+                    ? `${err.message} Tap Files to save original clips instead.`
+                    : 'Export failed. Tap Files to save original clips instead.',
                 )
               } finally {
                 setExportBusy(false)

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -17,7 +17,16 @@
   --radius: 18px;
   --safe-top: env(safe-area-inset-top, 0px);
   --safe-bottom: env(safe-area-inset-bottom, 0px);
+  /* Extra room for Android browser chrome (Brave/Chrome bottom URL bar). */
+  --browser-chrome: 72px;
+  --app-height: 100dvh;
   --tap: 44px;
+}
+
+@supports not (height: 100dvh) {
+  :root {
+    --app-height: 100vh;
+  }
 }
 
 * {
@@ -28,8 +37,8 @@ html,
 body,
 #root {
   margin: 0;
-  min-height: 100%;
-  height: 100%;
+  min-height: var(--app-height);
+  height: var(--app-height);
 }
 
 body {
@@ -67,7 +76,7 @@ a {
 }
 
 .app-shell {
-  height: 100%;
+  height: var(--app-height);
   max-width: 480px;
   margin: 0 auto;
   position: relative;
@@ -76,12 +85,15 @@ a {
 
 .screen {
   height: 100%;
+  max-height: var(--app-height);
   display: flex;
   flex-direction: column;
+  min-height: 0;
+  overflow: hidden;
   padding:
     calc(12px + var(--safe-top))
     16px
-    calc(16px + var(--safe-bottom));
+    calc(16px + var(--safe-bottom) + var(--browser-chrome));
   animation: rise-in 420ms cubic-bezier(0.22, 1, 0.36, 1) both;
 }
 
@@ -343,6 +355,14 @@ a {
 .camera-screen {
   padding: 0;
   background: #10171a;
+  overflow: hidden;
+}
+
+.camera-screen.editor-mode {
+  overflow-y: auto;
+  overflow-x: hidden;
+  overscroll-behavior-y: contain;
+  -webkit-overflow-scrolling: touch;
 }
 
 .camera-top {
@@ -392,11 +412,14 @@ a {
 }
 
 .editor-mode .camera-stage {
-  flex: 0 0 min(48vh, 430px);
-  margin: calc(62px + var(--safe-top)) 10px 0;
-  border-radius: 26px;
+  flex: 0 0 auto;
+  height: min(28svh, 220px);
+  min-height: 140px;
+  margin: calc(58px + var(--safe-top)) 12px 0;
+  border-radius: 22px;
   border: 1px solid var(--line);
   box-shadow: var(--shadow);
+  touch-action: pan-y;
 }
 
 .camera-video {
@@ -510,17 +533,18 @@ a {
   position: relative;
   z-index: 3;
   background: linear-gradient(180deg, rgba(16, 23, 26, 0), rgba(16, 23, 26, 0.95) 24%);
-  padding: 10px 12px calc(12px + var(--safe-bottom));
+  padding: 10px 12px calc(12px + var(--safe-bottom) + var(--browser-chrome));
   display: flex;
   flex-direction: column;
   gap: 10px;
+  flex-shrink: 0;
 }
 
 .editor-mode .camera-bottom {
-  flex: 1;
-  min-height: 0;
+  flex: 0 0 auto;
   background: transparent;
-  padding-top: 12px;
+  padding-top: 10px;
+  padding-bottom: calc(20px + var(--safe-bottom) + var(--browser-chrome));
 }
 
 .record-dock {
@@ -589,12 +613,11 @@ a {
 }
 
 .editor-panel {
-  min-height: 0;
-  flex: 1;
+  flex: 0 0 auto;
   display: flex;
   flex-direction: column;
   gap: 10px;
-  padding: 12px;
+  padding: 12px 12px 8px;
   border-radius: 28px 28px 0 0;
   background: linear-gradient(180deg, rgba(47, 62, 70, 0.92), rgba(23, 33, 38, 0.98));
   border: 1px solid var(--line);
@@ -694,13 +717,25 @@ a {
   right: 0;
   bottom: 0;
   z-index: 5;
+  max-height: min(78dvh, 640px);
+  overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
   background: linear-gradient(180deg, #364850, #172126);
   border-top-left-radius: 22px;
   border-top-right-radius: 22px;
   border-top: 1px solid var(--line);
-  padding: 16px 16px calc(16px + var(--safe-bottom));
+  padding: 16px 16px calc(20px + var(--safe-bottom) + var(--browser-chrome));
   box-shadow: 0 -20px 50px rgba(0, 0, 0, 0.45);
   animation: rise-in 280ms ease both;
+}
+
+.sheet-message {
+  margin: 12px 0 0;
+  line-height: 1.4;
+}
+
+.sheet-message.is-error {
+  color: #ffd2cb;
 }
 
 .sheet h3 {
@@ -710,12 +745,14 @@ a {
 
 .sheet-actions {
   display: flex;
+  flex-wrap: wrap;
   gap: 8px;
   margin-top: 14px;
 }
 
 .sheet-actions .btn {
   flex: 1;
+  min-width: 96px;
 }
 
 .field {
@@ -769,12 +806,13 @@ a {
 .toast {
   position: absolute;
   left: 50%;
-  bottom: calc(110px + var(--safe-bottom));
+  bottom: calc(110px + var(--safe-bottom) + var(--browser-chrome));
   transform: translateX(-50%);
   z-index: 6;
   display: flex;
   align-items: center;
   gap: 10px;
+  max-width: calc(100% - 24px);
   background: rgba(16, 23, 26, 0.92);
   border: 1px solid var(--line);
   color: var(--ink);
@@ -783,6 +821,24 @@ a {
   font-size: 0.9rem;
   white-space: nowrap;
   animation: rise-in 220ms ease both;
+}
+
+.editor-clip-preview {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+  background: #000;
+}
+
+.editor-empty-preview {
+  width: 100%;
+  height: 100%;
+  display: grid;
+  place-items: center;
+  color: var(--ink-muted);
+  padding: 16px;
+  text-align: center;
 }
 
 .toast button {
@@ -796,7 +852,8 @@ a {
   z-index: 7;
   display: grid;
   place-items: end center;
-  padding: 20px 16px calc(20px + var(--safe-bottom));
+  overflow-y: auto;
+  padding: 20px 16px calc(20px + var(--safe-bottom) + var(--browser-chrome));
   background:
     radial-gradient(85% 60% at 50% 16%, rgba(68, 215, 168, 0.18), transparent 60%),
     rgba(16, 23, 26, 0.76);
@@ -874,7 +931,30 @@ a {
   border: 0;
 }
 
+@media (max-height: 760px) {
+  .ok-button {
+    width: 72px;
+    height: 72px;
+    min-width: 72px;
+    font-size: 1.35rem;
+  }
+
+  .record-actions {
+    grid-template-columns: repeat(3, minmax(0, 1fr)) auto;
+    gap: 6px;
+  }
+
+  .editor-mode .camera-stage {
+    height: min(24svh, 180px);
+    min-height: 120px;
+  }
+}
+
 @media (min-width: 720px) {
+  :root {
+    --browser-chrome: 0px;
+  }
+
   body {
     overflow: auto;
   }
@@ -882,7 +962,7 @@ a {
   .app-shell {
     margin-top: 24px;
     margin-bottom: 24px;
-    height: min(920px, calc(100vh - 48px));
+    height: min(920px, calc(100dvh - 48px));
     border-radius: 28px;
     border: 1px solid var(--line);
     box-shadow: var(--shadow);


### PR DESCRIPTION
## Summary
Fixes Android Brave feedback:

1. **Viewport** — editor/actions were clipped under browser chrome. Uses `100dvh`, browser-chrome padding, shorter editor preview, scrollable project screen.
2. **Make video** — muted autoplay-safe canvas stitch, output size validation, share-sheet-first on phones, clearer Files fallback.

Editor preview now shows the selected clip instead of a black camera square.

## Verification
- `npm test` green
- `npm run test:smoke` 12/12 (includes editor scroll reachability)

## Deploy
Cloudflare Pages publishes https://kody-video.pages.dev from `main`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches client-side media export and mobile layout across core project/editor flows; regressions could affect stitch quality, share/download behavior, or editor scrolling on some devices.
> 
> **Overview**
> Addresses Android Brave feedback where **editor controls and bottom actions were hidden under mobile browser chrome**, and where **“Make video”** often produced broken or unsaveable exports.
> 
> **Viewport & layout:** Adds `interactive-widget=resizes-content`, switches shell height to `100dvh` (with fallback), extra `--browser-chrome` padding on screens/sheets/toasts, a shorter scrollable **editor** layout (`editor-mode` scroll on `.camera-screen`, smaller preview stage), and a smoke test that editor **Trim/Delete** stay reachable on short viewports.
> 
> **Export & share:** Reworks `exportProjectAsWebm` for phones—lower resolution/bitrate, canvas warm-up, muted autoplay-safe clip playback, dimension/stall guards, minimum output size check, optional audio when `AudioContext` works. **Share sheet first** on mobile (`shareOrDownload`, longer-lived blob URLs, blob-tab fallback); **Files** prefers `shareClipFile` for the latest clip with clearer copy and error styling on `ExportSheet`.
> 
> **Editor UX:** In editor mode, the stage shows **`BlobVideo`** of the selected clip (trim start), hold-to-record only in record mode, and permission UI only when recording.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 97d76e28d5effb597f02b38bd0ed50aa5ffd338e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->