### PR TITLE
Fix Brave mic conflict, export audio, and mobile tool sheets

### DIFF
--- a/manual-test-checklist.md
+++ b/manual-test-checklist.md
@@ -3,7 +3,10 @@
 Run locally with HTTPS or `localhost` (`npm run dev`). Camera/mic require a secure context.
 
 ## Permissions
-- [ ] First open prompts for camera + microphone
+- [ ] First open prompts for camera; microphone is requested when you start recording
+- [ ] Idle preview does not block Android voice-to-text in Brave/Chrome
+- [ ] Exported stitched video includes microphone audio from recorded clips
+- [ ] Record dock shows Tools + OK (Editor/Timer/Delete live in the Tools sheet)
 - [ ] Deny → clear denied panel with retry guidance
 - [ ] Allow → live rear-camera preview (or fallback)
 - [ ] Flip camera works when multiple cameras exist

--- a/scripts/manual-smoke.mjs
+++ b/scripts/manual-smoke.mjs
@@ -101,38 +101,48 @@ try {
   if (await stage.count()) pass('camera stage present')
   else fail('camera stage present')
 
-  // Self-timer control
-  const timer = page.getByRole('button', { name: /timer|self[- ]?timer/i })
-  if (await timer.count()) pass('self-timer control present')
-  else fail('self-timer control present')
-
-  // Editor mode
-  const editorBtn = page.getByRole('button', { name: /^editor$/i }).first()
-  if (await editorBtn.count()) {
-    await editorBtn.click()
-    const okBtn = page.getByRole('button', { name: /^ok$/i }).first()
-    const trimBtn = page.getByRole('button', { name: /^trim$/i }).first()
-    const deleteBtn = page.getByRole('button', { name: /^delete$/i }).first()
-    if (await okBtn.count()) pass('editor mode + OK CTA')
-    else fail('editor mode + OK CTA', 'OK button missing')
-
-    // On short mobile viewports, editor actions must remain reachable via scroll.
-    await page.setViewportSize({ width: 390, height: 640 })
-    const screen = page.locator('.camera-screen')
-    const before = await screen.evaluate((el) => el.scrollTop)
-    await screen.evaluate((el) => {
-      el.scrollTop = el.scrollHeight
-    })
-    const after = await screen.evaluate((el) => el.scrollTop)
-    const deleteBox = await deleteBtn.boundingBox()
-    const trimVisible = await trimBtn.isVisible()
-    if (trimVisible && (after >= before || (deleteBox && deleteBox.y > 0))) {
-      pass('editor scroll reaches actions', `scroll ${before}->${after}`)
+  // Tools sheet holds timer/editor to free the record dock on small phones.
+  const toolsBtn = page.getByRole('button', { name: /^tools$/i }).first()
+  if (await toolsBtn.count()) {
+    await toolsBtn.click()
+    const toolsDialog = page.getByRole('dialog', { name: /recording tools/i })
+    const timer = toolsDialog.getByRole('button', { name: /timer|self[- ]?timer/i })
+    if ((await toolsDialog.count()) && (await timer.count())) {
+      pass('tools sheet + self-timer', 'opened from record dock')
     } else {
-      fail('editor scroll reaches actions', `scroll ${before}->${after}, trim=${trimVisible}`)
+      fail('tools sheet + self-timer', 'dialog or timer missing')
     }
-    await page.setViewportSize({ width: 390, height: 844 })
+
+    const editorBtn = toolsDialog.getByRole('button', { name: /^editor$/i }).first()
+    if (await editorBtn.count()) {
+      await editorBtn.click()
+      const okBtn = page.getByRole('button', { name: /^ok$/i }).first()
+      const trimBtn = page.getByRole('button', { name: /^trim$/i }).first()
+      const deleteBtn = page.getByRole('button', { name: /^delete$/i }).first()
+      if (await okBtn.count()) pass('editor mode + OK CTA')
+      else fail('editor mode + OK CTA', 'OK button missing')
+
+      // On short mobile viewports, editor actions must remain reachable via scroll.
+      await page.setViewportSize({ width: 390, height: 640 })
+      const screen = page.locator('.camera-screen')
+      const before = await screen.evaluate((el) => el.scrollTop)
+      await screen.evaluate((el) => {
+        el.scrollTop = el.scrollHeight
+      })
+      const after = await screen.evaluate((el) => el.scrollTop)
+      const deleteBox = await deleteBtn.boundingBox()
+      const trimVisible = await trimBtn.isVisible()
+      if (trimVisible && (after >= before || (deleteBox && deleteBox.y > 0))) {
+        pass('editor scroll reaches actions', `scroll ${before}->${after}`)
+      } else {
+        fail('editor scroll reaches actions', `scroll ${before}->${after}, trim=${trimVisible}`)
+      }
+      await page.setViewportSize({ width: 390, height: 844 })
+    } else {
+      fail('editor mode toggle')
+    }
   } else {
+    fail('tools sheet + self-timer', 'Tools button missing')
     fail('editor mode toggle')
   }
 

--- a/src/components/editor-tools-sheet.tsx
+++ b/src/components/editor-tools-sheet.tsx
@@ -1,0 +1,79 @@
+interface EditorToolsSheetProps {
+  canAct: boolean
+  canUndo: boolean
+  onDuplicate: () => void
+  onMoveLeft: () => void
+  onMoveRight: () => void
+  onUndo: () => void
+  onClose: () => void
+}
+
+export function EditorToolsSheet({
+  canAct,
+  canUndo,
+  onDuplicate,
+  onMoveLeft,
+  onMoveRight,
+  onUndo,
+  onClose,
+}: EditorToolsSheetProps) {
+  return (
+    <div className="sheet tools-sheet" role="dialog" aria-label="Editor tools">
+      <h3>Clip tools</h3>
+      <p className="muted" style={{ margin: 0, lineHeight: 1.45 }}>
+        Reorder, duplicate, or undo without crowding the timeline.
+      </p>
+      <div className="tools-sheet-list">
+        <button
+          type="button"
+          className="btn btn-secondary"
+          disabled={!canAct}
+          onClick={() => {
+            onClose()
+            onDuplicate()
+          }}
+        >
+          Duplicate
+        </button>
+        <button
+          type="button"
+          className="btn btn-secondary"
+          disabled={!canAct}
+          onClick={() => {
+            onClose()
+            onMoveLeft()
+          }}
+        >
+          Move left
+        </button>
+        <button
+          type="button"
+          className="btn btn-secondary"
+          disabled={!canAct}
+          onClick={() => {
+            onClose()
+            onMoveRight()
+          }}
+        >
+          Move right
+        </button>
+        <button
+          type="button"
+          className="btn btn-ghost"
+          disabled={!canUndo}
+          onClick={() => {
+            onClose()
+            onUndo()
+          }}
+        >
+          Undo delete
+        </button>
+      </div>
+      <div className="sheet-actions">
+        <button type="button" className="btn btn-ghost" onClick={onClose}>
+          Close
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/src/components/onboarding-overlay.tsx
+++ b/src/components/onboarding-overlay.tsx
@@ -11,11 +11,11 @@ const steps = [
   },
   {
     title: 'Preview the take',
-    body: 'Open Editor to scrub clips, trim rough edges, and check the sequence.',
+    body: 'Open Tools → Editor to scrub clips, trim rough edges, and check the sequence.',
   },
   {
     title: 'Delete fast',
-    body: 'Use Delete last after a bad take. The snackbar gives you Undo.',
+    body: 'Open Tools → Delete last after a bad take. The snackbar gives you Undo.',
   },
   {
     title: 'Tap OK',

--- a/src/components/tools-sheet.tsx
+++ b/src/components/tools-sheet.tsx
@@ -1,0 +1,83 @@
+interface ToolsSheetProps {
+  canDeleteLast: boolean
+  canFlip: boolean
+  recording: boolean
+  countdownActive: boolean
+  onEditor: () => void
+  onTimer: () => void
+  onDeleteLast: () => void
+  onFlip: () => void
+  onClose: () => void
+}
+
+export function ToolsSheet({
+  canDeleteLast,
+  canFlip,
+  recording,
+  countdownActive,
+  onEditor,
+  onTimer,
+  onDeleteLast,
+  onFlip,
+  onClose,
+}: ToolsSheetProps) {
+  return (
+    <div className="sheet tools-sheet" role="dialog" aria-label="Recording tools">
+      <h3>Tools</h3>
+      <p className="muted" style={{ margin: 0, lineHeight: 1.45 }}>
+        Keep the camera clear — open editor, flip, timer, or delete from here.
+      </p>
+      <div className="tools-sheet-list">
+        <button
+          type="button"
+          className="btn btn-primary"
+          disabled={recording}
+          onClick={() => {
+            onClose()
+            onEditor()
+          }}
+        >
+          Editor
+        </button>
+        <button
+          type="button"
+          className="btn btn-secondary"
+          disabled={recording || countdownActive}
+          onClick={() => {
+            onClose()
+            onTimer()
+          }}
+        >
+          Timer
+        </button>
+        <button
+          type="button"
+          className="btn btn-secondary"
+          disabled={!canFlip || recording}
+          onClick={() => {
+            onClose()
+            onFlip()
+          }}
+        >
+          Flip camera
+        </button>
+        <button
+          type="button"
+          className="btn btn-ghost"
+          disabled={!canDeleteLast || recording}
+          onClick={() => {
+            onClose()
+            onDeleteLast()
+          }}
+        >
+          Delete last
+        </button>
+      </div>
+      <div className="sheet-actions">
+        <button type="button" className="btn btn-ghost" onClick={onClose}>
+          Close
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/src/components/tools-sheet.tsx
+++ b/src/components/tools-sheet.tsx
@@ -43,10 +43,7 @@ export function ToolsSheet({
           type="button"
           className="btn btn-secondary"
           disabled={recording || countdownActive}
-          onClick={() => {
-            onClose()
-            onTimer()
-          }}
+          onClick={onTimer}
         >
           Timer
         </button>

--- a/src/hooks/use-camera.ts
+++ b/src/hooks/use-camera.ts
@@ -2,7 +2,9 @@ import { useCallback, useRef, useState, type RefCallback } from 'react'
 import {
   canFlipCamera,
   openCameraStream,
+  openMicrophoneTrack,
   queryCameraPermission,
+  stopAudioTracks,
   stopStream,
   type CameraPermissionState,
   type FacingMode,
@@ -19,19 +21,22 @@ export interface UseCameraResult {
   start: () => Promise<void>
   flip: () => Promise<void>
   stop: () => void
+  enableMic: () => Promise<void>
+  releaseMic: () => void
 }
 
 /**
  * Camera lifecycle is event/ref-driven (no useEffect):
  * - Video ref callback attaches/detaches the stream and starts capture when mounted.
- * - Flip/retry run from user events.
- * - Unmounting the video element stops tracks.
+ * - Preview is video-only so Android OS voice-to-text can keep the mic.
+ * - enableMic/releaseMic attach a mic track only while recording.
  */
 export function useCamera(): UseCameraResult {
   const streamRef = useRef<MediaStream | null>(null)
   const videoElRef = useRef<HTMLVideoElement | null>(null)
   const facingRef = useRef<FacingMode>('environment')
   const startInFlightRef = useRef<Promise<void> | null>(null)
+  const micInFlightRef = useRef<Promise<void> | null>(null)
 
   const [stream, setStream] = useState<MediaStream | null>(null)
   const [facing, setFacing] = useState<FacingMode>('environment')
@@ -74,7 +79,7 @@ export function useCamera(): UseCameraResult {
       }
 
       try {
-        const next = await openCameraStream(facingRef.current)
+        const next = await openCameraStream(facingRef.current, { audio: false })
         setPermission({ status: 'granted' })
         replaceStream(next)
         setCanFlip(await canFlipCamera())
@@ -100,12 +105,46 @@ export function useCamera(): UseCameraResult {
     setFacing(nextFacing)
     setError(null)
     try {
-      const next = await openCameraStream(nextFacing)
+      const next = await openCameraStream(nextFacing, { audio: false })
       replaceStream(next)
     } catch (err) {
       setError(permissionMessage(err))
     }
   }, [replaceStream])
+
+  const releaseMic = useCallback(() => {
+    stopAudioTracks(streamRef.current)
+  }, [])
+
+  const enableMic = useCallback(async () => {
+    if (micInFlightRef.current) {
+      await micInFlightRef.current
+      return
+    }
+
+    const run = (async () => {
+      const current = streamRef.current
+      if (!current) return
+      if (current.getAudioTracks().some((track) => track.readyState === 'live')) return
+      try {
+        const audioTrack = await openMicrophoneTrack()
+        if (streamRef.current !== current) {
+          audioTrack.stop()
+          return
+        }
+        current.addTrack(audioTrack)
+      } catch (err) {
+        throw new Error(permissionMessage(err))
+      }
+    })()
+
+    micInFlightRef.current = run
+    try {
+      await run
+    } finally {
+      micInFlightRef.current = null
+    }
+  }, [])
 
   const stop = useCallback(() => {
     stopStream(streamRef.current)
@@ -144,6 +183,8 @@ export function useCamera(): UseCameraResult {
     start,
     flip,
     stop,
+    enableMic,
+    releaseMic,
   }
 }
 
@@ -158,7 +199,7 @@ function permissionMessage(err: unknown): string {
         return 'No camera was found on this device.'
       case 'NotReadableError':
       case 'TrackStartError':
-        return 'Camera is in use by another app. Close it and retry.'
+        return 'Camera or mic is in use by another app. Close it and retry.'
       case 'SecurityError':
         return 'Camera requires a secure context (HTTPS or localhost).'
       default:

--- a/src/hooks/use-camera.ts
+++ b/src/hooks/use-camera.ts
@@ -23,6 +23,8 @@ export interface UseCameraResult {
   stop: () => void
   enableMic: () => Promise<void>
   releaseMic: () => void
+  /** Latest live stream from the ref (safer than React state after awaits). */
+  getStream: () => MediaStream | null
 }
 
 /**
@@ -195,6 +197,8 @@ export function useCamera(): UseCameraResult {
     [attachToVideo, start, stop],
   )
 
+  const getStream = useCallback(() => streamRef.current, [])
+
   return {
     videoRef,
     stream,
@@ -208,6 +212,7 @@ export function useCamera(): UseCameraResult {
     stop,
     enableMic,
     releaseMic,
+    getStream,
   }
 }
 

--- a/src/hooks/use-camera.ts
+++ b/src/hooks/use-camera.ts
@@ -119,20 +119,43 @@ export function useCamera(): UseCameraResult {
   const enableMic = useCallback(async () => {
     if (micInFlightRef.current) {
       await micInFlightRef.current
+      if (!streamRef.current?.getAudioTracks().some((track) => track.readyState === 'live')) {
+        throw new Error('Microphone unavailable')
+      }
       return
     }
 
-    const run = (async () => {
+    const attachToCurrentStream = async (attempt = 0): Promise<void> => {
       const current = streamRef.current
-      if (!current) return
+      if (!current) {
+        throw new Error('Camera not ready')
+      }
       if (current.getAudioTracks().some((track) => track.readyState === 'live')) return
-      try {
-        const audioTrack = await openMicrophoneTrack()
-        if (streamRef.current !== current) {
-          audioTrack.stop()
-          return
+
+      const audioTrack = await openMicrophoneTrack()
+      const latest = streamRef.current
+      if (!latest) {
+        audioTrack.stop()
+        throw new Error('Camera not ready')
+      }
+      if (latest !== current) {
+        // Stream swapped (flip/restart) while the permission prompt was open — attach to the new one.
+        audioTrack.stop()
+        if (attempt >= 2) {
+          throw new Error('Camera changed while enabling microphone')
         }
-        current.addTrack(audioTrack)
+        await attachToCurrentStream(attempt + 1)
+        return
+      }
+      current.addTrack(audioTrack)
+    }
+
+    const run = (async () => {
+      try {
+        await attachToCurrentStream()
+        if (!streamRef.current?.getAudioTracks().some((track) => track.readyState === 'live')) {
+          throw new Error('Microphone unavailable')
+        }
       } catch (err) {
         throw new Error(permissionMessage(err))
       }

--- a/src/lib/media.ts
+++ b/src/lib/media.ts
@@ -40,7 +40,16 @@ export async function queryCameraPermission(): Promise<CameraPermissionState> {
   return { status: 'unknown' }
 }
 
-export async function openCameraStream(facing: FacingMode): Promise<MediaStream> {
+export interface OpenCameraOptions {
+  /** Preview should stay video-only so Android voice-to-text can use the mic. */
+  audio?: boolean
+}
+
+export async function openCameraStream(
+  facing: FacingMode,
+  options: OpenCameraOptions = {},
+): Promise<MediaStream> {
+  const withAudio = options.audio === true
   const videoConstraints: MediaTrackConstraints = {
     facingMode: { ideal: facing },
     width: { ideal: 1280 },
@@ -49,18 +58,35 @@ export async function openCameraStream(facing: FacingMode): Promise<MediaStream>
 
   try {
     return await navigator.mediaDevices.getUserMedia({
-      audio: true,
+      audio: withAudio,
       video: videoConstraints,
     })
   } catch (error) {
     if (isOverconstrained(error)) {
       return navigator.mediaDevices.getUserMedia({
-        audio: true,
+        audio: withAudio,
         video: true,
       })
     }
     throw error
   }
+}
+
+/** Grab a mic track only for the duration of a recording. */
+export async function openMicrophoneTrack(): Promise<MediaStreamTrack> {
+  const mic = await navigator.mediaDevices.getUserMedia({
+    audio: {
+      echoCancellation: true,
+      noiseSuppression: true,
+    },
+    video: false,
+  })
+  const track = mic.getAudioTracks()[0]
+  if (!track) {
+    mic.getTracks().forEach((t) => t.stop())
+    throw new Error('No microphone track available')
+  }
+  return track
 }
 
 function isOverconstrained(error: unknown): boolean {
@@ -69,6 +95,13 @@ function isOverconstrained(error: unknown): boolean {
 
 export function stopStream(stream: MediaStream | null | undefined): void {
   stream?.getTracks().forEach((track) => track.stop())
+}
+
+export function stopAudioTracks(stream: MediaStream | null | undefined): void {
+  stream?.getAudioTracks().forEach((track) => {
+    stream.removeTrack(track)
+    track.stop()
+  })
 }
 
 export function pickRecorderMimeType(): string {
@@ -137,14 +170,23 @@ function isMobileBrowser(): boolean {
   return /Android|iPhone|iPad|iPod|Mobile/i.test(navigator.userAgent)
 }
 
+export interface ExportWebmOptions {
+  /**
+   * Prefer creating/resuming this from the Make-video click so Android unlocks audio.
+   * Export closes the context when finished.
+   */
+  audioContext?: AudioContext
+}
+
 /**
  * Stitch clips into a single WebM using canvas captureStream + MediaRecorder.
  * Applies trim in/out by seeking each source clip.
- * Tradeoff: re-encodes video; quality depends on browser encoder; audio may be limited.
+ * Audio is mixed from decodeAudioData → BufferSource (muted video frames for autoplay).
  */
 export async function exportProjectAsWebm(
   clips: ClipRecord[],
   onProgress?: (ratio: number) => void,
+  options: ExportWebmOptions = {},
 ): Promise<Blob> {
   if (clips.length === 0) {
     throw new Error('Nothing to export')
@@ -168,16 +210,20 @@ export async function exportProjectAsWebm(
     throw new Error('This browser cannot capture canvas video for export')
   }
 
-  let audioContext: AudioContext | null = null
+  let audioContext: AudioContext | null = options.audioContext ?? null
   let dest: MediaStreamAudioDestinationNode | null = null
   try {
-    audioContext = new AudioContext()
+    if (!audioContext) {
+      audioContext = new AudioContext()
+    }
     if (audioContext.state === 'suspended') {
       await audioContext.resume().catch(() => undefined)
     }
     dest = audioContext.createMediaStreamDestination()
   } catch {
     // Video-only export if AudioContext is unavailable.
+    audioContext = null
+    dest = null
   }
 
   const mixedStream = new MediaStream([
@@ -278,10 +324,13 @@ async function paintClipToCanvas({
   video.src = url
   video.playsInline = true
   // Must be muted for autoplay policies on Android Chrome/Brave during export.
+  // Audio is mixed separately from a decoded AudioBuffer so the stitch keeps sound.
   video.muted = true
   video.preload = 'auto'
   video.setAttribute('playsinline', 'true')
   video.setAttribute('webkit-playsinline', 'true')
+
+  let bufferSource: AudioBufferSourceNode | null = null
 
   try {
     await waitForEvent(video, 'loadeddata')
@@ -294,23 +343,34 @@ async function paintClipToCanvas({
     video.currentTime = startSec
     await waitForEvent(video, 'seeked')
 
-    // Keep the element muted for Android autoplay policies. We still tap the
-    // MediaElementSource graph when available; some browsers deliver silent
-    // frames only, which is preferable to a failed stitch.
-    let sourceNode: MediaElementAudioSourceNode | null = null
-    if (audioContext && dest) {
+    const audioBuffer =
+      audioContext && dest ? await decodeClipAudio(audioContext, clip.blob) : null
+
+    if (audioContext && dest && audioBuffer) {
       try {
         if (audioContext.state === 'suspended') {
           await audioContext.resume().catch(() => undefined)
         }
-        sourceNode = audioContext.createMediaElementSource(video)
-        sourceNode.connect(dest)
+        bufferSource = audioContext.createBufferSource()
+        bufferSource.buffer = audioBuffer
+        bufferSource.connect(dest)
       } catch {
-        sourceNode = null
+        bufferSource = null
       }
     }
 
     await video.play()
+
+    if (bufferSource && audioContext && audioBuffer) {
+      const offset = Math.min(Math.max(0, startSec), Math.max(0, audioBuffer.duration - 0.01))
+      const duration = Math.min(
+        Math.max(0, endSec - startSec),
+        Math.max(0, audioBuffer.duration - offset),
+      )
+      if (duration > 0.02) {
+        bufferSource.start(audioContext.currentTime, offset, duration)
+      }
+    }
 
     await new Promise<void>((resolve, reject) => {
       let raf = 0
@@ -346,12 +406,29 @@ async function paintClipToCanvas({
       }
       raf = requestAnimationFrame(draw)
     })
-
-    sourceNode?.disconnect()
   } finally {
+    try {
+      bufferSource?.stop()
+    } catch {
+      // already ended
+    }
+    bufferSource?.disconnect()
     URL.revokeObjectURL(url)
     video.removeAttribute('src')
     video.load()
+  }
+}
+
+async function decodeClipAudio(
+  audioContext: AudioContext,
+  blob: Blob,
+): Promise<AudioBuffer | null> {
+  try {
+    const bytes = await blob.arrayBuffer()
+    // decodeAudioData may detach the buffer; copy so callers can reuse the blob.
+    return await audioContext.decodeAudioData(bytes.slice(0))
+  } catch {
+    return null
   }
 }
 

--- a/src/pages/project-page.tsx
+++ b/src/pages/project-page.tsx
@@ -71,6 +71,7 @@ export function ProjectPage() {
   const recorderRef = useRef(new HoldRecorder())
   const pointerIdRef = useRef<number | null>(null)
   const beginInFlightRef = useRef(false)
+  const sheetRef = useRef<Sheet>('none')
   const recordRafRef = useRef(0)
   const toastTimerRef = useRef(0)
   const countdownTimerRef = useRef(0)
@@ -85,6 +86,7 @@ export function ProjectPage() {
   const [recordMs, setRecordMs] = useState(0)
   const [countdown, setCountdown] = useState<number | null>(null)
   const [sheet, setSheet] = useState<Sheet>('none')
+  sheetRef.current = sheet
   const [playing, setPlaying] = useState(false)
   const [toast, setToast] = useState<ToastState | null>(null)
   const [exportProgress, setExportProgress] = useState<number | null>(null)
@@ -145,12 +147,12 @@ export function ProjectPage() {
         recording ||
         recorderRef.current.isRecording ||
         playing ||
-        sheet !== 'none' ||
+        sheetRef.current !== 'none' ||
         countdown !== null
       ) {
         return false
       }
-      if (!camera.stream || !camera.isReady) {
+      if (!camera.getStream() || !camera.isReady) {
         showToast('Camera not ready')
         return false
       }
@@ -168,8 +170,13 @@ export function ProjectPage() {
           camera.releaseMic()
           return false
         }
+        // Re-check after the mic await — a sheet may have opened meanwhile.
+        if (sheetRef.current !== 'none') {
+          camera.releaseMic()
+          return false
+        }
 
-        const stream = camera.stream
+        const stream = camera.getStream()
         if (!stream?.getAudioTracks().some((track) => track.readyState === 'live')) {
           throw new Error('Microphone unavailable')
         }
@@ -204,13 +211,12 @@ export function ProjectPage() {
     },
     [
       camera.enableMic,
+      camera.getStream,
       camera.isReady,
       camera.releaseMic,
-      camera.stream,
       countdown,
       playing,
       recording,
-      sheet,
       showToast,
     ],
   )
@@ -257,12 +263,15 @@ export function ProjectPage() {
   )
 
   const startSelfTimer = useCallback(() => {
-    if (recording || playing || sheet !== 'none' || countdown !== null) return
-    if (!camera.stream || !camera.isReady) {
+    if (recording || playing || countdown !== null) return
+    if (!camera.getStream() || !camera.isReady) {
       showToast('Camera not ready')
       return
     }
 
+    // Close any sheet first so hold/begin guards and UI stay consistent.
+    sheetRef.current = 'none'
+    setSheet('none')
     let next = 3
     setCountdown(next)
     const tick = () => {
@@ -282,16 +291,7 @@ export function ProjectPage() {
       countdownTimerRef.current = window.setTimeout(tick, 1000)
     }
     countdownTimerRef.current = window.setTimeout(tick, 1000)
-  }, [
-    beginRecord,
-    camera.isReady,
-    camera.stream,
-    countdown,
-    playing,
-    recording,
-    sheet,
-    showToast,
-  ])
+  }, [beginRecord, camera.getStream, camera.isReady, countdown, playing, recording, showToast])
 
   const deleteLastClip = useCallback(() => {
     const lastClip = data.clips.at(-1)

--- a/src/pages/project-page.tsx
+++ b/src/pages/project-page.tsx
@@ -8,10 +8,12 @@ import {
   type LoaderFunctionArgs,
 } from 'react-router-dom'
 import { BlobVideo } from '../components/blob-video'
+import { EditorToolsSheet } from '../components/editor-tools-sheet'
 import { ExportSheet } from '../components/export-sheet'
 import { OnboardingOverlay } from '../components/onboarding-overlay'
 import { PlaybackOverlay } from '../components/playback-overlay'
 import { Timeline } from '../components/timeline'
+import { ToolsSheet } from '../components/tools-sheet'
 import { TrimSheet } from '../components/trim-sheet'
 import { useCamera } from '../hooks/use-camera'
 import {
@@ -35,7 +37,7 @@ import { HoldRecorder } from '../lib/recorder'
 import { setOnboardingDismissed } from '../lib/storage'
 import { effectiveDurationMs, formatDuration, type ClipId } from '../lib/types'
 
-type Sheet = 'none' | 'trim' | 'export'
+type Sheet = 'none' | 'trim' | 'export' | 'tools' | 'editor-tools'
 type ProjectMode = 'record' | 'editor'
 type RecordingMode = 'hold' | 'hands-free'
 
@@ -136,7 +138,7 @@ export function ProjectPage() {
   )
 
   const beginRecord = useCallback(
-    (pointerId: number | null, nextRecordingMode: RecordingMode) => {
+    async (pointerId: number | null, nextRecordingMode: RecordingMode) => {
       if (recording || playing || sheet !== 'none' || countdown !== null) return
       if (!camera.stream || !camera.isReady) {
         showToast('Camera not ready')
@@ -144,9 +146,20 @@ export function ProjectPage() {
       }
       pointerIdRef.current = pointerId
       try {
+        // Grab the mic only for this take so Brave/Android voice-to-text stays free while idle.
+        await camera.enableMic()
+        if (pointerId !== null && pointerIdRef.current !== pointerId) {
+          camera.releaseMic()
+          return
+        }
+        if (nextRecordingMode === 'hold' && pointerId !== null && pointerIdRef.current === null) {
+          camera.releaseMic()
+          return
+        }
         const startedOk = recorderRef.current.start(camera.stream)
         if (!startedOk) {
           pointerIdRef.current = null
+          camera.releaseMic()
           showToast('Still finishing the last clip')
           return
         }
@@ -159,13 +172,24 @@ export function ProjectPage() {
           recordRafRef.current = requestAnimationFrame(tick)
         }
         recordRafRef.current = requestAnimationFrame(tick)
-      } catch {
-        showToast('Could not start recording')
+      } catch (err) {
+        camera.releaseMic()
+        showToast(err instanceof Error ? err.message : 'Could not start recording')
         pointerIdRef.current = null
         setRecordingMode(null)
       }
     },
-    [camera.isReady, camera.stream, countdown, playing, recording, sheet, showToast],
+    [
+      camera.enableMic,
+      camera.isReady,
+      camera.releaseMic,
+      camera.stream,
+      countdown,
+      playing,
+      recording,
+      sheet,
+      showToast,
+    ],
   )
 
   const endRecord = useCallback(
@@ -177,7 +201,12 @@ export function ProjectPage() {
       ) {
         return
       }
-      if (!recorderRef.current.isRecording && !recording) return
+      if (!recorderRef.current.isRecording && !recording) {
+        // Pointer released while mic grant was still in flight.
+        pointerIdRef.current = null
+        camera.releaseMic()
+        return
+      }
       pointerIdRef.current = null
       stopRecordTicker()
       setRecording(false)
@@ -197,9 +226,11 @@ export function ProjectPage() {
         }
       } catch (err) {
         showToast(err instanceof Error ? err.message : 'Save failed')
+      } finally {
+        camera.releaseMic()
       }
     },
-    [mode, projectId, recording, refresh, showToast, stopRecordTicker],
+    [camera.releaseMic, mode, projectId, recording, refresh, showToast, stopRecordTicker],
   )
 
   const startSelfTimer = useCallback(() => {
@@ -294,6 +325,7 @@ export function ProjectPage() {
             clearCountdown()
             stopRecordTicker()
             recorderRef.current.cancel()
+            camera.releaseMic()
             window.clearTimeout(toastTimerRef.current)
           }}
         >
@@ -399,7 +431,7 @@ export function ProjectPage() {
               <p>
                 {camera.error ??
                   camera.permission.message ??
-                  'Allow camera and microphone to record clips on this device.'}
+                  'Allow camera to preview. Microphone is requested only while you record.'}
               </p>
               <button type="button" className="btn btn-primary" onClick={() => void camera.start()}>
                 Try again
@@ -427,25 +459,9 @@ export function ProjectPage() {
                 type="button"
                 className="btn btn-secondary"
                 disabled={recording}
-                onClick={() => setMode('editor')}
+                onClick={() => setSheet('tools')}
               >
-                Editor
-              </button>
-              <button
-                type="button"
-                className="btn btn-ghost"
-                disabled={recording || countdown !== null}
-                onClick={startSelfTimer}
-              >
-                Timer
-              </button>
-              <button
-                type="button"
-                className="btn btn-ghost"
-                disabled={data.clips.length === 0 || recording}
-                onClick={deleteLastClip}
-              >
-                Delete last
+                Tools
               </button>
               <button
                 type="button"
@@ -468,7 +484,14 @@ export function ProjectPage() {
                 <p className="eyebrow">Editor</p>
                 <strong>{selected ? `Clip ${data.clips.findIndex((c) => c.id === selected.id) + 1}` : 'No clip selected'}</strong>
               </div>
-              <button type="button" className="btn btn-secondary" onClick={() => setMode('record')}>
+              <button
+                type="button"
+                className="btn btn-secondary"
+                onClick={() => {
+                  camera.releaseMic()
+                  setMode('record')
+                }}
+              >
                 Camera
               </button>
             </div>
@@ -517,60 +540,10 @@ export function ProjectPage() {
               <button
                 type="button"
                 className="btn btn-ghost"
-                disabled={!resolvedSelectedId || recording}
-                onClick={() => {
-                  void (async () => {
-                    if (!resolvedSelectedId) return
-                    const copy = await duplicateSelectedClip(resolvedSelectedId)
-                    setSelectedClipId(copy.id)
-                    refresh()
-                  })()
-                }}
+                disabled={recording}
+                onClick={() => setSheet('editor-tools')}
               >
-                Duplicate
-              </button>
-              <button
-                type="button"
-                className="btn btn-ghost"
-                disabled={!resolvedSelectedId || recording}
-                onClick={() => {
-                  void (async () => {
-                    if (!resolvedSelectedId) return
-                    await moveSelectedClip(projectId, resolvedSelectedId, 'left')
-                    refresh()
-                  })()
-                }}
-              >
-                Move left
-              </button>
-              <button
-                type="button"
-                className="btn btn-ghost"
-                disabled={!resolvedSelectedId || recording}
-                onClick={() => {
-                  void (async () => {
-                    if (!resolvedSelectedId) return
-                    await moveSelectedClip(projectId, resolvedSelectedId, 'right')
-                    refresh()
-                  })()
-                }}
-              >
-                Move right
-              </button>
-              <button
-                type="button"
-                className="btn btn-ghost"
-                disabled={!data.canUndo || recording}
-                onClick={() => {
-                  void (async () => {
-                    const restored = await undoLastDelete(projectId)
-                    if (restored) setSelectedClipId(restored.id)
-                    refresh()
-                    showToast('Clip restored')
-                  })()
-                }}
-              >
-                Undo
+                More
               </button>
             </div>
 
@@ -600,6 +573,61 @@ export function ProjectPage() {
           </div>
         )}
       </div>
+
+      {sheet === 'tools' ? (
+        <ToolsSheet
+          canDeleteLast={data.clips.length > 0}
+          canFlip={camera.canFlip}
+          recording={recording}
+          countdownActive={countdown !== null}
+          onEditor={() => {
+            camera.releaseMic()
+            setMode('editor')
+          }}
+          onTimer={startSelfTimer}
+          onDeleteLast={deleteLastClip}
+          onFlip={() => void camera.flip()}
+          onClose={() => setSheet('none')}
+        />
+      ) : null}
+
+      {sheet === 'editor-tools' ? (
+        <EditorToolsSheet
+          canAct={!!resolvedSelectedId && !recording}
+          canUndo={data.canUndo && !recording}
+          onDuplicate={() => {
+            void (async () => {
+              if (!resolvedSelectedId) return
+              const copy = await duplicateSelectedClip(resolvedSelectedId)
+              setSelectedClipId(copy.id)
+              refresh()
+            })()
+          }}
+          onMoveLeft={() => {
+            void (async () => {
+              if (!resolvedSelectedId) return
+              await moveSelectedClip(projectId, resolvedSelectedId, 'left')
+              refresh()
+            })()
+          }}
+          onMoveRight={() => {
+            void (async () => {
+              if (!resolvedSelectedId) return
+              await moveSelectedClip(projectId, resolvedSelectedId, 'right')
+              refresh()
+            })()
+          }}
+          onUndo={() => {
+            void (async () => {
+              const restored = await undoLastDelete(projectId)
+              if (restored) setSelectedClipId(restored.id)
+              refresh()
+              showToast('Clip restored')
+            })()
+          }}
+          onClose={() => setSheet('none')}
+        />
+      ) : null}
 
       {sheet === 'trim' && selected ? (
         <TrimSheet
@@ -671,7 +699,19 @@ export function ProjectPage() {
               setExportMessageTone('info')
               setExportProgress(0)
               try {
-                const blob = await exportProjectAsWebm(data.clips, setExportProgress)
+                // Unlock AudioContext from this tap so stitched export can mix clip audio.
+                let audioContext: AudioContext | undefined
+                try {
+                  audioContext = new AudioContext()
+                  if (audioContext.state === 'suspended') {
+                    await audioContext.resume()
+                  }
+                } catch {
+                  audioContext = undefined
+                }
+                const blob = await exportProjectAsWebm(data.clips, setExportProgress, {
+                  audioContext,
+                })
                 const filename = projectFilename(data.project!.name)
                 const shareMode = await shareOrDownload(blob, filename)
                 switch (shareMode) {

--- a/src/pages/project-page.tsx
+++ b/src/pages/project-page.tsx
@@ -70,6 +70,7 @@ export function ProjectPage() {
 
   const recorderRef = useRef(new HoldRecorder())
   const pointerIdRef = useRef<number | null>(null)
+  const beginInFlightRef = useRef(false)
   const recordRafRef = useRef(0)
   const toastTimerRef = useRef(0)
   const countdownTimerRef = useRef(0)
@@ -138,30 +139,48 @@ export function ProjectPage() {
   )
 
   const beginRecord = useCallback(
-    async (pointerId: number | null, nextRecordingMode: RecordingMode) => {
-      if (recording || playing || sheet !== 'none' || countdown !== null) return
+    async (pointerId: number | null, nextRecordingMode: RecordingMode): Promise<boolean> => {
+      if (
+        beginInFlightRef.current ||
+        recording ||
+        recorderRef.current.isRecording ||
+        playing ||
+        sheet !== 'none' ||
+        countdown !== null
+      ) {
+        return false
+      }
       if (!camera.stream || !camera.isReady) {
         showToast('Camera not ready')
-        return
+        return false
       }
+
+      beginInFlightRef.current = true
       pointerIdRef.current = pointerId
       try {
         // Grab the mic only for this take so Brave/Android voice-to-text stays free while idle.
         await camera.enableMic()
         if (pointerId !== null && pointerIdRef.current !== pointerId) {
           camera.releaseMic()
-          return
+          return false
         }
         if (nextRecordingMode === 'hold' && pointerId !== null && pointerIdRef.current === null) {
           camera.releaseMic()
-          return
+          return false
         }
-        const startedOk = recorderRef.current.start(camera.stream)
+
+        const stream = camera.stream
+        if (!stream?.getAudioTracks().some((track) => track.readyState === 'live')) {
+          throw new Error('Microphone unavailable')
+        }
+
+        const startedOk = recorderRef.current.start(stream)
         if (!startedOk) {
           pointerIdRef.current = null
-          camera.releaseMic()
+          // Never strip mic from an already-active recording owned by another start.
+          if (!recorderRef.current.isRecording) camera.releaseMic()
           showToast('Still finishing the last clip')
-          return
+          return false
         }
         setRecording(true)
         setRecordingMode(nextRecordingMode)
@@ -172,11 +191,15 @@ export function ProjectPage() {
           recordRafRef.current = requestAnimationFrame(tick)
         }
         recordRafRef.current = requestAnimationFrame(tick)
+        return true
       } catch (err) {
-        camera.releaseMic()
+        if (!recorderRef.current.isRecording) camera.releaseMic()
         showToast(err instanceof Error ? err.message : 'Could not start recording')
         pointerIdRef.current = null
         setRecordingMode(null)
+        return false
+      } finally {
+        beginInFlightRef.current = false
       }
     },
     [
@@ -247,8 +270,12 @@ export function ProjectPage() {
       if (next <= 0) {
         countdownTimerRef.current = 0
         setCountdown(null)
-        beginRecord(null, 'hands-free')
-        showToast('Hands-free recording. Tap preview to stop.')
+        void (async () => {
+          const started = await beginRecord(null, 'hands-free')
+          if (started) {
+            showToast('Hands-free recording. Tap preview to stop.')
+          }
+        })()
         return
       }
       setCountdown(next)
@@ -339,7 +366,7 @@ export function ProjectPage() {
           type="button"
           className="btn-icon"
           aria-label="Flip camera"
-          disabled={!camera.canFlip || recording}
+          disabled={!camera.canFlip || recording || countdown !== null}
           onClick={() => void camera.flip()}
         >
           ↻

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -635,14 +635,28 @@ a {
 
 .record-actions {
   display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr)) auto;
-  gap: 8px;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 12px;
   align-items: center;
 }
 
 .record-actions .btn {
   min-width: 0;
-  padding: 0 12px;
+  min-height: 52px;
+  padding: 0 16px;
+}
+
+.tools-sheet-list {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  margin-top: 14px;
+}
+
+.tools-sheet-list .btn {
+  width: 100%;
+  min-height: 48px;
+  justify-content: center;
 }
 
 .ok-button {
@@ -1003,8 +1017,8 @@ a {
   }
 
   .record-actions {
-    grid-template-columns: repeat(3, minmax(0, 1fr)) auto;
-    gap: 6px;
+    grid-template-columns: minmax(0, 1fr) auto;
+    gap: 10px;
   }
 
   .editor-mode .camera-stage {


### PR DESCRIPTION
## Summary
- Preview stays **video-only**; the mic is grabbed only while a take is recording and released afterward so Android voice-to-text works again in Brave.
- Stitched export mixes clip audio via `decodeAudioData` → `AudioBufferSourceNode` into the MediaRecorder stream (video frames stay muted for autoplay). `AudioContext` is resumed from the Make-video tap.
- Record dock is now **Tools + OK**; Editor / Timer / Flip / Delete last live in a bottom sheet. Editor secondary actions (duplicate / move / undo) move into a **More** sheet.

## Test plan
- [ ] On Android Brave: open the app, leave camera idle, confirm OS voice-to-text still works in another field/app.
- [ ] Record a clip with speech, Make video, and confirm the export has audio.
- [ ] Confirm Tools / More sheets fit small viewports without crowding OK.
- [ ] `npm test` and `npm run test:smoke`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes recording permission timing, MediaStream lifecycle, and export audio mixing—areas that are browser-sensitive but localized to camera/export UX.
> 
> **Overview**
> Fixes **Android Brave/Chrome** blocking OS voice-to-text by opening the camera **without audio** and attaching a mic track only when a take starts (`enableMic` / `releaseMic`), with tighter guards around async `beginRecord` (sheet open, pointer release during permission, stream flip).
> 
> **Stitched export** now mixes sound via `decodeAudioData` and `AudioBufferSourceNode` into the recorder stream (video elements stay muted for autoplay), with `AudioContext` resumed from the Make-video tap.
> 
> The record dock is reduced to **Tools + OK**; Editor, timer, flip, and delete-last move into a **Recording tools** sheet, and duplicate/move/undo move to **More** in editor mode. Manual checklist and smoke tests follow the new flows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a83f17f38c6ad52c8ff90a3bcec206ba4d9f021. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->