### PR TITLE
Light mode, export A/V sync, and editor clip preview

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,8 @@
       name="viewport"
       content="width=device-width, initial-scale=1.0, viewport-fit=cover, maximum-scale=1.0, user-scalable=no, interactive-widget=resizes-content"
     />
-    <meta name="theme-color" content="#2F3E46" />
+    <meta name="theme-color" media="(prefers-color-scheme: dark)" content="#2F3E46" />
+    <meta name="theme-color" media="(prefers-color-scheme: light)" content="#EEF5F1" />
     <meta
       name="description"
       content="Kody Video — hold anywhere to record clips. Privacy-first camera for the web."

--- a/manual-test-checklist.md
+++ b/manual-test-checklist.md
@@ -6,6 +6,9 @@ Run locally with HTTPS or `localhost` (`npm run dev`). Camera/mic require a secu
 - [ ] First open prompts for camera; microphone is requested when you start recording
 - [ ] Idle preview does not block Android voice-to-text in Brave/Chrome
 - [ ] Exported stitched video includes microphone audio from recorded clips
+- [ ] Export audio stays lined up with each clip (no early soundtrack / cross-clip drift)
+- [ ] Editor stage preview updates when tapping different timeline clips
+- [ ] Light/dark follows system `prefers-color-scheme`
 - [ ] Record dock shows Tools + OK (Editor/Timer/Delete live in the Tools sheet)
 - [ ] Deny → clear denied panel with retry guidance
 - [ ] Allow → live rear-camera preview (or fallback)

--- a/src/components/blob-video.tsx
+++ b/src/components/blob-video.tsx
@@ -5,15 +5,18 @@ type BlobVideoProps = Omit<VideoHTMLAttributes<HTMLVideoElement>, 'src'> & {
   blob: Blob
 }
 
-/** Video element bound to a Blob via ref callback (revokes URL on unmount). */
+/** Video element bound to a Blob via ref callback (revokes URL on unmount/blob change). */
 export function BlobVideo({ blob, ...props }: BlobVideoProps) {
-  const urlRef = useRef<string | null>(null)
+  const stateRef = useRef<{ current: string | null; blob: Blob | null }>({
+    current: null,
+    blob: null,
+  })
 
   return (
     <video
       {...props}
       ref={(element) => {
-        bindBlobUrl(element, blob, urlRef)
+        bindBlobUrl(element, blob, stateRef.current)
       }}
     />
   )

--- a/src/components/blob-video.tsx
+++ b/src/components/blob-video.tsx
@@ -1,4 +1,4 @@
-import { useRef, type VideoHTMLAttributes } from 'react'
+import { useCallback, useRef, type RefCallback, type VideoHTMLAttributes } from 'react'
 import { bindBlobUrl } from '../lib/blob-url'
 
 type BlobVideoProps = Omit<VideoHTMLAttributes<HTMLVideoElement>, 'src'> & {
@@ -12,12 +12,12 @@ export function BlobVideo({ blob, ...props }: BlobVideoProps) {
     blob: null,
   })
 
-  return (
-    <video
-      {...props}
-      ref={(element) => {
-        bindBlobUrl(element, blob, stateRef.current)
-      }}
-    />
+  const setVideoRef = useCallback<RefCallback<HTMLVideoElement>>(
+    (element) => {
+      bindBlobUrl(element, blob, stateRef.current)
+    },
+    [blob],
   )
+
+  return <video {...props} ref={setVideoRef} />
 }

--- a/src/components/editor-clip-preview.tsx
+++ b/src/components/editor-clip-preview.tsx
@@ -1,0 +1,42 @@
+import { BlobVideo } from './blob-video'
+import type { ClipRecord } from '../lib/types'
+
+interface EditorClipPreviewProps {
+  clip: ClipRecord
+}
+
+/**
+ * Stage preview for the selected timeline clip.
+ * Remounts whenever the clip identity, blob, or trim start changes so the
+ * object URL and seek target cannot stick on a previous selection.
+ */
+export function EditorClipPreview({ clip }: EditorClipPreviewProps) {
+  const startSec = clip.trimStartMs / 1000
+  const remountKey = `${clip.id}:${clip.blob.size}:${clip.blob.type}:${clip.trimStartMs}`
+
+  return (
+    <BlobVideo
+      key={remountKey}
+      blob={clip.blob}
+      className="editor-clip-preview"
+      muted
+      playsInline
+      preload="auto"
+      onLoadedData={(event) => {
+        const video = event.currentTarget
+        if (Math.abs(video.currentTime - startSec) > 0.04) {
+          video.currentTime = startSec
+        }
+      }}
+      onSeeked={(event) => {
+        // Nudge a frame decode after seek so WebM previews aren't stuck blank.
+        const video = event.currentTarget
+        if (video.paused && video.readyState >= 2) {
+          void video.play().then(() => {
+            video.pause()
+          }).catch(() => undefined)
+        }
+      }}
+    />
+  )
+}

--- a/src/components/editor-clip-preview.tsx
+++ b/src/components/editor-clip-preview.tsx
@@ -5,6 +5,16 @@ interface EditorClipPreviewProps {
   clip: ClipRecord
 }
 
+function nudgeFrame(video: HTMLVideoElement): void {
+  if (!video.paused || video.readyState < 2) return
+  void video
+    .play()
+    .then(() => {
+      video.pause()
+    })
+    .catch(() => undefined)
+}
+
 /**
  * Stage preview for the selected timeline clip.
  * Remounts whenever the clip identity, blob, or trim start changes so the
@@ -26,16 +36,14 @@ export function EditorClipPreview({ clip }: EditorClipPreviewProps) {
         const video = event.currentTarget
         if (Math.abs(video.currentTime - startSec) > 0.04) {
           video.currentTime = startSec
+          return
         }
+        // Already at trim start (common for trimStartMs = 0) — still nudge a
+        // decoded frame so WebM previews are not left blank without a seek.
+        nudgeFrame(video)
       }}
       onSeeked={(event) => {
-        // Nudge a frame decode after seek so WebM previews aren't stuck blank.
-        const video = event.currentTarget
-        if (video.paused && video.readyState >= 2) {
-          void video.play().then(() => {
-            video.pause()
-          }).catch(() => undefined)
-        }
+        nudgeFrame(event.currentTarget)
       }}
     />
   )

--- a/src/components/playback-overlay.tsx
+++ b/src/components/playback-overlay.tsx
@@ -24,17 +24,25 @@ export function PlaybackOverlay({ clips, onClose }: PlaybackOverlayProps) {
     <div className="permission-panel" style={{ background: 'rgba(0,0,0,0.92)' }}>
       <div style={{ width: '100%', maxWidth: 360 }}>
         <BlobVideo
-          key={clip.id}
+          key={`${clip.id}:${index}:${clip.blob.size}`}
           blob={clip.blob}
           className="camera-video"
           style={{ height: '55vh', borderRadius: 18, background: '#000' }}
           playsInline
           controls={false}
+          preload="auto"
           onLoadedData={(event) => {
             event.currentTarget.currentTime = startSec
           }}
           onSeeked={(event) => {
             void event.currentTarget.play().catch(() => undefined)
+          }}
+          onEnded={() => {
+            if (index < clips.length - 1) {
+              setIndex((current) => current + 1)
+              return
+            }
+            onClose()
           }}
           onTimeUpdate={(event) => {
             const video = event.currentTarget

--- a/src/components/playback-overlay.tsx
+++ b/src/components/playback-overlay.tsx
@@ -11,6 +11,7 @@ interface PlaybackOverlayProps {
 export function PlaybackOverlay({ clips, onClose }: PlaybackOverlayProps) {
   const [index, setIndex] = useState(0)
   const endSecRef = useRef(0)
+  const advancingRef = useRef(false)
   const clip = clips[index]
 
   if (!clip) {
@@ -19,6 +20,19 @@ export function PlaybackOverlay({ clips, onClose }: PlaybackOverlayProps) {
 
   const startSec = clip.trimStartMs / 1000
   endSecRef.current = Math.min(clip.trimEndMs, clip.durationMs) / 1000
+
+  const advance = () => {
+    if (advancingRef.current) return
+    advancingRef.current = true
+    if (index < clips.length - 1) {
+      setIndex((current) => current + 1)
+      return
+    }
+    onClose()
+  }
+
+  // Reset the guard whenever this clip instance mounts via key change.
+  advancingRef.current = false
 
   return (
     <div className="permission-panel" style={{ background: 'rgba(0,0,0,0.92)' }}>
@@ -37,22 +51,12 @@ export function PlaybackOverlay({ clips, onClose }: PlaybackOverlayProps) {
           onSeeked={(event) => {
             void event.currentTarget.play().catch(() => undefined)
           }}
-          onEnded={() => {
-            if (index < clips.length - 1) {
-              setIndex((current) => current + 1)
-              return
-            }
-            onClose()
-          }}
+          onEnded={advance}
           onTimeUpdate={(event) => {
             const video = event.currentTarget
             if (video.currentTime < endSecRef.current - 0.03) return
             video.pause()
-            if (index < clips.length - 1) {
-              setIndex((current) => current + 1)
-              return
-            }
-            onClose()
+            advance()
           }}
         />
         <p className="muted" style={{ margin: '12px 0 16px' }}>

--- a/src/components/playback-overlay.tsx
+++ b/src/components/playback-overlay.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from 'react'
+import { useLayoutEffect, useRef, useState } from 'react'
 import { BlobVideo } from './blob-video'
 import { effectiveDurationMs, type ClipRecord } from '../lib/types'
 
@@ -7,25 +7,30 @@ interface PlaybackOverlayProps {
   onClose: () => void
 }
 
-/** Sequential preview driven by media element events (no useEffect). */
+/** Sequential preview driven by media element events. */
 export function PlaybackOverlay({ clips, onClose }: PlaybackOverlayProps) {
   const [index, setIndex] = useState(0)
   const endSecRef = useRef(0)
   const advancingRef = useRef(false)
-  const indexRef = useRef(index)
   const clip = clips[index]
 
-  if (indexRef.current !== index) {
-    indexRef.current = index
+  useLayoutEffect(() => {
     advancingRef.current = false
-  }
+  }, [index])
+
+  useLayoutEffect(() => {
+    if (!clip) {
+      endSecRef.current = 0
+      return
+    }
+    endSecRef.current = Math.min(clip.trimEndMs, clip.durationMs) / 1000
+  }, [clip])
 
   if (!clip) {
     return null
   }
 
   const startSec = clip.trimStartMs / 1000
-  endSecRef.current = Math.min(clip.trimEndMs, clip.durationMs) / 1000
 
   const advance = () => {
     if (advancingRef.current) return

--- a/src/components/playback-overlay.tsx
+++ b/src/components/playback-overlay.tsx
@@ -12,7 +12,13 @@ export function PlaybackOverlay({ clips, onClose }: PlaybackOverlayProps) {
   const [index, setIndex] = useState(0)
   const endSecRef = useRef(0)
   const advancingRef = useRef(false)
+  const indexRef = useRef(index)
   const clip = clips[index]
+
+  if (indexRef.current !== index) {
+    indexRef.current = index
+    advancingRef.current = false
+  }
 
   if (!clip) {
     return null
@@ -30,9 +36,6 @@ export function PlaybackOverlay({ clips, onClose }: PlaybackOverlayProps) {
     }
     onClose()
   }
-
-  // Reset the guard whenever this clip instance mounts via key change.
-  advancingRef.current = false
 
   return (
     <div className="permission-panel" style={{ background: 'rgba(0,0,0,0.92)' }}>

--- a/src/lib/blob-url.ts
+++ b/src/lib/blob-url.ts
@@ -1,21 +1,27 @@
-/** Create an object URL and revoke it when the owning element unmounts. */
+/** Create an object URL and revoke it when the owning element unmounts or the blob changes. */
 export function bindBlobUrl(
   element: HTMLMediaElement | null,
   blob: Blob,
-  currentUrl: { current: string | null },
+  state: { current: string | null; blob: Blob | null },
 ): void {
   if (!element) {
-    if (currentUrl.current) {
-      URL.revokeObjectURL(currentUrl.current)
-      currentUrl.current = null
+    if (state.current) {
+      URL.revokeObjectURL(state.current)
     }
+    state.current = null
+    state.blob = null
     return
   }
 
-  if (!currentUrl.current) {
-    currentUrl.current = URL.createObjectURL(blob)
+  if (state.blob !== blob || !state.current) {
+    if (state.current) {
+      URL.revokeObjectURL(state.current)
+    }
+    state.current = URL.createObjectURL(blob)
+    state.blob = blob
   }
-  if (element.src !== currentUrl.current) {
-    element.src = currentUrl.current
+
+  if (element.src !== state.current) {
+    element.src = state.current
   }
 }

--- a/src/lib/media.ts
+++ b/src/lib/media.ts
@@ -367,7 +367,7 @@ async function paintClipToCanvas({
     const segmentSec = endSec - startSec
     if (!(segmentSec > 0.04)) return
 
-    if (audioContext && dest && audioBuffer && audioAvailable > 0.02) {
+    if (audioContext && dest && audioBuffer && audioAvailable > 0.05) {
       try {
         if (audioContext.state === 'suspended') {
           await audioContext.resume().catch(() => undefined)
@@ -385,6 +385,11 @@ async function paintClipToCanvas({
     // lead the picture by the play()/decoder startup gap.
     await waitForPlaybackStart(video, startSec)
 
+    // Always stamp at least one frame after startup (covers ended-on-start).
+    if (video.videoWidth > 0) {
+      drawCover(ctx, video, canvas.width, canvas.height)
+    }
+
     const videoLeadSec = Math.max(0, video.currentTime - startSec)
     const audioPlayOffset = audioOffset + videoLeadSec
     const audioPlayDuration = Math.max(0, Math.min(segmentSec - videoLeadSec, audioAvailable - videoLeadSec))
@@ -400,6 +405,9 @@ async function paintClipToCanvas({
       let lastVideoTime = video.currentTime
 
       const finish = () => {
+        if (video.videoWidth > 0) {
+          drawCover(ctx, video, canvas.width, canvas.height)
+        }
         cancelAnimationFrame(raf)
         video.pause()
         resolve()

--- a/src/lib/media.ts
+++ b/src/lib/media.ts
@@ -261,13 +261,20 @@ export async function exportProjectAsWebm(
   // Give the recorder a moment to latch onto the canvas track.
   await wait(120)
 
-  const totalMs = clips.reduce((sum, clip) => sum + effectiveDurationMs(clip), 0)
-  let elapsed = 0
+  const exportable = clips.filter((clip) => effectiveDurationMs(clip) >= 40)
+  if (exportable.length === 0) {
+    throw new Error('Nothing to export')
+  }
+
+  let paintedTotalMs = 0
 
   try {
-    for (const clip of clips) {
-      const clipMs = effectiveDurationMs(clip)
-      if (clipMs < 40) continue
+    for (let i = 0; i < exportable.length; i += 1) {
+      const clip = exportable[i]
+      const remainingGuessMs = exportable
+        .slice(i + 1)
+        .reduce((sum, item) => sum + effectiveDurationMs(item), 0)
+
       const paintedMs = await paintClipToCanvas({
         clip,
         canvas,
@@ -275,15 +282,21 @@ export async function exportProjectAsWebm(
         audioContext,
         dest,
         onFrameProgress: (clipElapsed) => {
-          if (totalMs > 0) onProgress?.((elapsed + clipElapsed) / totalMs)
+          const denom = paintedTotalMs + clipElapsed + remainingGuessMs
+          if (denom > 0) onProgress?.((paintedTotalMs + clipElapsed) / denom)
         },
       })
-      elapsed += paintedMs > 0 ? paintedMs : clipMs
-      onProgress?.(totalMs > 0 ? Math.min(1, elapsed / totalMs) : 1)
+      if (paintedMs <= 0) {
+        throw new Error('A clip produced no exportable video frames')
+      }
+      paintedTotalMs += paintedMs
+      const denom = paintedTotalMs + remainingGuessMs
+      onProgress?.(denom > 0 ? paintedTotalMs / denom : 1)
     }
 
     // Hold the last frame briefly so the final GOP isn't truncated.
     await wait(180)
+    onProgress?.(1)
   } finally {
     if (recorder.state !== 'inactive') recorder.stop()
     canvasStream.getTracks().forEach((t) => t.stop())
@@ -293,7 +306,7 @@ export async function exportProjectAsWebm(
   }
 
   const blob = await stopped
-  const minBytes = Math.max(8_000, Math.floor(totalMs * 4))
+  const minBytes = Math.max(8_000, Math.floor(Math.max(paintedTotalMs, 1_000) * 4))
   if (blob.size < minBytes) {
     throw new Error(
       `Export produced an unusable file (${Math.round(blob.size / 1024)}KB). Try “Files” instead.`,

--- a/src/lib/media.ts
+++ b/src/lib/media.ts
@@ -268,7 +268,7 @@ export async function exportProjectAsWebm(
     for (const clip of clips) {
       const clipMs = effectiveDurationMs(clip)
       if (clipMs < 40) continue
-      await paintClipToCanvas({
+      const paintedMs = await paintClipToCanvas({
         clip,
         canvas,
         ctx,
@@ -278,8 +278,8 @@ export async function exportProjectAsWebm(
           if (totalMs > 0) onProgress?.((elapsed + clipElapsed) / totalMs)
         },
       })
-      elapsed += clipMs
-      onProgress?.(totalMs > 0 ? elapsed / totalMs : 1)
+      elapsed += paintedMs > 0 ? paintedMs : clipMs
+      onProgress?.(totalMs > 0 ? Math.min(1, elapsed / totalMs) : 1)
     }
 
     // Hold the last frame briefly so the final GOP isn't truncated.
@@ -311,6 +311,7 @@ interface PaintArgs {
   onFrameProgress?: (clipElapsedMs: number) => void
 }
 
+/** @returns painted segment duration in milliseconds */
 async function paintClipToCanvas({
   clip,
   canvas,
@@ -318,7 +319,7 @@ async function paintClipToCanvas({
   audioContext,
   dest,
   onFrameProgress,
-}: PaintArgs): Promise<void> {
+}: PaintArgs): Promise<number> {
   const url = URL.createObjectURL(clip.blob)
   const video = document.createElement('video')
   video.src = url
@@ -338,7 +339,7 @@ async function paintClipToCanvas({
 
     const startSec = clip.trimStartMs / 1000
     const trimEndSec = Math.min(clip.trimEndMs, clip.durationMs) / 1000
-    if (!(trimEndSec > startSec)) return
+    if (!(trimEndSec > startSec)) return 0
 
     // Prefer real media durations over wall-clock capture estimates so A/V
     // segment lengths stay aligned across clips.
@@ -365,7 +366,7 @@ async function paintClipToCanvas({
     }
 
     const segmentSec = endSec - startSec
-    if (!(segmentSec > 0.04)) return
+    if (!(segmentSec > 0.04)) return 0
 
     if (audioContext && dest && audioBuffer && audioAvailable > 0.05) {
       try {
@@ -445,6 +446,8 @@ async function paintClipToCanvas({
       }
       raf = requestAnimationFrame(draw)
     })
+
+    return Math.max(40, Math.round(segmentSec * 1000))
   } finally {
     try {
       bufferSource?.stop()

--- a/src/lib/media.ts
+++ b/src/lib/media.ts
@@ -408,7 +408,9 @@ async function paintClipToCanvas({
     const audioPlayOffset = audioOffset + videoLeadSec
     const audioPlayDuration = Math.max(0, Math.min(segmentSec - videoLeadSec, audioAvailable - videoLeadSec))
     const audioStartedAt = audioContext?.currentTime ?? null
-    if (bufferSource && audioContext && audioStartedAt !== null && audioPlayDuration > 0.02) {
+    // Schedule any remaining audio after startup lead, including short floor
+    // segments where videoLeadSec can leave only a few milliseconds.
+    if (bufferSource && audioContext && audioStartedAt !== null && audioPlayDuration > 0) {
       // Skip the audio that already elapsed on the video clock during startup.
       bufferSource.start(audioStartedAt, audioPlayOffset, audioPlayDuration)
     }

--- a/src/lib/media.ts
+++ b/src/lib/media.ts
@@ -337,8 +337,13 @@ async function paintClipToCanvas({
     await waitForVideoDimensions(video)
 
     const startSec = clip.trimStartMs / 1000
-    const endSec = Math.min(clip.trimEndMs, clip.durationMs) / 1000
-    if (!(endSec > startSec)) return
+    const trimEndSec = Math.min(clip.trimEndMs, clip.durationMs) / 1000
+    if (!(trimEndSec > startSec)) return
+
+    // Prefer real media durations over wall-clock capture estimates so A/V
+    // segment lengths stay aligned across clips.
+    const videoMediaEnd = Number.isFinite(video.duration) ? video.duration : trimEndSec
+    let endSec = Math.min(trimEndSec, videoMediaEnd)
 
     video.currentTime = startSec
     await waitForEvent(video, 'seeked')
@@ -346,7 +351,23 @@ async function paintClipToCanvas({
     const audioBuffer =
       audioContext && dest ? await decodeClipAudio(audioContext, clip.blob) : null
 
-    if (audioContext && dest && audioBuffer) {
+    const audioOffset = audioBuffer
+      ? Math.min(Math.max(0, startSec), Math.max(0, audioBuffer.duration - 0.01))
+      : 0
+    const audioAvailable = audioBuffer
+      ? Math.max(0, audioBuffer.duration - audioOffset)
+      : 0
+
+    if (audioBuffer && audioAvailable > 0.05) {
+      // Keep each stitch segment to the shorter of video/audio so the next
+      // clip's soundtrack cannot start while the previous picture is still up.
+      endSec = Math.min(endSec, startSec + audioAvailable)
+    }
+
+    const segmentSec = endSec - startSec
+    if (!(segmentSec > 0.04)) return
+
+    if (audioContext && dest && audioBuffer && audioAvailable > 0.02) {
       try {
         if (audioContext.state === 'suspended') {
           await audioContext.resume().catch(() => undefined)
@@ -360,32 +381,43 @@ async function paintClipToCanvas({
     }
 
     await video.play()
+    // Wait until the video clock actually advances so BufferSource doesn't
+    // lead the picture by the play()/decoder startup gap.
+    await waitForPlaybackStart(video, startSec)
 
-    if (bufferSource && audioContext && audioBuffer) {
-      const offset = Math.min(Math.max(0, startSec), Math.max(0, audioBuffer.duration - 0.01))
-      const duration = Math.min(
-        Math.max(0, endSec - startSec),
-        Math.max(0, audioBuffer.duration - offset),
-      )
-      if (duration > 0.02) {
-        bufferSource.start(audioContext.currentTime, offset, duration)
-      }
+    const videoLeadSec = Math.max(0, video.currentTime - startSec)
+    const audioPlayOffset = audioOffset + videoLeadSec
+    const audioPlayDuration = Math.max(0, Math.min(segmentSec - videoLeadSec, audioAvailable - videoLeadSec))
+    const audioStartedAt = audioContext?.currentTime ?? null
+    if (bufferSource && audioContext && audioStartedAt !== null && audioPlayDuration > 0.02) {
+      // Skip the audio that already elapsed on the video clock during startup.
+      bufferSource.start(audioStartedAt, audioPlayOffset, audioPlayDuration)
     }
 
     await new Promise<void>((resolve, reject) => {
       let raf = 0
       let lastFrameAt = performance.now()
+      let lastVideoTime = video.currentTime
+
+      const finish = () => {
+        cancelAnimationFrame(raf)
+        video.pause()
+        resolve()
+      }
+
       const draw = () => {
         const now = performance.now()
-        if (video.ended || video.currentTime >= endSec - 0.04) {
-          cancelAnimationFrame(raf)
-          video.pause()
-          resolve()
+        const videoElapsed = Math.max(0, video.currentTime - startSec)
+
+        if (video.ended || video.currentTime >= endSec - 0.04 || videoElapsed >= segmentSec - 0.03) {
+          finish()
           return
         }
 
-        // Stall watchdog: if playback never advances, abort this clip.
-        if (now - lastFrameAt > 8000) {
+        if (video.currentTime > lastVideoTime + 0.001) {
+          lastVideoTime = video.currentTime
+          lastFrameAt = now
+        } else if (now - lastFrameAt > 8000) {
           cancelAnimationFrame(raf)
           video.pause()
           reject(new Error('Clip playback stalled during export'))
@@ -394,9 +426,8 @@ async function paintClipToCanvas({
 
         if (video.videoWidth > 0) {
           drawCover(ctx, video, canvas.width, canvas.height)
-          lastFrameAt = now
         }
-        onFrameProgress?.(Math.max(0, (video.currentTime - startSec) * 1000))
+        onFrameProgress?.(Math.min(segmentSec, videoElapsed) * 1000)
         raf = requestAnimationFrame(draw)
       }
 
@@ -417,6 +448,21 @@ async function paintClipToCanvas({
     video.removeAttribute('src')
     video.load()
   }
+}
+
+async function waitForPlaybackStart(video: HTMLVideoElement, startSec: number): Promise<void> {
+  if (video.currentTime > startSec + 0.01) return
+  const deadline = performance.now() + 1500
+  await new Promise<void>((resolve) => {
+    const tick = () => {
+      if (video.currentTime > startSec + 0.01 || video.ended || performance.now() > deadline) {
+        resolve()
+        return
+      }
+      requestAnimationFrame(tick)
+    }
+    tick()
+  })
 }
 
 async function decodeClipAudio(

--- a/src/pages/project-page.tsx
+++ b/src/pages/project-page.tsx
@@ -7,7 +7,7 @@ import {
   useRevalidator,
   type LoaderFunctionArgs,
 } from 'react-router-dom'
-import { BlobVideo } from '../components/blob-video'
+import { EditorClipPreview } from '../components/editor-clip-preview'
 import { EditorToolsSheet } from '../components/editor-tools-sheet'
 import { ExportSheet } from '../components/export-sheet'
 import { OnboardingOverlay } from '../components/onboarding-overlay'
@@ -413,18 +413,7 @@ export function ProjectPage() {
             autoPlay
           />
         ) : selected ? (
-          <BlobVideo
-            key={selected.id}
-            blob={selected.blob}
-            className="editor-clip-preview"
-            muted
-            playsInline
-            preload="metadata"
-            onLoadedData={(event) => {
-              const video = event.currentTarget
-              video.currentTime = selected.trimStartMs / 1000
-            }}
-          />
+          <EditorClipPreview clip={selected} />
         ) : (
           <div className="editor-empty-preview">Select a clip in the timeline</div>
         )}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -4,14 +4,27 @@
   --bg: #2f3e46;
   --bg-elevated: #364850;
   --bg-soft: #5f8575;
+  --bg-bottom: #10171a;
   --ink: #f3f5f4;
   --ink-muted: #b0b8bc;
+  --ink-strong: #10171a;
   --accent: #44d7a8;
   --accent-soft: rgba(68, 215, 168, 0.2);
   --ok: #5f8575;
   --line: rgba(243, 245, 244, 0.16);
   --danger: #ff6b5a;
+  --danger-soft: #ffd2cb;
   --shadow: 0 18px 50px rgba(0, 0, 0, 0.35);
+  --glow-accent: rgba(68, 215, 168, 0.2);
+  --glow-mist: rgba(176, 184, 188, 0.18);
+  --overlay-scrim: rgba(7, 20, 17, 0.72);
+  --overlay-scrim-strong: rgba(7, 20, 17, 0.92);
+  --panel-bg: linear-gradient(180deg, #364850, #172126);
+  --dock-fade: linear-gradient(180deg, rgba(16, 23, 26, 0), rgba(16, 23, 26, 0.95) 24%);
+  --chip-bg: rgba(16, 23, 26, 0.68);
+  --stage-bg: #050708;
+  --camera-chrome: #10171a;
+  --toast-bg: rgba(16, 23, 26, 0.92);
   --font-display: 'Fraunces', Georgia, serif;
   --font-body: 'DM Sans', 'Segoe UI', sans-serif;
   --radius: 18px;
@@ -21,6 +34,37 @@
   --browser-chrome: 72px;
   --app-height: 100dvh;
   --tap: 44px;
+}
+
+@media (prefers-color-scheme: light) {
+  :root {
+    color-scheme: light;
+    --bg-deep: #dfeae4;
+    --bg: #eef5f1;
+    --bg-elevated: #ffffff;
+    --bg-soft: #d5e6dd;
+    --bg-bottom: #cfdcd5;
+    --ink: #1a2824;
+    --ink-muted: #5a6d66;
+    --ink-strong: #102019;
+    --accent: #1f8a68;
+    --accent-soft: rgba(31, 138, 104, 0.14);
+    --ok: #3f6f5f;
+    --line: rgba(26, 40, 36, 0.12);
+    --danger: #c84b3c;
+    --danger-soft: #8a2e24;
+    --shadow: 0 18px 44px rgba(23, 45, 38, 0.12);
+    --glow-accent: rgba(31, 138, 104, 0.18);
+    --glow-mist: rgba(95, 133, 117, 0.16);
+    --overlay-scrim: rgba(238, 245, 241, 0.78);
+    --overlay-scrim-strong: rgba(238, 245, 241, 0.94);
+    --panel-bg: linear-gradient(180deg, #ffffff, #e7f0eb);
+    --dock-fade: linear-gradient(180deg, rgba(238, 245, 241, 0), rgba(223, 234, 228, 0.96) 24%);
+    --chip-bg: rgba(255, 255, 255, 0.78);
+    --stage-bg: #121a18;
+    --camera-chrome: #eef5f1;
+    --toast-bg: rgba(255, 255, 255, 0.94);
+  }
 }
 
 @supports not (height: 100dvh) {
@@ -45,9 +89,9 @@ body {
   font-family: var(--font-body);
   color: var(--ink);
   background:
-    radial-gradient(120% 80% at 10% -10%, rgba(68, 215, 168, 0.2), transparent 55%),
-    radial-gradient(90% 70% at 100% 0%, rgba(176, 184, 188, 0.18), transparent 50%),
-    linear-gradient(180deg, #2f3e46 0%, var(--bg-deep) 58%, #10171a 100%);
+    radial-gradient(120% 80% at 10% -10%, var(--glow-accent), transparent 55%),
+    radial-gradient(90% 70% at 100% 0%, var(--glow-mist), transparent 50%),
+    linear-gradient(180deg, var(--bg) 0%, var(--bg-deep) 58%, var(--bg-bottom) 100%);
   -webkit-font-smoothing: antialiased;
   text-rendering: optimizeLegibility;
   overflow: hidden;
@@ -260,7 +304,7 @@ a {
 
 .btn-primary {
   background: var(--accent);
-  color: #182227;
+  color: var(--ink-strong);
 }
 
 .btn-secondary {
@@ -281,7 +325,7 @@ a {
   min-height: var(--tap);
   padding: 0;
   border-radius: 50%;
-  background: rgba(7, 20, 17, 0.55);
+  background: color-mix(in srgb, var(--bg-elevated) 55%, transparent);
   border: 1px solid var(--line);
   backdrop-filter: blur(8px);
   display: grid;
@@ -325,8 +369,8 @@ a {
   border-radius: 24px;
   border: 1px solid var(--line);
   background:
-    linear-gradient(160deg, rgba(95, 133, 117, 0.34), rgba(47, 62, 70, 0.9)),
-    rgba(47, 62, 70, 0.84);
+    linear-gradient(160deg, color-mix(in srgb, var(--bg-soft) 34%, transparent), var(--bg-elevated)),
+    var(--bg-elevated);
   box-shadow: var(--shadow);
   overflow: hidden;
   transition: transform 180ms ease, border-color 180ms ease, opacity 180ms ease;
@@ -351,7 +395,7 @@ a {
   text-align: left;
   color: var(--ink);
   border-style: dashed;
-  background: rgba(243, 245, 244, 0.06);
+  background: color-mix(in srgb, var(--ink) 6%, transparent);
 }
 
 .project-slot.empty:disabled {
@@ -401,8 +445,8 @@ a {
 }
 
 .danger {
-  color: #ffd2cb;
-  border-color: rgba(255, 107, 90, 0.36);
+  color: var(--danger-soft);
+  border-color: color-mix(in srgb, var(--danger) 36%, transparent);
 }
 
 .home-footer {
@@ -417,7 +461,7 @@ a {
 
 .camera-screen {
   padding: 0;
-  background: #10171a;
+  background: var(--camera-chrome);
   overflow: hidden;
 }
 
@@ -467,8 +511,8 @@ a {
   flex: 1;
   min-height: 0;
   background:
-    radial-gradient(80% 60% at 50% 20%, rgba(68, 215, 168, 0.08), transparent 60%),
-    #050708;
+    radial-gradient(80% 60% at 50% 20%, var(--accent-soft), transparent 60%),
+    var(--stage-bg);
   overflow: hidden;
   touch-action: none;
   transition: flex-basis 220ms ease, margin 220ms ease, border-radius 220ms ease;
@@ -575,7 +619,7 @@ a {
   display: grid;
   place-items: center;
   padding: 24px;
-  background: linear-gradient(180deg, rgba(7, 20, 17, 0.72), rgba(7, 20, 17, 0.92));
+  background: linear-gradient(180deg, var(--overlay-scrim), var(--overlay-scrim-strong));
   z-index: 4;
   text-align: center;
 }
@@ -595,7 +639,7 @@ a {
 .camera-bottom {
   position: relative;
   z-index: 3;
-  background: linear-gradient(180deg, rgba(16, 23, 26, 0), rgba(16, 23, 26, 0.95) 24%);
+  background: var(--dock-fade);
   padding: 10px 12px calc(12px + var(--safe-bottom) + var(--browser-chrome));
   display: flex;
   flex-direction: column;
@@ -623,7 +667,7 @@ a {
   gap: 8px;
   padding: 7px 12px;
   border-radius: 999px;
-  background: rgba(16, 23, 26, 0.68);
+  background: var(--chip-bg);
   border: 1px solid var(--line);
   color: var(--ink);
 }
@@ -665,11 +709,11 @@ a {
   min-width: 86px;
   border-radius: 50%;
   background:
-    radial-gradient(circle at 34% 28%, rgba(243, 245, 244, 0.72), transparent 18%),
-    linear-gradient(145deg, var(--accent), #5f8575);
-  color: #10171a;
-  border: 4px solid rgba(243, 245, 244, 0.72);
-  box-shadow: 0 16px 34px rgba(68, 215, 168, 0.24);
+    radial-gradient(circle at 34% 28%, color-mix(in srgb, var(--bg-elevated) 72%, transparent), transparent 18%),
+    linear-gradient(145deg, var(--accent), var(--ok));
+  color: var(--ink-strong);
+  border: 4px solid color-mix(in srgb, var(--bg-elevated) 72%, transparent);
+  box-shadow: 0 16px 34px var(--accent-soft);
   font-family: var(--font-display);
   font-size: 1.55rem;
   font-weight: 700;
@@ -696,7 +740,7 @@ a {
   gap: 10px;
   padding: 12px 12px 8px;
   border-radius: 28px 28px 0 0;
-  background: linear-gradient(180deg, rgba(47, 62, 70, 0.92), rgba(23, 33, 38, 0.98));
+  background: var(--panel-bg);
   border: 1px solid var(--line);
   box-shadow: var(--shadow);
 }
@@ -797,12 +841,12 @@ a {
   max-height: min(78dvh, 640px);
   overflow-y: auto;
   -webkit-overflow-scrolling: touch;
-  background: linear-gradient(180deg, #364850, #172126);
+  background: var(--panel-bg);
   border-top-left-radius: 22px;
   border-top-right-radius: 22px;
   border-top: 1px solid var(--line);
   padding: 16px 16px calc(20px + var(--safe-bottom) + var(--browser-chrome));
-  box-shadow: 0 -20px 50px rgba(0, 0, 0, 0.45);
+  box-shadow: var(--shadow);
   animation: rise-in 280ms ease both;
 }
 
@@ -812,7 +856,7 @@ a {
 }
 
 .sheet-message.is-error {
-  color: #ffd2cb;
+  color: var(--danger-soft);
 }
 
 .sheet h3 {
@@ -849,13 +893,14 @@ a {
   min-height: 44px;
   border-radius: 12px;
   border: 1px solid var(--line);
-  background: rgba(0, 0, 0, 0.25);
+  background: color-mix(in srgb, var(--ink) 8%, transparent);
+  color: var(--ink);
   padding: 0 12px;
   outline: none;
 }
 
 .field input:focus {
-  border-color: rgba(68, 215, 168, 0.65);
+  border-color: color-mix(in srgb, var(--accent) 65%, transparent);
 }
 
 .trim-grid {
@@ -867,7 +912,7 @@ a {
 .progress-bar {
   height: 6px;
   border-radius: 999px;
-  background: rgba(255, 255, 255, 0.12);
+  background: color-mix(in srgb, var(--ink) 12%, transparent);
   overflow: hidden;
   margin-top: 12px;
 }
@@ -890,7 +935,7 @@ a {
   align-items: center;
   gap: 10px;
   max-width: calc(100% - 24px);
-  background: rgba(16, 23, 26, 0.92);
+  background: var(--toast-bg);
   border: 1px solid var(--line);
   color: var(--ink);
   padding: 10px 14px;
@@ -898,6 +943,7 @@ a {
   font-size: 0.9rem;
   white-space: nowrap;
   animation: rise-in 220ms ease both;
+  box-shadow: var(--shadow);
 }
 
 .editor-clip-preview {
@@ -932,8 +978,8 @@ a {
   overflow-y: auto;
   padding: 20px 16px calc(20px + var(--safe-bottom) + var(--browser-chrome));
   background:
-    radial-gradient(85% 60% at 50% 16%, rgba(68, 215, 168, 0.18), transparent 60%),
-    rgba(16, 23, 26, 0.76);
+    radial-gradient(85% 60% at 50% 16%, var(--glow-accent), transparent 60%),
+    color-mix(in srgb, var(--bg-deep) 76%, transparent);
   backdrop-filter: blur(12px);
 }
 
@@ -941,7 +987,7 @@ a {
   width: min(100%, 390px);
   border-radius: 30px;
   border: 1px solid var(--line);
-  background: linear-gradient(180deg, rgba(54, 72, 80, 0.98), rgba(23, 33, 38, 0.98));
+  background: var(--panel-bg);
   box-shadow: var(--shadow);
   padding: 20px;
 }


### PR DESCRIPTION
## Summary

Three related UX/export fixes for Kody Video:

1. **System-preference light mode** — Shared CSS theme tokens flip with `prefers-color-scheme: light` so the app tracks the OS appearance without a separate toggle.
2. **Export A/V sync** — Export audio is aligned to video playback per clip so rendered output stays in sync with what you hear/see in the editor.
3. **Editor clip preview** — Editor and playback overlays stay locked to the selected clip (blob URL helpers + clip preview component) instead of drifting to the wrong media.

## Test plan

- [ ] Toggle OS light/dark and confirm theme tokens update
- [ ] Select clips in the editor and confirm preview/playback show the selected clip
- [ ] Export a multi-clip project and confirm audio stays synced to video
- [ ] Smoke against `manual-test-checklist.md`

## History

Branch history was cleaned: noisy agent-push junk commits were replaced with a single squash commit on `main` (`890289aa11fced79cae4556cfe0c6e27d7a13520`). Remote file blob SHAs match the clean local tip.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Export timing logic in `paintClipToCanvas` is substantially changed and affects stitched output quality; preview/blob URL changes are lower risk but touch core editor UX.
> 
> **Overview**
> Adds **automatic light/dark theming** from `prefers-color-scheme`: shared CSS tokens and a light palette in `global.css`, plus separate `theme-color` meta tags in `index.html`.
> 
> **Editor and playback previews** are more reliable when switching clips: `bindBlobUrl` / `BlobVideo` recreate object URLs when the blob changes; new `EditorClipPreview` remounts on selection/trim and nudges WebM frames so the stage isn’t blank; `PlaybackOverlay` uses guarded clip advancement and stronger remount keys.
> 
> **Stitched WebM export** in `media.ts` aligns audio with video per segment—waits for playback start before scheduling `BufferSource`, caps each clip to the shorter of video/audio, and tightens progress/validation—aimed at cross-clip drift and early soundtrack.
> 
> Manual test checklist entries cover sync, preview updates, and theming.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1a496844a7109cc82a9432c421f41e074f3ba5c0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic light/dark theme support based on system preferences (including browser theme-color and tokenized styling).
  * Enhanced selected-clip previews with more dependable seeking and refresh when switching clips.
  * Playback now auto-advances between clips and closes when the final clip ends.

* **Bug Fixes**
  * Improved exported video/audio synchronization to reduce timing drift.
  * Stabilized media preview behavior when underlying clip/blobs change.

* **Documentation**
  * Updated the manual test checklist with added checks for synchronization, preview updates, and theming.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->