### PR TITLE
Restore zoom to pre-take level when hold-to-record ends

### DIFF
--- a/manual-test-checklist.md
+++ b/manual-test-checklist.md
@@ -15,6 +15,7 @@ Run locally with HTTPS or `localhost` (`npm run dev`). Camera/mic require a secu
 - [ ] Press/hold anywhere on the preview starts recording (REC pill + elapsed)
 - [ ] Camera preview stays smooth while recording (no visible frame drops)
 - [ ] Dragging up/down during a hold zooms in/out (zoom-capable devices)
+- [ ] Releasing the hold eases zoom back to the pre-take level (chip choice or 1×)
 - [ ] Release stops and appends a clip; filmstrip thumbnail appears shortly after
 - [ ] Self-timer counts down, starts hands-free recording, then tap stops
 - [ ] Very short taps do not create empty clips ("Hold a bit longer")

--- a/src/components/record-screen.tsx
+++ b/src/components/record-screen.tsx
@@ -97,6 +97,13 @@ export function RecordScreen({
   const dragZoomPressYRef = useRef(0)
   const dragZoomStartValueRef = useRef(0)
   const dragZoomStageHeightRef = useRef(0)
+  /** Whether the current hold actually changed zoom (gates the snap-back). */
+  const dragZoomMovedRef = useRef(false)
+  /** Last zoom value applied during the drag (ramp start for the snap-back). */
+  const dragZoomLastValueRef = useRef(0)
+  /** Zoom the user chose deliberately (chips) — what a take restores to. */
+  const zoomBaselineRef = useRef<number | null>(null)
+  const zoomRestoreRafRef = useRef(0)
   const stageRef = useRef<HTMLDivElement | null>(null)
 
   const [recording, setRecording] = useState(false)
@@ -114,6 +121,30 @@ export function RecordScreen({
     countdownTimerRef.current = 0
     setCountdown(null)
   }, [])
+
+  /**
+   * OK Video behavior: drag-to-zoom only lasts for the take. When the finger
+   * lifts, ease the lens back to the zoom the user had before recording.
+   */
+  const restoreZoomAfterHold = useCallback(() => {
+    if (!dragZoomMovedRef.current) return
+    dragZoomMovedRef.current = false
+    const from = dragZoomLastValueRef.current
+    const to = dragZoomStartValueRef.current
+    cancelAnimationFrame(zoomRestoreRafRef.current)
+    if (Math.abs(from - to) < 0.01) return
+    const started = performance.now()
+    const durationMs = 220
+    const tick = () => {
+      const t = Math.min(1, (performance.now() - started) / durationMs)
+      const eased = 1 - (1 - t) * (1 - t)
+      camera.setZoom(from + (to - from) * eased)
+      if (t < 1) {
+        zoomRestoreRafRef.current = requestAnimationFrame(tick)
+      }
+    }
+    zoomRestoreRafRef.current = requestAnimationFrame(tick)
+  }, [camera])
 
   const acquireWakeLock = useCallback(() => {
     const generation = wakeLockGenRef.current
@@ -295,6 +326,7 @@ export function RecordScreen({
 
   const cleanupOnUnmount = useCallback(() => {
     clearCountdown()
+    cancelAnimationFrame(zoomRestoreRafRef.current)
     recorderRef.current.cancel()
     releaseWakeLock()
   }, [clearCountdown, releaseWakeLock])
@@ -331,8 +363,12 @@ export function RecordScreen({
             void endRecord()
             return
           }
+          // A new hold interrupts any snap-back still easing; the take starts
+          // from the user's deliberate baseline zoom, not a mid-ramp value.
+          cancelAnimationFrame(zoomRestoreRafRef.current)
+          dragZoomMovedRef.current = false
           dragZoomPressYRef.current = event.clientY
-          dragZoomStartValueRef.current = camera.zoom?.value ?? 1
+          dragZoomStartValueRef.current = zoomBaselineRef.current ?? camera.zoom?.value ?? 1
           dragZoomStageHeightRef.current = event.currentTarget.clientHeight
           event.currentTarget.setPointerCapture(event.pointerId)
           void beginRecord(event.pointerId, 'hold')
@@ -348,17 +384,24 @@ export function RecordScreen({
           // Full zoom range over ~60% of stage height; drag up = zoom in.
           const travel = stageHeight * 0.6
           const deltaY = dragZoomPressYRef.current - event.clientY
-          const next = dragZoomStartValueRef.current + (deltaY / travel) * range
+          const next = Math.min(
+            zoom.max,
+            Math.max(zoom.min, dragZoomStartValueRef.current + (deltaY / travel) * range),
+          )
+          dragZoomMovedRef.current = true
+          dragZoomLastValueRef.current = next
           camera.setZoom(next)
         }}
         onPointerUp={(event) => {
           if (recordingMode !== 'hands-free') {
             void endRecord(event.pointerId)
+            restoreZoomAfterHold()
           }
         }}
         onPointerCancel={(event) => {
           if (recordingMode !== 'hands-free') {
             void endRecord(event.pointerId)
+            restoreZoomAfterHold()
           }
         }}
         onContextMenu={(event) => event.preventDefault()}
@@ -439,7 +482,14 @@ export function RecordScreen({
             className="btn-icon"
             aria-label="Flip camera"
             disabled={!camera.canFlip || recording || countdown !== null}
-            onClick={() => void camera.flip()}
+            onClick={() => {
+              // The baseline belongs to the previous lens; the new camera
+              // starts from its own default zoom.
+              cancelAnimationFrame(zoomRestoreRafRef.current)
+              zoomBaselineRef.current = null
+              dragZoomMovedRef.current = false
+              void camera.flip()
+            }}
           >
             <IconFlip />
           </button>
@@ -459,6 +509,8 @@ export function RecordScreen({
                 disabled={countdown !== null}
                 onClick={(event) => {
                   event.stopPropagation()
+                  cancelAnimationFrame(zoomRestoreRafRef.current)
+                  zoomBaselineRef.current = level
                   camera.setZoom(level)
                 }}
               >

--- a/src/components/record-screen.tsx
+++ b/src/components/record-screen.tsx
@@ -104,6 +104,8 @@ export function RecordScreen({
   /** Zoom the user chose deliberately (chips) — what a take restores to. */
   const zoomBaselineRef = useRef<number | null>(null)
   const zoomRestoreRafRef = useRef(0)
+  /** True while the snap-back ramp is still easing toward the baseline. */
+  const zoomRestoreActiveRef = useRef(false)
   const stageRef = useRef<HTMLDivElement | null>(null)
 
   const [recording, setRecording] = useState(false)
@@ -135,12 +137,15 @@ export function RecordScreen({
     if (Math.abs(from - to) < 0.01) return
     const started = performance.now()
     const durationMs = 220
+    zoomRestoreActiveRef.current = true
     const tick = () => {
       const t = Math.min(1, (performance.now() - started) / durationMs)
       const eased = 1 - (1 - t) * (1 - t)
       camera.setZoom(from + (to - from) * eased)
       if (t < 1) {
         zoomRestoreRafRef.current = requestAnimationFrame(tick)
+      } else {
+        zoomRestoreActiveRef.current = false
       }
     }
     zoomRestoreRafRef.current = requestAnimationFrame(tick)
@@ -363,12 +368,21 @@ export function RecordScreen({
             void endRecord()
             return
           }
+          // A second finger landing during an active hold must not reset the
+          // drag-zoom state or start another take.
+          if (pointerIdRef.current !== null) return
           // A new hold interrupts any snap-back still easing; the take starts
           // from the user's deliberate baseline zoom, not a mid-ramp value.
           cancelAnimationFrame(zoomRestoreRafRef.current)
           dragZoomMovedRef.current = false
           dragZoomPressYRef.current = event.clientY
           dragZoomStartValueRef.current = zoomBaselineRef.current ?? camera.zoom?.value ?? 1
+          if (zoomRestoreActiveRef.current) {
+            // Finish the interrupted ramp instantly so a motionless hold
+            // still records from the baseline, not a mid-ramp zoom.
+            zoomRestoreActiveRef.current = false
+            camera.setZoom(dragZoomStartValueRef.current)
+          }
           dragZoomStageHeightRef.current = event.currentTarget.clientHeight
           event.currentTarget.setPointerCapture(event.pointerId)
           void beginRecord(event.pointerId, 'hold')
@@ -394,14 +408,21 @@ export function RecordScreen({
         }}
         onPointerUp={(event) => {
           if (recordingMode !== 'hands-free') {
+            // Only the pointer that owns the hold may end the take and start
+            // the snap-back — a stray second finger lifting must not zoom
+            // out mid-recording.
+            const ownsHold =
+              pointerIdRef.current === null || pointerIdRef.current === event.pointerId
             void endRecord(event.pointerId)
-            restoreZoomAfterHold()
+            if (ownsHold) restoreZoomAfterHold()
           }
         }}
         onPointerCancel={(event) => {
           if (recordingMode !== 'hands-free') {
+            const ownsHold =
+              pointerIdRef.current === null || pointerIdRef.current === event.pointerId
             void endRecord(event.pointerId)
-            restoreZoomAfterHold()
+            if (ownsHold) restoreZoomAfterHold()
           }
         }}
         onContextMenu={(event) => event.preventDefault()}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

OK Video parity for the zoom gesture: while holding to record, dragging your finger up zooms in and down zooms out (already shipped). This adds the missing half — **when you lift your finger, the zoom eases back to your regular level** (the zoom-chip selection, or the lens default) instead of staying wherever the drag left it.

## How

In `record-screen.tsx`:

- Track the **baseline zoom** the user chose deliberately (zoom-chip taps update it; flipping cameras resets it since the baseline belongs to the previous lens).
- Flag when a hold actually changed zoom, and on `pointerup`/`pointercancel` ease back to the baseline over 220 ms (ease-out rAF ramp) rather than snapping.
- A new hold interrupts an in-flight snap-back and starts from the true baseline, not a mid-ramp value; the ramp is cancelled on unmount.

No changes to the recording flow itself — zoom is applied through the existing ref-driven `camera.setZoom`, which doesn't re-render the page during capture.

## Verification

- `npm run lint`, `npm test` (15), `npm run build`, smoke suite **20/20** — all green.
- Playwright probe stubbing `MediaStreamTrack` zoom capabilities and spying on `applyConstraints`: hold + drag up reached **3.05×**, release eased back **1.24 → 1.15 → 1.08 → 1.03 → 1.00** over 14 frames, ending exactly at the 1× baseline.
- Manual checklist updated with the snap-back step.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-16d17496-6b5b-4e12-b600-6933357c2059"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-16d17496-6b5b-4e12-b600-6933357c2059"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

