### PR TITLE
Release camera and mic when the app leaves the foreground

### DIFF
--- a/manual-test-checklist.md
+++ b/manual-test-checklist.md
@@ -9,6 +9,8 @@ Run locally with HTTPS or `localhost` (`npm run dev`). Camera/mic require a secu
 - [ ] Allow → live rear-camera preview (or fallback)
 - [ ] Flip camera works when multiple cameras exist
 - [ ] Torch toggle appears on devices with a flash; zoom chips appear when supported
+- [ ] Backgrounding the app releases camera/mic (green dot goes out); returning restarts the preview
+- [ ] Backgrounding mid-recording still saves the take
 - [ ] Light/dark follows system `prefers-color-scheme`
 
 ## Hold-to-record

--- a/src/components/record-screen.tsx
+++ b/src/components/record-screen.tsx
@@ -336,15 +336,42 @@ export function RecordScreen({
     releaseWakeLock()
   }, [clearCountdown, releaseWakeLock])
 
+  // Release the camera whenever the app leaves the foreground — Android keeps
+  // the privacy indicator (green dot) lit as long as any track is live. An
+  // in-progress take is finished and saved first; the preview restarts when
+  // the app becomes visible again.
+  const visibilityActionRef = useRef<() => void>(() => undefined)
+  visibilityActionRef.current = () => {
+    if (document.hidden) {
+      clearCountdown()
+      if (recorderRef.current.isRecording || recording) {
+        // MediaRecorder.stop() runs synchronously inside endRecord, so the
+        // encoder has flushed by the time the tracks are stopped below; the
+        // save itself continues in the background.
+        void endRecord()
+      }
+      camera.stop()
+    } else if (!camera.getStream()) {
+      void camera.start()
+    }
+  }
+
+  const onVisibilityChange = useCallback(() => {
+    visibilityActionRef.current()
+  }, [])
+
   const attachCameraVideo = camera.videoRef
   const bindCameraVideo = useCallback(
     (element: HTMLVideoElement | null) => {
       if (!element) {
+        document.removeEventListener('visibilitychange', onVisibilityChange)
         cleanupOnUnmount()
+      } else {
+        document.addEventListener('visibilitychange', onVisibilityChange)
       }
       attachCameraVideo(element)
     },
-    [attachCameraVideo, cleanupOnUnmount],
+    [attachCameraVideo, cleanupOnUnmount, onVisibilityChange],
   )
 
   const needsPermission =

--- a/src/lib/export/shared.ts
+++ b/src/lib/export/shared.ts
@@ -93,6 +93,8 @@ export function waitForCondition(check: () => boolean, timeoutMs: number): Promi
   if (check()) return Promise.resolve()
   return new Promise((resolve, reject) => {
     const started = performance.now()
+    // Timer-based polling, not rAF: this must keep running in hidden tabs so
+    // a take can finish saving after the app is backgrounded mid-recording.
     const tick = () => {
       if (check()) {
         resolve()
@@ -102,7 +104,7 @@ export function waitForCondition(check: () => boolean, timeoutMs: number): Promi
         reject(new Error('Timed out preparing clip media'))
         return
       }
-      requestAnimationFrame(tick)
+      window.setTimeout(tick, 50)
     }
     tick()
   })


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Android keeps the privacy indicator (green dot) lit as long as any camera/mic track is live — and Kody Video kept the camera stream open on the record screen even when the app was backgrounded. The dot only went out after navigating to the projects page or killing the app.

## Fix

The record screen (the only surface that holds the camera) now listens for `visibilitychange`:

- **On hide:** any in-progress take is finished and saved first (`MediaRecorder.stop()` flushes synchronously before tracks stop, and the save continues in the background), any self-timer countdown is cancelled, and **every camera/mic track is stopped** — the green dot goes out.
- **On return:** the preview restarts automatically.
- The editor and home screens never hold the camera, so nothing changes there; the listener is bound to the camera video element's lifecycle, so it can't fire on other screens.

Supporting fix: `waitForCondition` (used by clip duration measurement in the save path) now polls with `setTimeout` instead of `requestAnimationFrame`, which freezes in hidden tabs — without this, a take interrupted by backgrounding wouldn't finish saving until the app returned and could be lost if Android killed it.

## Verification

Dedicated visibility probe (spying on all `getUserMedia` tracks), **7/7**:

- Hide on idle record screen → all tracks end, preview detached
- Return → preview restarts
- Hide **mid-recording** → all tracks end *and* the take is saved
- Return after that → preview restarts again
- Visibility flips in the editor → no camera restart, no new tracks

Plus `npm run lint`, `npm test` (15), `npm run build`, smoke suite **20/20** — all green. Rebased on main including PR #8's zoom changes.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-16d17496-6b5b-4e12-b600-6933357c2059"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-16d17496-6b5b-4e12-b600-6933357c2059"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Camera and microphone access now pauses when the app is backgrounded and resumes when you return.
  * Active recordings are safely completed and saved when the app is backgrounded.
  * Self-timer countdowns are canceled when leaving the app.

* **Bug Fixes**
  * Clip preparation now continues reliably while the app is in the background.

* **Documentation**
  * Added manual test checklist items covering background camera behavior and recording persistence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->