### PR TITLE
Timeline: drive touch scrolling manually and fix long-press lift on real devices

### DIFF
--- a/scripts/probe-touch-timeline.mjs
+++ b/scripts/probe-touch-timeline.mjs
@@ -1,0 +1,147 @@
+import { chromium } from 'playwright'
+import { spawn } from 'node:child_process'
+import { setTimeout as sleep } from 'node:timers/promises'
+
+const PORT = 4180
+const BASE = `http://127.0.0.1:${PORT}`
+const preview = spawn('npm', ['run', 'preview', '--', '--host', '127.0.0.1', '--port', String(PORT)], {
+  cwd: process.cwd(),
+  stdio: ['ignore', 'pipe', 'pipe'],
+})
+async function waitForServer(url) {
+  for (let i = 0; i < 60; i++) {
+    try {
+      if ((await fetch(url)).ok) return
+    } catch {}
+    await sleep(250)
+  }
+  throw new Error('server not ready')
+}
+const results = []
+const check = (name, ok, detail = '') => {
+  results.push(ok)
+  console.log(`${ok ? 'PASS' : 'FAIL'}  ${name}${detail ? ` — ${detail}` : ''}`)
+}
+try {
+  await waitForServer(BASE)
+  const browser = await chromium.launch({
+    headless: true,
+    args: ['--use-fake-ui-for-media-stream', '--use-fake-device-for-media-stream'],
+  })
+  const context = await browser.newContext({
+    viewport: { width: 320, height: 700 },
+    isMobile: true,
+    hasTouch: true,
+    permissions: ['camera', 'microphone'],
+  })
+  const page = await context.newPage()
+  const cdp = await context.newCDPSession(page)
+  const touch = {
+    start: (x, y) => cdp.send('Input.dispatchTouchEvent', { type: 'touchStart', touchPoints: [{ x, y }] }),
+    move: (x, y) => cdp.send('Input.dispatchTouchEvent', { type: 'touchMove', touchPoints: [{ x, y }] }),
+    end: () => cdp.send('Input.dispatchTouchEvent', { type: 'touchEnd', touchPoints: [] }),
+  }
+
+  await page.goto(BASE, { waitUntil: 'networkidle' })
+  await page.getByRole('button', { name: /new project/i }).first().click()
+  await page.waitForURL(/\/project\//)
+  const ob = page.getByRole('dialog', { name: /quick start/i })
+  if (await ob.count()) await page.getByRole('button', { name: /start recording/i }).click()
+  await page.waitForFunction(() => {
+    const v = document.querySelector('.record-stage video')
+    return v && v.videoWidth > 0
+  })
+  const stage = page.locator('.record-stage')
+  const sbox = await stage.boundingBox()
+  await page.mouse.move(sbox.x + sbox.width / 2, sbox.y + sbox.height / 2)
+  for (let i = 0; i < 4; i++) {
+    await page.mouse.down()
+    await sleep(3800)
+    await page.mouse.up()
+    await sleep(1600)
+  }
+  await page.getByRole('button', { name: /open editor/i }).click()
+  await page.locator('[data-clip-id]').first().waitFor()
+  await sleep(800)
+
+  const timeline = page.locator('.timeline')
+  const overflow = await timeline.evaluate((el) => el.scrollWidth - el.clientWidth)
+  check('timeline overflows viewport', overflow > 0, `overflow=${overflow}px`)
+  const orderBefore = await page.$$eval('[data-clip-id]', (els) => els.map((e) => e.dataset.clipId))
+  const selectedBefore = await page.$$eval('[data-clip-id]', (els) =>
+    els.findIndex((e) => e.classList.contains('selected')),
+  )
+
+  // 1. TOUCH swipe left = scroll, no lift, no reorder, no selection change.
+  const t0 = await page.locator('[data-clip-id]').first().boundingBox()
+  const cx = t0.x + t0.width / 2
+  const cy = t0.y + t0.height / 2
+  let liftedDuringSwipe = false
+  await touch.start(cx, cy)
+  for (let i = 1; i <= 6; i++) {
+    await touch.move(cx - i * 18, cy)
+    if (await page.locator('.clip-thumb.lifting').count()) liftedDuringSwipe = true
+    await sleep(16)
+  }
+  const scrollBeforeEnd = await timeline.evaluate((el) => el.scrollLeft)
+  await touch.end()
+  await sleep(120)
+  const scrollAfterFling = await timeline.evaluate((el) => el.scrollLeft)
+  await sleep(500)
+  const orderAfterSwipe = await page.$$eval('[data-clip-id]', (els) => els.map((e) => e.dataset.clipId))
+  const selectedAfterSwipe = await page.$$eval('[data-clip-id]', (els) =>
+    els.findIndex((e) => e.classList.contains('selected')),
+  )
+  check('touch swipe scrolls the strip', scrollBeforeEnd > 10, `scrollLeft=${scrollBeforeEnd}`)
+  check('release fling continues the scroll', scrollAfterFling > scrollBeforeEnd, `${scrollBeforeEnd} -> ${scrollAfterFling}`)
+  check('touch swipe never lifts a clip', !liftedDuringSwipe)
+  check('touch swipe does not reorder', JSON.stringify(orderAfterSwipe) === JSON.stringify(orderBefore))
+  check('touch swipe does not change selection', selectedAfterSwipe === selectedBefore, `sel ${selectedBefore} -> ${selectedAfterSwipe}`)
+
+  await timeline.evaluate((el) => {
+    el.scrollLeft = 0
+  })
+  await sleep(200)
+
+  // 2. TOUCH long-press lifts (after 500ms, not before) and drag reorders.
+  const tiles = await page.$$('[data-clip-id]')
+  const a = await tiles[0].boundingBox()
+  const b = await tiles[1].boundingBox()
+  await touch.start(a.x + a.width / 2, a.y + a.height / 2)
+  await sleep(350)
+  const liftedEarly = (await page.locator('.clip-thumb.lifting').count()) > 0
+  await sleep(350) // 700ms total
+  const lifted = (await page.locator('.clip-thumb.lifting').count()) > 0
+  check('no lift at 350ms', !liftedEarly)
+  check('touch long-press lifts at 500ms', lifted)
+  for (let i = 1; i <= 5; i++) {
+    await touch.move(a.x + a.width / 2 + (i * (b.x + b.width * 0.9 - a.x - a.width / 2)) / 5, cy)
+    await sleep(20)
+  }
+  await touch.end()
+  await sleep(600)
+  const orderAfterDrag = await page.$$eval('[data-clip-id]', (els) => els.map((e) => e.dataset.clipId))
+  check(
+    'touch long-press drag reorders',
+    orderAfterDrag[0] === orderBefore[1] && orderAfterDrag[1] === orderBefore[0],
+    `${orderBefore.map((s) => s.slice(-4))} -> ${orderAfterDrag.map((s) => s.slice(-4))}`,
+  )
+
+  // 3. TOUCH tap selects.
+  const third = await page.locator('[data-clip-id]').nth(2).boundingBox()
+  await touch.start(third.x + third.width / 2, third.y + third.height / 2)
+  await sleep(80)
+  await touch.end()
+  await sleep(200)
+  const thirdSelected = await page
+    .locator('[data-clip-id]')
+    .nth(2)
+    .evaluate((el) => el.classList.contains('selected'))
+  check('touch tap selects a clip', thirdSelected)
+
+  await browser.close()
+} finally {
+  preview.kill('SIGKILL')
+}
+console.log(`\n${results.filter(Boolean).length}/${results.length} passed`)
+process.exitCode = results.every(Boolean) ? 0 : 1

--- a/src/components/timeline.tsx
+++ b/src/components/timeline.tsx
@@ -12,13 +12,16 @@ import { TimelineThumbImage } from './timeline-thumb-image'
 const PX_PER_SECOND = 26
 const MIN_TILE_WIDTH = 56
 const MAX_TILE_WIDTH = 200
-/** Reorder only starts after a deliberate press-and-hold — plain horizontal
- * swipes must scroll the strip, never grab a clip. */
-const LONG_PRESS_MS = 400
+/** Reorder only starts after a deliberate motionless press-and-hold — any
+ * swipe must scroll the strip, never grab a clip. */
+const LONG_PRESS_MS = 500
 /** Movement beyond this before the long press cancels the pending lift. */
 const MOVE_CANCEL_PX = 8
 const EDGE_SCROLL_ZONE_PX = 44
 const EDGE_SCROLL_STEP_PX = 12
+/** Per-frame velocity decay for the release fling. */
+const FLING_DECAY = 0.94
+const FLING_MIN_VELOCITY = 0.06
 
 interface TimelineProps {
   projectId: ProjectId
@@ -38,7 +41,7 @@ export function Timeline({ projectId, clips, selectedClipId, onSelect, refresh }
   const [gapIndex, setGapIndex] = useState<number | null>(null)
   const trackRef = useRef<HTMLDivElement | null>(null)
   const tileRefs = useRef(new Map<ClipId, HTMLButtonElement>())
-  const touchBlockerRef = useRef<((event: TouchEvent) => void) | null>(null)
+  const flingRafRef = useRef(0)
   const dragRef = useRef<{
     clipId: ClipId
     startX: number
@@ -46,12 +49,13 @@ export function Timeline({ projectId, clips, selectedClipId, onSelect, refresh }
     startScrollLeft: number
     fromIndex: number
     pointerId: number
-    pointerType: string
     longPressTimer: ReturnType<typeof setTimeout> | null
     lifted: boolean
-    /** Mouse/pen gesture turned into a manual drag-to-scroll. */
+    /** Gesture turned into a drag-to-scroll (all pointer types). */
     scrolling: boolean
     gapIndex: number
+    /** Recent pointer samples for the release fling. */
+    samples: { t: number; x: number }[]
   } | null>(null)
 
   const selectClip = (id: ClipId) => {
@@ -68,28 +72,42 @@ export function Timeline({ projectId, clips, selectedClipId, onSelect, refresh }
     )
   }
 
-  /** While a clip is lifted, stop native panning from hijacking the drag.
-   * (React registers touch listeners as passive, so this must be native.) */
-  const addPanBlocker = () => {
-    const track = trackRef.current
-    if (!track || touchBlockerRef.current) return
-    const blocker = (event: TouchEvent) => event.preventDefault()
-    touchBlockerRef.current = blocker
-    track.addEventListener('touchmove', blocker, { passive: false })
+  const stopFling = () => {
+    cancelAnimationFrame(flingRafRef.current)
+    flingRafRef.current = 0
   }
 
-  const removePanBlocker = () => {
+  /** Continue a released swipe with decaying momentum. */
+  const startFling = (samples: { t: number; x: number }[]) => {
     const track = trackRef.current
-    if (track && touchBlockerRef.current) {
-      track.removeEventListener('touchmove', touchBlockerRef.current)
+    if (!track || samples.length < 2) return
+    const last = samples[samples.length - 1]
+    const first = samples[0]
+    // A finger that stopped moving before lifting should not fling.
+    if (performance.now() - last.t > 80) return
+    const dt = last.t - first.t
+    if (dt <= 0) return
+    // Finger velocity in px/ms; the strip scrolls opposite the finger.
+    let velocity = -((last.x - first.x) / dt)
+    if (Math.abs(velocity) < FLING_MIN_VELOCITY) return
+    let previous = performance.now()
+    const tick = (now: number) => {
+      const elapsed = Math.min(64, now - previous)
+      previous = now
+      track.scrollLeft += velocity * elapsed
+      velocity *= FLING_DECAY ** (elapsed / 16)
+      if (Math.abs(velocity) >= FLING_MIN_VELOCITY) {
+        flingRafRef.current = requestAnimationFrame(tick)
+      } else {
+        flingRafRef.current = 0
+      }
     }
-    touchBlockerRef.current = null
+    flingRafRef.current = requestAnimationFrame(tick)
   }
 
   const clearDrag = () => {
     const state = dragRef.current
     if (state?.longPressTimer) clearTimeout(state.longPressTimer)
-    removePanBlocker()
     dragRef.current = null
     setDraggingId(null)
     setGapIndex(null)
@@ -114,7 +132,6 @@ export function Timeline({ projectId, clips, selectedClipId, onSelect, refresh }
     state.gapIndex = state.fromIndex
     setDraggingId(clipId)
     setGapIndex(state.fromIndex)
-    addPanBlocker()
     navigator.vibrate?.(20)
   }
 
@@ -124,6 +141,7 @@ export function Timeline({ projectId, clips, selectedClipId, onSelect, refresh }
     index: number,
   ) => {
     if (event.button !== 0) return
+    stopFling()
     // A previous session that never reached finishPointer (e.g. its tile
     // unmounted mid-drag) must not leak into this gesture.
     if (dragRef.current) clearDrag()
@@ -136,11 +154,11 @@ export function Timeline({ projectId, clips, selectedClipId, onSelect, refresh }
       startScrollLeft: trackRef.current?.scrollLeft ?? 0,
       fromIndex: index,
       pointerId: event.pointerId,
-      pointerType: event.pointerType,
       longPressTimer: setTimeout(() => beginLift(clip.id), LONG_PRESS_MS),
       lifted: false,
       scrolling: false,
       gapIndex: index,
+      samples: [{ t: performance.now(), x: event.clientX }],
     }
   }
 
@@ -179,14 +197,13 @@ export function Timeline({ projectId, clips, selectedClipId, onSelect, refresh }
       state.longPressTimer = null
     }
     state.scrolling = true
-    if (state.pointerType === 'touch') {
-      // touch-action: pan-x lets the browser scroll the strip natively (with
-      // momentum); it will send pointercancel when it takes over.
-      return
-    }
-    // Mouse/pen have no native pan — scroll the strip manually.
+    // Drive the scroll ourselves for every pointer type — relying on native
+    // pan proved flaky on real Android devices, where the gesture could end
+    // up neither scrolling nor cancelling.
     const track = trackRef.current
     if (track) track.scrollLeft = state.startScrollLeft - dx
+    state.samples.push({ t: performance.now(), x: event.clientX })
+    if (state.samples.length > 6) state.samples.shift()
   }
 
   const finishPointer = (event: ReactPointerEvent<HTMLButtonElement>, cancelled: boolean) => {
@@ -199,10 +216,14 @@ export function Timeline({ projectId, clips, selectedClipId, onSelect, refresh }
       /* already released */
     }
 
-    const { clipId, fromIndex, lifted, scrolling, gapIndex: gap } = state
+    const { clipId, fromIndex, lifted, scrolling, gapIndex: gap, samples } = state
     clearDrag()
 
-    if (cancelled || scrolling) return
+    if (scrolling) {
+      if (!cancelled) startFling(samples)
+      return
+    }
+    if (cancelled) return
     if (!lifted) {
       selectClip(clipId)
       return
@@ -227,6 +248,11 @@ export function Timeline({ projectId, clips, selectedClipId, onSelect, refresh }
       role="listbox"
       aria-label="Clip timeline"
       ref={trackRef}
+      onContextMenu={(event) => {
+        // Android long-press opens a context menu and cancels the pointer
+        // stream, which would kill the lift right as it begins.
+        event.preventDefault()
+      }}
     >
       {clips.map((clip, index) => {
         const selected = clip.id === selectedClipId
@@ -258,10 +284,15 @@ export function Timeline({ projectId, clips, selectedClipId, onSelect, refresh }
                   tileRefs.current.set(clip.id, el)
                 } else {
                   tileRefs.current.delete(clip.id)
-                  // The dragged tile disappeared (clip deleted/reordered by a
-                  // revalidation) — end the session so the pan blocker and
-                  // is-dragging dimming can't stick around.
-                  if (dragRef.current?.clipId === clip.id) clearDrag()
+                  // Inline refs re-run on every render (null, then the new
+                  // element), so defer: only treat this as an unmount — and
+                  // end a drag session for a truly removed tile — if the
+                  // tile did not immediately re-register in the same commit.
+                  queueMicrotask(() => {
+                    if (!tileRefs.current.has(clip.id) && dragRef.current?.clipId === clip.id) {
+                      clearDrag()
+                    }
+                  })
                 }
               }}
             >

--- a/src/styles/editor.css
+++ b/src/styles/editor.css
@@ -176,8 +176,9 @@
   overflow: hidden;
   position: relative;
   padding: 0;
-  /* Horizontal swipes must scroll the strip; reorder is long-press only. */
-  touch-action: pan-x;
+  /* The strip drives its own scrolling from pointer events (native pan was
+   * unreliable on real Android hardware); reorder is long-press only. */
+  touch-action: none;
   transition: transform 140ms ease, box-shadow 140ms ease, border-color 140ms ease,
     opacity 140ms ease;
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem (real-device report)

On a real Android phone the timeline still couldn't be swiped — touching it selected/moved the clip — and (found while reproducing with real touch events) long-press reorder never actually worked on touch at all.

## Root causes — three, found by driving the UI with real CDP touch events

1. **Native pan was unreliable.** The previous design relied on `touch-action: pan-x` letting the browser take over swipes; on real hardware the gesture could end up neither scrolling nor cancelling. The strip now **drives its own scrolling from pointer events for every pointer type** (`touch-action: none`), with a decaying fling on release, so behavior no longer depends on browser pan heuristics.
2. **Android long-press fires `contextmenu`**, which cancels the pointer stream right as the lift begins — so the 400/500ms hold could never complete on touch. Now prevented on the timeline (the record stage already did this).
3. **The stale-session cleanup self-destructed the lift.** The tile ref callback is inline, so React re-runs it (null → element) on *every* render; the cleanup added for Bugbot's stale-drag finding therefore ran the instant `beginLift` re-rendered the strip, reverting the lift immediately. Cleanup is now deferred to a microtask and only fires when a tile truly unmounted.

Long-press threshold raised to 500ms (top of the requested range) so a brief rest before swiping doesn't turn into a drag.

## Verification

New **real-touch gesture probe** (CDP `Input.dispatchTouchEvent`), kept as `scripts/probe-touch-timeline.mjs`, **10/10**:

- touch swipe scrolls the strip and flings on release (108 → 130 after lift-off)
- swipe never lifts, never reorders, never changes selection
- no lift at 350ms; lift at 500ms with the visual drag state; drag reorders
- touch tap still selects

Plus `npm run lint`, `npm test` (15), `npm run build`, smoke **20/20**.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-16d17496-6b5b-4e12-b600-6933357c2059"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-16d17496-6b5b-4e12-b600-6933357c2059"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

