### PR TITLE
Restart the camera whenever the app returns to the foreground

### DIFF
--- a/manual-test-checklist.md
+++ b/manual-test-checklist.md
@@ -11,6 +11,7 @@ Run locally with HTTPS or `localhost` (`npm run dev`). Camera/mic require a secu
 - [ ] Torch toggle appears on devices with a flash; zoom chips appear when supported
 - [ ] Backgrounding the app releases camera/mic (green dot goes out); returning restarts the preview
 - [ ] Backgrounding mid-recording still saves the take
+- [ ] Screen off → on while on the camera view: preview is live again, not frozen; recording works
 - [ ] Light/dark follows system `prefers-color-scheme`
 
 ## Hold-to-record

--- a/src/components/record-screen.tsx
+++ b/src/components/record-screen.tsx
@@ -88,6 +88,7 @@ export function RecordScreen({
   const recorderRef = useRef(new HoldRecorder())
   const pointerIdRef = useRef<number | null>(null)
   const beginInFlightRef = useRef(false)
+  const endInFlightRef = useRef(false)
   const countdownTimerRef = useRef(0)
   const wakeLockRef = useRef<WakeLockSentinel | null>(null)
   const wakeLockGenRef = useRef(0)
@@ -247,12 +248,17 @@ export function RecordScreen({
       ) {
         return
       }
+      // One end per take: stop() resolves asynchronously (duration is
+      // measured), so a second caller (e.g. hide + return in quick
+      // succession) must not re-enter and double-save the clip.
+      if (endInFlightRef.current) return
       if (!recorderRef.current.isRecording && !recording) {
         // Pointer released while mic grant was still in flight.
         pointerIdRef.current = null
         camera.releaseMic()
         return
       }
+      endInFlightRef.current = true
       pointerIdRef.current = null
       setRecording(false)
       setRecordingMode(null)
@@ -267,6 +273,7 @@ export function RecordScreen({
       } catch (err) {
         showToast(err instanceof Error ? err.message : 'Save failed')
       } finally {
+        endInFlightRef.current = false
         // stop() resolves only after the blob's duration is measured, so a
         // quick next hold may already be recording (or acquiring the mic) by
         // now — never strip the mic or wake lock from that newer session.
@@ -363,7 +370,11 @@ export function RecordScreen({
         await endRecord()
       }
       camera.stop()
+      // The app may have been hidden again while the take was finishing —
+      // never reopen the camera (and relight the privacy dot) in background.
+      if (document.hidden) return
       await camera.start()
+      if (document.hidden) camera.stop()
     })()
   }
 

--- a/src/components/record-screen.tsx
+++ b/src/components/record-screen.tsx
@@ -351,9 +351,20 @@ export function RecordScreen({
         void endRecord()
       }
       camera.stop()
-    } else if (!camera.getStream()) {
-      void camera.start()
+      return
     }
+    // Coming back to the foreground: restart the camera unconditionally.
+    // Screen-off freezes the camera track at the OS level, and on some
+    // Android paths no `hidden` event ever fires — a surviving stream would
+    // keep previewing (and recording!) a single stale frame forever. If a
+    // take was somehow still running on that frozen stream, save it first.
+    void (async () => {
+      if (recorderRef.current.isRecording || recording) {
+        await endRecord()
+      }
+      camera.stop()
+      await camera.start()
+    })()
   }
 
   const onVisibilityChange = useCallback(() => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem (real-device report)

Turn the screen off while on the camera view, turn it back on → the preview is frozen, and recording captures that frozen frame.

## Root cause

Screen-off freezes the camera track at the OS level, and on some Android paths Chrome never fires a `hidden` visibility event for the lock — so the previous logic ("restart only if there's no stream") found the surviving-but-frozen stream on return and skipped the restart. Preview and MediaRecorder then consumed a track that never delivers another frame.

## Fix

On `visibilitychange` → visible, the record screen now **unconditionally stops and reopens the camera**. If a take was somehow still running on the frozen stream, it is ended and saved first. The hide path is unchanged (finish + save any take, stop all tracks so the green privacy dot goes out).

## Verification

Visibility probe (spying on all `getUserMedia` tracks), **5/5**, including the exact reported scenario:

- visible fires with a surviving live stream (no prior hidden) → all old tracks end, a fresh track is live, preview renders frames
- a recording running on that surviving stream → take saved, camera restarted
- normal hide → all tracks stop; show → preview restarts

Plus `npm run lint`, `npm test` (15), `npm run build`, smoke **20/20**.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-16d17496-6b5b-4e12-b600-6933357c2059"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-16d17496-6b5b-4e12-b600-6933357c2059"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue that could trigger duplicate save actions when ending a recording.
  * Improved camera recovery when returning to the app, including cases where the screen is turned off and back on.
  * Recording now resumes reliably with a live camera preview after returning to the foreground.
  * Improved handling when the app is hidden again during camera restart or recording completion.

* **Documentation**
  * Added a manual test checklist item for verifying camera and recording recovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->