### PR TITLE
Remove Watermark purchase: $0.99 Stripe link, verified unlock, friend promo path

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,11 +107,27 @@ Verified approach: `npm run build && npm run preview`, load once online, then De
 - **Storage quotas:** large projects can hit IndexedDB quotas; the soft 6-project cap helps.
 - **Background tabs:** recording should stay in the foreground; browsers may throttle capture.
 
+## Remove Watermark purchase
+
+Exports carry a small Kody Video mark in the corner. A one-time $0.99 Stripe
+Payment Link removes it: the export sheet links to checkout, Stripe redirects
+back to `/unlocked?session_id=…`, and a single Cloudflare Pages Function
+(`functions/api/verify-purchase.ts`) verifies the session server-side before
+the entitlement is stored in IndexedDB. 100%-off promotion codes (friends /
+the developer) flow through the exact same verification. Restore on another
+device: paste the Stripe receipt link into "Already paid?" on the export
+sheet.
+
+Deployment requirement: set `STRIPE_SECRET_KEY` (a restricted key with
+Checkout Sessions read access is enough) on the Cloudflare Pages project.
+
 ## Privacy
 
 - No telemetry, analytics, or accounts.
 - No clip upload endpoints exist in this app.
 - Share/export uses user-gesture download or the Web Share API only.
+- The only network call besides Stripe checkout (opened in the browser) is
+  the purchase-verification function above; it never sees media.
 
 ## Scripts
 

--- a/functions/api/verify-purchase.ts
+++ b/functions/api/verify-purchase.ts
@@ -1,0 +1,78 @@
+/**
+ * Cloudflare Pages Function: verify a Stripe Checkout session for the
+ * "Remove Watermark" purchase. The only backend surface in the app — it
+ * never stores anything and never sees media; it just asks Stripe whether
+ * the session really completed (including 100%-off promo checkouts).
+ *
+ * Requires the STRIPE_SECRET_KEY environment variable on the Pages project
+ * (a restricted key with Checkout Sessions read access is enough).
+ */
+
+interface Env {
+  STRIPE_SECRET_KEY?: string
+  /** Optional override; defaults to the production payment link. */
+  STRIPE_PAYMENT_LINK_ID?: string
+}
+
+interface PagesContext {
+  request: Request
+  env: Env
+}
+
+const PRODUCTION_PAYMENT_LINK_ID = 'plink_1TxcxULAQpAnsYszr2bLuqOl'
+const SESSION_ID_PATTERN = /^cs_[a-zA-Z0-9_]+$/
+
+function json(body: unknown, status: number): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      'content-type': 'application/json',
+      'cache-control': 'no-store',
+    },
+  })
+}
+
+export async function onRequestGet(context: PagesContext): Promise<Response> {
+  const { request, env } = context
+  const secretKey = env.STRIPE_SECRET_KEY
+  if (!secretKey) {
+    return json({ unlocked: false, error: 'Purchase verification is not configured yet.' }, 503)
+  }
+
+  const sessionId = new URL(request.url).searchParams.get('session_id') ?? ''
+  if (!SESSION_ID_PATTERN.test(sessionId)) {
+    return json({ unlocked: false, error: 'Invalid session id.' }, 400)
+  }
+
+  const response = await fetch(
+    `https://api.stripe.com/v1/checkout/sessions/${encodeURIComponent(sessionId)}`,
+    { headers: { authorization: `Bearer ${secretKey}` } },
+  )
+  if (response.status === 404) {
+    return json({ unlocked: false, error: 'No such purchase.' }, 404)
+  }
+  if (!response.ok) {
+    return json({ unlocked: false, error: 'Could not reach Stripe. Try again shortly.' }, 502)
+  }
+
+  const session = (await response.json()) as {
+    status?: string
+    payment_status?: string
+    payment_link?: string
+  }
+
+  const expectedLink = env.STRIPE_PAYMENT_LINK_ID ?? PRODUCTION_PAYMENT_LINK_ID
+  const complete = session.status === 'complete'
+  // 100%-off promotion-code checkouts complete with 'no_payment_required'.
+  const paid =
+    session.payment_status === 'paid' || session.payment_status === 'no_payment_required'
+  const rightProduct = session.payment_link === expectedLink
+
+  if (complete && paid && rightProduct) {
+    return json({ unlocked: true }, 200)
+  }
+  return json(
+    { unlocked: false, error: 'This checkout session is not a completed watermark purchase.' },
+    403,
+  )
+}

--- a/manual-test-checklist.md
+++ b/manual-test-checklist.md
@@ -47,6 +47,10 @@ Run locally with HTTPS or `localhost` (`npm run dev`). Camera/mic require a secu
 - [ ] Exported video: clips in order, trims applied, audio in sync across clips, smooth frame rate
 - [ ] Export failure path offers "Save clips instead"
 - [ ] Network tab shows no upload of clip binaries
+- [ ] Exported video shows the small Kody mark bottom-right (before purchase)
+- [ ] "Remove it — $0.99" opens Stripe checkout; KODYFRIEND promo checks out at $0
+- [ ] After checkout, /unlocked verifies and celebrates; next export has no mark
+- [ ] "Already paid?" restore accepts the receipt link and unlocks
 
 ## Persistence / offline
 - [ ] Hard refresh restores projects and clip media

--- a/scripts/manual-smoke.mjs
+++ b/scripts/manual-smoke.mjs
@@ -221,7 +221,57 @@ try {
   const saveBtn = exportDialog.getByRole('button', { name: /^save$/i })
   if (await saveBtn.count()) pass('export offers Save')
   else fail('export offers Save')
+
+  const upsell = exportDialog.getByRole('button', { name: /remove it — \$0\.99/i })
+  if (await upsell.count()) pass('watermark upsell shown while locked')
+  else fail('watermark upsell shown while locked')
   await exportDialog.getByRole('button', { name: /done|close/i }).first().click()
+
+  // --- Purchase verification flow (mocked endpoint) + unlocked state ---
+  await page.route('**/api/verify-purchase*', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ unlocked: true }),
+    }),
+  )
+  await page.goto(`${BASE}/unlocked?session_id=cs_live_smoketest123`, {
+    waitUntil: 'networkidle',
+  })
+  const celebrated = await page
+    .waitForSelector('text=/watermark removed/i', { timeout: 5000 })
+    .then(() => true)
+    .catch(() => false)
+  if (celebrated) pass('unlock page verifies and celebrates')
+  else fail('unlock page verifies and celebrates')
+  await shot(page, '10-unlocked')
+
+  await page.getByRole('link', { name: /start creating/i }).click()
+  await page.waitForURL(BASE + '/', { timeout: 5000 }).catch(() => undefined)
+  await page.locator('.project-slot.filled .slot-open').first().click()
+  await page.waitForURL(/\/project\//, { timeout: 5000 })
+  await page.getByRole('button', { name: /^ok$/i }).first().click()
+  const unlockedExport = await page
+    .waitForFunction(
+      () => {
+        const dialog = document.querySelector('[aria-label="Share project"]')
+        return dialog && /video is ready/i.test(dialog.textContent || '')
+      },
+      { timeout: 45000 },
+    )
+    .then(() => true)
+    .catch(() => false)
+  const upsellGone =
+    unlockedExport &&
+    (await page.getByRole('button', { name: /remove it — \$0\.99/i }).count()) === 0
+  if (upsellGone) pass('purchase removes the watermark upsell')
+  else fail('purchase removes the watermark upsell', `exported=${unlockedExport}`)
+  await page
+    .getByRole('dialog', { name: /share project/i })
+    .getByRole('button', { name: /done|close/i })
+    .first()
+    .click()
+  await page.unroute('**/api/verify-purchase*')
 
   // --- Playback preview overlay ---
   await page.getByRole('button', { name: /play project preview/i }).click()

--- a/src/components/export-sheet.tsx
+++ b/src/components/export-sheet.tsx
@@ -12,8 +12,10 @@ interface ExportSheetProps {
   fileSizeBytes: number | null
   /** Feedback after a share/save action ("Saved to downloads", …). */
   notice: string | null
-  /** True when the export was stamped with the Kody Video mark. */
+  /** True when THIS export was stamped with the Kody Video mark. */
   watermarked: boolean
+  /** True when the removal purchase is unlocked (may change mid-sheet). */
+  purchased: boolean
   onShare: () => void
   onSave: () => void
   onSaveClips: () => void
@@ -36,6 +38,7 @@ export function ExportSheet({
   fileSizeBytes,
   notice,
   watermarked,
+  purchased,
   onShare,
   onSave,
   onSaveClips,
@@ -74,7 +77,7 @@ export function ExportSheet({
                 Done
               </button>
             </div>
-            {watermarked ? (
+            {watermarked && !purchased ? (
               <p className="watermark-note">
                 Includes a small Kody mark in the corner.{' '}
                 <button type="button" className="link-button" onClick={onRemoveWatermark}>
@@ -84,6 +87,11 @@ export function ExportSheet({
                 <button type="button" className="link-button" onClick={onRestorePurchase}>
                   Already paid?
                 </button>
+              </p>
+            ) : null}
+            {watermarked && purchased ? (
+              <p className="watermark-note">
+                This video still includes the Kody mark — tap OK again for a clean export.
               </p>
             ) : null}
           </>

--- a/src/components/export-sheet.tsx
+++ b/src/components/export-sheet.tsx
@@ -12,9 +12,13 @@ interface ExportSheetProps {
   fileSizeBytes: number | null
   /** Feedback after a share/save action ("Saved to downloads", …). */
   notice: string | null
+  /** True when the export was stamped with the Kody Video mark. */
+  watermarked: boolean
   onShare: () => void
   onSave: () => void
   onSaveClips: () => void
+  onRemoveWatermark: () => void
+  onRestorePurchase: () => void
   onRetry: () => void
   onClose: () => void
 }
@@ -31,9 +35,12 @@ export function ExportSheet({
   fileExtension,
   fileSizeBytes,
   notice,
+  watermarked,
   onShare,
   onSave,
   onSaveClips,
+  onRemoveWatermark,
+  onRestorePurchase,
   onRetry,
   onClose,
 }: ExportSheetProps) {
@@ -67,6 +74,18 @@ export function ExportSheet({
                 Done
               </button>
             </div>
+            {watermarked ? (
+              <p className="watermark-note">
+                Includes a small Kody mark in the corner.{' '}
+                <button type="button" className="link-button" onClick={onRemoveWatermark}>
+                  Remove it — $0.99
+                </button>{' '}
+                ·{' '}
+                <button type="button" className="link-button" onClick={onRestorePurchase}>
+                  Already paid?
+                </button>
+              </p>
+            ) : null}
           </>
         ) : null}
 

--- a/src/components/restore-sheet.tsx
+++ b/src/components/restore-sheet.tsx
@@ -1,0 +1,73 @@
+import { useState } from 'react'
+import { extractSessionId, verifyPurchaseSession } from '../lib/entitlement'
+
+interface RestoreSheetProps {
+  onRestored: () => void
+  onClose: () => void
+}
+
+/**
+ * Restore the "Remove Watermark" purchase on a new device: paste the link
+ * from the Stripe receipt email (or the checkout session id) and re-verify.
+ */
+export function RestoreSheet({ onRestored, onClose }: RestoreSheetProps) {
+  const [value, setValue] = useState('')
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  return (
+    <>
+      <div
+        className="sheet-backdrop"
+        onClick={() => {
+          if (!busy) onClose()
+        }}
+      />
+      <div className="sheet" role="dialog" aria-label="Restore purchase">
+        <h3>Restore purchase</h3>
+        <p className="muted sheet-lede">
+          Paste the confirmation link from your Stripe receipt email (or the checkout session id
+          starting with “cs_”). We’ll verify it and remove the watermark on this device.
+        </p>
+        <div className="field">
+          <label htmlFor="restore-input">Receipt link or session id</label>
+          <input
+            id="restore-input"
+            type="text"
+            value={value}
+            autoFocus
+            placeholder="https://… or cs_live_…"
+            onChange={(e) => setValue(e.target.value)}
+          />
+        </div>
+        {error ? <div className="error-banner">{error}</div> : null}
+        <div className="sheet-actions">
+          <button type="button" className="btn btn-ghost" onClick={onClose} disabled={busy}>
+            Cancel
+          </button>
+          <button
+            type="button"
+            className="btn btn-primary"
+            disabled={busy || !extractSessionId(value)}
+            onClick={() => {
+              const sessionId = extractSessionId(value)
+              if (!sessionId) return
+              setBusy(true)
+              setError(null)
+              void verifyPurchaseSession(sessionId).then((result) => {
+                setBusy(false)
+                if (result.unlocked) {
+                  onRestored()
+                } else {
+                  setError(result.error ?? 'Could not verify the purchase.')
+                }
+              })
+            }}
+          >
+            {busy ? 'Verifying…' : 'Restore'}
+          </button>
+        </div>
+      </div>
+    </>
+  )
+}

--- a/src/lib/entitlement.ts
+++ b/src/lib/entitlement.ts
@@ -1,0 +1,52 @@
+import { getDb, getSettings } from './storage'
+
+/** Stripe Payment Link for the one-time "Remove Watermark" unlock ($0.99). */
+export const REMOVE_WATERMARK_LINK = 'https://buy.stripe.com/00wfZi71ibU30rk9hU2Ry07'
+
+const SESSION_ID_PATTERN = /cs_(?:live|test)_[a-zA-Z0-9]+/
+
+export async function isWatermarkRemoved(): Promise<boolean> {
+  const settings = await getSettings()
+  return settings.watermarkRemoved === true
+}
+
+export async function markWatermarkRemoved(sessionId: string): Promise<void> {
+  const db = await getDb()
+  const settings = await getSettings()
+  await db.put('meta', { ...settings, watermarkRemoved: true, purchaseSessionId: sessionId })
+}
+
+export interface VerifyResult {
+  unlocked: boolean
+  error?: string
+}
+
+/**
+ * Ask the Pages Function to confirm a Stripe Checkout session, and persist
+ * the entitlement when it checks out.
+ */
+export async function verifyPurchaseSession(sessionId: string): Promise<VerifyResult> {
+  try {
+    const response = await fetch(
+      `/api/verify-purchase?session_id=${encodeURIComponent(sessionId)}`,
+      { headers: { accept: 'application/json' } },
+    )
+    const body = (await response.json().catch(() => null)) as VerifyResult | null
+    if (response.ok && body?.unlocked) {
+      await markWatermarkRemoved(sessionId)
+      return { unlocked: true }
+    }
+    return {
+      unlocked: false,
+      error: body?.error ?? 'Could not verify the purchase. Try again shortly.',
+    }
+  } catch {
+    return { unlocked: false, error: 'Could not verify the purchase — are you offline?' }
+  }
+}
+
+/** Pull a checkout session id out of pasted text (receipt URL, session id, …). */
+export function extractSessionId(text: string): string | null {
+  const match = text.match(SESSION_ID_PATTERN)
+  return match ? match[0] : null
+}

--- a/src/lib/export/encode-realtime.ts
+++ b/src/lib/export/encode-realtime.ts
@@ -5,6 +5,7 @@ import {
   blitPreview,
   decodeClipAudio,
   drawCover,
+  drawWatermark,
   loadClipVideo,
   pickOutputSize,
   seekTo,
@@ -21,6 +22,8 @@ export interface RealtimeExportOptions {
   onProgress?: (ratio: number) => void
   /** Visible canvas to mirror sampled frames onto while exporting. */
   getPreviewCanvas?: () => HTMLCanvasElement | null
+  /** Mark stamped onto each frame; null when the user purchased removal. */
+  watermarkImage?: HTMLImageElement | null
 }
 
 /**
@@ -108,6 +111,7 @@ export async function exportRealtime(
           dest,
           frameCounter,
           getPreviewCanvas: options.getPreviewCanvas,
+          watermarkImage: options.watermarkImage ?? null,
           onElapsedMs: (elapsed) => {
             if (plan.totalMs > 0) {
               options.onProgress?.(Math.min(1, (paintedTotalMs + elapsed) / plan.totalMs))
@@ -159,6 +163,7 @@ interface PaintSegmentArgs {
   dest: MediaStreamAudioDestinationNode | null
   frameCounter: { count: number }
   getPreviewCanvas?: () => HTMLCanvasElement | null
+  watermarkImage: HTMLImageElement | null
   onElapsedMs: (elapsedMs: number) => void
 }
 
@@ -174,6 +179,7 @@ async function paintSegment({
   dest,
   frameCounter,
   getPreviewCanvas,
+  watermarkImage,
   onElapsedMs,
 }: PaintSegmentArgs): Promise<number> {
   const segmentSec = endSec - startSec
@@ -189,7 +195,13 @@ async function paintSegment({
     await video.play()
     await waitForPlaybackStart(video, startSec)
 
-    drawCover(ctx, video, canvas.width, canvas.height)
+    const paintFrame = () => {
+      drawCover(ctx, video, canvas.width, canvas.height)
+      if (watermarkImage) {
+        drawWatermark(ctx, watermarkImage, canvas.width, canvas.height)
+      }
+    }
+    paintFrame()
 
     if (audioContext && dest && audioBuffer) {
       const videoLeadSec = Math.max(0, video.currentTime - startSec)
@@ -214,7 +226,7 @@ async function paintSegment({
       let lastVideoTime = video.currentTime
 
       const finish = () => {
-        drawCover(ctx, video, canvas.width, canvas.height)
+        paintFrame()
         cancelAnimationFrame(raf)
         video.pause()
         resolve()
@@ -236,7 +248,7 @@ async function paintSegment({
           reject(new Error('Clip playback stalled during export'))
           return
         }
-        drawCover(ctx, video, canvas.width, canvas.height)
+        paintFrame()
         if (frameCounter.count % PREVIEW_EVERY_N_FRAMES === 0) {
           blitPreview(canvas, getPreviewCanvas?.())
         }

--- a/src/lib/export/encode-webcodecs.ts
+++ b/src/lib/export/encode-webcodecs.ts
@@ -12,6 +12,7 @@ import {
   blitPreview,
   decodeClipAudio,
   drawCover,
+  drawWatermark,
   loadClipVideo,
   pickOutputSize,
   seekTo,
@@ -122,6 +123,7 @@ export async function exportWithWebCodecs(
   plan: ExportPlan,
   onProgress?: (ratio: number) => void,
   getPreviewCanvas?: () => HTMLCanvasElement | null,
+  watermarkImage?: HTMLImageElement | null,
 ): Promise<ExportResult> {
   if (!supportsWebCodecsExport()) {
     throw new Error('WebCodecs is not available')
@@ -239,6 +241,7 @@ export async function exportWithWebCodecs(
           videoEncoder,
           state,
           getPreviewCanvas,
+          watermarkImage,
           hasError: () => encoderError !== null,
           onElapsedMs: (elapsed) => {
             if (plan.totalMs > 0) {
@@ -300,6 +303,7 @@ interface PumpArgs {
     frameCount: number
   }
   getPreviewCanvas?: () => HTMLCanvasElement | null
+  watermarkImage?: HTMLImageElement | null
   hasError: () => boolean
   onElapsedMs: (elapsedMs: number) => void
 }
@@ -313,6 +317,7 @@ async function pumpSegmentVideo({
   videoEncoder,
   state,
   getPreviewCanvas,
+  watermarkImage,
   hasError,
   onElapsedMs,
 }: PumpArgs): Promise<void> {
@@ -325,6 +330,9 @@ async function pumpSegmentVideo({
       tsUs = state.lastVideoTsUs + 1000
     }
     drawCover(ctx, video, canvas.width, canvas.height)
+    if (watermarkImage) {
+      drawWatermark(ctx, watermarkImage, canvas.width, canvas.height)
+    }
     const frame = new VideoFrame(canvas, {
       timestamp: tsUs,
       duration: Math.round(1_000_000 / FPS),

--- a/src/lib/export/index.ts
+++ b/src/lib/export/index.ts
@@ -2,7 +2,7 @@ import type { ClipRecord } from '../types'
 import { exportRealtime } from './encode-realtime'
 import { exportWithWebCodecs, supportsWebCodecsExport } from './encode-webcodecs'
 import { planExport } from './plan'
-import type { ExportResult } from './shared'
+import { loadWatermarkImage, type ExportResult } from './shared'
 
 export type { ExportResult } from './shared'
 export { planExport, type ExportPlan, type PlannedSegment } from './plan'
@@ -20,6 +20,8 @@ export interface ExportOptions {
    * after the export starts.
    */
   getPreviewCanvas?: () => HTMLCanvasElement | null
+  /** Stamp the Kody Video mark on frames (default true; off after purchase). */
+  watermark?: boolean
 }
 
 /**
@@ -36,9 +38,16 @@ export async function exportProject(
     throw new Error('Nothing to export yet — record a clip first')
   }
 
+  const watermarkImage = options.watermark === false ? null : await loadWatermarkImage()
+
   if (supportsWebCodecsExport()) {
     try {
-      return await exportWithWebCodecs(plan, options.onProgress, options.getPreviewCanvas)
+      return await exportWithWebCodecs(
+        plan,
+        options.onProgress,
+        options.getPreviewCanvas,
+        watermarkImage,
+      )
     } catch (error) {
       console.warn('WebCodecs export failed; falling back to realtime stitcher', error)
     }
@@ -48,5 +57,6 @@ export async function exportProject(
     audioContext: options.audioContext,
     onProgress: options.onProgress,
     getPreviewCanvas: options.getPreviewCanvas,
+    watermarkImage,
   })
 }

--- a/src/lib/export/shared.ts
+++ b/src/lib/export/shared.ts
@@ -166,6 +166,41 @@ export async function decodeClipAudio(
   }
 }
 
+/**
+ * Load the mark stamped onto exported frames (unless the user purchased the
+ * watermark removal). Best-effort: a missing asset must never fail an export.
+ */
+export function loadWatermarkImage(): Promise<HTMLImageElement | null> {
+  return new Promise((resolve) => {
+    const image = new Image()
+    image.onload = () => resolve(image)
+    image.onerror = () => resolve(null)
+    image.src = '/pwa-192.png'
+  })
+}
+
+/** Stamp the Kody Video mark in the bottom-right corner of a frame. */
+export function drawWatermark(
+  ctx: CanvasRenderingContext2D,
+  image: HTMLImageElement,
+  width: number,
+  height: number,
+): void {
+  const size = Math.round(Math.min(width, height) * 0.12)
+  const margin = Math.round(size * 0.3)
+  const x = width - size - margin
+  const y = height - size - margin
+  const radius = Math.round(size * 0.22)
+
+  ctx.save()
+  ctx.globalAlpha = 0.78
+  ctx.beginPath()
+  ctx.roundRect(x, y, size, size, radius)
+  ctx.clip()
+  ctx.drawImage(image, x, y, size, size)
+  ctx.restore()
+}
+
 /** How often the engines mirror an encoded frame to the UI preview canvas. */
 export const PREVIEW_EVERY_N_FRAMES = 10
 

--- a/src/lib/project-actions.ts
+++ b/src/lib/project-actions.ts
@@ -34,6 +34,8 @@ export interface ProjectLoaderData {
   clips: ClipRecord[]
   canUndo: boolean
   onboardingDismissed: boolean
+  /** True when the one-time "Remove Watermark" purchase is unlocked. */
+  watermarkRemoved: boolean
   error: string | null
 }
 
@@ -71,6 +73,7 @@ export async function loadProjectPage(projectId: ProjectId): Promise<ProjectLoad
         clips: [],
         canUndo: false,
         onboardingDismissed: settings.onboardingDismissed,
+        watermarkRemoved: settings.watermarkRemoved === true,
         error: 'Project not found',
       }
     }
@@ -87,6 +90,7 @@ export async function loadProjectPage(projectId: ProjectId): Promise<ProjectLoad
       clips: hydrated,
       canUndo: !!undo,
       onboardingDismissed: settings.onboardingDismissed,
+      watermarkRemoved: settings.watermarkRemoved === true,
       error: null,
     }
   } catch (err) {
@@ -95,6 +99,7 @@ export async function loadProjectPage(projectId: ProjectId): Promise<ProjectLoad
       clips: [],
       canUndo: false,
       onboardingDismissed: true,
+      watermarkRemoved: false,
       error: err instanceof Error ? err.message : 'Failed to load project',
     }
   }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -40,6 +40,9 @@ export interface AppMeta {
   maxProjects: number
   lastOpenedProjectId: ProjectId | null
   onboardingDismissed: boolean
+  /** One-time "Remove Watermark" purchase (verified via Stripe). */
+  watermarkRemoved?: boolean
+  purchaseSessionId?: string | null
 }
 
 export const MAX_PROJECTS = 6

--- a/src/lib/verify-purchase.test.ts
+++ b/src/lib/verify-purchase.test.ts
@@ -1,0 +1,80 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { onRequestGet } from '../../functions/api/verify-purchase'
+
+const PLINK = 'plink_1TxcxULAQpAnsYszr2bLuqOl'
+
+function makeContext(url: string, env: Record<string, string> = {}) {
+  return { request: new Request(url), env }
+}
+
+function stripeResponds(session: unknown, status = 200) {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async () => new Response(JSON.stringify(session), { status })),
+  )
+}
+
+async function body(response: Response) {
+  return (await response.json()) as { unlocked: boolean; error?: string }
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('verify-purchase function', () => {
+  const url = 'https://kody-video.pages.dev/api/verify-purchase?session_id=cs_live_abc123'
+  const env = { STRIPE_SECRET_KEY: 'rk_test_x' }
+
+  it('returns 503 when the secret is not configured', async () => {
+    const response = await onRequestGet(makeContext(url, {}))
+    expect(response.status).toBe(503)
+    expect((await body(response)).unlocked).toBe(false)
+  })
+
+  it('rejects malformed session ids without calling Stripe', async () => {
+    const fetchSpy = vi.fn()
+    vi.stubGlobal('fetch', fetchSpy)
+    const response = await onRequestGet(
+      makeContext('https://x.dev/api/verify-purchase?session_id=<script>', env),
+    )
+    expect(response.status).toBe(400)
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
+
+  it('unlocks a paid completed session for our payment link', async () => {
+    stripeResponds({ status: 'complete', payment_status: 'paid', payment_link: PLINK })
+    const response = await onRequestGet(makeContext(url, env))
+    expect(response.status).toBe(200)
+    expect((await body(response)).unlocked).toBe(true)
+  })
+
+  it('unlocks a 100%-off promo checkout (no_payment_required)', async () => {
+    stripeResponds({
+      status: 'complete',
+      payment_status: 'no_payment_required',
+      payment_link: PLINK,
+    })
+    const response = await onRequestGet(makeContext(url, env))
+    expect((await body(response)).unlocked).toBe(true)
+  })
+
+  it('rejects sessions from other payment links', async () => {
+    stripeResponds({ status: 'complete', payment_status: 'paid', payment_link: 'plink_other' })
+    const response = await onRequestGet(makeContext(url, env))
+    expect(response.status).toBe(403)
+    expect((await body(response)).unlocked).toBe(false)
+  })
+
+  it('rejects incomplete or unpaid sessions', async () => {
+    stripeResponds({ status: 'open', payment_status: 'unpaid', payment_link: PLINK })
+    const response = await onRequestGet(makeContext(url, env))
+    expect(response.status).toBe(403)
+  })
+
+  it('maps unknown sessions to 404', async () => {
+    stripeResponds({ error: { type: 'invalid_request_error' } }, 404)
+    const response = await onRequestGet(makeContext(url, env))
+    expect(response.status).toBe(404)
+  })
+})

--- a/src/pages/project-page.tsx
+++ b/src/pages/project-page.tsx
@@ -13,6 +13,8 @@ import { OnboardingOverlay } from '../components/onboarding-overlay'
 import { PlaybackOverlay } from '../components/playback-overlay'
 import { RecordScreen, type ToastAction } from '../components/record-screen'
 import { useCamera } from '../hooks/use-camera'
+import { RestoreSheet } from '../components/restore-sheet'
+import { REMOVE_WATERMARK_LINK } from '../lib/entitlement'
 import { exportProject, type ExportResult } from '../lib/export'
 import {
   canShareFile,
@@ -46,6 +48,7 @@ export async function projectLoader({ params }: LoaderFunctionArgs): Promise<Pro
       clips: [],
       canUndo: false,
       onboardingDismissed: true,
+      watermarkRemoved: false,
       error: 'Project not found',
     }
   }
@@ -70,6 +73,7 @@ export function ProjectPage() {
   const [playing, setPlaying] = useState(false)
   const [toast, setToast] = useState<ToastState | null>(null)
   const [exportState, setExportState] = useState<ExportUiState | null>(null)
+  const [restoring, setRestoring] = useState(false)
 
   const refresh = useCallback(() => {
     startTransition(() => {
@@ -108,6 +112,7 @@ export function ProjectPage() {
       try {
         const result = await exportProject(clips, {
           audioContext,
+          watermark: !data.watermarkRemoved,
           getPreviewCanvas: () => previewCanvasRef.current,
           onProgress: (ratio) => {
             if (exportRunRef.current !== runId) return
@@ -137,7 +142,7 @@ export function ProjectPage() {
         }
       }
     })()
-  }, [clips])
+  }, [clips, data.watermarkRemoved])
 
   const closeExport = useCallback(() => {
     exportRunRef.current += 1
@@ -216,6 +221,11 @@ export function ProjectPage() {
           status={exportState.status}
           error={exportState.error}
           notice={exportState.notice}
+          watermarked={!data.watermarkRemoved}
+          onRemoveWatermark={() => {
+            window.open(REMOVE_WATERMARK_LINK, '_blank', 'noopener')
+          }}
+          onRestorePurchase={() => setRestoring(true)}
           canShare={
             !!exportState.result &&
             !!exportFilename &&
@@ -248,6 +258,17 @@ export function ProjectPage() {
           }}
           onRetry={startExport}
           onClose={closeExport}
+        />
+      ) : null}
+
+      {restoring ? (
+        <RestoreSheet
+          onClose={() => setRestoring(false)}
+          onRestored={() => {
+            setRestoring(false)
+            showToast('Purchase restored — new exports are watermark-free')
+            refresh()
+          }}
         />
       ) : null}
 

--- a/src/pages/project-page.tsx
+++ b/src/pages/project-page.tsx
@@ -38,6 +38,8 @@ interface ExportUiState {
   result: ExportResult | null
   error: string | null
   notice: string | null
+  /** Whether THIS export was stamped (entitlement can change mid-sheet). */
+  watermarked: boolean
 }
 
 export async function projectLoader({ params }: LoaderFunctionArgs): Promise<ProjectLoaderData> {
@@ -107,12 +109,20 @@ export function ProjectPage() {
       audioContext = undefined
     }
 
-    setExportState({ status: 'exporting', progress: 0, result: null, error: null, notice: null })
+    const watermarked = !data.watermarkRemoved
+    setExportState({
+      status: 'exporting',
+      progress: 0,
+      result: null,
+      error: null,
+      notice: null,
+      watermarked,
+    })
     void (async () => {
       try {
         const result = await exportProject(clips, {
           audioContext,
-          watermark: !data.watermarkRemoved,
+          watermark: watermarked,
           getPreviewCanvas: () => previewCanvasRef.current,
           onProgress: (ratio) => {
             if (exportRunRef.current !== runId) return
@@ -124,7 +134,14 @@ export function ProjectPage() {
           },
         })
         if (exportRunRef.current !== runId) return
-        setExportState({ status: 'ready', progress: 1, result, error: null, notice: null })
+        setExportState({
+          status: 'ready',
+          progress: 1,
+          result,
+          error: null,
+          notice: null,
+          watermarked,
+        })
       } catch (err) {
         if (exportRunRef.current !== runId) return
         setExportState({
@@ -133,6 +150,7 @@ export function ProjectPage() {
           result: null,
           error: err instanceof Error ? err.message : 'Export failed.',
           notice: null,
+          watermarked,
         })
       } finally {
         // The realtime engine closes the context it used; when WebCodecs
@@ -221,7 +239,8 @@ export function ProjectPage() {
           status={exportState.status}
           error={exportState.error}
           notice={exportState.notice}
-          watermarked={!data.watermarkRemoved}
+          watermarked={exportState.watermarked}
+          purchased={data.watermarkRemoved}
           onRemoveWatermark={() => {
             window.open(REMOVE_WATERMARK_LINK, '_blank', 'noopener')
           }}

--- a/src/pages/unlocked-page.tsx
+++ b/src/pages/unlocked-page.tsx
@@ -1,0 +1,51 @@
+import { Link, useLoaderData, type LoaderFunctionArgs } from 'react-router-dom'
+import { BrandMark } from '../components/brand-mark'
+import { verifyPurchaseSession, type VerifyResult } from '../lib/entitlement'
+
+/**
+ * Stripe's Payment Link redirects here after checkout with
+ * ?session_id={CHECKOUT_SESSION_ID}; the loader verifies it server-side and
+ * persists the entitlement before the page renders.
+ */
+export async function unlockedLoader({ request }: LoaderFunctionArgs): Promise<VerifyResult> {
+  const sessionId = new URL(request.url).searchParams.get('session_id')
+  if (!sessionId) {
+    return { unlocked: false, error: 'Missing checkout session. Use the link from your receipt.' }
+  }
+  return verifyPurchaseSession(sessionId)
+}
+
+export function UnlockedPage() {
+  const result = useLoaderData() as VerifyResult
+
+  return (
+    <div className="screen unlocked-screen">
+      <div className="unlocked-card">
+        <BrandMark size={110} className="export-celebrate-art" variant="share" />
+        {result.unlocked ? (
+          <>
+            <p className="eyebrow">Purchase verified</p>
+            <h1>Watermark removed! 🎉</h1>
+            <p className="muted">
+              Thank you for supporting Kody Video. Every export from this device is now
+              watermark-free. Keep your Stripe receipt email — its link restores the purchase on
+              another device.
+            </p>
+          </>
+        ) : (
+          <>
+            <p className="eyebrow">Verification failed</p>
+            <h1>Hmm, that didn’t check out</h1>
+            <p className="muted">
+              {result.error ?? 'Could not verify this purchase.'} If you paid and keep seeing
+              this, retry from the link in your Stripe receipt email.
+            </p>
+          </>
+        )}
+        <Link className="btn btn-primary" to="/">
+          {result.unlocked ? 'Start creating' : 'Back to Kody Video'}
+        </Link>
+      </div>
+    </div>
+  )
+}

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -1,6 +1,7 @@
 import { Navigate, createBrowserRouter } from 'react-router-dom'
 import { HomePage, homeLoader } from './pages/home-page'
 import { ProjectPage, projectLoader } from './pages/project-page'
+import { UnlockedPage, unlockedLoader } from './pages/unlocked-page'
 
 export const router = createBrowserRouter([
   {
@@ -12,6 +13,11 @@ export const router = createBrowserRouter([
     path: '/project/:projectId',
     element: <ProjectPage />,
     loader: projectLoader,
+  },
+  {
+    path: '/unlocked',
+    element: <UnlockedPage />,
+    loader: unlockedLoader,
   },
   {
     path: '*',

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -365,6 +365,53 @@ a {
   font-size: 0.9rem;
 }
 
+.watermark-note {
+  margin: 14px 0 0;
+  font-size: 0.85rem;
+  color: var(--ink-muted);
+  line-height: 1.5;
+}
+
+.link-button {
+  padding: 0;
+  color: var(--accent);
+  font-weight: 700;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+/* Post-checkout landing (/unlocked) */
+.unlocked-screen {
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+}
+
+.unlocked-card {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
+  max-width: 340px;
+}
+
+.unlocked-card h1 {
+  font-family: var(--font-display);
+  font-size: 1.9rem;
+  letter-spacing: -0.03em;
+  margin: 0;
+}
+
+.unlocked-card p {
+  line-height: 1.5;
+  margin: 0;
+}
+
+.unlocked-card .btn {
+  margin-top: 12px;
+  min-width: 220px;
+}
+
 .export-celebrate-art {
   display: block;
   margin: 0 auto 10px;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

OK Video-style monetization: exports now carry a small Kody Video mark bottom-right, removable with a **one-time $0.99 purchase** — with a built-in free-access path for the developer and friends.

## How it works

- **Watermark**: both export engines stamp the rounded Kody mark (12% of the short edge, 78% alpha) on every frame; the live export preview shows it. Verified present in a real exported file.
- **Purchase**: the export ready-sheet shows "Remove it — $0.99" → Stripe Payment Link (`buy.stripe.com/00wfZi71ibU30rk9hU2Ry07`). Stripe redirects to `/unlocked?session_id={CHECKOUT_SESSION_ID}`, whose route loader verifies the session **server-side** via a new Cloudflare Pages Function (`functions/api/verify-purchase.ts`: checks `status=complete`, `payment_status ∈ {paid, no_payment_required}`, and that the session belongs to our payment link). On success the entitlement persists in the IndexedDB settings row and a celebration page confirms.
- **Free access**: the link accepts promotion codes; the 100%-off code **KODYFRIEND** checks out at $0 and completes with `no_payment_required` — flowing through the *exact same* verification. Revocable and auditable in the Stripe dashboard.
- **Restore**: "Already paid?" opens a sheet that accepts the Stripe receipt link / session id and re-verifies on a new device.
- The app stays account-less and tracking-free; the verification function never sees media. README documents the flow.

## ⚠️ One manual deploy step

Set **`STRIPE_SECRET_KEY`** on the Cloudflare Pages project (Settings → Environment variables) — a **restricted key** with *Checkout Sessions: Read* is sufficient. Until then, verification returns a clear "not configured" error and the app degrades gracefully (watermark stays on).

## Verification

- 7 new unit tests for the Pages Function (paid, promo/no_payment_required, wrong payment link, unpaid/incomplete, malformed ids, missing config) — **22 unit tests total**.
- Smoke suite extended to **24/24**: upsell visible while locked → mocked `/unlocked` verification celebrates → subsequent export shows no upsell.
- Watermark visually confirmed in a frame extracted from a real Chrome export.
- `npm run lint`, `npm run build` green.

![Watermarked export frame](https://cursor.com/artifacts/c/art-c2ddb298-0c2b-4c46-b16c-7181df08baca)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-16d17496-6b5b-4e12-b600-6933357c2059"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-16d17496-6b5b-4e12-b600-6933357c2059"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a small watermark to exported videos.
  * Added a one-time $0.99 purchase option to remove the watermark.
  * Added checkout confirmation and an unlocked success page.
  * Added purchase restoration using a receipt link on another device.
  * Updated export controls to show watermark status and available actions.

* **Documentation**
  * Documented the purchase, restoration, deployment, and privacy flows.

* **Tests**
  * Added automated and manual checks for purchasing, restoration, and watermark-free exports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->