### PR TITLE
Add About page: open-source repo link and OK Video shout-out

### DIFF
--- a/scripts/manual-smoke.mjs
+++ b/scripts/manual-smoke.mjs
@@ -293,6 +293,19 @@ try {
   await shot(page, '08-playback')
   await page.getByRole('button', { name: /stop preview/i }).click()
 
+  // --- About page: open-source + OK Video credits ---
+  await page.goto(BASE, { waitUntil: 'networkidle' })
+  await page.getByRole('link', { name: /^about$/i }).click()
+  await page.waitForURL(/\/about/, { timeout: 5000 })
+  await page.waitForSelector('.about-section', { timeout: 5000 }).catch(() => undefined)
+  const repoLink = await page
+    .locator('a[href="https://github.com/kentcdodds/kody-video"]')
+    .count()
+  const okVideoLink = await page.locator('a[href="https://okvideo.app"]').count()
+  if (repoLink > 0 && okVideoLink > 0) pass('about page links repo and OK Video')
+  else fail('about page links repo and OK Video', `repo=${repoLink} okvideo=${okVideoLink}`)
+  await shot(page, '11-about')
+
   // --- Persistence / offline / SPA fallback ---
   await page.goto(BASE, { waitUntil: 'networkidle' })
   const filled = await page.locator('.project-slot.filled').count()

--- a/src/pages/about-page.tsx
+++ b/src/pages/about-page.tsx
@@ -1,0 +1,75 @@
+import { Link } from 'react-router-dom'
+import { BrandMark } from '../components/brand-mark'
+
+/** Credits, inspiration, and the open-source pointer. */
+export function AboutPage() {
+  return (
+    <div className="screen about-screen">
+      <div className="about-top">
+        <Link to="/" className="btn-icon" aria-label="Back to projects">
+          ←
+        </Link>
+        <strong>About</strong>
+        <span className="about-top-spacer" aria-hidden="true" />
+      </div>
+
+      <div className="about-body">
+        <div className="about-hero" aria-hidden="true">
+          <BrandMark size={96} className="brand-hero-art" variant="icon" />
+        </div>
+        <h1>
+          Kody <span>Video</span>
+        </h1>
+
+        <section className="about-section">
+          <h2>Free &amp; open source</h2>
+          <p>
+            Kody Video is open source — the whole app, including the export engine, lives at{' '}
+            <a
+              href="https://github.com/kentcdodds/kody-video"
+              target="_blank"
+              rel="noreferrer noopener"
+            >
+              github.com/kentcdodds/kody-video
+            </a>
+            . Issues, ideas, and pull requests are welcome.
+          </p>
+        </section>
+
+        <section className="about-section">
+          <h2>Inspired by OK Video</h2>
+          <p>
+            This app exists because of{' '}
+            <a href="https://okvideo.app" target="_blank" rel="noreferrer noopener">
+              OK Video
+            </a>{' '}
+            by Pim Coumans — a wonderful hold-to-record clips camera for iPhone and a heavy source
+            of inspiration for Kody Video&rsquo;s whole interaction model. If you&rsquo;re on iOS,
+            go get the real thing. Kody Video is an independent project and is not affiliated with
+            OK Video.
+          </p>
+        </section>
+
+        <section className="about-section">
+          <h2>Kody the koala</h2>
+          <p>
+            The mascot comes from the KCD community —{' '}
+            <a href="https://kentcdodds.com/kody" target="_blank" rel="noreferrer noopener">
+              kentcdodds.com/kody
+            </a>
+            .
+          </p>
+        </section>
+
+        <section className="about-section">
+          <h2>Private by design</h2>
+          <p>
+            No accounts, no analytics, no uploads. Clips live in this browser&rsquo;s storage until
+            you export and share them yourself. The only network calls are Stripe checkout and its
+            purchase verification if you buy the watermark removal.
+          </p>
+        </section>
+      </div>
+    </div>
+  )
+}

--- a/src/pages/home-page.tsx
+++ b/src/pages/home-page.tsx
@@ -114,7 +114,9 @@ export function HomePage() {
         )}
       </section>
 
-      <p className="home-privacy">Clips stay on this phone until you share.</p>
+      <p className="home-privacy">
+        Clips stay on this phone until you share. <Link to="/about">About</Link>
+      </p>
 
       <div className="home-footer">
         <button

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -1,4 +1,5 @@
 import { Navigate, createBrowserRouter } from 'react-router-dom'
+import { AboutPage } from './pages/about-page'
 import { HomePage, homeLoader } from './pages/home-page'
 import { ProjectPage, projectLoader } from './pages/project-page'
 import { UnlockedPage, unlockedLoader } from './pages/unlocked-page'
@@ -18,6 +19,10 @@ export const router = createBrowserRouter([
     path: '/unlocked',
     element: <UnlockedPage />,
     loader: unlockedLoader,
+  },
+  {
+    path: '/about',
+    element: <AboutPage />,
   },
   {
     path: '*',

--- a/src/styles/home.css
+++ b/src/styles/home.css
@@ -288,6 +288,81 @@
   border-color: color-mix(in srgb, var(--danger) 36%, transparent);
 }
 
+.home-privacy a {
+  color: var(--accent);
+  font-weight: 600;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+/* About page */
+
+.about-top {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 4px;
+}
+
+.about-top strong {
+  font-family: var(--font-display);
+  font-size: 1.05rem;
+}
+
+.about-top-spacer {
+  width: var(--tap);
+}
+
+.about-body {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
+  padding-bottom: 16px;
+}
+
+.about-hero {
+  display: flex;
+  justify-content: center;
+  margin: 8px 0 6px;
+}
+
+.about-screen h1 {
+  font-family: var(--font-display);
+  font-size: 2rem;
+  letter-spacing: -0.03em;
+  text-align: center;
+  margin: 0 0 6px;
+}
+
+.about-screen h1 span {
+  color: var(--accent);
+}
+
+.about-section {
+  margin-top: 18px;
+}
+
+.about-section h2 {
+  font-family: var(--font-display);
+  font-size: 1.15rem;
+  margin: 0 0 6px;
+}
+
+.about-section p {
+  margin: 0;
+  color: var(--ink-muted);
+  line-height: 1.55;
+}
+
+.about-section a {
+  color: var(--accent);
+  font-weight: 600;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
 /* Onboarding */
 
 .onboarding-overlay {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

New `/about` page, linked from an "About" link next to the home screen's privacy note:

- **Free & open source** — links straight to [github.com/kentcdodds/kody-video](https://github.com/kentcdodds/kody-video)
- **Inspired by OK Video** — a proper shout-out to [okvideo.app](https://okvideo.app) by Pim Coumans as the heavy source of inspiration for the whole interaction model, with a nudge for iOS folks to get the real thing, and a not-affiliated note
- **Kody the koala** — mascot credit to [kentcdodds.com/kody](https://kentcdodds.com/kody)
- **Private by design** — restates the privacy stance (incl. the Stripe purchase being the only network calls)

## Verification

`npm run lint`, `npm test` (22), `npm run build` green; smoke suite extended with an About check — **25/25 passing**.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-16d17496-6b5b-4e12-b600-6933357c2059"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-16d17496-6b5b-4e12-b600-6933357c2059"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

