### PR TITLE
Storage meter with almost-full warnings; watermark shows domain at 50% opacity

### DIFF
--- a/manual-test-checklist.md
+++ b/manual-test-checklist.md
@@ -57,6 +57,12 @@ Run locally with HTTPS or `localhost` (`npm run dev`). Camera/mic require a secu
 - [ ] Airplane mode after first visit still loads the app shell (PWA/service worker)
 - [ ] Offline, existing projects open and clips play from IndexedDB
 
+## Storage
+- [ ] Home shows "X of Y used" in the footer line
+- [ ] ≥80% full: amber banner on home with delete-a-project guidance; pill on the record screen
+- [ ] ≥92% full: banner/pill turn red; starting a recording shows a warning toast
+- [ ] Watermark (before purchase) shows the mark + domain at 50% opacity
+
 ## Projects
 - [ ] Create up to 6 projects; 7th is blocked with clear UX
 - [ ] Slot order is stable (does not shuffle after opening projects)

--- a/scripts/manual-smoke.mjs
+++ b/scripts/manual-smoke.mjs
@@ -332,6 +332,27 @@ try {
   if (backHome) pass('unknown project redirects home')
   else fail('unknown project redirects home')
 
+  // --- Storage warning (stubbed estimate: 93% full) ---
+  const stubbed = await context.newPage()
+  await stubbed.addInitScript(() => {
+    navigator.storage.estimate = async () => ({
+      usage: 9.3 * 1024 ** 3,
+      quota: 10 * 1024 ** 3,
+    })
+  })
+  await stubbed.goto(BASE, { waitUntil: 'networkidle' })
+  const bannerText = await stubbed
+    .locator('.storage-banner.is-critical')
+    .innerText()
+    .catch(() => '')
+  if (/93% full/.test(bannerText) && /delete an old project/i.test(bannerText)) {
+    pass('storage warning appears when nearly full')
+  } else {
+    fail('storage warning appears when nearly full', bannerText.slice(0, 80))
+  }
+  await shot(stubbed, '12-storage-warning')
+  await stubbed.close()
+
   const realErrors = pageErrors.filter(
     (err) =>
       !/service worker|workbox|manifest|favicon|fonts\.googleapis|fonts\.gstatic|net::ERR_INTERNET_DISCONNECTED/i.test(

--- a/src/components/record-screen.tsx
+++ b/src/components/record-screen.tsx
@@ -3,6 +3,11 @@ import { Link } from 'react-router-dom'
 import type { CameraZoomRange, UseCameraResult } from '../hooks/use-camera'
 import { appendRecording, removeClip, undoLastDelete } from '../lib/project-actions'
 import { HoldRecorder } from '../lib/recorder'
+import {
+  formatStoragePercent,
+  storageSeverity,
+  type StorageSpace,
+} from '../lib/storage-space'
 import { effectiveDurationMs, formatDuration, type ClipRecord, type Project } from '../lib/types'
 import {
   IconBack,
@@ -26,6 +31,8 @@ interface RecordScreenProps {
   project: Project
   clips: ClipRecord[]
   camera: UseCameraResult
+  /** Device storage estimate for the almost-full warning. */
+  storage: StorageSpace | null
   /** True while an overlay (export, preview, onboarding) should block capture. */
   interactionLocked: boolean
   onOpenEditor: () => void
@@ -78,6 +85,7 @@ export function RecordScreen({
   project,
   clips,
   camera,
+  storage,
   interactionLocked,
   onOpenEditor,
   onOpenExport,
@@ -85,6 +93,7 @@ export function RecordScreen({
   showToast,
   refresh,
 }: RecordScreenProps) {
+  const storageState = storage ? storageSeverity(storage.ratio) : 'ok'
   const recorderRef = useRef(new HoldRecorder())
   const pointerIdRef = useRef<number | null>(null)
   const beginInFlightRef = useRef(false)
@@ -225,6 +234,9 @@ export function RecordScreen({
         setRecording(true)
         setRecordingMode(nextRecordingMode)
         setRecordStartedAt(performance.now())
+        if (storageState === 'critical') {
+          showToast('Storage almost full — delete an old project soon')
+        }
         return true
       } catch (err) {
         if (!recorderRef.current.isRecording) camera.releaseMic()
@@ -236,7 +248,7 @@ export function RecordScreen({
         beginInFlightRef.current = false
       }
     },
-    [acquireWakeLock, camera, countdown, recording, showToast],
+    [acquireWakeLock, camera, countdown, recording, showToast, storageState],
   )
 
   const endRecord = useCallback(
@@ -533,6 +545,15 @@ export function RecordScreen({
         <div className="record-meta">
           <strong>{project.name}</strong>
           <span className="record-total">{formatDuration(totalDurationMs)}</span>
+          {storage && storageState !== 'ok' && !recording ? (
+            <Link
+              to="/"
+              className={`storage-pill${storageState === 'critical' ? ' is-critical' : ''}`}
+              aria-label="Device storage almost full — manage projects"
+            >
+              Storage {formatStoragePercent(storage.ratio)} full
+            </Link>
+          ) : null}
         </div>
         <div className="record-top-actions">
           {camera.torchAvailable ? (

--- a/src/lib/export/shared.ts
+++ b/src/lib/export/shared.ts
@@ -179,25 +179,47 @@ export function loadWatermarkImage(): Promise<HTMLImageElement | null> {
   })
 }
 
-/** Stamp the Kody Video mark in the bottom-right corner of a frame. */
+/** The domain shown next to the watermark mark. */
+export function watermarkDomain(): string {
+  const host = typeof location !== 'undefined' ? location.hostname : ''
+  // Dev servers and IPs shouldn't end up stamped on anyone's video.
+  if (!host || host === 'localhost' || /^[\d.]+$/.test(host)) {
+    return 'kody-video.pages.dev'
+  }
+  return host
+}
+
+/** Stamp the Kody Video mark + domain in the bottom-right corner of a frame. */
 export function drawWatermark(
   ctx: CanvasRenderingContext2D,
   image: HTMLImageElement,
   width: number,
   height: number,
 ): void {
-  const size = Math.round(Math.min(width, height) * 0.12)
-  const margin = Math.round(size * 0.3)
+  const size = Math.round(Math.min(width, height) * 0.11)
+  const margin = Math.round(size * 0.35)
   const x = width - size - margin
   const y = height - size - margin
   const radius = Math.round(size * 0.22)
 
   ctx.save()
-  ctx.globalAlpha = 0.78
+  ctx.globalAlpha = 0.5
+
+  ctx.save()
   ctx.beginPath()
   ctx.roundRect(x, y, size, size, radius)
   ctx.clip()
   ctx.drawImage(image, x, y, size, size)
+  ctx.restore()
+
+  ctx.font = `600 ${Math.max(10, Math.round(size * 0.38))}px 'DM Sans', system-ui, sans-serif`
+  ctx.textAlign = 'right'
+  ctx.textBaseline = 'middle'
+  ctx.fillStyle = '#fff'
+  ctx.shadowColor = 'rgba(0, 0, 0, 0.6)'
+  ctx.shadowBlur = Math.round(size * 0.12)
+  ctx.fillText(watermarkDomain(), x - Math.round(size * 0.22), y + Math.round(size / 2))
+
   ctx.restore()
 }
 

--- a/src/lib/project-actions.ts
+++ b/src/lib/project-actions.ts
@@ -13,6 +13,7 @@ import {
   undoDeleteLastClip,
   updateClipTrim,
 } from './storage'
+import { estimateStorageSpace, type StorageSpace } from './storage-space'
 import { ensureClipThumbs } from './thumbs'
 import {
   effectiveDurationMs,
@@ -36,7 +37,19 @@ export interface ProjectLoaderData {
   onboardingDismissed: boolean
   /** True when the one-time "Remove Watermark" purchase is unlocked. */
   watermarkRemoved: boolean
+  /** Device storage estimate (null when the API is unavailable). */
+  storage: StorageSpace | null
   error: string | null
+}
+
+export interface HomeLoaderData {
+  projects: ProjectSummary[]
+  storage: StorageSpace | null
+}
+
+export async function loadHomePage(): Promise<HomeLoaderData> {
+  const [projects, storage] = await Promise.all([loadHomeProjects(), estimateStorageSpace()])
+  return { projects, storage }
 }
 
 export async function loadHomeProjects(): Promise<ProjectSummary[]> {
@@ -61,11 +74,12 @@ export async function loadHomeProjects(): Promise<ProjectSummary[]> {
 
 export async function loadProjectPage(projectId: ProjectId): Promise<ProjectLoaderData> {
   try {
-    const [project, clips, undo, settings] = await Promise.all([
+    const [project, clips, undo, settings, storage] = await Promise.all([
       getProject(projectId),
       getClipsForProject(projectId),
       getUndoSnapshot(projectId),
       getSettings(),
+      estimateStorageSpace(),
     ])
     if (!project) {
       return {
@@ -74,6 +88,7 @@ export async function loadProjectPage(projectId: ProjectId): Promise<ProjectLoad
         canUndo: false,
         onboardingDismissed: settings.onboardingDismissed,
         watermarkRemoved: settings.watermarkRemoved === true,
+        storage,
         error: 'Project not found',
       }
     }
@@ -91,6 +106,7 @@ export async function loadProjectPage(projectId: ProjectId): Promise<ProjectLoad
       canUndo: !!undo,
       onboardingDismissed: settings.onboardingDismissed,
       watermarkRemoved: settings.watermarkRemoved === true,
+      storage,
       error: null,
     }
   } catch (err) {
@@ -100,6 +116,7 @@ export async function loadProjectPage(projectId: ProjectId): Promise<ProjectLoad
       canUndo: false,
       onboardingDismissed: true,
       watermarkRemoved: false,
+      storage: null,
       error: err instanceof Error ? err.message : 'Failed to load project',
     }
   }

--- a/src/lib/storage-space.test.ts
+++ b/src/lib/storage-space.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest'
+import { formatBytes, formatStoragePercent, storageSeverity } from './storage-space'
+
+describe('storageSeverity', () => {
+  it('is ok below 80%', () => {
+    expect(storageSeverity(0)).toBe('ok')
+    expect(storageSeverity(0.79)).toBe('ok')
+  })
+
+  it('warns from 80%', () => {
+    expect(storageSeverity(0.8)).toBe('warning')
+    expect(storageSeverity(0.91)).toBe('warning')
+  })
+
+  it('is critical from 92%', () => {
+    expect(storageSeverity(0.92)).toBe('critical')
+    expect(storageSeverity(1)).toBe('critical')
+  })
+})
+
+describe('formatBytes', () => {
+  it('formats megabytes below 1GB', () => {
+    expect(formatBytes(500 * 1024 * 1024)).toBe('500 MB')
+    expect(formatBytes(1024)).toBe('1 MB')
+  })
+
+  it('formats gigabytes with one decimal under 10GB', () => {
+    expect(formatBytes(1.25 * 1024 * 1024 * 1024)).toBe('1.3 GB')
+    expect(formatBytes(12 * 1024 * 1024 * 1024)).toBe('12 GB')
+  })
+
+  it('handles nonsense input', () => {
+    expect(formatBytes(-5)).toBe('0 MB')
+    expect(formatBytes(Number.NaN)).toBe('0 MB')
+  })
+})
+
+describe('formatStoragePercent', () => {
+  it('rounds to whole percent', () => {
+    expect(formatStoragePercent(0.876)).toBe('88%')
+  })
+})

--- a/src/lib/storage-space.test.ts
+++ b/src/lib/storage-space.test.ts
@@ -29,7 +29,8 @@ describe('formatBytes', () => {
     expect(formatBytes(12 * 1024 * 1024 * 1024)).toBe('12 GB')
   })
 
-  it('handles nonsense input', () => {
+  it('handles zero and nonsense input', () => {
+    expect(formatBytes(0)).toBe('0 MB')
     expect(formatBytes(-5)).toBe('0 MB')
     expect(formatBytes(Number.NaN)).toBe('0 MB')
   })

--- a/src/lib/storage-space.ts
+++ b/src/lib/storage-space.ts
@@ -1,0 +1,42 @@
+/** Device storage awareness: clips are big, quotas are finite. */
+
+export interface StorageSpace {
+  usedBytes: number
+  quotaBytes: number
+  /** 0..1 share of the quota already used. */
+  ratio: number
+}
+
+export type StorageSeverity = 'ok' | 'warning' | 'critical'
+
+export async function estimateStorageSpace(): Promise<StorageSpace | null> {
+  try {
+    if (!navigator.storage?.estimate) return null
+    const { usage, quota } = await navigator.storage.estimate()
+    if (!quota || quota <= 0) return null
+    const usedBytes = usage ?? 0
+    return { usedBytes, quotaBytes: quota, ratio: Math.min(1, usedBytes / quota) }
+  } catch {
+    return null
+  }
+}
+
+export function storageSeverity(ratio: number): StorageSeverity {
+  if (ratio >= 0.92) return 'critical'
+  if (ratio >= 0.8) return 'warning'
+  return 'ok'
+}
+
+export function formatBytes(bytes: number): string {
+  if (!Number.isFinite(bytes) || bytes < 0) return '0 MB'
+  const gb = bytes / (1024 * 1024 * 1024)
+  if (gb >= 1) {
+    return `${gb >= 10 ? Math.round(gb) : Math.round(gb * 10) / 10} GB`
+  }
+  const mb = bytes / (1024 * 1024)
+  return `${Math.max(1, Math.round(mb))} MB`
+}
+
+export function formatStoragePercent(ratio: number): string {
+  return `${Math.round(ratio * 100)}%`
+}

--- a/src/lib/storage-space.ts
+++ b/src/lib/storage-space.ts
@@ -28,7 +28,7 @@ export function storageSeverity(ratio: number): StorageSeverity {
 }
 
 export function formatBytes(bytes: number): string {
-  if (!Number.isFinite(bytes) || bytes < 0) return '0 MB'
+  if (!Number.isFinite(bytes) || bytes <= 0) return '0 MB'
   const gb = bytes / (1024 * 1024 * 1024)
   if (gb >= 1) {
     return `${gb >= 10 ? Math.round(gb) : Math.round(gb * 10) / 10} GB`

--- a/src/pages/home-page.tsx
+++ b/src/pages/home-page.tsx
@@ -6,16 +6,21 @@ import { ConfirmSheet } from '../components/confirm-sheet'
 import { HomeOptionsSheet } from '../components/home-options-sheet'
 import { IconMore, IconPlus } from '../components/icons'
 import { RenameSheet } from '../components/rename-sheet'
-import { loadHomeProjects, type ProjectSummary } from '../lib/project-actions'
+import { loadHomePage, type HomeLoaderData, type ProjectSummary } from '../lib/project-actions'
 import { createProject, deleteProject, renameProject } from '../lib/storage'
+import {
+  formatBytes,
+  formatStoragePercent,
+  storageSeverity,
+} from '../lib/storage-space'
 import { MAX_PROJECTS, formatDuration } from '../lib/types'
 
-export async function homeLoader(): Promise<ProjectSummary[]> {
-  return loadHomeProjects()
+export async function homeLoader(): Promise<HomeLoaderData> {
+  return loadHomePage()
 }
 
 export function HomePage() {
-  const projects = useLoaderData() as ProjectSummary[]
+  const { projects, storage } = useLoaderData() as HomeLoaderData
   const revalidator = useRevalidator()
   const navigate = useNavigate()
   const [error, setError] = useState<string | null>(null)
@@ -47,6 +52,8 @@ export function HomePage() {
 
   const slots = Array.from({ length: MAX_PROJECTS }, (_, index) => projects[index] ?? null)
   const atCap = projects.length >= MAX_PROJECTS
+  const severity = storage ? storageSeverity(storage.ratio) : 'ok'
+  const oldestProject = projects[0] ?? null
 
   return (
     <div className="screen home-screen">
@@ -61,6 +68,24 @@ export function HomePage() {
       </div>
 
       {error ? <div className="error-banner">{error}</div> : null}
+
+      {storage && severity !== 'ok' ? (
+        <div
+          className={`storage-banner${severity === 'critical' ? ' is-critical' : ''}`}
+          role="alert"
+        >
+          <strong>
+            Device storage {formatStoragePercent(storage.ratio)} full
+            {severity === 'critical' ? ' — recordings may start failing' : ''}
+          </strong>
+          <span>
+            {formatBytes(storage.usedBytes)} of {formatBytes(storage.quotaBytes)} used.
+            {oldestProject
+              ? ` Free space fast: delete an old project (⋯ on “${oldestProject.name}”, then Delete).`
+              : ' Free space by clearing other site data or files on this device.'}
+          </span>
+        </div>
+      ) : null}
 
       <section className="project-slots" aria-label="Kody Video projects">
         {slots.map((project, index) =>
@@ -115,7 +140,9 @@ export function HomePage() {
       </section>
 
       <p className="home-privacy">
-        Clips stay on this phone until you share. <Link to="/about">About</Link>
+        Clips stay on this phone until you share.
+        {storage ? ` ${formatBytes(storage.usedBytes)} of ${formatBytes(storage.quotaBytes)} used.` : ''}{' '}
+        <Link to="/about">About</Link>
       </p>
 
       <div className="home-footer">

--- a/src/pages/project-page.tsx
+++ b/src/pages/project-page.tsx
@@ -51,6 +51,7 @@ export async function projectLoader({ params }: LoaderFunctionArgs): Promise<Pro
       canUndo: false,
       onboardingDismissed: true,
       watermarkRemoved: false,
+      storage: null,
       error: 'Project not found',
     }
   }
@@ -204,6 +205,7 @@ export function ProjectPage() {
           project={project}
           clips={clips}
           camera={camera}
+          storage={data.storage}
           interactionLocked={overlayOpen}
           onOpenEditor={() => setMode('editor')}
           onOpenExport={startExport}

--- a/src/styles/home.css
+++ b/src/styles/home.css
@@ -288,6 +288,28 @@
   border-color: color-mix(in srgb, var(--danger) 36%, transparent);
 }
 
+.storage-banner {
+  margin-top: 12px;
+  padding: 12px 14px;
+  border-radius: 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  background: color-mix(in srgb, #e0a63a 16%, transparent);
+  border: 1px solid color-mix(in srgb, #e0a63a 45%, transparent);
+  font-size: 0.9rem;
+  line-height: 1.4;
+}
+
+.storage-banner span {
+  color: var(--ink-muted);
+}
+
+.storage-banner.is-critical {
+  background: color-mix(in srgb, var(--danger) 14%, transparent);
+  border-color: color-mix(in srgb, var(--danger) 45%, transparent);
+}
+
 .home-privacy a {
   color: var(--accent);
   font-weight: 600;

--- a/src/styles/record.css
+++ b/src/styles/record.css
@@ -117,6 +117,23 @@
   color: #fff;
 }
 
+.storage-pill {
+  margin-top: 4px;
+  padding: 3px 10px;
+  border-radius: 999px;
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  color: #1a1206;
+  background: #e8b64c;
+  border: 1px solid rgba(0, 0, 0, 0.2);
+}
+
+.storage-pill.is-critical {
+  color: #fff;
+  background: var(--danger);
+}
+
 .record-overlay {
   position: absolute;
   inset: 0;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Storage awareness

Clips are big and IndexedDB quotas are finite — the app now tells you where you stand and what to do about it, via `navigator.storage.estimate()`:

- **Home footer**: "9.3 GB of 10 GB used" always visible.
- **≥80% used**: amber banner on home — *"Device storage 84% full — X of Y used. Free space fast: delete an old project (⋯ on '{oldest project}', then Delete)."*
- **≥92%**: banner turns red ("recordings may start failing"), the record screen shows a red **Storage N% full** pill (tappable, links home where deletion lives), and starting a recording surfaces a warning toast.
- Thresholds/formatting unit-tested; smoke stubs a 93%-full device and asserts the banner.

![Critical storage banner](https://cursor.com/artifacts/c/art-eb680e87-9f2d-4a7c-bcc5-37a0a8b7bc1f)

## Watermark refinement

The export watermark is now the mark **plus the site domain** at **50% opacity** (was mark-only at 78%). The domain comes from `location.hostname` (with a `kody-video.pages.dev` fallback for dev/IP hosts), so when the custom domain lands it flows into exports automatically with zero code changes. Verified in a real exported frame:

![Watermarked frame with domain](https://cursor.com/artifacts/c/art-949759a2-3d30-472d-96ce-c4e070d7def3)

## Verification

`npm run lint` · `npm test` (30 tests) · `npm run build` — green; smoke **26/26**.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-16d17496-6b5b-4e12-b600-6933357c2059"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-16d17496-6b5b-4e12-b600-6933357c2059"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

