### PR TITLE
Project backup and import: move projects between devices and origins

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,9 @@ For a phone on the same network, use your machine’s LAN URL over HTTPS, or tun
 - Up to **6** stable project slots (create / open / rename / delete, poster art from your clips)
 - Big OK CTA: on-device export to **one video file**, then Share (system sheet) or Save
 - Fallback: save clips as separate files
+- Project **backup/import**: one `.kodyvideo` file per project (clips, trims,
+  location data) — a safety net, and the way to move a project between
+  devices or origins (e.g. kody-video.pages.dev → kody.video)
 - Installable PWA (manifest + Workbox service worker for the app shell)
 - **No accounts, no uploads, no analytics**
 

--- a/manual-test-checklist.md
+++ b/manual-test-checklist.md
@@ -76,3 +76,6 @@ Run locally with HTTPS or `localhost` (`npm run dev`). Camera/mic require a secu
 - [ ] Slots show poster art from the first clip
 - [ ] ⋯ menu: Open / Rename / Delete (styled confirm, no browser dialog)
 - [ ] Deleting a project frees its stored clips
+- [ ] ⋯ → Save backup produces a .kodyvideo file (share sheet on Android)
+- [ ] Import on another domain/device restores the project with clips, trims, and geo
+- [ ] Importing at the 6-project cap is blocked with a clear message

--- a/scripts/manual-smoke.mjs
+++ b/scripts/manual-smoke.mjs
@@ -340,6 +340,34 @@ try {
   if (filledAfterRefresh >= 1) pass('hard refresh restores projects', `${filledAfterRefresh} filled`)
   else fail('hard refresh restores projects', `${filledAfterRefresh} filled`)
 
+  // --- Project backup round trip (backup → import as new project) ---
+  const filledBefore = await page.locator('.project-slot.filled').count()
+  await page.getByRole('button', { name: /^options for/i }).first().click()
+  const downloadPromise = page.waitForEvent('download', { timeout: 10000 })
+  await page.getByRole('button', { name: /save backup/i }).click()
+  const download = await downloadPromise.catch(() => null)
+  if (download && download.suggestedFilename().endsWith('.kodyvideo')) {
+    pass('project backup downloads', download.suggestedFilename())
+  } else {
+    fail('project backup downloads')
+  }
+  if (download) {
+    const backupPath = await download.path()
+    await page.locator('.home-import input[type=file]').setInputFiles(backupPath)
+    const imported = await page
+      .waitForFunction(
+        (before) => document.querySelectorAll('.project-slot.filled').length > before,
+        filledBefore,
+        { timeout: 10000 },
+      )
+      .then(() => true)
+      .catch(() => false)
+    if (imported) pass('backup imports as a new project')
+    else fail('backup imports as a new project')
+  } else {
+    fail('backup imports as a new project', 'no backup file to import')
+  }
+
   await page.goto(BASE, { waitUntil: 'networkidle' })
   await sleep(1000)
   await context.setOffline(true)

--- a/src/components/home-options-sheet.tsx
+++ b/src/components/home-options-sheet.tsx
@@ -2,15 +2,17 @@ interface HomeOptionsSheetProps {
   projectName: string
   onOpen: () => void
   onRename: () => void
+  onBackup: () => void
   onDelete: () => void
   onClose: () => void
 }
 
-/** Bottom sheet with Open / Rename / Delete for a filled project slot. */
+/** Bottom sheet with Open / Rename / Backup / Delete for a filled project slot. */
 export function HomeOptionsSheet({
   projectName,
   onOpen,
   onRename,
+  onBackup,
   onDelete,
   onClose,
 }: HomeOptionsSheetProps) {
@@ -26,6 +28,9 @@ export function HomeOptionsSheet({
           </button>
           <button type="button" className="home-option-btn" onClick={onRename}>
             Rename
+          </button>
+          <button type="button" className="home-option-btn" onClick={onBackup}>
+            Save backup
           </button>
           <button type="button" className="home-option-btn home-option-danger" onClick={onDelete}>
             Delete

--- a/src/lib/project-transfer.test.ts
+++ b/src/lib/project-transfer.test.ts
@@ -1,0 +1,82 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import {
+  importProjectBackup,
+  parseProjectBackup,
+  projectBackupFilename,
+  serializeProject,
+} from './project-transfer'
+import { __resetDbForTests, getClipsForProject, listProjects } from './storage'
+import type { ClipRecord, Project } from './types'
+
+function fakeProject(name = 'Road Trip'): Project {
+  return { id: 'proj_x', name, createdAt: 1, updatedAt: 2, clipIds: ['clip_a', 'clip_b'] }
+}
+
+function fakeClip(id: string, content: string, extra: Partial<ClipRecord> = {}): ClipRecord {
+  return {
+    id,
+    projectId: 'proj_x',
+    blob: new Blob([content], { type: 'video/mp4' }),
+    mimeType: 'video/mp4',
+    durationMs: 1500,
+    trimStartMs: 100,
+    trimEndMs: 1200,
+    createdAt: 1700000000000,
+    lat: 40.2338,
+    lng: -111.6585,
+    locationAccuracyM: 12,
+    ...extra,
+  }
+}
+
+describe('project backup round trip', () => {
+  beforeEach(async () => {
+    await __resetDbForTests()
+  })
+
+  it('serializes and parses a project faithfully', async () => {
+    const clips = [fakeClip('clip_a', 'AAAA'), fakeClip('clip_b', 'BBBBBBBB', { lat: undefined, lng: undefined })]
+    const backup = serializeProject(fakeProject(), clips)
+
+    const parsed = await parseProjectBackup(backup)
+    expect(parsed.projectName).toBe('Road Trip')
+    expect(parsed.clips).toHaveLength(2)
+    expect(parsed.clips[0].trimStartMs).toBe(100)
+    expect(parsed.clips[0].trimEndMs).toBe(1200)
+    expect(parsed.clips[0].lat).toBe(40.2338)
+    expect(parsed.clips[1].lat).toBeUndefined()
+    expect(await parsed.clips[0].blob.text()).toBe('AAAA')
+    expect(await parsed.clips[1].blob.text()).toBe('BBBBBBBB')
+    expect(parsed.clips[0].blob.type).toBe('video/mp4')
+  })
+
+  it('imports a backup as a fresh project with trims and geo intact', async () => {
+    const backup = serializeProject(fakeProject('Moved'), [fakeClip('clip_a', 'MEDIA')])
+    const parsed = await parseProjectBackup(backup)
+    const project = await importProjectBackup(parsed)
+
+    const projects = await listProjects()
+    expect(projects.map((p) => p.id)).toContain(project.id)
+    const clips = await getClipsForProject(project.id)
+    expect(clips).toHaveLength(1)
+    expect(clips[0].trimStartMs).toBe(100)
+    expect(clips[0].trimEndMs).toBe(1200)
+    expect(clips[0].lat).toBe(40.2338)
+    expect(await clips[0].blob.text()).toBe('MEDIA')
+  })
+
+  it('rejects non-backup files', async () => {
+    await expect(parseProjectBackup(new Blob(['just a video']))).rejects.toThrow(/not a kody video/i)
+  })
+
+  it('rejects truncated backups', async () => {
+    const backup = serializeProject(fakeProject(), [fakeClip('clip_a', 'AAAAAAAAAA')])
+    const truncated = backup.slice(0, backup.size - 4)
+    await expect(parseProjectBackup(truncated)).rejects.toThrow(/damaged/i)
+  })
+
+  it('builds a sensible filename', () => {
+    expect(projectBackupFilename('Röad Trip!!')).toBe('r-ad-trip.kodyvideo')
+    expect(projectBackupFilename('   ')).toBe('project.kodyvideo')
+  })
+})

--- a/src/lib/project-transfer.test.ts
+++ b/src/lib/project-transfer.test.ts
@@ -62,7 +62,19 @@ describe('project backup round trip', () => {
     expect(clips[0].trimStartMs).toBe(100)
     expect(clips[0].trimEndMs).toBe(1200)
     expect(clips[0].lat).toBe(40.2338)
+    expect(clips[0].createdAt).toBe(1700000000000)
     expect(await clips[0].blob.text()).toBe('MEDIA')
+  })
+
+  it('rolls back the project when an import fails midway', async () => {
+    const backup = serializeProject(fakeProject('Broken'), [fakeClip('clip_a', 'MEDIA')])
+    const parsed = await parseProjectBackup(backup)
+    // Corrupt one clip so addClip's trim restore blows up deterministically.
+    parsed.clips[0].trimStartMs = Number.NaN
+
+    await expect(importProjectBackup(parsed)).rejects.toThrow()
+    const projects = await listProjects()
+    expect(projects.map((p) => p.name)).not.toContain('Broken')
   })
 
   it('rejects non-backup files', async () => {

--- a/src/lib/project-transfer.ts
+++ b/src/lib/project-transfer.ts
@@ -124,8 +124,9 @@ export async function parseProjectBackup(file: Blob): Promise<ParsedBackup> {
     ) {
       throw new Error('This backup file is damaged')
     }
+    const mimeType = typeof clip.mimeType === 'string' ? clip.mimeType : 'video/webm'
     clips.push({
-      mimeType: typeof clip.mimeType === 'string' ? clip.mimeType : 'video/webm',
+      mimeType,
       durationMs: clip.durationMs,
       trimStartMs: clip.trimStartMs,
       trimEndMs: clip.trimEndMs,
@@ -135,7 +136,7 @@ export async function parseProjectBackup(file: Blob): Promise<ParsedBackup> {
       lat: clip.lat,
       lng: clip.lng,
       locationAccuracyM: clip.locationAccuracyM,
-      blob: file.slice(offset, offset + clip.byteLength, clip.mimeType),
+      blob: file.slice(offset, offset + clip.byteLength, mimeType),
     })
     offset += clip.byteLength
   }

--- a/src/lib/project-transfer.ts
+++ b/src/lib/project-transfer.ts
@@ -1,4 +1,4 @@
-import { addClip, createProject, updateClipTrim } from './storage'
+import { addClip, createProject, deleteProject, updateClipTrim } from './storage'
 import type { ClipRecord, Project } from './types'
 
 /**
@@ -143,23 +143,43 @@ export async function parseProjectBackup(file: Blob): Promise<ParsedBackup> {
   return { projectName: String(manifest.projectName || 'Imported project'), clips }
 }
 
+function assertImportableClip(clip: ParsedBackup['clips'][number]): void {
+  const finite =
+    Number.isFinite(clip.durationMs) &&
+    Number.isFinite(clip.trimStartMs) &&
+    Number.isFinite(clip.trimEndMs) &&
+    Number.isFinite(clip.createdAt)
+  if (!finite || clip.durationMs <= 0 || clip.blob.size <= 0) {
+    throw new Error('This backup file is damaged')
+  }
+}
+
 /** Create a fresh project (new ids) from a parsed backup. */
 export async function importProjectBackup(parsed: ParsedBackup): Promise<Project> {
   const project = await createProject(parsed.projectName)
-  for (const clip of parsed.clips) {
-    const added = await addClip({
-      projectId: project.id,
-      blob: clip.blob,
-      mimeType: clip.mimeType,
-      durationMs: clip.durationMs,
-      width: clip.width,
-      height: clip.height,
-      lat: clip.lat,
-      lng: clip.lng,
-      locationAccuracyM: clip.locationAccuracyM,
-    })
-    // Restore trims (addClip resets them to the full clip).
-    await updateClipTrim(added.id, clip.trimStartMs, clip.trimEndMs)
+  try {
+    for (const clip of parsed.clips) {
+      assertImportableClip(clip)
+      const added = await addClip({
+        projectId: project.id,
+        blob: clip.blob,
+        mimeType: clip.mimeType,
+        durationMs: clip.durationMs,
+        // Keep the original capture time so chapter titles stay truthful.
+        createdAt: clip.createdAt,
+        width: clip.width,
+        height: clip.height,
+        lat: clip.lat,
+        lng: clip.lng,
+        locationAccuracyM: clip.locationAccuracyM,
+      })
+      // Restore trims (addClip resets them to the full clip).
+      await updateClipTrim(added.id, clip.trimStartMs, clip.trimEndMs)
+    }
+    return project
+  } catch (error) {
+    // Never leave a half-imported project behind.
+    await deleteProject(project.id).catch(() => undefined)
+    throw error
   }
-  return project
 }

--- a/src/lib/project-transfer.ts
+++ b/src/lib/project-transfer.ts
@@ -1,0 +1,165 @@
+import { addClip, createProject, updateClipTrim } from './storage'
+import type { ClipRecord, Project } from './types'
+
+/**
+ * Single-file project backup, used both as a safety net and to move a
+ * project between origins (e.g. kody-video.pages.dev → kody.video, whose
+ * browser storage is separate).
+ *
+ * Format: `KODYVID1` magic, u32 big-endian JSON manifest length, UTF-8 JSON
+ * manifest, then every clip's media bytes concatenated in manifest order.
+ * Thumbnails are intentionally excluded — the loader regenerates them.
+ */
+const MAGIC = 'KODYVID1'
+const MAGIC_BYTES = new TextEncoder().encode(MAGIC)
+
+interface ManifestClip {
+  mimeType: string
+  durationMs: number
+  trimStartMs: number
+  trimEndMs: number
+  createdAt: number
+  width?: number
+  height?: number
+  lat?: number
+  lng?: number
+  locationAccuracyM?: number
+  /** Byte length of this clip's media in the blob section. */
+  byteLength: number
+}
+
+interface Manifest {
+  version: 1
+  app: 'kody-video'
+  exportedAt: number
+  projectName: string
+  clips: ManifestClip[]
+}
+
+export function projectBackupFilename(projectName: string): string {
+  const slug =
+    projectName
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/(^-|-$)/g, '')
+      .slice(0, 40) || 'project'
+  return `${slug}.kodyvideo`
+}
+
+/** Bundle a project into one shareable/downloadable backup Blob. */
+export function serializeProject(project: Project, clips: ClipRecord[]): Blob {
+  const manifest: Manifest = {
+    version: 1,
+    app: 'kody-video',
+    exportedAt: Date.now(),
+    projectName: project.name,
+    clips: clips.map((clip) => ({
+      mimeType: clip.mimeType,
+      durationMs: clip.durationMs,
+      trimStartMs: clip.trimStartMs,
+      trimEndMs: clip.trimEndMs,
+      createdAt: clip.createdAt,
+      width: clip.width,
+      height: clip.height,
+      lat: clip.lat,
+      lng: clip.lng,
+      locationAccuracyM: clip.locationAccuracyM,
+      byteLength: clip.blob.size,
+    })),
+  }
+
+  const manifestBytes = new TextEncoder().encode(JSON.stringify(manifest))
+  const header = new Uint8Array(MAGIC_BYTES.byteLength + 4)
+  header.set(MAGIC_BYTES, 0)
+  new DataView(header.buffer).setUint32(MAGIC_BYTES.byteLength, manifestBytes.byteLength)
+
+  // Blob composition references the clip blobs — nothing is copied here.
+  return new Blob([header, manifestBytes, ...clips.map((clip) => clip.blob)], {
+    type: 'application/octet-stream',
+  })
+}
+
+export interface ParsedBackup {
+  projectName: string
+  clips: Array<Omit<ManifestClip, 'byteLength'> & { blob: Blob }>
+}
+
+/**
+ * Parse a backup file. Media bytes are sliced lazily per clip (File.slice),
+ * so large backups never need the whole file in memory at once.
+ */
+export async function parseProjectBackup(file: Blob): Promise<ParsedBackup> {
+  const headerLength = MAGIC_BYTES.byteLength + 4
+  if (file.size < headerLength) throw new Error('Not a Kody Video backup file')
+
+  const header = new Uint8Array(await file.slice(0, headerLength).arrayBuffer())
+  for (let i = 0; i < MAGIC_BYTES.byteLength; i += 1) {
+    if (header[i] !== MAGIC_BYTES[i]) throw new Error('Not a Kody Video backup file')
+  }
+  const manifestLength = new DataView(header.buffer).getUint32(MAGIC_BYTES.byteLength)
+  if (manifestLength <= 0 || headerLength + manifestLength > file.size) {
+    throw new Error('This backup file is damaged')
+  }
+
+  let manifest: Manifest
+  try {
+    const manifestBytes = await file
+      .slice(headerLength, headerLength + manifestLength)
+      .arrayBuffer()
+    manifest = JSON.parse(new TextDecoder().decode(manifestBytes)) as Manifest
+  } catch {
+    throw new Error('This backup file is damaged')
+  }
+  if (manifest.app !== 'kody-video' || manifest.version !== 1 || !Array.isArray(manifest.clips)) {
+    throw new Error('This backup was made by a newer app version — update and retry')
+  }
+
+  let offset = headerLength + manifestLength
+  const clips: ParsedBackup['clips'] = []
+  for (const clip of manifest.clips) {
+    if (
+      !Number.isFinite(clip.byteLength) ||
+      clip.byteLength <= 0 ||
+      offset + clip.byteLength > file.size
+    ) {
+      throw new Error('This backup file is damaged')
+    }
+    clips.push({
+      mimeType: typeof clip.mimeType === 'string' ? clip.mimeType : 'video/webm',
+      durationMs: clip.durationMs,
+      trimStartMs: clip.trimStartMs,
+      trimEndMs: clip.trimEndMs,
+      createdAt: clip.createdAt,
+      width: clip.width,
+      height: clip.height,
+      lat: clip.lat,
+      lng: clip.lng,
+      locationAccuracyM: clip.locationAccuracyM,
+      blob: file.slice(offset, offset + clip.byteLength, clip.mimeType),
+    })
+    offset += clip.byteLength
+  }
+
+  return { projectName: String(manifest.projectName || 'Imported project'), clips }
+}
+
+/** Create a fresh project (new ids) from a parsed backup. */
+export async function importProjectBackup(parsed: ParsedBackup): Promise<Project> {
+  const project = await createProject(parsed.projectName)
+  for (const clip of parsed.clips) {
+    const added = await addClip({
+      projectId: project.id,
+      blob: clip.blob,
+      mimeType: clip.mimeType,
+      durationMs: clip.durationMs,
+      width: clip.width,
+      height: clip.height,
+      lat: clip.lat,
+      lng: clip.lng,
+      locationAccuracyM: clip.locationAccuracyM,
+    })
+    // Restore trims (addClip resets them to the full clip).
+    await updateClipTrim(added.id, clip.trimStartMs, clip.trimEndMs)
+  }
+  return project
+}

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -215,6 +215,9 @@ export interface AddClipInput {
   lat?: number
   lng?: number
   locationAccuracyM?: number
+  /** Original capture time — used when importing backups so chapter titles
+   * keep the real recording time. Defaults to now. */
+  createdAt?: number
 }
 
 export async function addClip(input: AddClipInput): Promise<ClipRecord> {
@@ -231,7 +234,7 @@ export async function addClip(input: AddClipInput): Promise<ClipRecord> {
     durationMs: input.durationMs,
     trimStartMs: 0,
     trimEndMs: input.durationMs,
-    createdAt: now,
+    createdAt: input.createdAt ?? now,
     width: input.width,
     height: input.height,
     lat: input.lat,

--- a/src/pages/home-page.tsx
+++ b/src/pages/home-page.tsx
@@ -1,4 +1,4 @@
-import { startTransition, useState } from 'react'
+import { startTransition, useRef, useState } from 'react'
 import { Link, useLoaderData, useNavigate, useRevalidator } from 'react-router-dom'
 import { BlobImage } from '../components/blob-image'
 import { BrandMark } from '../components/brand-mark'
@@ -20,7 +20,7 @@ import {
   formatStoragePercent,
   storageSeverity,
 } from '../lib/storage-space'
-import { MAX_PROJECTS, formatDuration } from '../lib/types'
+import { MAX_PROJECTS, formatDuration, type ClipRecord } from '../lib/types'
 
 export async function homeLoader(): Promise<HomeLoaderData> {
   return loadHomePage()
@@ -36,6 +36,11 @@ export function HomePage() {
   const [deleting, setDeleting] = useState<ProjectSummary | null>(null)
   const [busy, setBusy] = useState(false)
   const [notice, setNotice] = useState<string | null>(null)
+  // Prefetched when the options sheet opens so the Save-backup tap keeps its
+  // user activation (Web Share needs it; an IndexedDB read can outlive it).
+  const prefetchedClipsRef = useRef<{ projectId: string; clips: Promise<ClipRecord[]> } | null>(
+    null,
+  )
 
   const refresh = () => {
     startTransition(() => {
@@ -64,7 +69,11 @@ export function HomePage() {
       setError(null)
       setNotice(null)
       try {
-        const clips = await getClipsForProject(project.id)
+        const prefetched = prefetchedClipsRef.current
+        const clips =
+          prefetched && prefetched.projectId === project.id
+            ? await prefetched.clips
+            : await getClipsForProject(project.id)
         if (clips.length === 0) throw new Error('Nothing to back up — this project has no clips.')
         const backup = serializeProject(project, clips)
         const outcome = await shareOrDownload(backup, projectBackupFilename(project.name))
@@ -166,7 +175,13 @@ export function HomePage() {
                 type="button"
                 className="slot-options"
                 aria-label={`Options for ${project.name}`}
-                onClick={() => setMenuProject(project)}
+                onClick={() => {
+                  prefetchedClipsRef.current = {
+                    projectId: project.id,
+                    clips: getClipsForProject(project.id),
+                  }
+                  setMenuProject(project)
+                }}
               >
                 <IconMore />
               </button>
@@ -204,13 +219,23 @@ export function HomePage() {
         >
           {atCap ? `Limit ${MAX_PROJECTS}` : 'New project'}
         </button>
-        <label className={`btn btn-ghost home-import${busy || atCap ? ' is-disabled' : ''}`}>
+        <label
+          className={`btn btn-ghost home-import${busy ? ' is-disabled' : ''}`}
+          onClick={(event) => {
+            if (atCap) {
+              event.preventDefault()
+              setError(
+                `Project limit reached (${MAX_PROJECTS}). Delete a project before importing.`,
+              )
+            }
+          }}
+        >
           Import
           <input
             type="file"
             accept=".kodyvideo,application/octet-stream"
             className="visually-hidden"
-            disabled={busy || atCap}
+            disabled={busy}
             onChange={(event) => {
               const file = event.target.files?.[0]
               event.target.value = ''

--- a/src/pages/home-page.tsx
+++ b/src/pages/home-page.tsx
@@ -6,8 +6,15 @@ import { ConfirmSheet } from '../components/confirm-sheet'
 import { HomeOptionsSheet } from '../components/home-options-sheet'
 import { IconMore, IconPlus } from '../components/icons'
 import { RenameSheet } from '../components/rename-sheet'
+import { shareOrDownload } from '../lib/media'
 import { loadHomePage, type HomeLoaderData, type ProjectSummary } from '../lib/project-actions'
-import { createProject, deleteProject, renameProject } from '../lib/storage'
+import {
+  importProjectBackup,
+  parseProjectBackup,
+  projectBackupFilename,
+  serializeProject,
+} from '../lib/project-transfer'
+import { createProject, deleteProject, getClipsForProject, renameProject } from '../lib/storage'
 import {
   formatBytes,
   formatStoragePercent,
@@ -28,6 +35,7 @@ export function HomePage() {
   const [renaming, setRenaming] = useState<ProjectSummary | null>(null)
   const [deleting, setDeleting] = useState<ProjectSummary | null>(null)
   const [busy, setBusy] = useState(false)
+  const [notice, setNotice] = useState<string | null>(null)
 
   const refresh = () => {
     startTransition(() => {
@@ -44,6 +52,47 @@ export function HomePage() {
         navigate(`/project/${project.id}`)
       } catch (err) {
         setError(err instanceof Error ? err.message : 'Could not create project')
+      } finally {
+        setBusy(false)
+      }
+    })()
+  }
+
+  const backupProject = (project: ProjectSummary) => {
+    void (async () => {
+      setBusy(true)
+      setError(null)
+      setNotice(null)
+      try {
+        const clips = await getClipsForProject(project.id)
+        if (clips.length === 0) throw new Error('Nothing to back up — this project has no clips.')
+        const backup = serializeProject(project, clips)
+        const outcome = await shareOrDownload(backup, projectBackupFilename(project.name))
+        if (outcome !== 'cancelled') {
+          setNotice(
+            'Backup saved. Open kody.video (or any Kody Video) and tap Import to restore it.',
+          )
+        }
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Could not create the backup')
+      } finally {
+        setBusy(false)
+      }
+    })()
+  }
+
+  const importBackup = (file: File) => {
+    void (async () => {
+      setBusy(true)
+      setError(null)
+      setNotice(null)
+      try {
+        const parsed = await parseProjectBackup(file)
+        const project = await importProjectBackup(parsed)
+        refresh()
+        setNotice(`Imported “${project.name}” — ${parsed.clips.length} clip${parsed.clips.length === 1 ? '' : 's'}.`)
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Could not import that file')
       } finally {
         setBusy(false)
       }
@@ -68,6 +117,7 @@ export function HomePage() {
       </div>
 
       {error ? <div className="error-banner">{error}</div> : null}
+      {notice ? <p className="home-notice">{notice}</p> : null}
 
       {storage && severity !== 'ok' ? (
         <div
@@ -154,6 +204,20 @@ export function HomePage() {
         >
           {atCap ? `Limit ${MAX_PROJECTS}` : 'New project'}
         </button>
+        <label className={`btn btn-ghost home-import${busy || atCap ? ' is-disabled' : ''}`}>
+          Import
+          <input
+            type="file"
+            accept=".kodyvideo,application/octet-stream"
+            className="visually-hidden"
+            disabled={busy || atCap}
+            onChange={(event) => {
+              const file = event.target.files?.[0]
+              event.target.value = ''
+              if (file) importBackup(file)
+            }}
+          />
+        </label>
       </div>
 
       {menuProject ? (
@@ -168,6 +232,11 @@ export function HomePage() {
           onRename={() => {
             setRenaming(menuProject)
             setMenuProject(null)
+          }}
+          onBackup={() => {
+            const project = menuProject
+            setMenuProject(null)
+            backupProject(project)
           }}
           onDelete={() => {
             setDeleting(menuProject)

--- a/src/styles/home.css
+++ b/src/styles/home.css
@@ -247,6 +247,26 @@
   flex: 1;
 }
 
+.home-footer .home-import {
+  flex: 0 0 auto;
+  cursor: pointer;
+}
+
+.home-footer .home-import.is-disabled {
+  opacity: 0.45;
+  pointer-events: none;
+}
+
+.home-notice {
+  margin: 10px 0 0;
+  padding: 10px 12px;
+  border-radius: 12px;
+  background: var(--accent-soft);
+  border: 1px solid color-mix(in srgb, var(--accent) 40%, transparent);
+  font-size: 0.9rem;
+  line-height: 1.4;
+}
+
 /* Options + confirm sheets (home-owned) */
 
 .home-options-list {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

An in-progress project lives in `kody-video.pages.dev`'s origin storage, which can't follow the app to `kody.video` (browser storage is per-origin). This adds a **project backup file** — the clean way to move that project over, and a real backup/safety-net feature in its own right.

## What

- **`.kodyvideo` format**: `KODYVID1` magic + u32 manifest length + JSON manifest + concatenated clip media. Writing composes the existing clip Blobs by reference (no copying); reading slices the file lazily per clip — large projects never sit in memory whole. Round-trips clips, trims, timestamps, and opt-in location data; thumbnails are excluded and regenerate via the existing loader backfill.
- **UI**: each project slot's ⋯ sheet gains **Save backup** (Android share sheet / download), and the home footer gains an **Import** file picker. Success/error notices; import creates a fresh project (new ids) and respects the six-project cap with a clear message.
- Corrupt/truncated/foreign files are rejected with friendly errors; a `version` field future-proofs the format.

## Migration recipe (pages.dev → kody.video)

On kody-video.pages.dev: ⋯ on the project → **Save backup** → save the file. On kody.video: **Import** → pick the file. Done — clips, trims, and geo intact.

## Verification

- 5 new unit tests: serialize→parse round trip (media bytes, trims, geo, mime), full import into IndexedDB, non-backup rejection, truncation rejection, filename slugging — **47 total**.
- Smoke round trip: taps Save backup, captures the download, re-imports it, asserts a new filled slot — **30/30**.
- `npm run lint`, `npm run build` green.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-16d17496-6b5b-4e12-b600-6933357c2059"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-16d17496-6b5b-4e12-b600-6933357c2059"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

