### PR TITLE
Fix imported projects: materialize media bytes instead of storing file slices

### DIFF
--- a/scripts/manual-smoke.mjs
+++ b/scripts/manual-smoke.mjs
@@ -358,12 +358,48 @@ try {
       .waitForFunction(
         (before) => document.querySelectorAll('.project-slot.filled').length > before,
         filledBefore,
-        { timeout: 10000 },
+        { timeout: 15000 },
       )
       .then(() => true)
       .catch(() => false)
     if (imported) pass('backup imports as a new project')
     else fail('backup imports as a new project')
+
+    // Poster art must appear immediately (thumbs generate during import).
+    const postersReady = await page
+      .waitForFunction(
+        () =>
+          document.querySelectorAll('.project-slot.filled .slot-poster').length ===
+          document.querySelectorAll('.project-slot.filled').length,
+        undefined,
+        { timeout: 10000 },
+      )
+      .then(() => true)
+      .catch(() => false)
+    if (postersReady) pass('imported project shows poster art immediately')
+    else fail('imported project shows poster art immediately')
+
+    // The imported project must actually open with playable clips.
+    const slots = page.locator('.project-slot.filled .slot-open')
+    await slots.nth((await slots.count()) - 1).click()
+    const openedImported = await page
+      .waitForURL(/\/project\//, { timeout: 10000 })
+      .then(() => true)
+      .catch(() => false)
+    const importedCameraReady = await page
+      .waitForFunction(
+        () => {
+          const v = document.querySelector('.record-stage video')
+          return v && v.videoWidth > 0
+        },
+        undefined,
+        { timeout: 10000 },
+      )
+      .then(() => true)
+      .catch(() => false)
+    if (openedImported && importedCameraReady) pass('imported project opens')
+    else fail('imported project opens', `nav=${openedImported} camera=${importedCameraReady}`)
+    await page.goto(BASE, { waitUntil: 'networkidle' })
   } else {
     fail('backup imports as a new project', 'no backup file to import')
   }

--- a/src/lib/project-transfer.ts
+++ b/src/lib/project-transfer.ts
@@ -1,4 +1,5 @@
 import { addClip, createProject, deleteProject, updateClipTrim } from './storage'
+import { ensureClipThumbs } from './thumbs'
 import type { ClipRecord, Project } from './types'
 
 /**
@@ -161,9 +162,15 @@ export async function importProjectBackup(parsed: ParsedBackup): Promise<Project
   try {
     for (const clip of parsed.clips) {
       assertImportableClip(clip)
+      // CRITICAL: materialize the media bytes. The parsed blob is a lazy
+      // slice of the picked backup File; persisting that into IndexedDB
+      // stores a reference to the underlying file, which goes stale (esp.
+      // Android content URIs) and leaves clips unreadable. Reading it here
+      // both copies the bytes and proves the file is intact.
+      const bytes = await clip.blob.arrayBuffer()
       const added = await addClip({
         projectId: project.id,
-        blob: clip.blob,
+        blob: new Blob([bytes], { type: clip.mimeType }),
         mimeType: clip.mimeType,
         durationMs: clip.durationMs,
         // Keep the original capture time so chapter titles stay truthful.
@@ -175,7 +182,10 @@ export async function importProjectBackup(parsed: ParsedBackup): Promise<Project
         locationAccuracyM: clip.locationAccuracyM,
       })
       // Restore trims (addClip resets them to the full clip).
-      await updateClipTrim(added.id, clip.trimStartMs, clip.trimEndMs)
+      const trimmed = await updateClipTrim(added.id, clip.trimStartMs, clip.trimEndMs)
+      // Generate thumbnails now so the slot poster shows right away and the
+      // first open doesn't pay the backfill cost.
+      await ensureClipThumbs({ ...added, ...trimmed, blob: added.blob }).catch(() => undefined)
     }
     return project
   } catch (error) {

--- a/src/lib/thumbs.ts
+++ b/src/lib/thumbs.ts
@@ -67,6 +67,9 @@ function canvasToBlob(canvas: HTMLCanvasElement): Promise<Blob | null> {
 }
 
 const inFlight = new Map<string, Promise<ClipRecord>>()
+/** Clips whose thumbnail generation failed this session — don't retry on
+ * every load (an unreadable blob costs an 8s media timeout per attempt). */
+const failedThisSession = new Set<string>()
 
 /**
  * Generate and persist thumbnails for a clip that does not have them yet
@@ -76,6 +79,7 @@ const inFlight = new Map<string, Promise<ClipRecord>>()
  */
 export function ensureClipThumbs(clip: ClipRecord): Promise<ClipRecord> {
   if (clip.thumbs && clip.thumbs.length > 0) return Promise.resolve(clip)
+  if (failedThisSession.has(clip.id)) return Promise.resolve(clip)
   const existing = inFlight.get(clip.id)
   if (existing) return existing
 
@@ -92,6 +96,7 @@ export function ensureClipThumbs(clip: ClipRecord): Promise<ClipRecord> {
         height: clip.height ?? generated.videoHeight,
       }
     } catch {
+      failedThisSession.add(clip.id)
       return clip
     } finally {
       inFlight.delete(clip.id)

--- a/src/lib/thumbs.ts
+++ b/src/lib/thumbs.ts
@@ -85,8 +85,21 @@ export function ensureClipThumbs(clip: ClipRecord): Promise<ClipRecord> {
 
   const run = (async () => {
     try {
-      const generated = await generateClipThumbs(clip.blob)
-      await updateClipThumbs(clip.id, generated)
+      let generated: GeneratedThumbs
+      try {
+        generated = await generateClipThumbs(clip.blob)
+      } catch {
+        // Unreadable/undecodable media — retrying costs an 8s timeout every
+        // load, so skip this clip for the rest of the session.
+        failedThisSession.add(clip.id)
+        return clip
+      }
+      try {
+        await updateClipThumbs(clip.id, generated)
+      } catch {
+        // Transient persistence failure: still use the thumbs in memory and
+        // let a later load retry the (cheap-by-then) save.
+      }
       return {
         ...clip,
         thumbs: generated.thumbs,
@@ -95,9 +108,6 @@ export function ensureClipThumbs(clip: ClipRecord): Promise<ClipRecord> {
         width: clip.width ?? generated.videoWidth,
         height: clip.height ?? generated.videoHeight,
       }
-    } catch {
-      failedThisSession.add(clip.id)
-      return clip
     } finally {
       inFlight.delete(clip.id)
     }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem (real-device report)

An imported project appeared on the home screen but wouldn't open (tapping the slot or ⋯ → Open did nothing), and its poster art never showed.

## Root cause

Import stored each clip's media as a **lazy slice of the picked backup `File`**. Chromium persists file-backed blobs into IndexedDB as references to the underlying file, and those references go stale — especially with Android content URIs from the file picker. Every clip read then fails: the project loader's thumbnail backfill burned an **8-second media timeout per clip on every open attempt** (looking exactly like "nothing happens"), and no thumbnails/poster could ever generate.

## Fix

- **Materialize bytes at import**: each clip's slice is read into memory (per clip, not the whole file) and stored as a real `Blob` — which also proves the source file is intact before anything persists (a failed read triggers the existing full rollback).
- **Thumbnails generate during import**, so the slot poster shows immediately and the first open doesn't pay any backfill cost.
- **Failure caching**: a clip whose thumbnail generation fails is skipped for the rest of the session instead of re-hanging every subsequent load.

## Note for anyone with an already-broken import

Projects imported with the previous build hold dead file references that can't be repaired — delete the imported project and re-import the same `.kodyvideo` file on this build.

## Verification

Smoke extended and green (**32/32**): after import, the new slot must show poster art immediately **and** the imported project must actually open to a working record screen. `npm run lint`, `npm test` (48), `npm run build` green.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-16d17496-6b5b-4e12-b600-6933357c2059"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-16d17496-6b5b-4e12-b600-6933357c2059"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved project backup imports so restored projects display poster artwork more reliably.
  * Imported projects can now be opened and used immediately after restoration.
  * Improved thumbnail handling when media decoding or thumbnail saving encounters an error.
  * Prevented repeated attempts to process media that has already failed during the current session.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->