### PR TITLE
Import progress, land in the imported project, download large backups directly

### DIFF
--- a/scripts/manual-smoke.mjs
+++ b/scripts/manual-smoke.mjs
@@ -354,36 +354,9 @@ try {
   if (download) {
     const backupPath = await download.path()
     await page.locator('.home-import input[type=file]').setInputFiles(backupPath)
-    const imported = await page
-      .waitForFunction(
-        (before) => document.querySelectorAll('.project-slot.filled').length > before,
-        filledBefore,
-        { timeout: 15000 },
-      )
-      .then(() => true)
-      .catch(() => false)
-    if (imported) pass('backup imports as a new project')
-    else fail('backup imports as a new project')
-
-    // Poster art must appear immediately (thumbs generate during import).
-    const postersReady = await page
-      .waitForFunction(
-        () =>
-          document.querySelectorAll('.project-slot.filled .slot-poster').length ===
-          document.querySelectorAll('.project-slot.filled').length,
-        undefined,
-        { timeout: 10000 },
-      )
-      .then(() => true)
-      .catch(() => false)
-    if (postersReady) pass('imported project shows poster art immediately')
-    else fail('imported project shows poster art immediately')
-
-    // The imported project must actually open with playable clips.
-    const slots = page.locator('.project-slot.filled .slot-open')
-    await slots.nth((await slots.count()) - 1).click()
+    // Import now lands directly inside the imported project.
     const openedImported = await page
-      .waitForURL(/\/project\//, { timeout: 10000 })
+      .waitForURL(/\/project\//, { timeout: 20000 })
       .then(() => true)
       .catch(() => false)
     const importedCameraReady = await page
@@ -397,9 +370,37 @@ try {
       )
       .then(() => true)
       .catch(() => false)
-    if (openedImported && importedCameraReady) pass('imported project opens')
-    else fail('imported project opens', `nav=${openedImported} camera=${importedCameraReady}`)
+    if (openedImported && importedCameraReady) {
+      pass('import navigates into a working imported project')
+    } else {
+      fail('import navigates into a working imported project', `nav=${openedImported} camera=${importedCameraReady}`)
+    }
+
     await page.goto(BASE, { waitUntil: 'networkidle' })
+    const imported = await page
+      .waitForFunction(
+        (before) => document.querySelectorAll('.project-slot.filled').length > before,
+        filledBefore,
+        { timeout: 10000 },
+      )
+      .then(() => true)
+      .catch(() => false)
+    if (imported) pass('imported project appears on home')
+    else fail('imported project appears on home')
+
+    // Poster art must be present already (thumbs generate during import).
+    const postersReady = await page
+      .waitForFunction(
+        () =>
+          document.querySelectorAll('.project-slot.filled .slot-poster').length ===
+          document.querySelectorAll('.project-slot.filled').length,
+        undefined,
+        { timeout: 10000 },
+      )
+      .then(() => true)
+      .catch(() => false)
+    if (postersReady) pass('imported project shows poster art immediately')
+    else fail('imported project shows poster art immediately')
   } else {
     fail('backup imports as a new project', 'no backup file to import')
   }

--- a/src/lib/project-transfer.test.ts
+++ b/src/lib/project-transfer.test.ts
@@ -66,6 +66,21 @@ describe('project backup round trip', () => {
     expect(await clips[0].blob.text()).toBe('MEDIA')
   })
 
+  it('reports per-clip progress during import', async () => {
+    const backup = serializeProject(fakeProject('Progress'), [
+      fakeClip('clip_a', 'AAAA'),
+      fakeClip('clip_b', 'BBBB'),
+    ])
+    const parsed = await parseProjectBackup(backup)
+    const seen: Array<[number, number]> = []
+    await importProjectBackup(parsed, (done, total) => seen.push([done, total]))
+    expect(seen).toEqual([
+      [0, 2],
+      [1, 2],
+      [2, 2],
+    ])
+  })
+
   it('rolls back the project when an import fails midway', async () => {
     const backup = serializeProject(fakeProject('Broken'), [fakeClip('clip_a', 'MEDIA')])
     const parsed = await parseProjectBackup(backup)

--- a/src/lib/project-transfer.ts
+++ b/src/lib/project-transfer.ts
@@ -157,9 +157,14 @@ function assertImportableClip(clip: ParsedBackup['clips'][number]): void {
 }
 
 /** Create a fresh project (new ids) from a parsed backup. */
-export async function importProjectBackup(parsed: ParsedBackup): Promise<Project> {
+export async function importProjectBackup(
+  parsed: ParsedBackup,
+  onProgress?: (doneClips: number, totalClips: number) => void,
+): Promise<Project> {
   const project = await createProject(parsed.projectName)
   try {
+    let done = 0
+    onProgress?.(0, parsed.clips.length)
     for (const clip of parsed.clips) {
       assertImportableClip(clip)
       // CRITICAL: materialize the media bytes. The parsed blob is a lazy
@@ -186,6 +191,8 @@ export async function importProjectBackup(parsed: ParsedBackup): Promise<Project
       // Generate thumbnails now so the slot poster shows right away and the
       // first open doesn't pay the backfill cost.
       await ensureClipThumbs({ ...added, ...trimmed, blob: added.blob }).catch(() => undefined)
+      done += 1
+      onProgress?.(done, parsed.clips.length)
     }
     return project
   } catch (error) {

--- a/src/pages/home-page.tsx
+++ b/src/pages/home-page.tsx
@@ -6,7 +6,7 @@ import { ConfirmSheet } from '../components/confirm-sheet'
 import { HomeOptionsSheet } from '../components/home-options-sheet'
 import { IconMore, IconPlus } from '../components/icons'
 import { RenameSheet } from '../components/rename-sheet'
-import { shareOrDownload } from '../lib/media'
+import { downloadBlob, shareOrDownload } from '../lib/media'
 import { loadHomePage, type HomeLoaderData, type ProjectSummary } from '../lib/project-actions'
 import {
   importProjectBackup,
@@ -22,6 +22,9 @@ import {
 } from '../lib/storage-space'
 import { MAX_PROJECTS, formatDuration, type ClipRecord } from '../lib/types'
 
+/** Android share targets get flaky well below this; bigger backups download. */
+const SHARE_BACKUP_LIMIT_BYTES = 50 * 1024 * 1024
+
 export async function homeLoader(): Promise<HomeLoaderData> {
   return loadHomePage()
 }
@@ -36,6 +39,7 @@ export function HomePage() {
   const [deleting, setDeleting] = useState<ProjectSummary | null>(null)
   const [busy, setBusy] = useState(false)
   const [notice, setNotice] = useState<string | null>(null)
+  const [importProgress, setImportProgress] = useState<string | null>(null)
   // Prefetched when the options sheet opens so the Save-backup tap keeps its
   // user activation (Web Share needs it; an IndexedDB read can outlive it).
   const prefetchedClipsRef = useRef<{ projectId: string; clips: Promise<ClipRecord[]> } | null>(
@@ -76,11 +80,23 @@ export function HomePage() {
             : await getClipsForProject(project.id)
         if (clips.length === 0) throw new Error('Nothing to back up — this project has no clips.')
         const backup = serializeProject(project, clips)
-        const outcome = await shareOrDownload(backup, projectBackupFilename(project.name))
-        if (outcome !== 'cancelled') {
+        const filename = projectBackupFilename(project.name)
+        const sizeLabel = formatBytes(backup.size)
+        // Android's share sheet fails (often silently) on very large files —
+        // route big backups straight to a download instead.
+        if (backup.size > SHARE_BACKUP_LIMIT_BYTES) {
+          await downloadBlob(backup, filename)
           setNotice(
-            'Backup saved. Open kody.video (or any Kody Video) and tap Import to restore it.',
+            `Backup (${sizeLabel}) saved to your downloads — too large for the share sheet. ` +
+              'Open kody.video and tap Import to restore it.',
           )
+        } else {
+          const outcome = await shareOrDownload(backup, filename)
+          if (outcome !== 'cancelled') {
+            setNotice(
+              `Backup (${sizeLabel}) saved. Open kody.video (or any Kody Video) and tap Import to restore it.`,
+            )
+          }
         }
       } catch (err) {
         setError(err instanceof Error ? err.message : 'Could not create the backup')
@@ -95,14 +111,19 @@ export function HomePage() {
       setBusy(true)
       setError(null)
       setNotice(null)
+      setImportProgress('Reading backup…')
       try {
         const parsed = await parseProjectBackup(file)
-        const project = await importProjectBackup(parsed)
-        refresh()
-        setNotice(`Imported “${project.name}” — ${parsed.clips.length} clip${parsed.clips.length === 1 ? '' : 's'}.`)
+        const project = await importProjectBackup(parsed, (done, total) => {
+          setImportProgress(`Importing clip ${Math.min(done + 1, total)} of ${total}…`)
+        })
+        // Land directly in the imported project — unambiguous success, and
+        // no dependence on the list revalidating behind the scenes.
+        navigate(`/project/${project.id}`)
       } catch (err) {
         setError(err instanceof Error ? err.message : 'Could not import that file')
       } finally {
+        setImportProgress(null)
         setBusy(false)
       }
     })()
@@ -127,6 +148,11 @@ export function HomePage() {
 
       {error ? <div className="error-banner">{error}</div> : null}
       {notice ? <p className="home-notice">{notice}</p> : null}
+      {importProgress ? (
+        <p className="home-notice" role="status" aria-live="polite">
+          {importProgress} Keep this tab open.
+        </p>
+      ) : null}
 
       {storage && severity !== 'ok' ? (
         <div


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problems (real-device report, ~200 MB project)

1. The big project "does not export and import cleanly" while a fresh small one worked.
2. Import has no progress indication — a 200 MB import legitimately takes a while (per-clip byte materialization + thumbnail generation) and looks hung.
3. After import, the home list didn't update until remounting the route (navigating to About and back).

## Fixes

- **Large backups download directly**: Android's share sheet fails on large files, often silently — the most likely cause of the 200 MB export failing while small ones succeed. Backups over 50 MB now skip Web Share and go straight to a download, with the file size shown in the notice either way.
- **Per-clip import progress**: `importProjectBackup` reports `(done, total)`; the home screen shows "Importing clip 3 of 12… Keep this tab open."
- **Success lands inside the imported project**: instead of relying on the home list revalidating (observably flaky after import), a successful import navigates straight into the new project — unambiguous, and the home list is fresh by the time you go back.

## Verification

- New unit test asserts progress callbacks fire per clip ([0,2] → [1,2] → [2,2]); **49 unit tests** total.
- Smoke reworked for the new flow: import must navigate into a working project (camera live), and the home list must then show the new slot with poster art — **32/32 passing**.
- `npm run lint`, `npm run build` green.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-16d17496-6b5b-4e12-b600-6933357c2059"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-16d17496-6b5b-4e12-b600-6933357c2059"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

