### PR TITLE
Rear lens switching — reach the ultra-wide (0.5×) camera

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,9 @@ Verified approach: `npm run build && npm run preview`, load once online, then De
 - **Permissions:** denied camera/mic must be re-enabled in site settings; the UI surfaces this.
 - **Storage quotas:** large projects can hit IndexedDB quotas; the soft 6-project cap helps.
 - **Background tabs:** recording should stay in the foreground; browsers may throttle capture.
+- **Ultra-wide (0.5×):** Android usually exposes the ultra-wide/telephoto as *separate* rear
+  cameras, not as zoom below 1× — the lens chip next to the zoom chips switches between them.
+  Some devices don't expose the extra lenses to browsers at all; the chip is hidden there.
 
 ## Desktop keyboard support
 
@@ -167,5 +170,6 @@ Checkout Sessions read access is enough) on the Cloudflare Pages project.
 | `npm run test:smoke`                 | Playwright smoke: record → edit → export   |
 | `node scripts/probe-export-chrome.mjs` | Export validation in Chrome stable (real codecs) |
 | `node scripts/probe-keyboard.mjs`    | Desktop keyboard flows (record/edit/playback) |
+| `node scripts/probe-rear-lens.mjs`   | Rear lens switching (ultra-wide) with fake cameras |
 | `node scripts/probe-touch-timeline.mjs` | Touch timeline gestures (scroll, long-press lift) |
 | `node scripts/probe-webkit.mjs`      | WebKit engine sanity + feature matrix (iOS proxy, not a substitute for a real device) |

--- a/manual-test-checklist.md
+++ b/manual-test-checklist.md
@@ -9,6 +9,7 @@ Run locally with HTTPS or `localhost` (`npm run dev`). Camera/mic require a secu
 - [ ] Allow → live rear-camera preview (or fallback)
 - [ ] Flip camera works when multiple cameras exist
 - [ ] Torch toggle appears on devices with a flash; zoom chips appear when supported
+- [ ] Phones with multiple rear cameras show a lens chip (e.g. "1/3") that switches to the ultra-wide/telephoto; choice sticks across flips and restarts
 - [ ] Backgrounding the app releases camera/mic (green dot goes out); returning restarts the preview
 - [ ] Backgrounding mid-recording still saves the take
 - [ ] Screen off → on while on the camera view: preview is live again, not frozen; recording works

--- a/scripts/probe-rear-lens.mjs
+++ b/scripts/probe-rear-lens.mjs
@@ -1,0 +1,127 @@
+// Rear-lens switching probe: Chromium's fake cameras are relabeled as three
+// rear cameras so the lens chip renders and can be exercised end to end.
+import { chromium } from 'playwright'
+import { spawn } from 'node:child_process'
+import { setTimeout as sleep } from 'node:timers/promises'
+
+const PORT = 4185
+const BASE = `http://127.0.0.1:${PORT}`
+const preview = spawn('npm', ['run', 'preview', '--', '--host', '127.0.0.1', '--port', String(PORT)], {
+  cwd: process.cwd(),
+  stdio: ['ignore', 'pipe', 'pipe'],
+})
+async function waitForServer(url) {
+  for (let i = 0; i < 60; i++) {
+    try {
+      if ((await fetch(url)).ok) return
+    } catch {}
+    await sleep(250)
+  }
+  throw new Error('server not ready')
+}
+const results = []
+const check = (name, ok, detail = '') => {
+  results.push(ok)
+  console.log(`${ok ? 'PASS' : 'FAIL'}  ${name}${detail ? ` — ${detail}` : ''}`)
+}
+try {
+  await waitForServer(BASE)
+  const browser = await chromium.launch({
+    headless: true,
+    args: ['--use-fake-ui-for-media-stream', '--use-fake-device-for-media-stream=device-count=3'],
+  })
+  const context = await browser.newContext({
+    viewport: { width: 390, height: 844 },
+    isMobile: true,
+    hasTouch: true,
+    permissions: ['camera', 'microphone'],
+  })
+  await context.addInitScript(() => {
+    const original = navigator.mediaDevices.enumerateDevices.bind(navigator.mediaDevices)
+    navigator.mediaDevices.enumerateDevices = async () => {
+      const devices = await original()
+      return devices.map((device, index) => {
+        if (device.kind !== 'videoinput') return device
+        return new Proxy(device, {
+          get(target, prop) {
+            if (prop === 'label') return `camera2 ${index}, facing back`
+            const value = Reflect.get(target, prop)
+            return typeof value === 'function' ? value.bind(target) : value
+          },
+        })
+      })
+    }
+  })
+  const page = await context.newPage()
+  const errors = []
+  page.on('pageerror', (err) => errors.push(String(err)))
+
+  await page.goto(BASE, { waitUntil: 'networkidle' })
+  await page.getByRole('button', { name: /new project/i }).first().click()
+  await page.waitForURL(/\/project\//)
+  const ob = page.getByRole('dialog', { name: /quick start/i })
+  if (await ob.count()) await page.getByRole('button', { name: /start recording/i }).click()
+  const waitForCamera = () =>
+    page.waitForFunction(() => {
+      const v = document.querySelector('.record-stage video')
+      return v && v.videoWidth > 0
+    })
+  await waitForCamera()
+  await sleep(600)
+
+  const lensChip = page.locator('.lens-chip')
+  const activeDeviceId = () =>
+    page.evaluate(
+      () =>
+        document.querySelector('.record-stage video')?.srcObject?.getVideoTracks()[0]?.getSettings()
+          .deviceId ?? null,
+    )
+
+  check('lens chip renders with 3 rear cameras', (await lensChip.count()) === 1)
+  check('chip starts at lens 1', (await lensChip.textContent()) === '1/3')
+
+  const firstId = await activeDeviceId()
+  await lensChip.click()
+  await waitForCamera()
+  await sleep(800)
+  const secondId = await activeDeviceId()
+  check('tap switches to a different camera device', firstId !== secondId)
+  check('chip advances to lens 2', (await lensChip.textContent()) === '2/3')
+
+  await page.reload({ waitUntil: 'networkidle' })
+  await waitForCamera()
+  await sleep(800)
+  check('lens choice survives reload', (await lensChip.textContent()) === '2/3')
+
+  await page.locator('button[aria-label="Flip camera"]').click()
+  await sleep(1200)
+  check('chip hidden while facing user', (await lensChip.count()) === 0)
+  await page.locator('button[aria-label="Flip camera"]').click()
+  await sleep(1200)
+  check('lens choice survives flip roundtrip', (await lensChip.textContent()) === '2/3')
+
+  // Recording still works on the switched lens.
+  const box = await page.locator('.record-stage').boundingBox()
+  const cdp = await context.newCDPSession(page)
+  await cdp.send('Input.dispatchTouchEvent', {
+    type: 'touchStart',
+    touchPoints: [{ x: box.x + box.width / 2, y: box.y + box.height / 2 }],
+  })
+  await sleep(2500)
+  await cdp.send('Input.dispatchTouchEvent', { type: 'touchEnd', touchPoints: [] })
+  await sleep(1800)
+  // UI-level assertion: the editor button is enabled once a clip exists.
+  const editorEnabled = await page
+    .locator('button[aria-label="Open editor"]')
+    .isEnabled()
+    .catch(() => false)
+  check('recording works on the switched lens', editorEnabled)
+
+  check('no page errors', errors.length === 0, errors.join(' | '))
+  await browser.close()
+} catch (err) {
+  check('probe crashed', false, String(err))
+} finally {
+  preview.kill()
+}
+process.exit(results.every(Boolean) ? 0 : 1)

--- a/scripts/probe-rear-lens.mjs
+++ b/scripts/probe-rear-lens.mjs
@@ -6,9 +6,11 @@ import { setTimeout as sleep } from 'node:timers/promises'
 
 const PORT = 4185
 const BASE = `http://127.0.0.1:${PORT}`
+// Detached so the whole npm→vite process group can be killed at the end.
 const preview = spawn('npm', ['run', 'preview', '--', '--host', '127.0.0.1', '--port', String(PORT)], {
   cwd: process.cwd(),
   stdio: ['ignore', 'pipe', 'pipe'],
+  detached: true,
 })
 async function waitForServer(url) {
   for (let i = 0; i < 60; i++) {
@@ -122,6 +124,10 @@ try {
 } catch (err) {
   check('probe crashed', false, String(err))
 } finally {
-  preview.kill()
+  try {
+    process.kill(-preview.pid, 'SIGTERM')
+  } catch {
+    preview.kill()
+  }
 }
 process.exit(results.every(Boolean) ? 0 : 1)

--- a/src/components/icons.tsx
+++ b/src/components/icons.tsx
@@ -189,3 +189,12 @@ export function IconUndo({ size = 22 }: IconProps) {
     </svg>
   )
 }
+
+export function IconLens({ size = 22 }: IconProps) {
+  return (
+    <svg {...baseProps(size)}>
+      <circle cx="12" cy="12" r="8.5" />
+      <circle cx="12" cy="12" r="3.5" />
+    </svg>
+  )
+}

--- a/src/components/record-screen.tsx
+++ b/src/components/record-screen.tsx
@@ -16,6 +16,7 @@ import {
   IconDeleteLast,
   IconEditor,
   IconFlip,
+  IconLens,
   IconLocation,
   IconPlay,
   IconTimer,
@@ -151,6 +152,9 @@ export function RecordScreen({
   const zoomLevels = camera.zoom ? zoomChipLevels(camera.zoom) : []
   const activeZoomLevel =
     camera.zoom && zoomLevels.length > 0 ? nearestZoomLevel(zoomLevels, camera.zoom.value) : null
+  // Ultra-wide/telephoto are usually separate rear cameras on Android — a
+  // lens chip is the only way to reach 0.5× when zoom can't go below 1×.
+  const showLensChip = camera.facing === 'environment' && camera.rearLensCount > 1
 
   const clearCountdown = useCallback(() => {
     window.clearTimeout(countdownTimerRef.current)
@@ -778,8 +782,27 @@ export function RecordScreen({
         </div>
       </div>
 
-      {camera.zoom && zoomLevels.length > 0 ? (
-        <div className="record-zoom" role="group" aria-label="Zoom">
+      {(camera.zoom && zoomLevels.length > 0) || showLensChip ? (
+        <div className="record-zoom" role="group" aria-label="Zoom and lens">
+          {showLensChip ? (
+            <button
+              type="button"
+              className="zoom-chip lens-chip"
+              aria-label={`Switch rear lens (${camera.rearLensIndex + 1} of ${camera.rearLensCount})`}
+              disabled={recording || countdown !== null}
+              onClick={(event) => {
+                event.stopPropagation()
+                // Each lens has its own zoom range and default.
+                cancelAnimationFrame(zoomRestoreRafRef.current)
+                zoomBaselineRef.current = null
+                dragZoomMovedRef.current = false
+                void camera.switchRearLens()
+              }}
+            >
+              <IconLens size={14} />
+              {camera.rearLensIndex + 1}/{camera.rearLensCount}
+            </button>
+          ) : null}
           {zoomLevels.map((level) => {
             const isActive = activeZoomLevel !== null && Math.abs(activeZoomLevel - level) < 0.05
             return (

--- a/src/components/record-screen.tsx
+++ b/src/components/record-screen.tsx
@@ -789,7 +789,7 @@ export function RecordScreen({
               type="button"
               className="zoom-chip lens-chip"
               aria-label={`Switch rear lens (${camera.rearLensIndex + 1} of ${camera.rearLensCount})`}
-              disabled={recording || countdown !== null}
+              disabled={recording || countdown !== null || !camera.isReady}
               onClick={(event) => {
                 event.stopPropagation()
                 // Each lens has its own zoom range and default.

--- a/src/hooks/use-camera.ts
+++ b/src/hooks/use-camera.ts
@@ -284,14 +284,26 @@ export function useCamera(): UseCameraResult {
       stopStream(current)
       streamRef.current = null
       setIsReady(false)
+      // A flip may land while a lens open is in flight; its stream must win.
+      const adopt = (opened: MediaStream): boolean => {
+        if (facingRef.current !== 'environment') {
+          stopStream(opened)
+          return false
+        }
+        replaceStream(opened)
+        void syncRearLenses(opened)
+        return true
+      }
       try {
         const next = await openCameraStream('environment', { audio: false, deviceId: nextId })
         const openedId = next.getVideoTracks()[0]?.getSettings().deviceId ?? ''
-        // openCameraStream falls back to facing mode on stale ids; only
-        // remember the lens the browser actually opened.
-        rememberRearLens(openedId ? { id: openedId, index: lenses.indexOf(openedId) } : null)
-        replaceStream(next)
-        void syncRearLenses(next)
+        if (!adopt(next)) return
+        // openCameraStream falls back to facing mode when the exact device
+        // can't be opened — only persist a lens the user actually reached,
+        // never an unintended fallback.
+        if (openedId === nextId) {
+          rememberRearLens({ id: openedId, index: lenses.indexOf(openedId) })
+        }
       } catch (err) {
         // Try to restore the lens we just released.
         try {
@@ -299,8 +311,7 @@ export function useCamera(): UseCameraResult {
             audio: false,
             deviceId: activeId || undefined,
           })
-          replaceStream(restored)
-          void syncRearLenses(restored)
+          adopt(restored)
         } catch {
           setError(permissionMessage(err))
         }

--- a/src/hooks/use-camera.ts
+++ b/src/hooks/use-camera.ts
@@ -204,6 +204,9 @@ export function useCamera(): UseCameraResult {
       return
     }
     const lenses = await listRearCameras()
+    // A flip/stop/switch may have replaced the stream while enumerating —
+    // stale results must not clobber the newer call's state.
+    if (streamRef.current !== active || facingRef.current !== 'environment') return
     rearLensesRef.current = lenses
     setRearLensCount(lenses.length)
     const activeId = active.getVideoTracks()[0]?.getSettings().deviceId ?? ''
@@ -276,6 +279,9 @@ export function useCamera(): UseCameraResult {
   const switchRearLens = useCallback(async () => {
     const lenses = rearLensesRef.current
     if (facingRef.current !== 'environment' || lenses.length < 2) return
+    // No live stream means the camera is stopped or restarting — switching
+    // now would open a camera behind that lifecycle's back.
+    if (!streamRef.current) return
     if (lensSwitchInFlightRef.current) return
     lensSwitchInFlightRef.current = true
     try {

--- a/src/hooks/use-camera.ts
+++ b/src/hooks/use-camera.ts
@@ -128,7 +128,10 @@ export function useCamera(): UseCameraResult {
   const [rearLensCount, setRearLensCount] = useState(0)
   const [rearLensIndex, setRearLensIndex] = useState(0)
   const rearLensesRef = useRef<string[]>([])
+  const rearLensIndexRef = useRef(0)
   const lensSwitchInFlightRef = useRef(false)
+  /** Bumped by stop(): async opens started before a stop must not adopt. */
+  const cameraEpochRef = useRef(0)
 
   const zoomRangeRef = useRef<CameraZoomRange | null>(null)
   const zoomSyncTimerRef = useRef(0)
@@ -205,6 +208,7 @@ export function useCamera(): UseCameraResult {
     setRearLensCount(lenses.length)
     const activeId = active.getVideoTracks()[0]?.getSettings().deviceId ?? ''
     const index = lenses.indexOf(activeId)
+    rearLensIndexRef.current = index >= 0 ? index : 0
     setRearLensIndex(index >= 0 ? index : 0)
   }, [])
 
@@ -277,16 +281,22 @@ export function useCamera(): UseCameraResult {
     try {
       const current = streamRef.current
       const activeId = current?.getVideoTracks()[0]?.getSettings().deviceId ?? ''
-      const activeIndex = lenses.indexOf(activeId)
+      const foundIndex = lenses.indexOf(activeId)
+      // When the open stream and the enumeration disagree (id rotation,
+      // fallback opens), advance from the lens the UI shows instead of
+      // silently jumping back to the first lens.
+      const activeIndex = foundIndex >= 0 ? foundIndex : rearLensIndexRef.current
       const nextId = lenses[(activeIndex + 1) % lenses.length]!
       // Android camera HALs are often exclusive across rear lenses: release
       // the current camera before opening the next one.
       stopStream(current)
       streamRef.current = null
       setIsReady(false)
-      // A flip may land while a lens open is in flight; its stream must win.
+      // A flip or a full stop (e.g. tab hidden) may land while a lens open
+      // is in flight — never adopt a stream into a stopped or flipped camera.
+      const epoch = cameraEpochRef.current
       const adopt = (opened: MediaStream): boolean => {
-        if (facingRef.current !== 'environment') {
+        if (facingRef.current !== 'environment' || cameraEpochRef.current !== epoch) {
           stopStream(opened)
           return false
         }
@@ -409,6 +419,7 @@ export function useCamera(): UseCameraResult {
   }, [])
 
   const stop = useCallback(() => {
+    cameraEpochRef.current += 1
     stopStream(streamRef.current)
     streamRef.current = null
     setStream(null)

--- a/src/hooks/use-camera.ts
+++ b/src/hooks/use-camera.ts
@@ -1,6 +1,7 @@
 import { useCallback, useRef, useState, type RefCallback } from 'react'
 import {
   canFlipCamera,
+  listRearCameras,
   openCameraStream,
   openMicrophoneTrack,
   queryCameraPermission,
@@ -9,6 +10,47 @@ import {
   type CameraPermissionState,
   type FacingMode,
 } from '../lib/media'
+
+/** Remembered rear lens (e.g. the ultra-wide) across sessions. */
+const REAR_LENS_STORAGE_KEY = 'kodyVideo.rearLens'
+
+interface RememberedLens {
+  id: string
+  /** Position in enumeration order — device ids rotate when the browser
+   * clears site data, but the lens order on a given phone is stable. */
+  index: number
+}
+
+function rememberedRearLens(): RememberedLens | null {
+  try {
+    const raw = localStorage.getItem(REAR_LENS_STORAGE_KEY)
+    if (!raw) return null
+    const parsed = JSON.parse(raw) as Partial<RememberedLens>
+    if (typeof parsed.id !== 'string' || typeof parsed.index !== 'number') return null
+    return { id: parsed.id, index: parsed.index }
+  } catch {
+    return null
+  }
+}
+
+function rememberRearLens(lens: RememberedLens | null): void {
+  try {
+    if (lens) localStorage.setItem(REAR_LENS_STORAGE_KEY, JSON.stringify(lens))
+    else localStorage.removeItem(REAR_LENS_STORAGE_KEY)
+  } catch {
+    // Storage unavailable (private mode) — lens choice just won't persist.
+  }
+}
+
+/** Resolve a remembered lens against the current enumeration: exact id when
+ * still valid, otherwise the same position, otherwise nothing. */
+async function resolveRememberedLens(): Promise<string | undefined> {
+  const remembered = rememberedRearLens()
+  if (!remembered) return undefined
+  const lenses = await listRearCameras()
+  if (lenses.includes(remembered.id)) return remembered.id
+  return lenses[remembered.index]
+}
 
 export interface CameraZoomRange {
   min: number
@@ -29,6 +71,12 @@ export interface UseCameraResult {
   zoom: CameraZoomRange | null
   torchAvailable: boolean
   torchOn: boolean
+  /** Number of rear camera devices (ultra-wide/tele are often separate). */
+  rearLensCount: number
+  /** Index of the active rear lens, when facing the environment. */
+  rearLensIndex: number
+  /** Cycle to the next rear lens (no-op while facing the user). */
+  switchRearLens: () => Promise<void>
   start: () => Promise<void>
   flip: () => Promise<void>
   stop: () => void
@@ -77,6 +125,10 @@ export function useCamera(): UseCameraResult {
   const [zoom, setZoomState] = useState<CameraZoomRange | null>(null)
   const [torchAvailable, setTorchAvailable] = useState(false)
   const [torchOn, setTorchOn] = useState(false)
+  const [rearLensCount, setRearLensCount] = useState(0)
+  const [rearLensIndex, setRearLensIndex] = useState(0)
+  const rearLensesRef = useRef<string[]>([])
+  const lensSwitchInFlightRef = useRef(false)
 
   const zoomRangeRef = useRef<CameraZoomRange | null>(null)
   const zoomSyncTimerRef = useRef(0)
@@ -140,6 +192,22 @@ export function useCamera(): UseCameraResult {
     [attachToVideo, readTrackCapabilities],
   )
 
+  /** Discover rear lenses and locate the active one (post-permission only). */
+  const syncRearLenses = useCallback(async (active: MediaStream) => {
+    if (facingRef.current !== 'environment') {
+      rearLensesRef.current = []
+      setRearLensCount(0)
+      setRearLensIndex(0)
+      return
+    }
+    const lenses = await listRearCameras()
+    rearLensesRef.current = lenses
+    setRearLensCount(lenses.length)
+    const activeId = active.getVideoTracks()[0]?.getSettings().deviceId ?? ''
+    const index = lenses.indexOf(activeId)
+    setRearLensIndex(index >= 0 ? index : 0)
+  }, [])
+
   const start = useCallback(async () => {
     if (startInFlightRef.current) {
       await startInFlightRef.current
@@ -156,10 +224,16 @@ export function useCamera(): UseCameraResult {
       }
 
       try {
-        const next = await openCameraStream(facingRef.current, { audio: false })
+        const rememberedLens =
+          facingRef.current === 'environment' ? await resolveRememberedLens() : undefined
+        const next = await openCameraStream(facingRef.current, {
+          audio: false,
+          deviceId: rememberedLens,
+        })
         setPermission({ status: 'granted' })
         replaceStream(next)
         setCanFlip(await canFlipCamera())
+        void syncRearLenses(next)
       } catch (err) {
         const message = permissionMessage(err)
         setPermission({ status: 'denied', message })
@@ -183,14 +257,58 @@ export function useCamera(): UseCameraResult {
     setFacing(nextFacing)
     setError(null)
     try {
-      const next = await openCameraStream(nextFacing, { audio: false })
+      const rememberedLens =
+        nextFacing === 'environment' ? await resolveRememberedLens() : undefined
+      const next = await openCameraStream(nextFacing, { audio: false, deviceId: rememberedLens })
       replaceStream(next)
+      void syncRearLenses(next)
     } catch (err) {
       facingRef.current = previousFacing
       setFacing(previousFacing)
       setError(permissionMessage(err))
     }
-  }, [replaceStream])
+  }, [replaceStream, syncRearLenses])
+
+  const switchRearLens = useCallback(async () => {
+    const lenses = rearLensesRef.current
+    if (facingRef.current !== 'environment' || lenses.length < 2) return
+    if (lensSwitchInFlightRef.current) return
+    lensSwitchInFlightRef.current = true
+    try {
+      const current = streamRef.current
+      const activeId = current?.getVideoTracks()[0]?.getSettings().deviceId ?? ''
+      const activeIndex = lenses.indexOf(activeId)
+      const nextId = lenses[(activeIndex + 1) % lenses.length]!
+      // Android camera HALs are often exclusive across rear lenses: release
+      // the current camera before opening the next one.
+      stopStream(current)
+      streamRef.current = null
+      setIsReady(false)
+      try {
+        const next = await openCameraStream('environment', { audio: false, deviceId: nextId })
+        const openedId = next.getVideoTracks()[0]?.getSettings().deviceId ?? ''
+        // openCameraStream falls back to facing mode on stale ids; only
+        // remember the lens the browser actually opened.
+        rememberRearLens(openedId ? { id: openedId, index: lenses.indexOf(openedId) } : null)
+        replaceStream(next)
+        void syncRearLenses(next)
+      } catch (err) {
+        // Try to restore the lens we just released.
+        try {
+          const restored = await openCameraStream('environment', {
+            audio: false,
+            deviceId: activeId || undefined,
+          })
+          replaceStream(restored)
+          void syncRearLenses(restored)
+        } catch {
+          setError(permissionMessage(err))
+        }
+      }
+    } finally {
+      lensSwitchInFlightRef.current = false
+    }
+  }, [replaceStream, syncRearLenses])
 
   const setZoom = useCallback((value: number) => {
     const track = streamRef.current?.getVideoTracks()[0]
@@ -321,6 +439,9 @@ export function useCamera(): UseCameraResult {
     zoom,
     torchAvailable,
     torchOn,
+    rearLensCount,
+    rearLensIndex,
+    switchRearLens,
     start,
     flip,
     stop,

--- a/src/hooks/use-camera.ts
+++ b/src/hooks/use-camera.ts
@@ -297,6 +297,7 @@ export function useCamera(): UseCameraResult {
       // the current camera before opening the next one.
       stopStream(current)
       streamRef.current = null
+      setStream(null)
       setIsReady(false)
       // A flip or a full stop (e.g. tab hidden) may land while a lens open
       // is in flight — never adopt a stream into a stopped or flipped camera.

--- a/src/hooks/use-camera.ts
+++ b/src/hooks/use-camera.ts
@@ -314,12 +314,13 @@ export function useCamera(): UseCameraResult {
         const next = await openCameraStream('environment', { audio: false, deviceId: nextId })
         const openedId = next.getVideoTracks()[0]?.getSettings().deviceId ?? ''
         if (!adopt(next)) return
-        // openCameraStream falls back to facing mode when the exact device
-        // can't be opened — only persist a lens the user actually reached,
-        // never an unintended fallback.
-        if (openedId === nextId) {
-          rememberRearLens({ id: openedId, index: lenses.indexOf(openedId) })
-        }
+        // Memory must mirror what's actually on screen: the requested lens,
+        // or the fallback the browser opened instead (facing-mode fallback on
+        // stale ids) — never a stale entry a reload would diverge to.
+        const openedIndex = lenses.indexOf(openedId)
+        rememberRearLens(
+          openedId && openedIndex >= 0 ? { id: openedId, index: openedIndex } : null,
+        )
       } catch (err) {
         // Try to restore the lens we just released.
         try {

--- a/src/lib/media.ts
+++ b/src/lib/media.ts
@@ -67,7 +67,16 @@ export async function openCameraStream(
         video: { ...baseConstraints, deviceId: { exact: options.deviceId } },
       })
     } catch {
-      // Fall through to the facing-mode request below.
+      // Some Android HALs choke on resolution hints for auxiliary lenses —
+      // retry the exact device bare before giving up on it.
+      try {
+        return await navigator.mediaDevices.getUserMedia({
+          audio: withAudio,
+          video: { deviceId: { exact: options.deviceId } },
+        })
+      } catch {
+        // Fall through to the facing-mode request below.
+      }
     }
   }
 

--- a/src/lib/media.ts
+++ b/src/lib/media.ts
@@ -43,6 +43,8 @@ export async function queryCameraPermission(): Promise<CameraPermissionState> {
 export interface OpenCameraOptions {
   /** Preview should stay video-only so Android voice-to-text can use the mic. */
   audio?: boolean
+  /** Open a specific camera (rear lens switching); falls back to facing. */
+  deviceId?: string
 }
 
 export async function openCameraStream(
@@ -50,17 +52,29 @@ export async function openCameraStream(
   options: OpenCameraOptions = {},
 ): Promise<MediaStream> {
   const withAudio = options.audio === true
-  const videoConstraints: MediaTrackConstraints = {
-    facingMode: { ideal: facing },
+  const baseConstraints: MediaTrackConstraints = {
     width: { ideal: 1280 },
     height: { ideal: 720 },
     frameRate: { ideal: 30 },
   }
 
+  // A specific lens (e.g. the rear ultra-wide) is requested by device id;
+  // stale ids (permission reset, OS updates) fall back to facing mode.
+  if (options.deviceId) {
+    try {
+      return await navigator.mediaDevices.getUserMedia({
+        audio: withAudio,
+        video: { ...baseConstraints, deviceId: { exact: options.deviceId } },
+      })
+    } catch {
+      // Fall through to the facing-mode request below.
+    }
+  }
+
   try {
     return await navigator.mediaDevices.getUserMedia({
       audio: withAudio,
-      video: videoConstraints,
+      video: { ...baseConstraints, facingMode: { ideal: facing } },
     })
   } catch (error) {
     if (isOverconstrained(error)) {
@@ -70,6 +84,40 @@ export async function openCameraStream(
       })
     }
     throw error
+  }
+}
+
+interface InputDeviceWithCapabilities extends MediaDeviceInfo {
+  getCapabilities?: () => MediaTrackCapabilities
+}
+
+/**
+ * Rear camera devices, in enumeration order. Many Androids expose the
+ * ultra-wide (and telephoto) as separate rear cameras rather than as zoom
+ * below 1× on the main one — reaching them requires opening that device.
+ * Labels/capabilities are only populated once camera permission is granted.
+ */
+export async function listRearCameras(): Promise<string[]> {
+  if (!navigator.mediaDevices?.enumerateDevices) return []
+  try {
+    const devices = await navigator.mediaDevices.enumerateDevices()
+    return devices
+      .filter((device): device is InputDeviceWithCapabilities => device.kind === 'videoinput')
+      .filter((device) => {
+        try {
+          const facing = device.getCapabilities?.().facingMode
+          if (Array.isArray(facing) && facing.length > 0) {
+            return facing.includes('environment')
+          }
+        } catch {
+          // Fall through to the label heuristic.
+        }
+        return /\bback\b|\brear\b|environment/i.test(device.label)
+      })
+      .map((device) => device.deviceId)
+      .filter((id) => id.length > 0)
+  } catch {
+    return []
   }
 }
 

--- a/src/styles/record.css
+++ b/src/styles/record.css
@@ -315,6 +315,15 @@
   cursor: not-allowed;
 }
 
+.lens-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  border-right: 1px solid rgba(255, 255, 255, 0.18);
+  border-radius: 999px 0 0 999px;
+  padding-right: 12px;
+}
+
 .record-dock {
   position: absolute;
   left: 0;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

You can't reach 0.5×/0.7× by zooming on most Android phones: the ultra-wide (and telephoto) are usually exposed to browsers as *separate rear camera devices*, and the main camera's track reports `zoom.min = 1`. (Devices whose logical camera does report `zoom.min < 1` already got a sub-1× chip from the existing zoom-chip code.)

This adds real rear-lens switching:

- `listRearCameras()` in `src/lib/media.ts` enumerates rear cameras (via `InputDeviceInfo.getCapabilities().facingMode`, falling back to a label heuristic), and `openCameraStream` accepts a `deviceId` with graceful fallback to facing mode on stale ids.
- `use-camera` tracks the rear lens list and active index, and exposes `switchRearLens()`. Switching releases the current camera first (Android HALs are often exclusive across rear lenses), opens the next, and restores the previous lens if the open fails.
- The record screen shows a lens chip (`◎ 2/3`) at the head of the zoom row whenever the device has more than one rear camera and the camera faces the environment. Each lens re-reads its own zoom/torch capabilities on switch. The chip is disabled while recording or during the countdown.
- The chosen lens is remembered across flips, restarts, and sessions (`localStorage`), stored as id + enumeration index so it survives Chrome's device-id rotation when site data is cleared.

Phones that don't expose their extra lenses to browsers at all (some OEMs restrict them to the stock camera app) can't be reached by any web app — the chip simply stays hidden there.

## Testing

- New `scripts/probe-rear-lens.mjs` (9/9): relabels Chromium's three fake cameras as rear lenses and verifies the chip renders, switches the actual device, survives reload and flip roundtrips, hides while facing the user, and that recording works on a switched lens.
- Full smoke suite 32/32, keyboard probe 18/18, 49 unit tests, typecheck + build pass.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-16d17496-6b5b-4e12-b600-6933357c2059"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-16d17496-6b5b-4e12-b600-6933357c2059"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for switching between multiple rear-camera lenses, including ultra-wide and telephoto options.
  * Added a lens selector showing the active lens and available lens count.
  * Preserved the selected rear lens across camera flips, page reloads, and app restarts.
  * Added safeguards and fallback behavior when switching lenses is unavailable.

* **Documentation**
  * Documented browser limitations for ultra-wide cameras.
  * Added rear-lens validation instructions and a permissions checklist.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->