### PR TITLE
Speed up drag-to-zoom ramp

### DIFF
--- a/src/components/record-screen.tsx
+++ b/src/components/record-screen.tsx
@@ -647,10 +647,11 @@ export function RecordScreen({
           }
           const stageHeight = dragZoomStageHeightRef.current || stageRef.current?.clientHeight || 1
           // Multiplicative zoom: equal finger travel = equal zoom *ratio*
-          // (drag up to zoom in). Each ~55% of stage height doubles the zoom,
-          // which is far gentler than the old linear full-range mapping —
-          // especially near 1× and on cameras with big zoom ranges.
-          const travelPerDoubling = stageHeight * 0.55
+          // (drag up to zoom in). Each ~28% of stage height doubles the zoom,
+          // so a full-stage drag covers ~3.5 doublings (≈11×) — quick enough
+          // to feel responsive, while the dead zone above still absorbs
+          // accidental finger drift.
+          const travelPerDoubling = stageHeight * 0.28
           const deltaY = dragZoomPressYRef.current - event.clientY
           const next = Math.min(
             zoom.max,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Real-device feedback: drag-to-zoom felt too gentle after the last tuning pass. This changes the multiplicative mapping from one zoom doubling per ~55% of stage height to one per ~28% — a full-stage drag now covers ~3.5 doublings (≈11×), so the lens responds decisively once the drag is deliberate.

The 14px dead zone is unchanged: accidental finger drift while holding to record still doesn't zoom, and the drag re-anchors at the dead-zone edge so there's no jump when it engages.

## Testing

- Full smoke suite 32/32, keyboard probe 18/18, typecheck + build pass.
- One-line constant change in the drag-zoom math; zoom clamping to the device range and the snap-back-after-take behavior are untouched.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-16d17496-6b5b-4e12-b600-6933357c2059"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-16d17496-6b5b-4e12-b600-6933357c2059"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved drag-to-zoom responsiveness by making zoom adjustments more sensitive to finger movement.
  * Preserved the existing dead-zone behavior to prevent unintended zoom changes from minor movements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->