### PR TITLE
Add team@kody.video support email across About, legal pages, and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,11 @@ sheet.
 Deployment requirement: set `STRIPE_SECRET_KEY` (a restricted key with
 Checkout Sessions read access is enough) on the Cloudflare Pages project.
 
+## Support
+
+Email [team@kody.video](mailto:team@kody.video) or open a GitHub issue (the
+in-app About page has a link that pre-fills device details).
+
 ## Privacy
 
 - No telemetry, analytics, or accounts.

--- a/src/pages/about-page.tsx
+++ b/src/pages/about-page.tsx
@@ -103,13 +103,15 @@ export function AboutPage() {
         </section>
 
         <section className="about-section">
-          <h2>Report a problem</h2>
+          <h2>Support</h2>
           <p>
             Hit a bug? Please{' '}
             <a href={reportProblemUrl()} target="_blank" rel="noreferrer noopener">
               open an issue on GitHub
             </a>{' '}
             — the link pre-fills your device details so you only have to describe what went wrong.
+            Prefer email (or need help with a purchase)? Write to{' '}
+            <a href="mailto:team@kody.video">team@kody.video</a>.
           </p>
         </section>
 

--- a/src/pages/privacy-page.tsx
+++ b/src/pages/privacy-page.tsx
@@ -72,7 +72,7 @@ export function PrivacyPage() {
         <section className="about-section">
           <h2>Questions</h2>
           <p>
-            Open an issue at{' '}
+            Email <a href="mailto:team@kody.video">team@kody.video</a> or open an issue at{' '}
             <a
               href="https://github.com/kentcdodds/kody-video"
               target="_blank"

--- a/src/pages/terms-page.tsx
+++ b/src/pages/terms-page.tsx
@@ -38,7 +38,7 @@ export function TermsPage() {
             Watermark removal is a one-time $0.99 purchase that unlocks watermark-free exports for
             the browser profile where it&rsquo;s verified. You can restore the purchase on another
             device via the Stripe receipt link. Payments are handled by Stripe. For refunds or
-            purchase trouble, open a GitHub issue.
+            purchase trouble, email <a href="mailto:team@kody.video">team@kody.video</a>.
           </p>
         </section>
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

`team@kody.video` is now a live support address (Cloudflare Email Routing on the kody.video zone forwards it to the maintainer — configured outside this repo). This PR surfaces it in the app:

- **About**: the "Report a problem" section is now "Support" and offers both the prefilled GitHub issue link and a `mailto:team@kody.video` link.
- **Privacy**: the "Questions" section leads with the support email.
- **Terms**: refund/purchase-trouble contact is now the support email instead of "open a GitHub issue".
- **README**: new Support section.

## Testing

- Full smoke suite 32/32 (about/legal assertions unaffected), typecheck + build pass.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-16d17496-6b5b-4e12-b600-6933357c2059"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-16d17496-6b5b-4e12-b600-6933357c2059"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

