### PR TITLE
Add Sentry crash reporting (errors only, production hostnames only)

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,10 +163,11 @@ in-app About page has a link that pre-fills device details).
 - Share/export uses user-gesture download or the Web Share API only.
 - Network calls besides Stripe checkout (opened in the browser): the
   purchase-verification function above (never sees media), and anonymous
-  Sentry crash reports (error + stack trace only, no PII, no media; only
-  from production hostnames — dev and tests never report). Every export or
-  import failure the UI softens into a toast is also captured with the step
-  name so real-device bugs surface.
+  Sentry crash reports (error + stack trace only — breadcrumbs and request
+  metadata are stripped in the SDK config; no PII, no media; only from
+  production hostnames — dev and tests never report). Export and import
+  failures the UI surfaces as friendly messages are also captured, tagged
+  with the failing step, so real-device bugs surface.
 
 ## Scripts
 

--- a/README.md
+++ b/README.md
@@ -158,11 +158,15 @@ in-app About page has a link that pre-fills device details).
 
 ## Privacy
 
-- No telemetry, analytics, or accounts.
+- No analytics or accounts.
 - No clip upload endpoints exist in this app.
 - Share/export uses user-gesture download or the Web Share API only.
-- The only network call besides Stripe checkout (opened in the browser) is
-  the purchase-verification function above; it never sees media.
+- Network calls besides Stripe checkout (opened in the browser): the
+  purchase-verification function above (never sees media), and anonymous
+  Sentry crash reports (error + stack trace only, no PII, no media; only
+  from production hostnames — dev and tests never report). Every export or
+  import failure the UI softens into a toast is also captured with the step
+  name so real-device bugs surface.
 
 ## Scripts
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "kody-video",
       "version": "0.1.0",
       "dependencies": {
+        "@sentry/react": "^10.68.0",
         "idb": "^8.0.3",
         "mp4-muxer": "^5.2.2",
         "react": "^19.1.0",
@@ -17,6 +18,7 @@
       },
       "devDependencies": {
         "@playwright/test": "^1.62.0",
+        "@sentry/vite-plugin": "^5.4.0",
         "@types/node": "^26.1.1",
         "@types/react": "^19.1.8",
         "@types/react-dom": "^19.1.6",
@@ -2633,6 +2635,348 @@
         "win32"
       ]
     },
+    "node_modules/@sentry/browser": {
+      "version": "10.68.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-10.68.0.tgz",
+      "integrity": "sha512-8xVgk7oG2lajXnbXF6a7H1xMZ/U6icqSldHGzQu1+bajfrK8Gan9ULG/Xsj1VM1LlNeK6/7znDJ3u1jgvIwznw==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/browser-utils": "10.68.0",
+        "@sentry/conventions": "^0.16.0",
+        "@sentry/core": "10.68.0",
+        "@sentry/feedback": "10.68.0",
+        "@sentry/replay": "10.68.0",
+        "@sentry/replay-canvas": "10.68.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/browser-utils": {
+      "version": "10.68.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser-utils/-/browser-utils-10.68.0.tgz",
+      "integrity": "sha512-be8VtdjCngKc77cstJeV+gO15iH+blyXpBDk8yOehmtX4BkFO33mfTMNCWVR2LA0oOxjIHWRAhf77fIUEhzxPg==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/conventions": "^0.16.0",
+        "@sentry/core": "10.68.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/bundler-plugins": {
+      "version": "10.68.0",
+      "resolved": "https://registry.npmjs.org/@sentry/bundler-plugins/-/bundler-plugins-10.68.0.tgz",
+      "integrity": "sha512-XWv7asJuTTUSlacROvqcIFKuNxAf3PYL/mdjMBhBwp3rJ4vMkA73jqNPjqCTm726cHs/Y4yadbbFA/OZLPWzeg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.18.5",
+        "@sentry/cli": "^2.58.6",
+        "@sentry/core": "10.68.0",
+        "dotenv": "^17.4.2",
+        "find-up": "^5.0.0",
+        "glob": "^13.0.6",
+        "magic-string": "~0.30.8"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "rollup": ">=3.2.0",
+        "webpack": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        },
+        "webpack": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@sentry/bundler-plugins/node_modules/glob": {
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@sentry/cli": {
+      "version": "2.58.6",
+      "resolved": "https://registry.npmjs.org/@sentry/cli/-/cli-2.58.6.tgz",
+      "integrity": "sha512-baBcNPLLfUi9WuL+Tpri9BFaAdvugZIKelC5X0tt0Zdy+K0K+PCVSrnNmwMWU/HyaF/SEv6b6UHnXIdqanBlcg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "FSL-1.1-MIT",
+      "dependencies": {
+        "https-proxy-agent": "^5.0.0",
+        "node-fetch": "^2.6.7",
+        "progress": "^2.0.3",
+        "proxy-from-env": "^1.1.0",
+        "which": "^2.0.2"
+      },
+      "bin": {
+        "sentry-cli": "bin/sentry-cli"
+      },
+      "engines": {
+        "node": ">= 10"
+      },
+      "optionalDependencies": {
+        "@sentry/cli-darwin": "2.58.6",
+        "@sentry/cli-linux-arm": "2.58.6",
+        "@sentry/cli-linux-arm64": "2.58.6",
+        "@sentry/cli-linux-i686": "2.58.6",
+        "@sentry/cli-linux-x64": "2.58.6",
+        "@sentry/cli-win32-arm64": "2.58.6",
+        "@sentry/cli-win32-i686": "2.58.6",
+        "@sentry/cli-win32-x64": "2.58.6"
+      }
+    },
+    "node_modules/@sentry/cli-darwin": {
+      "version": "2.58.6",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-darwin/-/cli-darwin-2.58.6.tgz",
+      "integrity": "sha512-udAVvcyfNa0R+95GvPz/+43/N3TC0TYKdkQ7D7jhPSzbcMc7l2fxRNN5yB3UpCA5fWFnW4toeaqwDBhb/Wh3LA==",
+      "dev": true,
+      "license": "FSL-1.1-MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-linux-arm": {
+      "version": "2.58.6",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-arm/-/cli-linux-arm-2.58.6.tgz",
+      "integrity": "sha512-pD0LAt5PcUzAinBwvDqc66x9+2CabHEv486yP0gRjWO7SakbaxmfVq/EXd8VLq/Tzi39LAu422UYK1lpW3MILw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "FSL-1.1-MIT",
+      "optional": true,
+      "os": [
+        "linux",
+        "freebsd",
+        "android"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-linux-arm64": {
+      "version": "2.58.6",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-arm64/-/cli-linux-arm64-2.58.6.tgz",
+      "integrity": "sha512-q8mEcNNmeXMy5i+jWT30TVpH7LcP4HD21CD5XRSPAd/a912HF6EpK0ybf/1USO14WOhoXbAGi9txwaWabSe33g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "FSL-1.1-MIT",
+      "optional": true,
+      "os": [
+        "linux",
+        "freebsd",
+        "android"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-linux-i686": {
+      "version": "2.58.6",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-i686/-/cli-linux-i686-2.58.6.tgz",
+      "integrity": "sha512-q8vNJi1eOV/4vxAFWBsEwLHoSYapaZHIf4j76KJGJXFKTkEbsjCOOsKbwUIBTQQhRgV4DFWh3ryfsPS/que4Kg==",
+      "cpu": [
+        "x86",
+        "ia32"
+      ],
+      "dev": true,
+      "license": "FSL-1.1-MIT",
+      "optional": true,
+      "os": [
+        "linux",
+        "freebsd",
+        "android"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-linux-x64": {
+      "version": "2.58.6",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-x64/-/cli-linux-x64-2.58.6.tgz",
+      "integrity": "sha512-DZu956Mhi3ZRjTBe1WdbGV46ldVbA8d2rgp/fh51GsI25zjBHah4wZnPTSzpc+YqxU6pJpg579B/r3jrIK530Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "FSL-1.1-MIT",
+      "optional": true,
+      "os": [
+        "linux",
+        "freebsd",
+        "android"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-win32-arm64": {
+      "version": "2.58.6",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-arm64/-/cli-win32-arm64-2.58.6.tgz",
+      "integrity": "sha512-nj0Ff/kmAB73EPDhR8B4O9r+NUHK5GkPCkGWC+kXVemqAJWL5jcJ5KdxG0l/S0z6RoEoltID8/43/B+TaMlT7A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "FSL-1.1-MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-win32-i686": {
+      "version": "2.58.6",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-i686/-/cli-win32-i686-2.58.6.tgz",
+      "integrity": "sha512-WNZiDzPbgsEMQWq4avsQ391v/xWKJDIWWWo9GYl+N/w5qcYKkoDW7wQG7T9FasI6ENn68phChTOAPXXxbfAdOg==",
+      "cpu": [
+        "x86",
+        "ia32"
+      ],
+      "dev": true,
+      "license": "FSL-1.1-MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-win32-x64": {
+      "version": "2.58.6",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-x64/-/cli-win32-x64-2.58.6.tgz",
+      "integrity": "sha512-R35WJ17oF4D2eqI1DR2sQQqr0fjRTt5xoP16WrTu91XM2lndRMFsnjh+/GttbxapLCBNlrjzia99MJ0PZHZpgA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "FSL-1.1-MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/conventions": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@sentry/conventions/-/conventions-0.16.0.tgz",
+      "integrity": "sha512-fO9PLmHdVURcSPUpWCItWAtgKiMwGdJHbovoSEyLplX5sxs2ugvI4CBPTrkkgqhObnZOD0CnWBKDzSVQYBKEyQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@sentry/core": {
+      "version": "10.68.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.68.0.tgz",
+      "integrity": "sha512-5Amhx8ltVz7vb1bRGyf3c4J69/iHW8R/H+SJxTRILHlsSOBrnVVc/IQEYDC6PTRdRdZ3x2u7RVjxZi2Mhe525g==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/conventions": "^0.16.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/feedback": {
+      "version": "10.68.0",
+      "resolved": "https://registry.npmjs.org/@sentry/feedback/-/feedback-10.68.0.tgz",
+      "integrity": "sha512-XbdcXiBnpC3vgw46eHOPeD/ZQ+XzluP75ubdUcaPDW02hCh2nsdXiwjZ2DBImbpvIpTbJgjHf/sIlHWvcZJ2Mg==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "10.68.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/react": {
+      "version": "10.68.0",
+      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-10.68.0.tgz",
+      "integrity": "sha512-rIq4QR4ScMHHx9JJZv7Jgw31bMdUVJMx+ykHIJb7htjY6mj78sjKs+KpCsMDnvJxDhSmvftGM1KfKD4BggL7OQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/browser": "10.68.0",
+        "@sentry/conventions": "^0.16.0",
+        "@sentry/core": "10.68.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.14.0 || 17.x || 18.x || 19.x"
+      }
+    },
+    "node_modules/@sentry/replay": {
+      "version": "10.68.0",
+      "resolved": "https://registry.npmjs.org/@sentry/replay/-/replay-10.68.0.tgz",
+      "integrity": "sha512-ZoG2n16vbkx4GWSCnLIqUUN9xlUmccQFbQ2US2rhruQeHTUnHl/ukr8NHOQXZaEbwKyMkX9bEMwfmZHJm+wSTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/browser-utils": "10.68.0",
+        "@sentry/core": "10.68.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/replay-canvas": {
+      "version": "10.68.0",
+      "resolved": "https://registry.npmjs.org/@sentry/replay-canvas/-/replay-canvas-10.68.0.tgz",
+      "integrity": "sha512-HusYcr+He+ohnUDHunYrc5St6vdDnBXpUAndnT5ReyUMVSCiWKfY3paXowU/0787HwYfxdcpZgwC5u79+XbEIg==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "10.68.0",
+        "@sentry/replay": "10.68.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/vite-plugin": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@sentry/vite-plugin/-/vite-plugin-5.4.0.tgz",
+      "integrity": "sha512-fFJgCxs5hDyAm9BbZJ+LbA+LK2tjX5OoD0v0ARU4StR6KQmGUduoPs69yJ9AfqZ0om3Rlp5JDliiwFcNkasORA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/bundler-plugins": "^10.64.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
     "node_modules/@trickfilm400/rollup-plugin-off-main-thread": {
       "version": "3.0.0-pre1",
       "resolved": "https://registry.npmjs.org/@trickfilm400/rollup-plugin-off-main-thread/-/rollup-plugin-off-main-thread-3.0.0-pre1.tgz",
@@ -2922,6 +3266,19 @@
       },
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
       }
     },
     "node_modules/ajv": {
@@ -3471,6 +3828,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/dotenv": {
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -3868,6 +4238,23 @@
         "node": ">=10"
       }
     },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/for-each": {
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
@@ -4204,6 +4591,20 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/idb": {
@@ -4763,6 +5164,22 @@
         "node": ">=6"
       }
     },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
@@ -4870,6 +5287,27 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/node-releases": {
       "version": "2.0.51",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.51.tgz",
@@ -4943,12 +5381,54 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/package-json-from-dist": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
       "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
       "dev": true,
       "license": "BlueOak-1.0.0"
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/path-key": {
       "version": "3.1.1",
@@ -5129,6 +5609,23 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/react": {
       "version": "19.2.8",
@@ -5967,6 +6464,13 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/type-fest": {
       "version": "0.16.0",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.16.0.tgz",
@@ -6409,6 +6913,13 @@
         }
       }
     },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
     "node_modules/webm-muxer": {
       "version": "5.1.4",
       "resolved": "https://registry.npmjs.org/webm-muxer/-/webm-muxer-5.1.4.tgz",
@@ -6418,6 +6929,17 @@
       "dependencies": {
         "@types/dom-webcodecs": "^0.1.4",
         "@types/wicg-file-system-access": "^2020.9.5"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/which": {
@@ -6782,6 +7304,19 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "lint": "tsc -b --pretty false"
   },
   "dependencies": {
+    "@sentry/react": "^10.68.0",
     "idb": "^8.0.3",
     "mp4-muxer": "^5.2.2",
     "react": "^19.1.0",
@@ -22,6 +23,7 @@
   },
   "devDependencies": {
     "@playwright/test": "^1.62.0",
+    "@sentry/vite-plugin": "^5.4.0",
     "@types/node": "^26.1.1",
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.6",

--- a/src/lib/error-reporting.ts
+++ b/src/lib/error-reporting.ts
@@ -35,3 +35,18 @@ export function initErrorReporting(): void {
 export function reportError(error: unknown, context?: Record<string, unknown>): void {
   Sentry.captureException(error, context ? { extra: context } : undefined)
 }
+
+/**
+ * React 19 routes uncaught render errors through createRoot options instead
+ * of window.onerror — without these, UI crashes would never reach Sentry.
+ * The console callbacks preserve React's default logging behavior.
+ */
+export const reactRootErrorHandlers = {
+  onUncaughtError: Sentry.reactErrorHandler((error, errorInfo) => {
+    console.error('Uncaught React error', error, errorInfo.componentStack)
+  }),
+  onCaughtError: Sentry.reactErrorHandler(),
+  onRecoverableError: Sentry.reactErrorHandler((error, errorInfo) => {
+    console.warn('Recoverable React error', error, errorInfo.componentStack)
+  }),
+}

--- a/src/lib/error-reporting.ts
+++ b/src/lib/error-reporting.ts
@@ -17,23 +17,33 @@ export function initErrorReporting(): void {
     environment: location.hostname === 'kody.video' ? 'production' : 'legacy-pages-dev',
     // Crash reports only: no tracing, no session replay, no PII. Clips and
     // media never leave the device — this reports errors and stack traces.
+    // These settings ENFORCE the privacy-page wording ("error message, stack
+    // trace, browser/OS, failed step — nothing else"); keep them in sync.
     sendDefaultPii: false,
     tracesSampleRate: 0,
+    maxBreadcrumbs: 0,
+    beforeBreadcrumb: () => null,
     beforeSend(event) {
-      // Belt and braces: never attach user context (Sentry would otherwise
-      // infer an IP-based user for browser events).
+      // Never attach user context (Sentry would otherwise infer an IP-based
+      // user) or request metadata (URL/headers).
       delete event.user
+      delete event.request
       return event
     },
   })
 }
 
 /**
- * Explicit capture for errors we catch and soften into toasts (export or
- * import failures, …) — the user sees a friendly message, we see the cause.
+ * Explicit capture for errors we catch and surface as in-app messages
+ * (export error sheet, import error banner, …) — the user sees a friendly
+ * message, we see the cause. The step lands as a searchable Sentry tag.
  */
-export function reportError(error: unknown, context?: Record<string, unknown>): void {
-  Sentry.captureException(error, context ? { extra: context } : undefined)
+export function reportError(
+  error: unknown,
+  step: string,
+  extra?: Record<string, unknown>,
+): void {
+  Sentry.captureException(error, { tags: { step }, ...(extra ? { extra } : {}) })
 }
 
 /**

--- a/src/lib/error-reporting.ts
+++ b/src/lib/error-reporting.ts
@@ -49,13 +49,22 @@ export function reportError(
 /**
  * React 19 routes uncaught render errors through createRoot options instead
  * of window.onerror — without these, UI crashes would never reach Sentry.
- * The console callbacks preserve React's default logging behavior.
+ *
+ * Classification subtlety: `reactErrorHandler(callback)` marks the event
+ * handled, `reactErrorHandler()` marks it unhandled. Uncaught root errors
+ * must stay *unhandled*, so their console logging wraps the capture instead
+ * of being passed as the callback.
  */
+const captureUncaughtReactError = Sentry.reactErrorHandler()
+
 export const reactRootErrorHandlers = {
-  onUncaughtError: Sentry.reactErrorHandler((error, errorInfo) => {
+  onUncaughtError: (error: unknown, errorInfo: React.ErrorInfo) => {
     console.error('Uncaught React error', error, errorInfo.componentStack)
+    captureUncaughtReactError(error, errorInfo)
+  },
+  onCaughtError: Sentry.reactErrorHandler((error, errorInfo) => {
+    console.error('Caught React error', error, errorInfo.componentStack)
   }),
-  onCaughtError: Sentry.reactErrorHandler(),
   onRecoverableError: Sentry.reactErrorHandler((error, errorInfo) => {
     console.warn('Recoverable React error', error, errorInfo.componentStack)
   }),

--- a/src/lib/error-reporting.ts
+++ b/src/lib/error-reporting.ts
@@ -1,4 +1,5 @@
 import * as Sentry from '@sentry/react'
+import type { ErrorInfo } from 'react'
 
 /** Publishable client key for the kody-video Sentry project (not a secret). */
 const SENTRY_DSN =
@@ -58,7 +59,7 @@ export function reportError(
 const captureUncaughtReactError = Sentry.reactErrorHandler()
 
 export const reactRootErrorHandlers = {
-  onUncaughtError: (error: unknown, errorInfo: React.ErrorInfo) => {
+  onUncaughtError: (error: unknown, errorInfo: ErrorInfo) => {
     console.error('Uncaught React error', error, errorInfo.componentStack)
     captureUncaughtReactError(error, errorInfo)
   },

--- a/src/lib/error-reporting.ts
+++ b/src/lib/error-reporting.ts
@@ -1,0 +1,37 @@
+import * as Sentry from '@sentry/react'
+
+/** Publishable client key for the kody-video Sentry project (not a secret). */
+const SENTRY_DSN =
+  'https://6cd948aa99f6c1fbb8df9c4df47f284d@o913766.ingest.us.sentry.io/4511810800713728'
+
+/** Only real deployments report — dev servers and test runs stay silent. */
+const REPORTING_HOSTNAMES = new Set(['kody.video', 'kody-video.pages.dev'])
+
+declare const __COMMIT_SHA__: string
+
+export function initErrorReporting(): void {
+  if (!REPORTING_HOSTNAMES.has(location.hostname)) return
+  Sentry.init({
+    dsn: SENTRY_DSN,
+    release: __COMMIT_SHA__,
+    environment: location.hostname === 'kody.video' ? 'production' : 'legacy-pages-dev',
+    // Crash reports only: no tracing, no session replay, no PII. Clips and
+    // media never leave the device — this reports errors and stack traces.
+    sendDefaultPii: false,
+    tracesSampleRate: 0,
+    beforeSend(event) {
+      // Belt and braces: never attach user context (Sentry would otherwise
+      // infer an IP-based user for browser events).
+      delete event.user
+      return event
+    },
+  })
+}
+
+/**
+ * Explicit capture for errors we catch and soften into toasts (export or
+ * import failures, …) — the user sees a friendly message, we see the cause.
+ */
+export function reportError(error: unknown, context?: Record<string, unknown>): void {
+  Sentry.captureException(error, context ? { extra: context } : undefined)
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,7 +1,7 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import { App } from './app'
-import { initErrorReporting } from './lib/error-reporting'
+import { initErrorReporting, reactRootErrorHandlers } from './lib/error-reporting'
 import './lib/install-prompt'
 import './styles/global.css'
 import './styles/home.css'
@@ -10,7 +10,7 @@ import './styles/editor.css'
 
 initErrorReporting()
 
-createRoot(document.getElementById('root')!).render(
+createRoot(document.getElementById('root')!, reactRootErrorHandlers).render(
   <StrictMode>
     <App />
   </StrictMode>,

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,11 +1,14 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import { App } from './app'
+import { initErrorReporting } from './lib/error-reporting'
 import './lib/install-prompt'
 import './styles/global.css'
 import './styles/home.css'
 import './styles/record.css'
 import './styles/editor.css'
+
+initErrorReporting()
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>

--- a/src/pages/about-page.tsx
+++ b/src/pages/about-page.tsx
@@ -84,7 +84,8 @@ export function AboutPage() {
           <p>
             No accounts, no analytics, no uploads. Clips live in this browser&rsquo;s storage until
             you export and share them yourself. The only network calls are Stripe checkout and its
-            purchase verification if you buy the watermark removal.
+            purchase verification if you buy the watermark removal, plus anonymous crash reports
+            (error and stack trace only — never your media) when something breaks.
           </p>
         </section>
 

--- a/src/pages/home-page.tsx
+++ b/src/pages/home-page.tsx
@@ -15,6 +15,7 @@ import {
   serializeProject,
 } from '../lib/project-transfer'
 import { createProject, deleteProject, getClipsForProject, renameProject } from '../lib/storage'
+import { reportError } from '../lib/error-reporting'
 import { canPromptInstall, promptInstall, subscribeInstallPrompt } from '../lib/install-prompt'
 import {
   formatBytes,
@@ -137,6 +138,7 @@ export function HomePage() {
         // no dependence on the list revalidating behind the scenes.
         navigate(`/project/${project.id}`)
       } catch (err) {
+        reportError(err, { where: 'import' })
         setError(err instanceof Error ? err.message : 'Could not import that file')
       } finally {
         setImportProgress(null)

--- a/src/pages/home-page.tsx
+++ b/src/pages/home-page.tsx
@@ -138,7 +138,7 @@ export function HomePage() {
         // no dependence on the list revalidating behind the scenes.
         navigate(`/project/${project.id}`)
       } catch (err) {
-        reportError(err, { where: 'import' })
+        reportError(err, 'import')
         setError(err instanceof Error ? err.message : 'Could not import that file')
       } finally {
         setImportProgress(null)

--- a/src/pages/privacy-page.tsx
+++ b/src/pages/privacy-page.tsx
@@ -26,6 +26,17 @@ export function PrivacyPage() {
         </section>
 
         <section className="about-section">
+          <h2>Anonymous crash reports</h2>
+          <p>
+            When the app itself breaks, an error report (the error message, a stack trace, browser
+            and OS names, and which step failed — e.g. &ldquo;export&rdquo;) is sent to Sentry so
+            bugs get found and fixed. Crash reports never contain your clips, audio, location, or
+            any account identifier, and no IP-based user profile is kept. This is the only data
+            the app sends anywhere on its own.
+          </p>
+        </section>
+
+        <section className="about-section">
           <h2>Camera &amp; microphone</h2>
           <p>
             The camera and microphone are used only while the app is open and you are recording.

--- a/src/pages/project-page.tsx
+++ b/src/pages/project-page.tsx
@@ -15,6 +15,7 @@ import { RecordScreen, type ToastAction } from '../components/record-screen'
 import { useCamera } from '../hooks/use-camera'
 import { RestoreSheet } from '../components/restore-sheet'
 import { REMOVE_WATERMARK_LINK } from '../lib/entitlement'
+import { reportError } from '../lib/error-reporting'
 import { exportProject, type ExportResult } from '../lib/export'
 import {
   canShareFile,
@@ -146,6 +147,7 @@ export function ProjectPage() {
         })
       } catch (err) {
         if (exportRunRef.current !== runId) return
+        reportError(err, { where: 'export', clips: clips.length })
         setExportState({
           status: 'error',
           progress: 0,

--- a/src/pages/project-page.tsx
+++ b/src/pages/project-page.tsx
@@ -146,8 +146,10 @@ export function ProjectPage() {
           watermarked,
         })
       } catch (err) {
+        // Report even when the run was abandoned (closed sheet / retry) —
+        // only the UI update is stale, the failure is real.
+        reportError(err, 'export', { clips: clips.length })
         if (exportRunRef.current !== runId) return
-        reportError(err, { where: 'export', clips: clips.length })
         setExportState({
           status: 'error',
           progress: 0,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,10 +1,33 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import { VitePWA } from 'vite-plugin-pwa'
+import { sentryVitePlugin } from '@sentry/vite-plugin'
+
+// Cloudflare Pages exposes the commit; local builds tag as 'dev'.
+const commitSha = process.env.CF_PAGES_COMMIT_SHA ?? 'dev'
+// Source maps upload only when the CI token is present (Cloudflare Pages env).
+const sentryUpload = Boolean(process.env.SENTRY_AUTH_TOKEN)
 
 export default defineConfig({
+  define: {
+    __COMMIT_SHA__: JSON.stringify(commitSha),
+  },
+  build: {
+    // Generated for Sentry upload, never referenced from the served bundles.
+    sourcemap: sentryUpload ? 'hidden' : false,
+  },
   plugins: [
     react(),
+    ...(sentryUpload
+      ? [
+          sentryVitePlugin({
+            org: 'kent-c-dodds-tech-llc',
+            project: 'kody-video',
+            release: { name: commitSha },
+            sourcemaps: { filesToDeleteAfterUpload: 'dist/**/*.map' },
+          }),
+        ]
+      : []),
     VitePWA({
       // Prompt-based updates: users see "new version ready — update" instead
       // of silently running stale code until some future reload.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Wires the app into the new `kody-video` Sentry project (created alongside this PR, with the same autonomous triage automation the Kody repo uses — new issues spawn a triage agent on this repository).

- `src/lib/error-reporting.ts`: Sentry init gated to `kody.video` / `kody-video.pages.dev` — dev servers, previews, and Playwright runs never report. Errors only: `tracesSampleRate: 0`, no session replay, `sendDefaultPii: false`, and `beforeSend` strips any user object so no IP-based profile exists. Release tagged with the Pages commit SHA.
- Explicit `reportError` capture in the two highest-value swallowed-error paths (export failure, import failure) with a step tag — the user sees the friendly toast, the error still surfaces.
- `vite.config.ts`: `@sentry/vite-plugin` activates only when `SENTRY_AUTH_TOKEN` is present in the build env (hidden source maps, deleted after upload — never served).
- Privacy honesty: the privacy page gains an "Anonymous crash reports" section, the About page's "Private by design" mentions crash reports, and the README privacy list is updated. The DSN in the client is publishable by design.

## Testing

- Full smoke suite 32/32 (Sentry stays inert on 127.0.0.1), typecheck + build pass.
- Bundle builds cleanly with and without `SENTRY_AUTH_TOKEN`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-16d17496-6b5b-4e12-b600-6933357c2059"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-16d17496-6b5b-4e12-b600-6933357c2059"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added anonymous crash reporting for production errors, capturing error details and stack traces without media or account identifiers.
  * Export and import failures are now automatically recorded so issues can be reviewed with the failed step context.
* **Privacy & Transparency**
  * Updated the Privacy content to clarify the app’s network-data posture and describe the scope of anonymous crash reports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->