### PR TITLE
Add Fathom Analytics (cookieless page-view counts)

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,10 @@ in-app About page has a link that pre-fills device details).
 
 ## Privacy
 
-- No analytics or accounts.
+- No accounts, no cookies, no cross-site tracking.
+- Page views are counted with [Fathom Analytics](https://usefathom.com)
+  (cookieless, anonymous, aggregate-only), loaded only on production
+  hostnames.
 - No clip upload endpoints exist in this app.
 - Share/export uses user-gesture download or the Web Share API only.
 - Network calls besides Stripe checkout (opened in the browser): the

--- a/index.html
+++ b/index.html
@@ -34,6 +34,19 @@
     />
     <meta name="twitter:image" content="https://kody.video/og-image.png" />
     <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
+    <script>
+      // Fathom Analytics (cookieless, anonymous page-view counts). Loaded
+      // only on real deployments so dev servers and test runs stay out of
+      // the stats; data-spa covers client-side route changes.
+      if (['kody.video', 'kody-video.pages.dev'].includes(location.hostname)) {
+        var fathomScript = document.createElement('script')
+        fathomScript.src = 'https://cdn.usefathom.com/script.js'
+        fathomScript.setAttribute('data-site', 'YKYNNRMZ')
+        fathomScript.setAttribute('data-spa', 'auto')
+        fathomScript.defer = true
+        document.head.appendChild(fathomScript)
+      }
+    </script>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link

--- a/src/pages/about-page.tsx
+++ b/src/pages/about-page.tsx
@@ -82,10 +82,11 @@ export function AboutPage() {
         <section className="about-section">
           <h2>Private by design</h2>
           <p>
-            No accounts, no analytics, no uploads. Clips live in this browser&rsquo;s storage until
-            you export and share them yourself. The only network calls are Stripe checkout and its
-            purchase verification if you buy the watermark removal, plus anonymous crash reports
-            (error and stack trace only — never your media) when something breaks.
+            No accounts, no uploads, no cross-site tracking. Clips live in this browser&rsquo;s
+            storage until you export and share them yourself. The app&rsquo;s only own network
+            traffic: Stripe checkout and its purchase verification if you buy the watermark
+            removal, anonymous crash reports (error and stack trace only — never your media) when
+            something breaks, and cookieless page-view counts via Fathom Analytics.
           </p>
         </section>
 

--- a/src/pages/privacy-page.tsx
+++ b/src/pages/privacy-page.tsx
@@ -20,8 +20,21 @@ export function PrivacyPage() {
           <h2>Everything stays on your device</h2>
           <p>
             All recordings, projects, and edits live in this browser&rsquo;s on-device storage
-            (IndexedDB). Nothing is uploaded. There are no accounts, no analytics, no tracking, and
-            no cookies beyond what the browser itself does.
+            (IndexedDB). Nothing is uploaded. There are no accounts, no cookies, and no cross-site
+            tracking.
+          </p>
+        </section>
+
+        <section className="about-section">
+          <h2>Anonymous page-view counts</h2>
+          <p>
+            The app counts page views with{' '}
+            <a href="https://usefathom.com" target="_blank" rel="noreferrer noopener">
+              Fathom Analytics
+            </a>
+            , a privacy-first service: no cookies, no personal identifiers, no cross-site
+            tracking, and nothing that requires a consent banner. We only ever see aggregate
+            numbers like &ldquo;how many people opened the app today&rdquo;.
           </p>
         </section>
 
@@ -31,8 +44,8 @@ export function PrivacyPage() {
             When the app itself breaks, an error report (the error message, a stack trace, browser
             and OS names, and which step failed — e.g. &ldquo;export&rdquo;) is sent to Sentry so
             bugs get found and fixed. Crash reports never contain your clips, audio, location, or
-            any account identifier, and no IP-based user profile is kept. This is the only data
-            the app sends anywhere on its own.
+            any account identifier, and no IP-based user profile is kept. Page-view counts and
+            crash reports are the only data the app sends anywhere on its own.
           </p>
         </section>
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Adds Fathom Analytics (site `YKYNNRMZ`) — privacy-first, cookieless, aggregate-only page-view counting.

- Inline head loader in `index.html` injects the Fathom script with `data-spa="auto"` (covers client-side route changes) **only on production hostnames** (`kody.video`, `kody-video.pages.dev`) — dev servers, previews, and Playwright runs stay out of the stats, matching the Sentry gating pattern.
- Privacy copy updated honestly across the privacy page (new "Anonymous page-view counts" section; the "no analytics" phrasing is replaced with the specific no-cookies / no-cross-site-tracking claims that remain true), the About page, and the README.

## Testing

- Full smoke suite 32/32 (loader stays inert on 127.0.0.1), typecheck + build pass.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-16d17496-6b5b-4e12-b600-6933357c2059"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-16d17496-6b5b-4e12-b600-6933357c2059"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

