### PR TITLE
Filter Sentry monitoring self-test synthetic errors (KODY-VIDEO-1)

### DIFF
--- a/src/lib/error-reporting.test.ts
+++ b/src/lib/error-reporting.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest'
+import { isMonitoringSelfTestEvent } from './error-reporting'
+
+describe('isMonitoringSelfTestEvent', () => {
+  it('drops the setup-agent synthetic exception signature', () => {
+    expect(
+      isMonitoringSelfTestEvent({
+        exception: {
+          values: [
+            {
+              type: 'Error',
+              value:
+                'KodyVideoMonitoringSelfTest: synthetic uncaught error from the setup agent',
+            },
+          ],
+        },
+      }),
+    ).toBe(true)
+  })
+
+  it('drops when the marker appears only in message', () => {
+    expect(
+      isMonitoringSelfTestEvent({
+        message: 'KodyVideoMonitoringSelfTest: synthetic uncaught error',
+      }),
+    ).toBe(true)
+  })
+
+  it('keeps ordinary application errors', () => {
+    expect(
+      isMonitoringSelfTestEvent({
+        exception: {
+          values: [{ type: 'Error', value: 'Export failed: encoder closed' }],
+        },
+      }),
+    ).toBe(false)
+  })
+
+  it('keeps events with no exception payload', () => {
+    expect(isMonitoringSelfTestEvent({})).toBe(false)
+  })
+})

--- a/src/lib/error-reporting.ts
+++ b/src/lib/error-reporting.ts
@@ -8,7 +8,31 @@ const SENTRY_DSN =
 /** Only real deployments report — dev servers and test runs stay silent. */
 const REPORTING_HOSTNAMES = new Set(['kody.video', 'kody-video.pages.dev'])
 
+/**
+ * Marker used by the monitoring setup agent when it throws a synthetic
+ * uncaught error to verify the DSN. Not app code — drop it so drills do not
+ * open triage issues.
+ */
+const MONITORING_SELF_TEST_MARKER = 'KodyVideoMonitoringSelfTest'
+
+type FilterableSentryEvent = {
+  exception?: { values?: Array<{ value?: string }> }
+  message?: string
+}
+
 declare const __COMMIT_SHA__: string
+
+/** True for intentional monitoring self-test events (narrow signature only). */
+export function isMonitoringSelfTestEvent(event: FilterableSentryEvent): boolean {
+  const exceptionValues = event.exception?.values ?? []
+  for (const value of exceptionValues) {
+    if (value.value?.includes(MONITORING_SELF_TEST_MARKER)) return true
+  }
+  return (
+    typeof event.message === 'string' &&
+    event.message.includes(MONITORING_SELF_TEST_MARKER)
+  )
+}
 
 export function initErrorReporting(): void {
   if (!REPORTING_HOSTNAMES.has(location.hostname)) return
@@ -29,6 +53,7 @@ export function initErrorReporting(): void {
       // user) or request metadata (URL/headers).
       delete event.user
       delete event.request
+      if (isMonitoringSelfTestEvent(event)) return null
       return event
     },
   })

--- a/src/lib/error-reporting.ts
+++ b/src/lib/error-reporting.ts
@@ -16,7 +16,7 @@ const REPORTING_HOSTNAMES = new Set(['kody.video', 'kody-video.pages.dev'])
 const MONITORING_SELF_TEST_MARKER = 'KodyVideoMonitoringSelfTest'
 
 type FilterableSentryEvent = {
-  exception?: { values?: Array<{ value?: string }> }
+  exception?: { values?: Array<{ type?: string; value?: string }> }
   message?: string
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sentry issue [KODY-VIDEO-1](https://kent-c-dodds-tech-llc.sentry.io/issues/7637241018/) is a single intentional synthetic error thrown by the monitoring setup agent (`KodyVideoMonitoringSelfTest: synthetic uncaught error from the setup agent`, via `setTimeout`/`eval`) to verify the production DSN after Sentry was wired up. It is not an application bug.

## Change

- Add a narrow `beforeSend` filter that drops events whose exception value or message includes `KodyVideoMonitoringSelfTest`.
- Unit tests cover the self-test signature and ensure ordinary errors still report.

## Outcome

`filtered` — low-risk wiring/filter change. After merge + deploy, the Sentry issue will be marked ignored so the existing event stops alerting; the filter prevents recurrence if the drill is re-run.

## Test plan

- [x] `npx vitest run` (53 tests)
- [x] `npm run build` (including Cloudflare Pages `tsc -b`)
- [x] `node scripts/manual-smoke.mjs` (32/32)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6eba8ee8-663f-47b5-85ec-614b6d76c076"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6eba8ee8-663f-47b5-85ec-614b6d76c076"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Monitoring self-test events are now filtered out before reporting, preventing synthetic events from triggering unnecessary triage.

* **Tests**
  * Added coverage confirming self-test events are detected in exception details and messages, while ordinary errors and events without exception data remain unaffected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->