### PR TITLE
Fix IndexedDB AbortError unhandled rejections (KODY-VIDEO-2)

### DIFF
--- a/src/components/record-screen.tsx
+++ b/src/components/record-screen.tsx
@@ -2,6 +2,7 @@ import { useCallback, useLayoutEffect, useRef, useState } from 'react'
 import { Link } from 'react-router-dom'
 import type { CameraZoomRange, UseCameraResult } from '../hooks/use-camera'
 import { getLocationFix, type LocationFix } from '../lib/location'
+import { reportError } from '../lib/error-reporting'
 import { appendRecording, removeClip, undoLastDelete } from '../lib/project-actions'
 import { HoldRecorder } from '../lib/recorder'
 import { setLocationTaggingEnabled } from '../lib/storage'
@@ -339,6 +340,9 @@ export function RecordScreen({
         })
         refresh()
       } catch (err) {
+        // Real store failures (quota, bad blob) must still reach Sentry as
+        // handled exceptions — without the twin unhandled AbortError from tx.done.
+        reportError(err, 'save-clip')
         showToast(err instanceof Error ? err.message : 'Save failed')
       } finally {
         endInFlightRef.current = false

--- a/src/lib/storage.test.ts
+++ b/src/lib/storage.test.ts
@@ -125,4 +125,34 @@ describe('storage layer', () => {
     const remaining = await getClipsForProject(project.id)
     expect(remaining).toHaveLength(0)
   })
+
+  it('does not leak AbortError unhandled rejections when a clip put fails', async () => {
+    const project = await createProject('Fail put')
+    const unhandled: unknown[] = []
+    const onUnhandled = (reason: unknown) => {
+      unhandled.push(reason)
+    }
+    process.on('unhandledRejection', onUnhandled)
+    try {
+      // Functions are not structured-cloneable, so IndexedDB rejects the put.
+      await expect(
+        addClip({
+          projectId: project.id,
+          blob: fakeBlob('x'),
+          mimeType: 'video/webm',
+          durationMs: 1000,
+          lat: (() => 0) as unknown as number,
+        }),
+      ).rejects.toBeTruthy()
+      // Let any orphaned tx.done rejection surface if the leak regresses.
+      await new Promise<void>((resolve) => setTimeout(resolve, 0))
+      const abortLeaks = unhandled.filter(
+        (err) =>
+          (err instanceof DOMException || err instanceof Error) && err.name === 'AbortError',
+      )
+      expect(abortLeaks).toHaveLength(0)
+    } finally {
+      process.off('unhandledRejection', onUnhandled)
+    }
+  })
 })

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -173,13 +173,15 @@ export async function deleteProject(id: ProjectId): Promise<void> {
   if (!project) return
 
   const tx = db.transaction(['projects', 'clips', 'undo', 'meta'], 'readwrite')
+  // Read meta before queueing writes so a failed delete cannot reject while
+  // we are still awaiting get — that would reintroduce the AbortError leak.
+  const settings = await tx.objectStore('meta').get('settings')
   const clips = tx.objectStore('clips')
   const ops: Array<Promise<unknown>> = [
     ...project.clipIds.map((clipId) => clips.delete(clipId)),
     tx.objectStore('undo').delete(id),
     tx.objectStore('projects').delete(id),
   ]
-  const settings = await tx.objectStore('meta').get('settings')
   if (settings?.lastOpenedProjectId === id) {
     ops.push(tx.objectStore('meta').put({ ...settings, lastOpenedProjectId: null }))
   }

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -37,6 +37,22 @@ const DB_VERSION = 1
 
 let dbPromise: Promise<IDBPDatabase<ClipsDB>> | null = null
 
+/**
+ * Finish an explicit idb transaction without leaking AbortError.
+ *
+ * `tx.done` is created eagerly and rejects as soon as any request fails —
+ * often before a later `await tx.done` runs. Awaiting the requests and
+ * `tx.done` together keeps that rejection in the same catch path (see
+ * jakearchibald/idb#320). Otherwise Sentry sees `AbortError: AbortError`
+ * via `unhandledrejection` as a twin of the real store error.
+ */
+async function completeTransaction(
+  ops: Array<Promise<unknown>>,
+  tx: { done: Promise<void> },
+): Promise<void> {
+  await Promise.all([...ops, tx.done])
+}
+
 export function getDb(): Promise<IDBPDatabase<ClipsDB>> {
   if (!dbPromise) {
     dbPromise = openDB<ClipsDB>(DB_NAME, DB_VERSION, {
@@ -157,17 +173,17 @@ export async function deleteProject(id: ProjectId): Promise<void> {
   if (!project) return
 
   const tx = db.transaction(['projects', 'clips', 'undo', 'meta'], 'readwrite')
-  for (const clipId of project.clipIds) {
-    await tx.objectStore('clips').delete(clipId)
-  }
-  await tx.objectStore('undo').delete(id)
-  await tx.objectStore('projects').delete(id)
-
+  const clips = tx.objectStore('clips')
+  const ops: Array<Promise<unknown>> = [
+    ...project.clipIds.map((clipId) => clips.delete(clipId)),
+    tx.objectStore('undo').delete(id),
+    tx.objectStore('projects').delete(id),
+  ]
   const settings = await tx.objectStore('meta').get('settings')
   if (settings?.lastOpenedProjectId === id) {
-    await tx.objectStore('meta').put({ ...settings, lastOpenedProjectId: null })
+    ops.push(tx.objectStore('meta').put({ ...settings, lastOpenedProjectId: null }))
   }
-  await tx.done
+  await completeTransaction(ops, tx)
 }
 
 export async function touchProject(id: ProjectId): Promise<void> {
@@ -243,13 +259,17 @@ export async function addClip(input: AddClipInput): Promise<ClipRecord> {
   }
 
   const tx = db.transaction(['clips', 'projects'], 'readwrite')
-  await tx.objectStore('clips').put(clip)
-  await tx.objectStore('projects').put({
-    ...project,
-    clipIds: [...project.clipIds, clip.id],
-    updatedAt: now,
-  })
-  await tx.done
+  await completeTransaction(
+    [
+      tx.objectStore('clips').put(clip),
+      tx.objectStore('projects').put({
+        ...project,
+        clipIds: [...project.clipIds, clip.id],
+        updatedAt: now,
+      }),
+    ],
+    tx,
+  )
   return clip
 }
 
@@ -281,8 +301,7 @@ export async function updateClipThumbs(clipId: ClipId, input: ClipThumbsInput): 
     width: clip.width ?? input.videoWidth,
     height: clip.height ?? input.videoHeight,
   }
-  await tx.store.put(updated)
-  await tx.done
+  await completeTransaction([tx.store.put(updated)], tx)
 }
 
 export async function updateClipTrim(
@@ -354,13 +373,17 @@ export async function duplicateClip(clipId: ClipId): Promise<ClipRecord> {
   clipIds.splice(index + 1, 0, copy.id)
 
   const tx = db.transaction(['clips', 'projects'], 'readwrite')
-  await tx.objectStore('clips').put(copy)
-  await tx.objectStore('projects').put({
-    ...project,
-    clipIds,
-    updatedAt: now,
-  })
-  await tx.done
+  await completeTransaction(
+    [
+      tx.objectStore('clips').put(copy),
+      tx.objectStore('projects').put({
+        ...project,
+        clipIds,
+        updatedAt: now,
+      }),
+    ],
+    tx,
+  )
   return copy
 }
 
@@ -382,14 +405,18 @@ export async function deleteClip(clipId: ClipId): Promise<DeletedClipSnapshot | 
 
   const clipIds = project.clipIds.filter((id) => id !== clipId)
   const tx = db.transaction(['clips', 'projects', 'undo'], 'readwrite')
-  await tx.objectStore('clips').delete(clipId)
-  await tx.objectStore('projects').put({
-    ...project,
-    clipIds,
-    updatedAt: Date.now(),
-  })
-  await tx.objectStore('undo').put(snapshot)
-  await tx.done
+  await completeTransaction(
+    [
+      tx.objectStore('clips').delete(clipId),
+      tx.objectStore('projects').put({
+        ...project,
+        clipIds,
+        updatedAt: Date.now(),
+      }),
+      tx.objectStore('undo').put(snapshot),
+    ],
+    tx,
+  )
   return snapshot
 }
 
@@ -411,14 +438,18 @@ export async function undoDeleteLastClip(projectId: ProjectId): Promise<ClipReco
   clipIds.splice(insertAt, 0, snapshot.clip.id)
 
   const tx = db.transaction(['clips', 'projects', 'undo'], 'readwrite')
-  await tx.objectStore('clips').put(snapshot.clip)
-  await tx.objectStore('projects').put({
-    ...project,
-    clipIds,
-    updatedAt: Date.now(),
-  })
-  await tx.objectStore('undo').delete(projectId)
-  await tx.done
+  await completeTransaction(
+    [
+      tx.objectStore('clips').put(snapshot.clip),
+      tx.objectStore('projects').put({
+        ...project,
+        clipIds,
+        updatedAt: Date.now(),
+      }),
+      tx.objectStore('undo').delete(projectId),
+    ],
+    tx,
+  )
   return snapshot.clip
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sentry [KODY-VIDEO-2](https://kent-c-dodds-tech-llc.sentry.io/issues/7637320476/) (`AbortError: AbortError` via `unhandledrejection`) arrived in the same session/trace as [KODY-VIDEO-3](https://kent-c-dodds-tech-llc.sentry.io/issues/7637320492/) (`UnknownError: Error preparing Blob/File data to be stored in object store`).

Root cause: explicit `idb` transactions awaited store ops and then `tx.done` separately. When a `put` fails, `tx.done` rejects immediately (often as `AbortError: AbortError`) before the later `await tx.done`, so the AbortError becomes an unhandled rejection twin of the real store error ([jakearchibald/idb#320](https://github.com/jakearchibald/idb/issues/320)).

## Change

- Add `completeTransaction()` and use `Promise.all([…ops, tx.done])` for every explicit readwrite transaction in `storage.ts`.
- `deleteProject` reads meta before queueing deletes (Bugbot feedback) so a failed delete cannot reject during an intervening await.
- Unit test: forced non-cloneable put failure must not leak `AbortError` unhandled rejections.
- On record save failure, `reportError(err, 'save-clip')` so real store errors still reach Sentry as handled exceptions (with a step tag) once the AbortError twin is gone.

## Outcome

`fixed` — low-risk isolated bug fix with tests. Sibling KODY-VIDEO-3 shares the unhandled-rejection leak; after merge both unhandled issues should stop. Remaining real store failures will report as handled `save-clip` events.

## Test plan

- [x] `npx vitest run` (54 tests)
- [x] `npm run build` (including Cloudflare Pages `tsc -b`)
- [x] `node scripts/manual-smoke.mjs` (32/32)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3e4d4481-b8aa-460b-abcf-75eca56ad13a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3e4d4481-b8aa-460b-abcf-75eca56ad13a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

