### PR TITLE
Fix IndexedDB blob persist UnknownError/AbortError (KODY-VIDEO-3)

### DIFF
--- a/src/components/record-screen.tsx
+++ b/src/components/record-screen.tsx
@@ -2,6 +2,7 @@ import { useCallback, useLayoutEffect, useRef, useState } from 'react'
 import { Link } from 'react-router-dom'
 import type { CameraZoomRange, UseCameraResult } from '../hooks/use-camera'
 import { getLocationFix, type LocationFix } from '../lib/location'
+import { reportError } from '../lib/error-reporting'
 import { appendRecording, removeClip, undoLastDelete } from '../lib/project-actions'
 import { HoldRecorder } from '../lib/recorder'
 import { setLocationTaggingEnabled } from '../lib/storage'
@@ -339,6 +340,7 @@ export function RecordScreen({
         })
         refresh()
       } catch (err) {
+        reportError(err, 'save-clip')
         showToast(err instanceof Error ? err.message : 'Save failed')
       } finally {
         endInFlightRef.current = false

--- a/src/components/record-screen.tsx
+++ b/src/components/record-screen.tsx
@@ -340,6 +340,8 @@ export function RecordScreen({
         })
         refresh()
       } catch (err) {
+        // Real store failures (quota, bad blob) must still reach Sentry as
+        // handled exceptions — without the twin unhandled AbortError from tx.done.
         reportError(err, 'save-clip')
         showToast(err instanceof Error ? err.message : 'Save failed')
       } finally {

--- a/src/lib/storage.test.ts
+++ b/src/lib/storage.test.ts
@@ -15,6 +15,7 @@ import {
   moveClip,
   renameProject,
   setOnboardingDismissed,
+  toStoredBlob,
   undoDeleteLastClip,
   updateClipTrim,
 } from './storage'
@@ -124,5 +125,30 @@ describe('storage layer', () => {
     expect(await getClip(clip.id)).toBeUndefined()
     const remaining = await getClipsForProject(project.id)
     expect(remaining).toHaveLength(0)
+  })
+
+  it('toStoredBlob copies bytes into a fresh Blob', async () => {
+    const original = fakeBlob('recorder-bytes')
+    const copy = await toStoredBlob(original)
+    expect(copy).not.toBe(original)
+    expect(copy.type).toBe('video/webm')
+    expect(await copy.text()).toBe('recorder-bytes')
+  })
+
+  it('addClip persists a durable copy, not the caller Blob reference', async () => {
+    const project = await createProject('Durable')
+    const original = fakeBlob('take-1')
+    const clip = await addClip({
+      projectId: project.id,
+      blob: original,
+      mimeType: 'video/webm',
+      durationMs: 900,
+    })
+    expect(clip.blob).not.toBe(original)
+    expect(await clip.blob.text()).toBe('take-1')
+
+    const stored = await getClip(clip.id)
+    expect(stored?.blob).not.toBe(original)
+    expect(await stored!.blob.text()).toBe('take-1')
   })
 })

--- a/src/lib/storage.test.ts
+++ b/src/lib/storage.test.ts
@@ -151,4 +151,34 @@ describe('storage layer', () => {
     expect(stored?.blob).not.toBe(original)
     expect(await stored!.blob.text()).toBe('take-1')
   })
+
+  it('does not leak AbortError unhandled rejections when a clip put fails', async () => {
+    const project = await createProject('Fail put')
+    const unhandled: unknown[] = []
+    const onUnhandled = (reason: unknown) => {
+      unhandled.push(reason)
+    }
+    process.on('unhandledRejection', onUnhandled)
+    try {
+      // Functions are not structured-cloneable, so IndexedDB rejects the put.
+      await expect(
+        addClip({
+          projectId: project.id,
+          blob: fakeBlob('x'),
+          mimeType: 'video/webm',
+          durationMs: 1000,
+          lat: (() => 0) as unknown as number,
+        }),
+      ).rejects.toBeTruthy()
+      // Let any orphaned tx.done rejection surface if the leak regresses.
+      await new Promise<void>((resolve) => setTimeout(resolve, 0))
+      const abortLeaks = unhandled.filter(
+        (err) =>
+          (err instanceof DOMException || err instanceof Error) && err.name === 'AbortError',
+      )
+      expect(abortLeaks).toHaveLength(0)
+    } finally {
+      process.off('unhandledRejection', onUnhandled)
+    }
+  })
 })

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -37,6 +37,22 @@ const DB_VERSION = 1
 
 let dbPromise: Promise<IDBPDatabase<ClipsDB>> | null = null
 
+/**
+ * Finish an explicit idb transaction without leaking AbortError.
+ *
+ * `tx.done` is created eagerly and rejects as soon as any request fails —
+ * often before a later `await tx.done` runs. Awaiting the requests and
+ * `tx.done` together keeps that rejection in the same catch path (see
+ * jakearchibald/idb#320). Otherwise Sentry sees `AbortError: AbortError`
+ * via `unhandledrejection` as a twin of the real store error.
+ */
+async function completeTransaction(
+  ops: Array<Promise<unknown>>,
+  tx: { done: Promise<void> },
+): Promise<void> {
+  await Promise.all([...ops, tx.done])
+}
+
 export function getDb(): Promise<IDBPDatabase<ClipsDB>> {
   if (!dbPromise) {
     dbPromise = openDB<ClipsDB>(DB_NAME, DB_VERSION, {
@@ -157,22 +173,17 @@ export async function deleteProject(id: ProjectId): Promise<void> {
   if (!project) return
 
   const tx = db.transaction(['projects', 'clips', 'undo', 'meta'], 'readwrite')
-  try {
-    for (const clipId of project.clipIds) {
-      await tx.objectStore('clips').delete(clipId)
-    }
-    await tx.objectStore('undo').delete(id)
-    await tx.objectStore('projects').delete(id)
-
-    const settings = await tx.objectStore('meta').get('settings')
-    if (settings?.lastOpenedProjectId === id) {
-      await tx.objectStore('meta').put({ ...settings, lastOpenedProjectId: null })
-    }
-    await tx.done
-  } catch (error) {
-    await tx.done.catch(() => undefined)
-    throw error
+  const clips = tx.objectStore('clips')
+  const ops: Array<Promise<unknown>> = [
+    ...project.clipIds.map((clipId) => clips.delete(clipId)),
+    tx.objectStore('undo').delete(id),
+    tx.objectStore('projects').delete(id),
+  ]
+  const settings = await tx.objectStore('meta').get('settings')
+  if (settings?.lastOpenedProjectId === id) {
+    ops.push(tx.objectStore('meta').put({ ...settings, lastOpenedProjectId: null }))
   }
+  await completeTransaction(ops, tx)
 }
 
 export async function touchProject(id: ProjectId): Promise<void> {
@@ -263,17 +274,17 @@ export async function addClip(input: AddClipInput): Promise<ClipRecord> {
   }
 
   const tx = db.transaction(['clips', 'projects'], 'readwrite')
-  // Always include tx.done so a failed put's abort cannot surface later as an
-  // unhandledrejection (KODY-VIDEO-2 / KODY-VIDEO-3).
-  await Promise.all([
-    tx.objectStore('clips').put(clip),
-    tx.objectStore('projects').put({
-      ...project,
-      clipIds: [...project.clipIds, clip.id],
-      updatedAt: now,
-    }),
-    tx.done,
-  ])
+  await completeTransaction(
+    [
+      tx.objectStore('clips').put(clip),
+      tx.objectStore('projects').put({
+        ...project,
+        clipIds: [...project.clipIds, clip.id],
+        updatedAt: now,
+      }),
+    ],
+    tx,
+  )
   return clip
 }
 
@@ -295,26 +306,21 @@ export async function updateClipThumbs(clipId: ClipId, input: ClipThumbsInput): 
   // Read + merge + write in one transaction so a concurrent trim/delete can
   // never be clobbered by a stale snapshot of the clip record.
   const tx = db.transaction('clips', 'readwrite')
-  try {
-    const clip = await tx.store.get(clipId)
-    if (!clip) {
-      await tx.done
-      return
-    }
-    const updated: ClipRecord = {
-      ...clip,
-      thumbs,
-      poster,
-      thumbWidth: input.thumbWidth,
-      thumbHeight: input.thumbHeight,
-      width: clip.width ?? input.videoWidth,
-      height: clip.height ?? input.videoHeight,
-    }
-    await Promise.all([tx.store.put(updated), tx.done])
-  } catch (error) {
-    await tx.done.catch(() => undefined)
-    throw error
+  const clip = await tx.store.get(clipId)
+  if (!clip) {
+    await tx.done
+    return
   }
+  const updated: ClipRecord = {
+    ...clip,
+    thumbs,
+    poster,
+    thumbWidth: input.thumbWidth,
+    thumbHeight: input.thumbHeight,
+    width: clip.width ?? input.videoWidth,
+    height: clip.height ?? input.videoHeight,
+  }
+  await completeTransaction([tx.store.put(updated)], tx)
 }
 
 export async function updateClipTrim(
@@ -393,15 +399,17 @@ export async function duplicateClip(clipId: ClipId): Promise<ClipRecord> {
   clipIds.splice(index + 1, 0, copy.id)
 
   const tx = db.transaction(['clips', 'projects'], 'readwrite')
-  await Promise.all([
-    tx.objectStore('clips').put(copy),
-    tx.objectStore('projects').put({
-      ...project,
-      clipIds,
-      updatedAt: now,
-    }),
-    tx.done,
-  ])
+  await completeTransaction(
+    [
+      tx.objectStore('clips').put(copy),
+      tx.objectStore('projects').put({
+        ...project,
+        clipIds,
+        updatedAt: now,
+      }),
+    ],
+    tx,
+  )
   return copy
 }
 
@@ -423,16 +431,18 @@ export async function deleteClip(clipId: ClipId): Promise<DeletedClipSnapshot | 
 
   const clipIds = project.clipIds.filter((id) => id !== clipId)
   const tx = db.transaction(['clips', 'projects', 'undo'], 'readwrite')
-  await Promise.all([
-    tx.objectStore('clips').delete(clipId),
-    tx.objectStore('projects').put({
-      ...project,
-      clipIds,
-      updatedAt: Date.now(),
-    }),
-    tx.objectStore('undo').put(snapshot),
-    tx.done,
-  ])
+  await completeTransaction(
+    [
+      tx.objectStore('clips').delete(clipId),
+      tx.objectStore('projects').put({
+        ...project,
+        clipIds,
+        updatedAt: Date.now(),
+      }),
+      tx.objectStore('undo').put(snapshot),
+    ],
+    tx,
+  )
   return snapshot
 }
 
@@ -454,16 +464,18 @@ export async function undoDeleteLastClip(projectId: ProjectId): Promise<ClipReco
   clipIds.splice(insertAt, 0, snapshot.clip.id)
 
   const tx = db.transaction(['clips', 'projects', 'undo'], 'readwrite')
-  await Promise.all([
-    tx.objectStore('clips').put(snapshot.clip),
-    tx.objectStore('projects').put({
-      ...project,
-      clipIds,
-      updatedAt: Date.now(),
-    }),
-    tx.objectStore('undo').delete(projectId),
-    tx.done,
-  ])
+  await completeTransaction(
+    [
+      tx.objectStore('clips').put(snapshot.clip),
+      tx.objectStore('projects').put({
+        ...project,
+        clipIds,
+        updatedAt: Date.now(),
+      }),
+      tx.objectStore('undo').delete(projectId),
+    ],
+    tx,
+  )
   return snapshot.clip
 }
 

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -157,17 +157,22 @@ export async function deleteProject(id: ProjectId): Promise<void> {
   if (!project) return
 
   const tx = db.transaction(['projects', 'clips', 'undo', 'meta'], 'readwrite')
-  for (const clipId of project.clipIds) {
-    await tx.objectStore('clips').delete(clipId)
-  }
-  await tx.objectStore('undo').delete(id)
-  await tx.objectStore('projects').delete(id)
+  try {
+    for (const clipId of project.clipIds) {
+      await tx.objectStore('clips').delete(clipId)
+    }
+    await tx.objectStore('undo').delete(id)
+    await tx.objectStore('projects').delete(id)
 
-  const settings = await tx.objectStore('meta').get('settings')
-  if (settings?.lastOpenedProjectId === id) {
-    await tx.objectStore('meta').put({ ...settings, lastOpenedProjectId: null })
+    const settings = await tx.objectStore('meta').get('settings')
+    if (settings?.lastOpenedProjectId === id) {
+      await tx.objectStore('meta').put({ ...settings, lastOpenedProjectId: null })
+    }
+    await tx.done
+  } catch (error) {
+    await tx.done.catch(() => undefined)
+    throw error
   }
-  await tx.done
 }
 
 export async function touchProject(id: ProjectId): Promise<void> {
@@ -220,16 +225,31 @@ export interface AddClipInput {
   createdAt?: number
 }
 
+/**
+ * Copy blob bytes into a fresh Blob before IndexedDB persistence.
+ * MediaRecorder / File-backed blobs can fail Chromium's object-store write
+ * with UnknownError ("Error preparing Blob/File data to be stored…") when
+ * the original backing store is ephemeral or already released.
+ */
+export async function toStoredBlob(blob: Blob): Promise<Blob> {
+  const buffer = await blob.arrayBuffer()
+  return new Blob([buffer], { type: blob.type || 'application/octet-stream' })
+}
+
 export async function addClip(input: AddClipInput): Promise<ClipRecord> {
   const db = await getDb()
   const project = await db.get('projects', input.projectId)
   if (!project) throw new Error('Project not found')
 
+  // Materialize before opening the transaction — awaiting inside a tx lets
+  // IndexedDB auto-commit and abort subsequent puts.
+  const durableBlob = await toStoredBlob(input.blob)
+
   const now = Date.now()
   const clip: ClipRecord = {
     id: newId('clip'),
     projectId: input.projectId,
-    blob: input.blob,
+    blob: durableBlob,
     mimeType: input.mimeType,
     durationMs: input.durationMs,
     trimStartMs: 0,
@@ -243,13 +263,17 @@ export async function addClip(input: AddClipInput): Promise<ClipRecord> {
   }
 
   const tx = db.transaction(['clips', 'projects'], 'readwrite')
-  await tx.objectStore('clips').put(clip)
-  await tx.objectStore('projects').put({
-    ...project,
-    clipIds: [...project.clipIds, clip.id],
-    updatedAt: now,
-  })
-  await tx.done
+  // Always include tx.done so a failed put's abort cannot surface later as an
+  // unhandledrejection (KODY-VIDEO-2 / KODY-VIDEO-3).
+  await Promise.all([
+    tx.objectStore('clips').put(clip),
+    tx.objectStore('projects').put({
+      ...project,
+      clipIds: [...project.clipIds, clip.id],
+      updatedAt: now,
+    }),
+    tx.done,
+  ])
   return clip
 }
 
@@ -264,25 +288,33 @@ export interface ClipThumbsInput {
 
 export async function updateClipThumbs(clipId: ClipId, input: ClipThumbsInput): Promise<void> {
   const db = await getDb()
+  const [thumbs, poster] = await Promise.all([
+    Promise.all(input.thumbs.map((thumb) => toStoredBlob(thumb))),
+    toStoredBlob(input.poster),
+  ])
   // Read + merge + write in one transaction so a concurrent trim/delete can
   // never be clobbered by a stale snapshot of the clip record.
   const tx = db.transaction('clips', 'readwrite')
-  const clip = await tx.store.get(clipId)
-  if (!clip) {
-    await tx.done
-    return
+  try {
+    const clip = await tx.store.get(clipId)
+    if (!clip) {
+      await tx.done
+      return
+    }
+    const updated: ClipRecord = {
+      ...clip,
+      thumbs,
+      poster,
+      thumbWidth: input.thumbWidth,
+      thumbHeight: input.thumbHeight,
+      width: clip.width ?? input.videoWidth,
+      height: clip.height ?? input.videoHeight,
+    }
+    await Promise.all([tx.store.put(updated), tx.done])
+  } catch (error) {
+    await tx.done.catch(() => undefined)
+    throw error
   }
-  const updated: ClipRecord = {
-    ...clip,
-    thumbs: input.thumbs,
-    poster: input.poster,
-    thumbWidth: input.thumbWidth,
-    thumbHeight: input.thumbHeight,
-    width: clip.width ?? input.videoWidth,
-    height: clip.height ?? input.videoHeight,
-  }
-  await tx.store.put(updated)
-  await tx.done
 }
 
 export async function updateClipTrim(
@@ -343,24 +375,33 @@ export async function duplicateClip(clipId: ClipId): Promise<ClipRecord> {
 
   const index = project.clipIds.indexOf(clipId)
   const now = Date.now()
+  const [blob, thumbs, poster] = await Promise.all([
+    toStoredBlob(clip.blob),
+    clip.thumbs ? Promise.all(clip.thumbs.map((thumb) => toStoredBlob(thumb))) : Promise.resolve(undefined),
+    clip.poster ? toStoredBlob(clip.poster) : Promise.resolve(undefined),
+  ])
   const copy: ClipRecord = {
     ...clip,
     id: newId('clip'),
     createdAt: now,
-    blob: clip.blob.slice(0, clip.blob.size, clip.blob.type),
+    blob,
+    thumbs,
+    poster,
   }
 
   const clipIds = [...project.clipIds]
   clipIds.splice(index + 1, 0, copy.id)
 
   const tx = db.transaction(['clips', 'projects'], 'readwrite')
-  await tx.objectStore('clips').put(copy)
-  await tx.objectStore('projects').put({
-    ...project,
-    clipIds,
-    updatedAt: now,
-  })
-  await tx.done
+  await Promise.all([
+    tx.objectStore('clips').put(copy),
+    tx.objectStore('projects').put({
+      ...project,
+      clipIds,
+      updatedAt: now,
+    }),
+    tx.done,
+  ])
   return copy
 }
 
@@ -382,14 +423,16 @@ export async function deleteClip(clipId: ClipId): Promise<DeletedClipSnapshot | 
 
   const clipIds = project.clipIds.filter((id) => id !== clipId)
   const tx = db.transaction(['clips', 'projects', 'undo'], 'readwrite')
-  await tx.objectStore('clips').delete(clipId)
-  await tx.objectStore('projects').put({
-    ...project,
-    clipIds,
-    updatedAt: Date.now(),
-  })
-  await tx.objectStore('undo').put(snapshot)
-  await tx.done
+  await Promise.all([
+    tx.objectStore('clips').delete(clipId),
+    tx.objectStore('projects').put({
+      ...project,
+      clipIds,
+      updatedAt: Date.now(),
+    }),
+    tx.objectStore('undo').put(snapshot),
+    tx.done,
+  ])
   return snapshot
 }
 
@@ -411,14 +454,16 @@ export async function undoDeleteLastClip(projectId: ProjectId): Promise<ClipReco
   clipIds.splice(insertAt, 0, snapshot.clip.id)
 
   const tx = db.transaction(['clips', 'projects', 'undo'], 'readwrite')
-  await tx.objectStore('clips').put(snapshot.clip)
-  await tx.objectStore('projects').put({
-    ...project,
-    clipIds,
-    updatedAt: Date.now(),
-  })
-  await tx.objectStore('undo').delete(projectId)
-  await tx.done
+  await Promise.all([
+    tx.objectStore('clips').put(snapshot.clip),
+    tx.objectStore('projects').put({
+      ...project,
+      clipIds,
+      updatedAt: Date.now(),
+    }),
+    tx.objectStore('undo').delete(projectId),
+    tx.done,
+  ])
   return snapshot.clip
 }
 

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -249,11 +249,9 @@ export async function toStoredBlob(blob: Blob): Promise<Blob> {
 
 export async function addClip(input: AddClipInput): Promise<ClipRecord> {
   const db = await getDb()
-  const project = await db.get('projects', input.projectId)
-  if (!project) throw new Error('Project not found')
-
   // Materialize before opening the transaction — awaiting inside a tx lets
-  // IndexedDB auto-commit and abort subsequent puts.
+  // IndexedDB auto-commit and abort subsequent puts. Re-read the project
+  // inside the tx so overlapping saves cannot clobber fresher clipIds.
   const durableBlob = await toStoredBlob(input.blob)
 
   const now = Date.now()
@@ -274,6 +272,11 @@ export async function addClip(input: AddClipInput): Promise<ClipRecord> {
   }
 
   const tx = db.transaction(['clips', 'projects'], 'readwrite')
+  const project = await tx.objectStore('projects').get(input.projectId)
+  if (!project) {
+    await tx.done.catch(() => undefined)
+    throw new Error('Project not found')
+  }
   await completeTransaction(
     [
       tx.objectStore('clips').put(clip),
@@ -374,18 +377,34 @@ export async function moveClip(
 
 export async function duplicateClip(clipId: ClipId): Promise<ClipRecord> {
   const db = await getDb()
-  const clip = await db.get('clips', clipId)
-  if (!clip) throw new Error('Clip not found')
-  const project = await db.get('projects', clip.projectId)
-  if (!project) throw new Error('Project not found')
+  const source = await db.get('clips', clipId)
+  if (!source) throw new Error('Clip not found')
 
-  const index = project.clipIds.indexOf(clipId)
   const now = Date.now()
   const [blob, thumbs, poster] = await Promise.all([
-    toStoredBlob(clip.blob),
-    clip.thumbs ? Promise.all(clip.thumbs.map((thumb) => toStoredBlob(thumb))) : Promise.resolve(undefined),
-    clip.poster ? toStoredBlob(clip.poster) : Promise.resolve(undefined),
+    toStoredBlob(source.blob),
+    source.thumbs
+      ? Promise.all(source.thumbs.map((thumb) => toStoredBlob(thumb)))
+      : Promise.resolve(undefined),
+    source.poster ? toStoredBlob(source.poster) : Promise.resolve(undefined),
   ])
+
+  const tx = db.transaction(['clips', 'projects'], 'readwrite')
+  const clip = await tx.objectStore('clips').get(clipId)
+  const project = clip
+    ? await tx.objectStore('projects').get(clip.projectId)
+    : undefined
+  if (!clip || !project) {
+    await tx.done.catch(() => undefined)
+    throw new Error(!clip ? 'Clip not found' : 'Project not found')
+  }
+
+  const index = project.clipIds.indexOf(clipId)
+  if (index < 0) {
+    await tx.done.catch(() => undefined)
+    throw new Error('Clip not in project')
+  }
+
   const copy: ClipRecord = {
     ...clip,
     id: newId('clip'),
@@ -394,11 +413,9 @@ export async function duplicateClip(clipId: ClipId): Promise<ClipRecord> {
     thumbs,
     poster,
   }
-
   const clipIds = [...project.clipIds]
   clipIds.splice(index + 1, 0, copy.id)
 
-  const tx = db.transaction(['clips', 'projects'], 'readwrite')
   await completeTransaction(
     [
       tx.objectStore('clips').put(copy),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sentry [KODY-VIDEO-3](https://kent-c-dodds-tech-llc.sentry.io/issues/7637320492/) (`UnknownError: Error preparing Blob/File data to be stored in object store`) paired with sibling [KODY-VIDEO-2](https://kent-c-dodds-tech-llc.sentry.io/issues/7637320476/) (`AbortError`) in the same production session.

Sibling #33 already landed the `tx.done` / AbortError unhandledrejection leak fix. This PR adds the remaining root-cause fix for the UnknownError:

## Fix

- `toStoredBlob`: materialize MediaRecorder/File bytes into a fresh `Blob` before IndexedDB writes (clips, thumbs, duplicates).
- Re-read the project (and clip, for duplicate) inside the write transaction after materialize so overlapping saves cannot clobber fresher `clipIds`.

## Test plan

- [x] `npx vitest run` (durable blob + AbortError leak regression)
- [x] `npm run build`
- [x] `node scripts/manual-smoke.mjs` (32/32)
- [x] Rebased/merged onto main after #33
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6f9d6699-a5d2-4279-b531-dc547f80c237"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6f9d6699-a5d2-4279-b531-dc547f80c237"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability when saving, duplicating, updating, deleting, and restoring recorded clips.
  - Ensured media files are stored as durable copies, reducing risks of missing or corrupted clip data.
  - Improved handling of storage transaction errors during cleanup and clip management.
  - Added error reporting for failures encountered while saving clips.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->