### PR TITLE
Fix export media loadedmetadata failures (KODY-VIDEO-4)

### DIFF
--- a/src/lib/export/media-error.test.ts
+++ b/src/lib/export/media-error.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest'
+import { isMediaElementFailure, mediaErrorDetail } from './media-error'
+
+describe('mediaErrorDetail', () => {
+  it('returns empty when the element has no MediaError', () => {
+    expect(mediaErrorDetail({})).toBe('')
+    expect(mediaErrorDetail({ error: null })).toBe('')
+  })
+
+  it('formats known MediaError codes with optional message', () => {
+    expect(mediaErrorDetail({ error: { code: 4 } })).toBe(' (MEDIA_ERR_SRC_NOT_SUPPORTED)')
+    expect(
+      mediaErrorDetail({
+        error: { code: 3, message: 'PIPELINE_ERROR_DECODE' },
+      }),
+    ).toBe(' (MEDIA_ERR_DECODE: PIPELINE_ERROR_DECODE)')
+  })
+})
+
+describe('isMediaElementFailure', () => {
+  it('matches the waitForMediaEvent failure signature only', () => {
+    expect(
+      isMediaElementFailure(new Error('Media failed while waiting for "loadedmetadata"')),
+    ).toBe(true)
+    expect(
+      isMediaElementFailure(
+        new Error('Media failed while waiting for "loadedmetadata" (MEDIA_ERR_DECODE)'),
+      ),
+    ).toBe(true)
+    expect(isMediaElementFailure(new Error('Timed out waiting for media "loadedmetadata"'))).toBe(
+      false,
+    )
+    expect(isMediaElementFailure('Media failed while waiting for "loadedmetadata"')).toBe(false)
+  })
+})

--- a/src/lib/export/media-error.test.ts
+++ b/src/lib/export/media-error.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest'
-import { isMediaElementFailure, mediaErrorDetail } from './media-error'
+import {
+  isMediaElementFailure,
+  MediaElementFailureError,
+  mediaErrorDetail,
+} from './media-error'
 
 describe('mediaErrorDetail', () => {
   it('returns empty when the element has no MediaError', () => {
@@ -18,18 +22,22 @@ describe('mediaErrorDetail', () => {
 })
 
 describe('isMediaElementFailure', () => {
-  it('matches the waitForMediaEvent failure signature only', () => {
+  it('matches the typed media-failure marker only', () => {
     expect(
-      isMediaElementFailure(new Error('Media failed while waiting for "loadedmetadata"')),
+      isMediaElementFailure(new MediaElementFailureError('loadedmetadata', {})),
     ).toBe(true)
     expect(
       isMediaElementFailure(
-        new Error('Media failed while waiting for "loadedmetadata" (MEDIA_ERR_DECODE)'),
+        new MediaElementFailureError('loadedmetadata', {
+          error: { code: 3, message: 'PIPELINE_ERROR_DECODE' },
+        }),
       ),
     ).toBe(true)
+    expect(isMediaElementFailure(new Error('Media failed while waiting for "loadedmetadata"'))).toBe(
+      false,
+    )
     expect(isMediaElementFailure(new Error('Timed out waiting for media "loadedmetadata"'))).toBe(
       false,
     )
-    expect(isMediaElementFailure('Media failed while waiting for "loadedmetadata"')).toBe(false)
   })
 })

--- a/src/lib/export/media-error.ts
+++ b/src/lib/export/media-error.ts
@@ -1,0 +1,30 @@
+/** Narrow MediaError shape so helpers stay testable outside a browser DOM. */
+export interface MediaErrorLike {
+  code?: number
+  message?: string
+}
+
+export interface MediaElementLike {
+  error?: MediaErrorLike | null
+}
+
+const MEDIA_ERR_NAMES: Record<number, string> = {
+  1: 'MEDIA_ERR_ABORTED',
+  2: 'MEDIA_ERR_NETWORK',
+  3: 'MEDIA_ERR_DECODE',
+  4: 'MEDIA_ERR_SRC_NOT_SUPPORTED',
+}
+
+/** Append browser MediaError details when an HTMLMediaElement reports failure. */
+export function mediaErrorDetail(media: MediaElementLike): string {
+  const err = media.error
+  if (!err || typeof err.code !== 'number') return ''
+  const name = MEDIA_ERR_NAMES[err.code] ?? `code ${err.code}`
+  const message = typeof err.message === 'string' ? err.message.trim() : ''
+  return message ? ` (${name}: ${message})` : ` (${name})`
+}
+
+/** True when loadClipVideo / waitForMediaEvent rejected on the media error path. */
+export function isMediaElementFailure(error: unknown): boolean {
+  return error instanceof Error && error.message.startsWith('Media failed while waiting for')
+}

--- a/src/lib/export/media-error.ts
+++ b/src/lib/export/media-error.ts
@@ -15,6 +15,18 @@ const MEDIA_ERR_NAMES: Record<number, string> = {
   4: 'MEDIA_ERR_SRC_NOT_SUPPORTED',
 }
 
+/** Marker so retry/discard logic does not depend on Error.message wording. */
+export const MEDIA_ELEMENT_FAILURE = Symbol('kody.mediaElementFailure')
+
+export class MediaElementFailureError extends Error {
+  readonly [MEDIA_ELEMENT_FAILURE] = true as const
+
+  constructor(event: string, media: MediaElementLike) {
+    super(`Media failed while waiting for "${event}"${mediaErrorDetail(media)}`)
+    this.name = 'MediaElementFailureError'
+  }
+}
+
 /** Append browser MediaError details when an HTMLMediaElement reports failure. */
 export function mediaErrorDetail(media: MediaElementLike): string {
   const err = media.error
@@ -24,7 +36,12 @@ export function mediaErrorDetail(media: MediaElementLike): string {
   return message ? ` (${name}: ${message})` : ` (${name})`
 }
 
-/** True when loadClipVideo / waitForMediaEvent rejected on the media error path. */
+/** True when waitForMediaEvent rejected on the media error path. */
 export function isMediaElementFailure(error: unknown): boolean {
-  return error instanceof Error && error.message.startsWith('Media failed while waiting for')
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    MEDIA_ELEMENT_FAILURE in error &&
+    (error as { [MEDIA_ELEMENT_FAILURE]?: unknown })[MEDIA_ELEMENT_FAILURE] === true
+  )
 }

--- a/src/lib/export/shared.ts
+++ b/src/lib/export/shared.ts
@@ -1,3 +1,5 @@
+import { isMediaElementFailure, mediaErrorDetail } from './media-error'
+
 /** Helpers shared by the WebCodecs and realtime export engines. */
 
 export interface LoadedClipVideo {
@@ -7,12 +9,28 @@ export interface LoadedClipVideo {
   release: () => void
 }
 
+/** Pause briefly so a previous video/camera can release a hardware decoder. */
+const MEDIA_LOAD_RETRY_DELAY_MS = 200
+
 /**
  * Load a clip blob into an off-DOM video element and resolve its real
  * duration. MediaRecorder WebM blobs report `Infinity` until you seek far
  * past the end, so that dance is handled here.
+ *
+ * Retries once on media-element failure: Android often rejects the first
+ * open when a just-unmounted preview/camera still holds a decoder slot.
  */
 export async function loadClipVideo(blob: Blob, timeoutMs = 8000): Promise<LoadedClipVideo> {
+  try {
+    return await loadClipVideoOnce(blob, timeoutMs)
+  } catch (error) {
+    if (!isMediaElementFailure(error)) throw error
+    await wait(MEDIA_LOAD_RETRY_DELAY_MS)
+    return loadClipVideoOnce(blob, timeoutMs)
+  }
+}
+
+async function loadClipVideoOnce(blob: Blob, timeoutMs: number): Promise<LoadedClipVideo> {
   const url = URL.createObjectURL(blob)
   const video = document.createElement('video')
   video.preload = 'auto'
@@ -77,7 +95,9 @@ export function waitForMediaEvent(
     }
     const onErr = () => {
       cleanup()
-      reject(new Error(`Media failed while waiting for "${event}"`))
+      reject(
+        new Error(`Media failed while waiting for "${event}"${mediaErrorDetail(target)}`),
+      )
     }
     const cleanup = () => {
       window.clearTimeout(timer)

--- a/src/lib/export/shared.ts
+++ b/src/lib/export/shared.ts
@@ -1,4 +1,4 @@
-import { isMediaElementFailure, mediaErrorDetail } from './media-error'
+import { isMediaElementFailure, MediaElementFailureError } from './media-error'
 
 /** Helpers shared by the WebCodecs and realtime export engines. */
 
@@ -95,9 +95,7 @@ export function waitForMediaEvent(
     }
     const onErr = () => {
       cleanup()
-      reject(
-        new Error(`Media failed while waiting for "${event}"${mediaErrorDetail(target)}`),
-      )
+      reject(new MediaElementFailureError(event, target))
     }
     const cleanup = () => {
       window.clearTimeout(timer)

--- a/src/lib/recorder.ts
+++ b/src/lib/recorder.ts
@@ -1,3 +1,4 @@
+import { isMediaElementFailure } from './export/media-error'
 import { measureBlobDuration, pickRecordingMimeType } from './media'
 
 export interface RecordingResult {
@@ -92,7 +93,14 @@ export class HoldRecorder {
               height,
             })
           })
-          .catch(() => {
+          .catch((error) => {
+            // A media-element failure means the browser cannot decode this
+            // take at all — keeping it would only fail again at export.
+            // Timeouts still fall back to wall-clock (streamy WebM).
+            if (isMediaElementFailure(error)) {
+              resolve(null)
+              return
+            }
             resolve({
               blob,
               mimeType: this.mimeType || blob.type || 'video/webm',

--- a/src/pages/project-page.tsx
+++ b/src/pages/project-page.tsx
@@ -27,6 +27,20 @@ import {
 import { loadProjectPage, type ProjectLoaderData } from '../lib/project-actions'
 import { setOnboardingDismissed } from '../lib/storage'
 
+/** Resolve after the next animation frame (or a short timeout when rAF is busy). */
+function waitForNextPaint(): Promise<void> {
+  return new Promise((resolve) => {
+    let done = false
+    const finish = () => {
+      if (done) return
+      done = true
+      resolve()
+    }
+    requestAnimationFrame(() => finish())
+    window.setTimeout(finish, 50)
+  })
+}
+
 type ProjectMode = 'record' | 'editor'
 
 interface ToastState extends Partial<ToastAction> {
@@ -122,6 +136,13 @@ export function ProjectPage() {
       watermarked,
     })
     void (async () => {
+      // Export unmounts record/editor so camera + preview video release.
+      // Wait two frames so those hardware decoder slots free before we open
+      // new ones — otherwise loadClipVideo can fail with a media error on
+      // Android (KODY-VIDEO-4).
+      await waitForNextPaint()
+      await waitForNextPaint()
+      if (exportRunRef.current !== runId) return
       try {
         const result = await exportProject(clips, {
           audioContext,

--- a/src/pages/project-page.tsx
+++ b/src/pages/project-page.tsx
@@ -136,14 +136,16 @@ export function ProjectPage() {
       watermarked,
     })
     void (async () => {
-      // Export unmounts record/editor so camera + preview video release.
-      // Wait two frames so those hardware decoder slots free before we open
-      // new ones — otherwise loadClipVideo can fail with a media error on
-      // Android (KODY-VIDEO-4).
-      await waitForNextPaint()
-      await waitForNextPaint()
-      if (exportRunRef.current !== runId) return
       try {
+        // Export unmounts record/editor so camera + preview video release.
+        // Wait two frames so those hardware decoder slots free before we open
+        // new ones — otherwise loadClipVideo can fail with a media error on
+        // Android (KODY-VIDEO-4). Kept inside try/finally so canceling during
+        // the wait still closes the tap-created AudioContext.
+        await waitForNextPaint()
+        await waitForNextPaint()
+        if (exportRunRef.current !== runId) return
+
         const result = await exportProject(clips, {
           audioContext,
           watermark: watermarked,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sentry [KODY-VIDEO-4](https://kent-c-dodds-tech-llc.sentry.io/issues/7637321246/): handled export error `Media failed while waiting for "loadedmetadata"` (1 event, 5 clips, release `d980fc0`).

**Root cause (code-justified):** Export starts in the same turn as `setExportState('exporting')`, which unmounts record/editor so camera + preview video release. On decoder-limited devices, `loadClipVideo` can open a new `<video>` before those slots free and the media `error` event fires. Separately, `HoldRecorder` previously kept undecodable takes (wall-clock duration fallback), so a bad blob would fail again at export.

**Fix:**
- Wait two animation frames after entering the export overlay before calling `exportProject` (inside try/finally so cancel still closes AudioContext)
- Retry `loadClipVideo` once on typed `MediaElementFailureError`
- Include `MediaError` code/message in the thrown error
- Discard takes that fail media load at record time (timeouts still use wall-clock)

## Test plan

- [x] `npx vitest run` (includes new `media-error` unit tests)
- [x] `npm run build`
- [x] `node scripts/manual-smoke.mjs` (32/32)
- [x] Addressed Bugbot/CodeRabbit AudioContext leak + typed failure marker
- [ ] CI green on latest commit

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e09acf0c-e795-4bfb-aad8-56ebf1d912b0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e09acf0c-e795-4bfb-aad8-56ebf1d912b0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved project export reliability when media resources are still being released.
  - Automatically retries certain temporary media loading failures.
  - Added clearer error details for failed media playback or export operations.
  - Prevented recordings affected by media decoding or compatibility failures from being saved with inaccurate durations.
- **Error Handling**
  - Media-related failures are now identified more consistently, helping distinguish recoverable issues from other errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->