### PR TITLE
Filter Cloudflare Insights beacon Sentry noise (KODY-VIDEO beacon.at)

### DIFF
--- a/src/lib/error-reporting.test.ts
+++ b/src/lib/error-reporting.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'vitest'
-import { isMonitoringSelfTestEvent } from './error-reporting'
+import {
+  isCloudflareInsightsBeaconEvent,
+  isMonitoringSelfTestEvent,
+} from './error-reporting'
 
 describe('isMonitoringSelfTestEvent', () => {
   it('drops the setup-agent synthetic exception signature', () => {
@@ -38,5 +41,101 @@ describe('isMonitoringSelfTestEvent', () => {
 
   it('keeps events with no exception payload', () => {
     expect(isMonitoringSelfTestEvent({})).toBe(false)
+  })
+})
+
+describe('isCloudflareInsightsBeaconEvent', () => {
+  const beaconFrame = {
+    filename: '/beacon.min.js/v4513226cdae34746b4dedf0b4dfa099e1781791509496',
+    abs_path:
+      'https://static.cloudflareinsights.com/beacon.min.js/v4513226cdae34746b4dedf0b4dfa099e1781791509496',
+  }
+
+  it('drops events whose stack is only Cloudflare Insights beacon frames', () => {
+    expect(
+      isCloudflareInsightsBeaconEvent({
+        exception: {
+          values: [
+            {
+              type: 'TypeError',
+              value: 't.entries.at is not a function',
+              stacktrace: { frames: [beaconFrame, beaconFrame] },
+            },
+          ],
+        },
+      }),
+    ).toBe(true)
+  })
+
+  it('matches abs_path or filename containing the beacon host path', () => {
+    expect(
+      isCloudflareInsightsBeaconEvent({
+        exception: {
+          values: [
+            {
+              type: 'TypeError',
+              value: 'this.i.at is not a function',
+              stacktrace: {
+                frames: [
+                  {
+                    filename:
+                      'https://static.cloudflareinsights.com/beacon.min.js/v1',
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      }),
+    ).toBe(true)
+  })
+
+  it('keeps mixed stacks that include application frames', () => {
+    expect(
+      isCloudflareInsightsBeaconEvent({
+        exception: {
+          values: [
+            {
+              type: 'TypeError',
+              value: 't.entries.at is not a function',
+              stacktrace: {
+                frames: [
+                  beaconFrame,
+                  { filename: '/assets/index-abc123.js', abs_path: undefined },
+                ],
+              },
+            },
+          ],
+        },
+      }),
+    ).toBe(false)
+  })
+
+  it('keeps ordinary application errors with no beacon frames', () => {
+    expect(
+      isCloudflareInsightsBeaconEvent({
+        exception: {
+          values: [
+            {
+              type: 'Error',
+              value: 'Export failed: encoder closed',
+              stacktrace: {
+                frames: [{ filename: '/assets/index-abc123.js' }],
+              },
+            },
+          ],
+        },
+      }),
+    ).toBe(false)
+  })
+
+  it('keeps events with no stack frames', () => {
+    expect(
+      isCloudflareInsightsBeaconEvent({
+        exception: {
+          values: [{ type: 'TypeError', value: 't.entries.at is not a function' }],
+        },
+      }),
+    ).toBe(false)
   })
 })

--- a/src/lib/error-reporting.ts
+++ b/src/lib/error-reporting.ts
@@ -15,8 +15,27 @@ const REPORTING_HOSTNAMES = new Set(['kody.video', 'kody-video.pages.dev'])
  */
 const MONITORING_SELF_TEST_MARKER = 'KodyVideoMonitoringSelfTest'
 
+/**
+ * Cloudflare Web Analytics injects this script on Pages/zone analytics.
+ * It is not app-owned; older browsers lacking Array.prototype.at throw inside
+ * it and pollute Sentry (e.g. KODY-VIDEO issues on beacon.min.js).
+ */
+const CLOUDFLARE_INSIGHTS_BEACON_URL_MARKER =
+  'static.cloudflareinsights.com/beacon.min.js'
+
+type FilterableStackFrame = {
+  filename?: string
+  abs_path?: string
+}
+
 type FilterableSentryEvent = {
-  exception?: { values?: Array<{ type?: string; value?: string }> }
+  exception?: {
+    values?: Array<{
+      type?: string
+      value?: string
+      stacktrace?: { frames?: FilterableStackFrame[] }
+    }>
+  }
   message?: string
 }
 
@@ -31,6 +50,26 @@ export function isMonitoringSelfTestEvent(event: FilterableSentryEvent): boolean
   return (
     typeof event.message === 'string' &&
     event.message.includes(MONITORING_SELF_TEST_MARKER)
+  )
+}
+
+function frameUrl(frame: FilterableStackFrame): string {
+  return frame.abs_path ?? frame.filename ?? ''
+}
+
+/**
+ * True when every stack frame we have is from Cloudflare Insights' beacon
+ * (no app frames). Narrow: mixed stacks still report.
+ */
+export function isCloudflareInsightsBeaconEvent(
+  event: FilterableSentryEvent,
+): boolean {
+  const frames = (event.exception?.values ?? []).flatMap(
+    (value) => value.stacktrace?.frames ?? [],
+  )
+  if (frames.length === 0) return false
+  return frames.every((frame) =>
+    frameUrl(frame).includes(CLOUDFLARE_INSIGHTS_BEACON_URL_MARKER),
   )
 }
 
@@ -54,6 +93,7 @@ export function initErrorReporting(): void {
       delete event.user
       delete event.request
       if (isMonitoringSelfTestEvent(event)) return null
+      if (isCloudflareInsightsBeaconEvent(event)) return null
       return event
     },
   })


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sentry issues [7638409686](https://sentry.io/organizations/kent-c-dodds-tech-llc/issues/7638409686/) (`TypeError: t.entries.at is not a function`) and sibling [7638409671](https://sentry.io/organizations/kent-c-dodds-tech-llc/issues/7638409671/) (`TypeError: this.i.at is not a function`) are entirely from Cloudflare Web Analytics' injected script `https://static.cloudflareinsights.com/beacon.min.js` — not Kody Video app code (the app uses Fathom for page views).

Cloudflare's beacon uses `Array.prototype.at`, which throws on older browsers. We cannot fix the third-party script; continuing to report it is triage noise.

## Change

- Narrow `beforeSend` filter: drop events whose **every** stack frame URL contains `static.cloudflareinsights.com/beacon.min.js`.
- Mixed stacks (beacon + app) still report.
- Unit tests cover beacon-only, mixed, app-only, and empty-stack cases.

## Outcome

`filtered` — low-risk wiring/filter. After merge + deploy, both Sentry issues will be marked ignored; the filter prevents recurrence.

## Test plan

- [x] `npx vitest run` (64 tests)
- [x] `npm run build`
- [x] `node scripts/manual-smoke.mjs` (32/32)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-aef324e3-1519-4306-a7e0-502f67082dfa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-aef324e3-1519-4306-a7e0-502f67082dfa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented error reports generated solely by Cloudflare Insights beacon scripts from being sent.
  * Preserved reporting for application errors that include or differ from beacon-related stack frames.
  * Added coverage for beacon detection across supported stack trace formats and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->