### PR TITLE
Full-range drag zoom: press point to stage top always reaches max

### DIFF
--- a/manual-test-checklist.md
+++ b/manual-test-checklist.md
@@ -19,6 +19,7 @@ Run locally with HTTPS or `localhost` (`npm run dev`). Camera/mic require a secu
 - [ ] Press/hold anywhere on the preview starts recording (REC pill + elapsed)
 - [ ] Camera preview stays smooth while recording (no visible frame drops)
 - [ ] Dragging up/down during a hold zooms in/out (zoom-capable devices)
+- [ ] Dragging from the press point to the top of the preview reaches MAX zoom; to the bottom reaches MIN — regardless of where the hold started
 - [ ] Small finger tremble while holding (< ~14px) does not start zooming
 - [ ] Releasing the hold eases zoom back to the pre-take level (chip choice or 1×)
 - [ ] Release stops and appends a clip; filmstrip thumbnail appears shortly after

--- a/src/components/record-screen.tsx
+++ b/src/components/record-screen.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useLayoutEffect, useRef, useState } from 'react'
 import { Link } from 'react-router-dom'
 import type { CameraZoomRange, UseCameraResult } from '../hooks/use-camera'
+import { dragZoomValue } from '../lib/drag-zoom'
 import { getLocationFix, type LocationFix } from '../lib/location'
 import { reportError } from '../lib/error-reporting'
 import { appendRecording, removeClip, undoLastDelete } from '../lib/project-actions'
@@ -131,6 +132,7 @@ export function RecordScreen({
   const dragZoomPressYRef = useRef(0)
   const dragZoomStartValueRef = useRef(0)
   const dragZoomStageHeightRef = useRef(0)
+  const dragZoomStageTopRef = useRef(0)
   /** Whether the current hold actually changed zoom (gates the snap-back). */
   const dragZoomMovedRef = useRef(false)
   /** Last zoom value applied during the drag (ramp start for the snap-back). */
@@ -630,7 +632,9 @@ export function RecordScreen({
             zoomRestoreActiveRef.current = false
             camera.setZoom(dragZoomStartValueRef.current)
           }
-          dragZoomStageHeightRef.current = event.currentTarget.clientHeight
+          const stageRect = event.currentTarget.getBoundingClientRect()
+          dragZoomStageHeightRef.current = stageRect.height
+          dragZoomStageTopRef.current = stageRect.top
           event.currentTarget.setPointerCapture(event.pointerId)
           void beginRecord(event.pointerId, 'hold')
         }}
@@ -649,18 +653,18 @@ export function RecordScreen({
             }
             dragZoomPressYRef.current = event.clientY
           }
-          const stageHeight = dragZoomStageHeightRef.current || stageRef.current?.clientHeight || 1
-          // Multiplicative zoom: equal finger travel = equal zoom *ratio*
-          // (drag up to zoom in). Each ~28% of stage height doubles the zoom,
-          // so a full-stage drag covers ~3.5 doublings (≈11×) — quick enough
-          // to feel responsive, while the dead zone above still absorbs
-          // accidental finger drift.
-          const travelPerDoubling = stageHeight * 0.28
-          const deltaY = dragZoomPressYRef.current - event.clientY
-          const next = Math.min(
-            zoom.max,
-            Math.max(zoom.min, dragZoomStartValueRef.current * 2 ** (deltaY / travelPerDoubling)),
-          )
+          // Full-range mapping (see dragZoomValue): dragging up to the top
+          // of the stage reaches MAX zoom, down to the bottom reaches MIN —
+          // the whole range is always usable wherever the hold started.
+          const next = dragZoomValue({
+            anchorY: dragZoomPressYRef.current,
+            clientY: event.clientY,
+            stageTop: dragZoomStageTopRef.current,
+            stageHeight: dragZoomStageHeightRef.current || stageRef.current?.clientHeight || 1,
+            start: dragZoomStartValueRef.current,
+            min: zoom.min,
+            max: zoom.max,
+          })
           dragZoomMovedRef.current = true
           dragZoomLastValueRef.current = next
           camera.setZoom(next)

--- a/src/lib/drag-zoom.test.ts
+++ b/src/lib/drag-zoom.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest'
+import { dragZoomValue } from './drag-zoom'
+
+const stage = { stageTop: 0, stageHeight: 800 }
+
+describe('dragZoomValue', () => {
+  it('reaches MAX zoom at the top of the stage regardless of press point', () => {
+    for (const anchorY of [700, 400, 200]) {
+      const value = dragZoomValue({ ...stage, anchorY, clientY: 0, start: 1, min: 1, max: 8 })
+      expect(value).toBe(8)
+    }
+  })
+
+  it('reaches MIN zoom at the bottom of the stage', () => {
+    const value = dragZoomValue({
+      ...stage,
+      anchorY: 300,
+      clientY: 800,
+      start: 4,
+      min: 0.5,
+      max: 8,
+    })
+    expect(value).toBe(0.5)
+  })
+
+  it('interpolates exponentially: half the travel is the geometric midpoint', () => {
+    // Press at the bottom, drag halfway up: start 1, max 16 → sqrt(16) = 4.
+    const value = dragZoomValue({
+      ...stage,
+      anchorY: 800,
+      clientY: 400,
+      start: 1,
+      min: 1,
+      max: 16,
+    })
+    expect(value).toBeCloseTo(4, 5)
+  })
+
+  it('no movement means no change', () => {
+    const value = dragZoomValue({ ...stage, anchorY: 400, clientY: 400, start: 2, min: 1, max: 8 })
+    expect(value).toBe(2)
+  })
+
+  it('dragging down from min stays at min', () => {
+    const value = dragZoomValue({ ...stage, anchorY: 100, clientY: 500, start: 1, min: 1, max: 8 })
+    expect(value).toBe(1)
+  })
+
+  it('clamps beyond the stage edges', () => {
+    const value = dragZoomValue({
+      ...stage,
+      anchorY: 400,
+      clientY: -300,
+      start: 1,
+      min: 1,
+      max: 8,
+    })
+    expect(value).toBe(8)
+  })
+
+  it('applies the travel floor for presses near an edge (no hair-trigger)', () => {
+    // Press 10px from the top: available up-travel is floored at 20% of the
+    // stage (160px), so 10px of travel must NOT already reach max.
+    const value = dragZoomValue({ ...stage, anchorY: 10, clientY: 0, start: 1, min: 1, max: 8 })
+    expect(value).toBeLessThan(8)
+    expect(value).toBeGreaterThan(1)
+  })
+
+  it('supports sub-1x ranges (ultra-wide)', () => {
+    const value = dragZoomValue({
+      ...stage,
+      anchorY: 200,
+      clientY: 800,
+      start: 1,
+      min: 0.5,
+      max: 8,
+    })
+    expect(value).toBe(0.5)
+  })
+})

--- a/src/lib/drag-zoom.ts
+++ b/src/lib/drag-zoom.ts
@@ -1,0 +1,49 @@
+/**
+ * Drag-to-zoom mapping for hold-to-record.
+ *
+ * Full-range guarantee: wherever the finger pressed, dragging up to the top
+ * of the stage reaches MAX zoom and dragging down to the bottom reaches MIN.
+ * Interpolation is exponential (equal travel = equal zoom *ratio*, matching
+ * how zoom is perceived), and a floor on the available travel keeps presses
+ * near a stage edge from becoming hair-triggers.
+ */
+
+interface DragZoomInput {
+  /** Finger anchor (press point, possibly re-anchored after the dead zone). */
+  anchorY: number
+  /** Current pointer position. */
+  clientY: number
+  stageTop: number
+  stageHeight: number
+  /** Zoom value when the drag started. */
+  start: number
+  min: number
+  max: number
+}
+
+/** Presses closer to an edge than this fraction still get this much travel. */
+const MIN_TRAVEL_FRACTION = 0.2
+
+export function dragZoomValue({
+  anchorY,
+  clientY,
+  stageTop,
+  stageHeight,
+  start,
+  min,
+  max,
+}: DragZoomInput): number {
+  const minTravel = stageHeight * MIN_TRAVEL_FRACTION
+  const deltaY = anchorY - clientY
+  let next: number
+  if (deltaY >= 0) {
+    const available = Math.max(anchorY - stageTop, minTravel)
+    const t = Math.min(1, deltaY / available)
+    next = start * (max / start) ** t
+  } else {
+    const available = Math.max(stageTop + stageHeight - anchorY, minTravel)
+    const t = Math.min(1, -deltaY / available)
+    next = start * (min / start) ** t
+  }
+  return Math.min(max, Math.max(min, next))
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Real-device feedback: with a fixed distance-per-doubling mapping, a hold that starts mid-screen doesn't leave enough finger travel to reach max zoom — the full range was effectively unreachable.

The mapping is now range-anchored instead of rate-anchored: wherever the finger pressed, dragging up to the **top of the stage reaches MAX zoom** and dragging down to the **bottom reaches MIN**, interpolated exponentially (equal travel = equal zoom ratio, matching zoom perception). A floor of 20% stage height on the available travel keeps presses very close to an edge from becoming hair-triggers. The 14px dead zone before zoom engages is unchanged, and the anchor still re-bases at the dead-zone edge so there's no jump.

The math is extracted into `src/lib/drag-zoom.ts` (`dragZoomValue`, a pure function) with 8 unit tests pinning the behavior — full-range reachability from any press point, geometric-midpoint interpolation, clamping, the edge-press travel floor, and sub-1× (ultra-wide) ranges — since this interaction has now been tuned three times.

## Testing

- 72 unit tests (8 new), full smoke suite 32/32, keyboard probe, typecheck + build all pass.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-16d17496-6b5b-4e12-b600-6933357c2059"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-16d17496-6b5b-4e12-b600-6933357c2059"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved hold-to-record zoom controls with full-range dragging: dragging upward reaches maximum zoom, while dragging downward reaches minimum zoom.
  - Zoom transitions now interpolate smoothly and remain constrained within supported limits.

- **Documentation**
  - Updated the hold-to-record manual testing checklist to cover edge-to-edge drag behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->