### PR TITLE
Document the drag-zoom edge-floor contract; pin it in tests

### DIFF
--- a/manual-test-checklist.md
+++ b/manual-test-checklist.md
@@ -19,7 +19,7 @@ Run locally with HTTPS or `localhost` (`npm run dev`). Camera/mic require a secu
 - [ ] Press/hold anywhere on the preview starts recording (REC pill + elapsed)
 - [ ] Camera preview stays smooth while recording (no visible frame drops)
 - [ ] Dragging up/down during a hold zooms in/out (zoom-capable devices)
-- [ ] Dragging from the press point to the top of the preview reaches MAX zoom; to the bottom reaches MIN — regardless of where the hold started
+- [ ] Dragging from the press point to the top of the preview reaches MAX zoom; to the bottom reaches MIN (presses within ~20% of an edge keep a minimum ramp instead and cap partway at that edge — no hair-trigger)
 - [ ] Small finger tremble while holding (< ~14px) does not start zooming
 - [ ] Releasing the hold eases zoom back to the pre-take level (chip choice or 1×)
 - [ ] Release stops and appends a clip; filmstrip thumbnail appears shortly after

--- a/src/components/record-screen.tsx
+++ b/src/components/record-screen.tsx
@@ -653,9 +653,10 @@ export function RecordScreen({
             }
             dragZoomPressYRef.current = event.clientY
           }
-          // Full-range mapping (see dragZoomValue): dragging up to the top
-          // of the stage reaches MAX zoom, down to the bottom reaches MIN —
-          // the whole range is always usable wherever the hold started.
+          // Range-anchored mapping (see dragZoomValue's contract): dragging
+          // to the top of the stage reaches MAX zoom, to the bottom reaches
+          // MIN — except presses within ~20% of an edge, which keep a
+          // minimum ramp for control and cap partway at that edge.
           const next = dragZoomValue({
             anchorY: dragZoomPressYRef.current,
             clientY: event.clientY,

--- a/src/lib/drag-zoom.test.ts
+++ b/src/lib/drag-zoom.test.ts
@@ -4,8 +4,8 @@ import { dragZoomValue } from './drag-zoom'
 const stage = { stageTop: 0, stageHeight: 800 }
 
 describe('dragZoomValue', () => {
-  it('reaches MAX zoom at the top of the stage regardless of press point', () => {
-    for (const anchorY of [700, 400, 200]) {
+  it('reaches MAX zoom at the top of the stage from any press ≥20% from the edge', () => {
+    for (const anchorY of [700, 400, 200, 160]) {
       const value = dragZoomValue({ ...stage, anchorY, clientY: 0, start: 1, min: 1, max: 8 })
       expect(value).toBe(8)
     }
@@ -58,12 +58,13 @@ describe('dragZoomValue', () => {
     expect(value).toBe(8)
   })
 
-  it('applies the travel floor for presses near an edge (no hair-trigger)', () => {
-    // Press 10px from the top: available up-travel is floored at 20% of the
-    // stage (160px), so 10px of travel must NOT already reach max.
+  it('near-edge presses keep the minimum ramp and cap partway at the edge', () => {
+    // Contract trade-off: pressed 10px from the top, the ramp is floored at
+    // 20% of the stage (160px), so reaching the edge covers t = 10/160 of
+    // the range — controllable, but deliberately NOT max at the edge.
     const value = dragZoomValue({ ...stage, anchorY: 10, clientY: 0, start: 1, min: 1, max: 8 })
+    expect(value).toBeCloseTo(8 ** (10 / 160), 5)
     expect(value).toBeLessThan(8)
-    expect(value).toBeGreaterThan(1)
   })
 
   it('supports sub-1x ranges (ultra-wide)', () => {

--- a/src/lib/drag-zoom.ts
+++ b/src/lib/drag-zoom.ts
@@ -1,11 +1,15 @@
 /**
  * Drag-to-zoom mapping for hold-to-record.
  *
- * Full-range guarantee: wherever the finger pressed, dragging up to the top
- * of the stage reaches MAX zoom and dragging down to the bottom reaches MIN.
+ * Contract: for presses at least MIN_TRAVEL_FRACTION of the stage away from
+ * an edge (the practical case), dragging up to the top of the stage reaches
+ * MAX zoom and dragging down to the bottom reaches MIN. Presses closer to an
+ * edge than that deliberately keep the same minimum ramp length instead —
+ * zoom stays controllable but caps below the extreme at the edge. A
+ * hair-trigger ramp at recording start would be worse than that rare cap;
+ * re-pressing further from the edge always restores the full range.
  * Interpolation is exponential (equal travel = equal zoom *ratio*, matching
- * how zoom is perceived), and a floor on the available travel keeps presses
- * near a stage edge from becoming hair-triggers.
+ * how zoom is perceived).
  */
 
 interface DragZoomInput {
@@ -21,7 +25,10 @@ interface DragZoomInput {
   max: number
 }
 
-/** Presses closer to an edge than this fraction still get this much travel. */
+/**
+ * Presses closer to an edge than this fraction of the stage still get this
+ * much ramp (trading edge reachability for control — see the contract above).
+ */
 const MIN_TRAVEL_FRACTION = 0.2
 
 export function dragZoomValue({


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Follow-up to CodeRabbit's post-merge review of #38, which correctly flagged that the docs promised "the stage edge always reaches max/min" while the anti-hair-trigger travel floor means presses within 20% of an edge cap partway.

The floor is the right behavior — a hair-trigger ramp at recording start is worse than a rare cap, and re-pressing further from the edge always restores the full range — so this aligns the *documentation* with the behavior instead of removing the floor:

- `dragZoomValue`'s docblock now states the contract precisely, including the edge exception and its rationale.
- The `record-screen.tsx` usage comment and the manual-test checklist item say the same thing.
- The near-edge unit test now pins the exact capped value (`8 ** (10/160)`) instead of loose bounds, and the full-range test explicitly covers the ≥20%-from-edge boundary (press at exactly 160px).

No behavior change — documentation and test precision only.

## Testing

- 72 unit tests pass, typecheck + build pass.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-16d17496-6b5b-4e12-b600-6933357c2059"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-16d17496-6b5b-4e12-b600-6933357c2059"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

