### PR TITLE
Prime mic permission at camera startup; warn when the mic is blocked

### DIFF
--- a/manual-test-checklist.md
+++ b/manual-test-checklist.md
@@ -8,6 +8,8 @@ Run locally with HTTPS or `localhost` (`npm run dev`). Camera/mic require a secu
 - [ ] Deny → clear denied panel with retry guidance
 - [ ] Allow → live rear-camera preview (or fallback)
 - [ ] Flip camera works when multiple cameras exist
+- [ ] Opening the camera prompts for the microphone too (one-time priming); the mic is NOT held while idle (no OS mic indicator)
+- [ ] If the mic is blocked in site settings, a red "Mic blocked" pill shows on the record screen (Brave/Android regression)
 - [ ] Torch toggle appears on devices with a flash; zoom chips appear when supported
 - [ ] Phones with multiple rear cameras show a lens chip (e.g. "1/3") that switches to the ultra-wide/telephoto; choice sticks across flips and restarts
 - [ ] Backgrounding the app releases camera/mic (green dot goes out); returning restarts the preview

--- a/src/components/record-screen.tsx
+++ b/src/components/record-screen.tsx
@@ -759,6 +759,15 @@ export function RecordScreen({
               Storage {formatStoragePercent(storage.ratio)} full
             </Link>
           ) : null}
+          {camera.micPermission === 'denied' && !recording ? (
+            <span
+              className="storage-pill is-critical"
+              role="status"
+              aria-label="Microphone blocked — recordings need sound"
+            >
+              Mic blocked — allow it in site settings
+            </span>
+          ) : null}
         </div>
         <div className="record-top-actions">
           {camera.torchAvailable ? (

--- a/src/hooks/use-camera.ts
+++ b/src/hooks/use-camera.ts
@@ -246,12 +246,17 @@ export function useCamera(): UseCameraResult {
         replaceStream(next)
         setCanFlip(await canFlipCamera())
         void syncRearLenses(next)
-        // One-time mic permission priming (see primeMicrophonePermission):
-        // asking mid-hold is silently denied by some browsers (Brave/Android
-        // never shows the prompt). Prompt now, at a normal moment.
+        // Mic permission priming (see primeMicrophonePermission): asking
+        // mid-hold is silently denied by some browsers (Brave/Android never
+        // shows the prompt). Prompt now, at a normal moment. The claim is
+        // released when the outcome was ambiguous (prompt dismissed or
+        // interrupted by backgrounding) so the next camera start retries.
         if (!micPrimedRef.current) {
           micPrimedRef.current = true
-          void primeMicrophonePermission().then(setMicPermission)
+          void primeMicrophonePermission().then((state) => {
+            setMicPermission(state)
+            if (state === 'unknown') micPrimedRef.current = false
+          })
         }
       } catch (err) {
         const message = permissionMessage(err)

--- a/src/hooks/use-camera.ts
+++ b/src/hooks/use-camera.ts
@@ -4,6 +4,7 @@ import {
   listRearCameras,
   openCameraStream,
   openMicrophoneTrack,
+  primeMicrophonePermission,
   queryCameraPermission,
   stopAudioTracks,
   stopStream,
@@ -71,6 +72,8 @@ export interface UseCameraResult {
   zoom: CameraZoomRange | null
   torchAvailable: boolean
   torchOn: boolean
+  /** Mic permission state discovered by the startup priming prompt. */
+  micPermission: 'granted' | 'denied' | 'unknown'
   /** Number of rear camera devices (ultra-wide/tele are often separate). */
   rearLensCount: number
   /** Index of the active rear lens, when facing the environment. */
@@ -125,6 +128,8 @@ export function useCamera(): UseCameraResult {
   const [zoom, setZoomState] = useState<CameraZoomRange | null>(null)
   const [torchAvailable, setTorchAvailable] = useState(false)
   const [torchOn, setTorchOn] = useState(false)
+  const [micPermission, setMicPermission] = useState<'granted' | 'denied' | 'unknown'>('unknown')
+  const micPrimedRef = useRef(false)
   const [rearLensCount, setRearLensCount] = useState(0)
   const [rearLensIndex, setRearLensIndex] = useState(0)
   const rearLensesRef = useRef<string[]>([])
@@ -241,6 +246,13 @@ export function useCamera(): UseCameraResult {
         replaceStream(next)
         setCanFlip(await canFlipCamera())
         void syncRearLenses(next)
+        // One-time mic permission priming (see primeMicrophonePermission):
+        // asking mid-hold is silently denied by some browsers (Brave/Android
+        // never shows the prompt). Prompt now, at a normal moment.
+        if (!micPrimedRef.current) {
+          micPrimedRef.current = true
+          void primeMicrophonePermission().then(setMicPermission)
+        }
       } catch (err) {
         const message = permissionMessage(err)
         setPermission({ status: 'denied', message })
@@ -413,6 +425,8 @@ export function useCamera(): UseCameraResult {
         if (!streamRef.current?.getAudioTracks().some((track) => track.readyState === 'live')) {
           throw new Error('Microphone unavailable')
         }
+        // The user may have fixed a denied permission in site settings.
+        setMicPermission('granted')
       } catch (err) {
         throw new Error(permissionMessage(err))
       }
@@ -469,6 +483,7 @@ export function useCamera(): UseCameraResult {
     zoom,
     torchAvailable,
     torchOn,
+    micPermission,
     rearLensCount,
     rearLensIndex,
     switchRearLens,

--- a/src/lib/media.ts
+++ b/src/lib/media.ts
@@ -155,6 +155,36 @@ export async function openMicrophoneTrack(): Promise<MediaStreamTrack> {
   return track
 }
 
+/**
+ * Ask for microphone permission once, up front, and release the track
+ * immediately (idle stays mic-free so Android voice-to-text keeps working).
+ *
+ * Requesting the mic only mid-gesture — while the user is already holding to
+ * record with a live camera — gets silently auto-denied by some browsers
+ * (Brave on Android never even shows the prompt, so the site's settings have
+ * no microphone entry to flip). Priming at camera startup shows a normal
+ * prompt at a normal moment; later per-take requests then resolve silently.
+ */
+export async function primeMicrophonePermission(): Promise<'granted' | 'denied' | 'unknown'> {
+  try {
+    const status = await navigator.permissions.query({
+      name: 'microphone' as PermissionName,
+    })
+    if (status.state === 'granted') return 'granted'
+    // A persisted denial can't prompt again — asking would fail silently.
+    if (status.state === 'denied') return 'denied'
+  } catch {
+    // Permission query unsupported — fall through and prompt directly.
+  }
+  try {
+    const track = await openMicrophoneTrack()
+    track.stop()
+    return 'granted'
+  } catch {
+    return 'denied'
+  }
+}
+
 function isOverconstrained(error: unknown): boolean {
   return error instanceof DOMException && error.name === 'OverconstrainedError'
 }

--- a/src/lib/media.ts
+++ b/src/lib/media.ts
@@ -181,7 +181,16 @@ export async function primeMicrophonePermission(): Promise<'granted' | 'denied' 
     track.stop()
     return 'granted'
   } catch {
-    return 'denied'
+    // Distinguish a persisted denial from a dismissed/interrupted prompt
+    // (e.g. the app was backgrounded mid-prompt): only the former is final.
+    try {
+      const status = await navigator.permissions.query({
+        name: 'microphone' as PermissionName,
+      })
+      return status.state === 'denied' ? 'denied' : 'unknown'
+    } catch {
+      return 'denied'
+    }
   }
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Real-device report (Brave on Android): camera permission granted, but recording failed and the site's permission settings had **no microphone entry to enable** — the app never successfully asked. Root cause: we request the mic per-take, *mid hold-to-record gesture with the camera already live*, and Brave silently auto-denies that prompt.

- `primeMicrophonePermission()` in `src/lib/media.ts`: on camera startup, check `navigator.permissions.query({ name: 'microphone' })` — if granted, done; if hard-denied, report it; otherwise request the mic once and **immediately stop the track**. The idle-mic-free property is preserved (Android voice-to-text keeps working; no persistent OS mic indicator), and later per-take requests resolve silently because the permission is now persisted.
- `use-camera` primes once per session after the camera opens and exposes `micPermission`; a successful per-take mic grab upgrades it to granted (covers users who fix settings later).
- The record screen shows a red "Mic blocked — allow it in site settings" pill when the mic is hard-denied, instead of letting the user discover it mid-recording.

## Testing

- New probe checks: a camera-only-permission context (the Brave scenario) shows the mic-blocked pill; a fully-granted context shows no pill and recording works end to end.
- Full smoke suite 32/32, keyboard probe, typecheck + build pass.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-16d17496-6b5b-4e12-b600-6933357c2059"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-16d17496-6b5b-4e12-b600-6933357c2059"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

