### PR TITLE
Fix iOS black exports: encode realtime output from the on-DOM preview canvas

### DIFF
--- a/src/lib/error-reporting.ts
+++ b/src/lib/error-reporting.ts
@@ -73,6 +73,42 @@ export function isCloudflareInsightsBeaconEvent(
   )
 }
 
+/** Marker set while an export runs; still present at boot = the page died
+ * mid-export (tab crash / out-of-memory kill — no JS error ever fires). */
+const EXPORT_MARKER_KEY = 'kodyVideo.exportInFlight'
+
+export function markExportStarted(info: Record<string, unknown>): void {
+  try {
+    sessionStorage.setItem(EXPORT_MARKER_KEY, JSON.stringify({ ...info, startedAt: Date.now() }))
+  } catch {
+    // Storage unavailable — we just lose this diagnostic.
+  }
+}
+
+export function clearExportMarker(): void {
+  try {
+    sessionStorage.removeItem(EXPORT_MARKER_KEY)
+  } catch {
+    // Ignore.
+  }
+}
+
+function reportExportSessionDeath(): void {
+  try {
+    const raw = sessionStorage.getItem(EXPORT_MARKER_KEY)
+    if (!raw) return
+    sessionStorage.removeItem(EXPORT_MARKER_KEY)
+    const info = JSON.parse(raw) as Record<string, unknown>
+    Sentry.captureMessage('Export session died (page reloaded mid-export, likely OOM/crash)', {
+      level: 'error',
+      tags: { step: 'export-crash' },
+      extra: info,
+    })
+  } catch {
+    // Ignore.
+  }
+}
+
 export function initErrorReporting(): void {
   if (!REPORTING_HOSTNAMES.has(location.hostname)) return
   Sentry.init({
@@ -97,6 +133,7 @@ export function initErrorReporting(): void {
       return event
     },
   })
+  reportExportSessionDeath()
 }
 
 /**

--- a/src/lib/export/encode-realtime.ts
+++ b/src/lib/export/encode-realtime.ts
@@ -39,7 +39,18 @@ export async function exportRealtime(
   const { width, height } = pickOutputSize(probe.video.videoWidth, probe.video.videoHeight)
   probe.release()
 
-  const canvas = document.createElement('canvas')
+  // Encode from the overlay's on-DOM canvas whenever possible: iOS Safari's
+  // canvas.captureStream() delivers BLACK frames for canvases that aren't
+  // attached to the document (the preview looked fine — it was a different,
+  // visible canvas — while the detached encode canvas produced a black
+  // export). Rendering into the visible canvas fixes that and makes the
+  // preview show every frame. The overlay mounts a tick after the export
+  // starts, so wait briefly for it before falling back.
+  let canvas = await waitForPreviewCanvas(options.getPreviewCanvas)
+  const encodingIntoPreview = canvas !== null
+  if (!canvas) {
+    canvas = document.createElement('canvas')
+  }
   canvas.width = width
   canvas.height = height
   const ctx = canvas.getContext('2d', { alpha: false })
@@ -110,7 +121,8 @@ export async function exportRealtime(
           audioContext,
           dest,
           frameCounter,
-          getPreviewCanvas: options.getPreviewCanvas,
+          // No mirroring needed when the encode canvas is the preview.
+          getPreviewCanvas: encodingIntoPreview ? undefined : options.getPreviewCanvas,
           watermarkImage: options.watermarkImage ?? null,
           onElapsedMs: (elapsed) => {
             if (plan.totalMs > 0) {
@@ -273,6 +285,20 @@ async function paintSegment({
       // already ended
     }
     bufferSource?.disconnect()
+  }
+}
+
+/** The export overlay mounts just after the export starts — wait briefly. */
+async function waitForPreviewCanvas(
+  getPreviewCanvas: (() => HTMLCanvasElement | null) | undefined,
+): Promise<HTMLCanvasElement | null> {
+  if (!getPreviewCanvas) return null
+  const deadline = performance.now() + 1500
+  for (;;) {
+    const canvas = getPreviewCanvas()
+    if (canvas?.isConnected) return canvas
+    if (performance.now() > deadline) return null
+    await wait(50)
   }
 }
 

--- a/src/pages/project-page.tsx
+++ b/src/pages/project-page.tsx
@@ -15,7 +15,7 @@ import { RecordScreen, type ToastAction } from '../components/record-screen'
 import { useCamera } from '../hooks/use-camera'
 import { RestoreSheet } from '../components/restore-sheet'
 import { REMOVE_WATERMARK_LINK } from '../lib/entitlement'
-import { reportError } from '../lib/error-reporting'
+import { clearExportMarker, markExportStarted, reportError } from '../lib/error-reporting'
 import { exportProject, type ExportResult } from '../lib/export'
 import {
   canShareFile,
@@ -146,6 +146,9 @@ export function ProjectPage() {
         await waitForNextPaint()
         if (exportRunRef.current !== runId) return
 
+        // If the page dies mid-export (tab crash / OOM — no JS error fires),
+        // this marker survives the reload and reports the death at next boot.
+        markExportStarted({ clips: clips.length })
         const result = await exportProject(clips, {
           audioContext,
           watermark: watermarked,
@@ -182,6 +185,8 @@ export function ProjectPage() {
           watermarked,
         })
       } finally {
+        // The export ended in this session (success or error) — it did not die.
+        clearExportMarker()
         // The realtime engine closes the context it used; when WebCodecs
         // handled the export, release the unused tap-unlocked context.
         if (audioContext && audioContext.state !== 'closed') {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

X feedback (iPhone 17 Pro Max): the export preview looked fine during the render, but the result was black. iOS Safari's `canvas.captureStream()` delivers **black frames for canvases not attached to the document** — and the realtime fallback engine (which iOS uses when WebCodecs audio support is missing) encoded from exactly such a detached canvas. The live preview looked correct because it was a different, visible canvas being blitted every 10th frame.

- `exportRealtime` now adopts the export overlay's **on-DOM preview canvas as the encode target** whenever available (waiting up to 1.5s for the overlay to mount before falling back to the old detached canvas). Frames render once, into the visible canvas that `captureStream` records — fixing the iOS black output and making the preview show every frame instead of every 10th.
- Mirror blitting is skipped when the encode canvas *is* the preview.
- **Died-mid-export telemetry**: a `sessionStorage` marker is set when an export starts and cleared when it ends; if the app boots and finds it, the previous session died mid-export (tab crash / OOM kill — cases where no JS error can ever fire) and a tagged Sentry event reports it with the clip count. This gives us visibility into the alternate failure mode for reports like this one.

## Testing

- Forced-realtime probe (Chromium with `VideoEncoder` deleted): the on-DOM preview canvas becomes the encode target (backing size = output size, `isConnected: true`), the export completes, and ffmpeg signalstats confirms real content (average luma ~92 across frames, not black) with an audio track present.
- 72 unit tests, full smoke suite 32/32 (WebCodecs path unaffected), typecheck + build pass.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-16d17496-6b5b-4e12-b600-6933357c2059"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-16d17496-6b5b-4e12-b600-6933357c2059"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

