### PR TITLE
Fix iOS silent exports: decode fragmented MP4 audio via mp4box + AudioDecoder

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@sentry/react": "^10.68.0",
         "idb": "^8.0.3",
         "mp4-muxer": "^5.2.2",
+        "mp4box": "^2.4.1",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "react-router-dom": "^7.6.3",
@@ -5259,6 +5260,15 @@
       "dependencies": {
         "@types/dom-webcodecs": "^0.1.6",
         "@types/wicg-file-system-access": "^2020.9.5"
+      }
+    },
+    "node_modules/mp4box": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/mp4box/-/mp4box-2.4.1.tgz",
+      "integrity": "sha512-0HGX7nXoDIX6FKLVl4a3wtYjBlwqsN3xuQC3GXzNtKp98FXUOhDSq623azsz8DG5ptd9ZXcXodDkgbdMZOjWvw==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=20.8.1"
       }
     },
     "node_modules/ms": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@sentry/react": "^10.68.0",
     "idb": "^8.0.3",
     "mp4-muxer": "^5.2.2",
+    "mp4box": "^2.4.1",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-router-dom": "^7.6.3",

--- a/src/lib/build-info.ts
+++ b/src/lib/build-info.ts
@@ -1,10 +1,10 @@
-declare const __COMMIT_SHA__: string
-declare const __BUILD_DATE__: string
+declare const __COMMIT_SHA__: string | undefined
+declare const __BUILD_DATE__: string | undefined
 
-/** Full commit SHA the build was made from ('dev' outside CI). */
-export const COMMIT_SHA = __COMMIT_SHA__
+/** Full commit SHA the build was made from ('dev' outside CI/tests). */
+export const COMMIT_SHA = typeof __COMMIT_SHA__ === 'string' ? __COMMIT_SHA__ : 'dev'
 /** ISO timestamp of when the bundle was built. */
-export const BUILD_DATE = __BUILD_DATE__
+export const BUILD_DATE = typeof __BUILD_DATE__ === 'string' ? __BUILD_DATE__ : ''
 
 export function shortVersion(): string {
   return COMMIT_SHA === 'dev' ? 'dev' : COMMIT_SHA.slice(0, 7)

--- a/src/lib/export/mp4-audio.ts
+++ b/src/lib/export/mp4-audio.ts
@@ -1,0 +1,220 @@
+/**
+ * Fallback audio decoder for fragmented MP4 clips.
+ *
+ * Safari's MediaRecorder writes fragmented MP4, and WebKit's
+ * `decodeAudioData` throws `EncodingError` on fragmented files — which made
+ * every iOS export silent (the encoder happily wrote zeros). This module
+ * demuxes the AAC track with mp4box.js and decodes it with WebCodecs
+ * `AudioDecoder`, returning the same `AudioBuffer` shape `decodeAudioData`
+ * would have produced. Loaded dynamically so Chrome/WebM projects never pay
+ * for it.
+ */
+
+interface Mp4AudioTrackInfo {
+  id: number
+  codec: string
+  audio?: { sample_rate?: number; channel_count?: number }
+}
+
+interface Mp4Sample {
+  data: Uint8Array
+  cts: number
+  timescale: number
+  duration: number
+}
+
+export async function decodeMp4AudioWithWebCodecs(
+  blob: Blob,
+  targetSampleRate: number,
+): Promise<AudioBuffer | null> {
+  if (typeof AudioDecoder === 'undefined') return null
+
+  const { samples, track, description } = await demuxAudio(blob)
+  if (!track || samples.length === 0) return null
+
+  const decoded: AudioData[] = []
+  let decodeError: unknown = null
+  const decoder = new AudioDecoder({
+    output: (data) => decoded.push(data),
+    error: (err) => {
+      decodeError = err
+    },
+  })
+  try {
+    decoder.configure({
+      codec: track.codec,
+      sampleRate: track.audio?.sample_rate ?? targetSampleRate,
+      numberOfChannels: track.audio?.channel_count ?? 2,
+      ...(description ? { description } : {}),
+    })
+    for (const sample of samples) {
+      decoder.decode(
+        new EncodedAudioChunk({
+          type: 'key',
+          timestamp: Math.round((sample.cts / sample.timescale) * 1_000_000),
+          duration: Math.round((sample.duration / sample.timescale) * 1_000_000),
+          data: sample.data,
+        }),
+      )
+    }
+    await decoder.flush()
+  } catch (err) {
+    decodeError = decodeError ?? err
+  } finally {
+    try {
+      if (decoder.state !== 'closed') decoder.close()
+    } catch {
+      // already closed
+    }
+  }
+  if (decodeError || decoded.length === 0) {
+    decoded.forEach((d) => d.close())
+    return null
+  }
+
+  try {
+    const assembled = assembleAudioBuffer(decoded)
+    if (!assembled) return null
+    if (assembled.sampleRate === targetSampleRate) return assembled
+    return await resample(assembled, targetSampleRate)
+  } finally {
+    decoded.forEach((d) => {
+      try {
+        d.close()
+      } catch {
+        // copyTo may have detached it already
+      }
+    })
+  }
+}
+
+async function demuxAudio(blob: Blob): Promise<{
+  samples: Mp4Sample[]
+  track: Mp4AudioTrackInfo | null
+  description: Uint8Array | null
+}> {
+  const MP4Box = await import('mp4box')
+  const buffer = (await blob.arrayBuffer()) as ArrayBuffer & { fileStart: number }
+  buffer.fileStart = 0
+
+  return new Promise((resolve) => {
+    const file = MP4Box.createFile()
+    const samples: Mp4Sample[] = []
+    let track: Mp4AudioTrackInfo | null = null
+    let description: Uint8Array | null = null
+    let settled = false
+    const finish = () => {
+      if (settled) return
+      settled = true
+      resolve({ samples, track, description })
+    }
+    // Malformed files can produce neither onReady nor onError.
+    const timeout = setTimeout(finish, 10_000)
+
+    file.onError = () => {
+      clearTimeout(timeout)
+      finish()
+    }
+    file.onReady = (info: { audioTracks?: Mp4AudioTrackInfo[] }) => {
+      track = info.audioTracks?.[0] ?? null
+      if (!track) {
+        clearTimeout(timeout)
+        finish()
+        return
+      }
+      description = extractAudioSpecificConfig(file, track.id)
+      file.setExtractionOptions(track.id, null, { nbSamples: Number.MAX_SAFE_INTEGER })
+      file.start()
+      // All bytes are already appended; flush drives extraction to the end.
+      file.flush()
+      clearTimeout(timeout)
+      // onSamples fires synchronously during flush; resolve on next tick.
+      setTimeout(finish, 0)
+    }
+    file.onSamples = (
+      _id: number,
+      _user: unknown,
+      chunk: Array<{ data?: Uint8Array; cts: number; timescale: number; duration: number }>,
+    ) => {
+      for (const sample of chunk) {
+        if (sample.data) {
+          samples.push({
+            data: sample.data,
+            cts: sample.cts,
+            timescale: sample.timescale,
+            duration: sample.duration,
+          })
+        }
+      }
+    }
+    file.appendBuffer(buffer)
+    file.flush()
+  })
+}
+
+/** AAC's AudioSpecificConfig lives in stsd → esds; AudioDecoder needs it. */
+function extractAudioSpecificConfig(
+  file: { getTrackById(id: number): unknown },
+  trackId: number,
+): Uint8Array | null {
+  try {
+    const trak = file.getTrackById(trackId) as {
+      mdia?: {
+        minf?: {
+          stbl?: { stsd?: { entries?: Array<{ esds?: { esd?: unknown } }> } }
+        }
+      }
+    }
+    const entries = trak?.mdia?.minf?.stbl?.stsd?.entries ?? []
+    for (const entry of entries) {
+      const esd = entry.esds?.esd as
+        | { descs?: Array<{ descs?: Array<{ data?: Uint8Array }> }> }
+        | undefined
+      const data = esd?.descs?.[0]?.descs?.[0]?.data
+      if (data instanceof Uint8Array && data.length > 0) return data
+    }
+  } catch {
+    // Fall through — AudioDecoder.configure will reject without it.
+  }
+  return null
+}
+
+function assembleAudioBuffer(decoded: AudioData[]): AudioBuffer | null {
+  const first = decoded[0]
+  const sampleRate = first.sampleRate
+  const channels = Math.max(1, first.numberOfChannels)
+  const totalFrames = decoded.reduce((sum, d) => sum + d.numberOfFrames, 0)
+  if (totalFrames === 0) return null
+
+  const buffer = new AudioBuffer({ length: totalFrames, numberOfChannels: channels, sampleRate })
+  let offset = 0
+  for (const data of decoded) {
+    for (let ch = 0; ch < channels; ch += 1) {
+      const target = new Float32Array(data.numberOfFrames)
+      try {
+        data.copyTo(target, { planeIndex: ch, format: 'f32-planar' })
+      } catch {
+        // Mono data asked for a second channel, or an unconvertible format:
+        // duplicate channel 0 (already copied) or bail to silence for this ch.
+        if (ch > 0) {
+          buffer.copyToChannel(buffer.getChannelData(0).subarray(offset, offset + data.numberOfFrames), ch, offset)
+          continue
+        }
+        return null
+      }
+      buffer.copyToChannel(target, ch, offset)
+    }
+    offset += data.numberOfFrames
+  }
+  return buffer
+}
+
+async function resample(buffer: AudioBuffer, targetSampleRate: number): Promise<AudioBuffer> {
+  const length = Math.ceil(buffer.duration * targetSampleRate)
+  const ctx = new OfflineAudioContext(buffer.numberOfChannels, Math.max(1, length), targetSampleRate)
+  const source = ctx.createBufferSource()
+  source.buffer = buffer
+  source.connect(ctx.destination)
+  source.start()
+  return ctx.startRendering()
+}

--- a/src/lib/export/shared.ts
+++ b/src/lib/export/shared.ts
@@ -1,3 +1,4 @@
+import { reportError } from '../error-reporting'
 import { isMediaElementFailure, MediaElementFailureError } from './media-error'
 
 /** Helpers shared by the WebCodecs and realtime export engines. */
@@ -171,6 +172,8 @@ export function pickOutputSize(sourceWidth: number, sourceHeight: number): {
 }
 
 /** Decode a clip's audio track at the given sample rate. Null when it has none. */
+let audioDecodeFailureReported = false
+
 export async function decodeClipAudio(
   blob: Blob,
   sampleRate = 48000,
@@ -180,6 +183,23 @@ export async function decodeClipAudio(
     const ctx = new OfflineAudioContext(2, 1, sampleRate)
     return await ctx.decodeAudioData(bytes)
   } catch {
+    // Safari's MediaRecorder writes fragmented MP4, which decodeAudioData
+    // rejects — demux + AudioDecoder covers it (silent export otherwise).
+    if (/mp4/i.test(blob.type)) {
+      try {
+        const { decodeMp4AudioWithWebCodecs } = await import('./mp4-audio')
+        const decoded = await decodeMp4AudioWithWebCodecs(blob, sampleRate)
+        if (decoded) return decoded
+      } catch {
+        // Fall through to the failure report below.
+      }
+    }
+    if (!audioDecodeFailureReported) {
+      audioDecodeFailureReported = true
+      reportError(new Error('Clip audio decode failed — export audio will be silent'), 'export-audio', {
+        mimeType: blob.type,
+      })
+    }
     return null
   }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Follow-up X feedback (iPhone 17 Pro Max): after the black-video fix, exports render frames but have **no audio**.

Root cause, proven in WebKit: Safari's MediaRecorder writes clips as **fragmented MP4**, and WebKit's `decodeAudioData` throws `EncodingError` on fragmented MP4 (it decodes flat MP4 fine). `decodeClipAudio` swallowed that into `null`, and `encodeSegmentAudio` then encoded all-zero samples — a valid but silent AAC track. The same would bite iOS-recorded projects imported on Android (Chromium's `decodeAudioData` rejects fragmented MP4 too).

- New `src/lib/export/mp4-audio.ts`: demuxes the AAC track with **mp4box.js** (extracting the AudioSpecificConfig from `stsd → esds` for the decoder), decodes with WebCodecs **`AudioDecoder`**, assembles an `AudioBuffer`, and resamples via `OfflineAudioContext` when rates differ. Dynamically imported, so the 185KB mp4box chunk loads only when a fragmented clip is actually hit.
- `decodeClipAudio` tries `decodeAudioData` first (unchanged fast path for WebM/flat MP4), falls back to the new decoder for `video/mp4` blobs, and reports a tagged Sentry error once per session if both fail — silent exports can no longer happen invisibly.
- Fixes a test regression from #43: `build-info.ts` now guards its compile-time defines, so vitest (which doesn't inject them) runs again — main was silently failing 2 test files.

## Testing

- WebKit + Chromium probes: a fragmented H.264+AAC file fails raw `decodeAudioData` (reproducing the bug) and now decodes through `decodeClipAudio` to a real 48kHz `AudioBuffer` with the expected waveform peak (0.129 sine tone) in both engines.
- 72 unit tests (back from 56 — the #43 regression), full smoke suite 32/32, typecheck + build pass.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-16d17496-6b5b-4e12-b600-6933357c2059"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-16d17496-6b5b-4e12-b600-6933357c2059"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

