### PR TITLE
Fix black void in X's in-app browser: anchor app height to percentages, not dvh

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -29,7 +29,6 @@
   --radius: 18px;
   --safe-top: env(safe-area-inset-top, 0px);
   --safe-bottom: env(safe-area-inset-bottom, 0px);
-  --app-height: 100dvh;
   --tap: 44px;
 }
 
@@ -63,22 +62,21 @@
   }
 }
 
-@supports not (height: 100dvh) {
-  :root {
-    --app-height: 100vh;
-  }
-}
-
 * {
   box-sizing: border-box;
 }
 
+/* Percentage heights, not dvh: the initial containing block is always the
+ * real viewport — including inside in-app browsers (the X iOS WebView
+ * under-reports dvh on first layout, which squeezed the app into the top
+ * half of the screen over a black void). On modern iOS Safari the ICB is
+ * dynamic, so 100% tracks the toolbar exactly like dvh did. */
 html,
 body,
 #root {
   margin: 0;
-  min-height: var(--app-height);
-  height: var(--app-height);
+  min-height: 100%;
+  height: 100%;
 }
 
 body {
@@ -116,7 +114,7 @@ a {
 }
 
 .app-shell {
-  height: var(--app-height);
+  height: 100%;
   max-width: 480px;
   margin: 0 auto;
   position: relative;
@@ -125,7 +123,7 @@ a {
 
 .screen {
   height: 100%;
-  max-height: var(--app-height);
+  max-height: 100%;
   display: flex;
   flex-direction: column;
   min-height: 0;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

X feedback (iPhone, link opened from a DM): the app rendered squeezed into the top half of the screen with a black region below. The tell in the screenshot was the browser chrome — this was **X's in-app browser** (WebView), which under-reports `100dvh` on its first layout and doesn't reliably correct it. Our entire sizing chain (`html`/`body`/`#root`/`.app-shell`/`.screen`) trusted `--app-height: 100dvh`, so the whole app laid out at the stale short height over the body background (near-black in dark mode).

Fix: anchor the chain to **percentage heights** instead. The initial containing block is always the real viewport — including inside embedded WebViews — and on modern iOS Safari the ICB resizes with the toolbar, so `100%` tracks exactly like `dvh` did. Since we control the full ancestor chain, percentages resolve everywhere `dvh` did, minus the WebView bug. The now-unused `--app-height` variable and its `@supports` fallback are removed; the desktop (≥720px) card layout keeps its own `calc(100dvh - 48px)` where dvh is reliable.

## Testing

- WebView simulation: page loaded at a squeezed 465px viewport then resized to 844px — the shell tracks it (465 → 844) instead of staying stuck.
- Phone (WebKit dark, Chromium light): shell fills the viewport exactly (844/844). Desktop: card layout intact (852px in a 900px window, margins preserved).
- Full smoke suite 32/32, touch timeline probe 11/11, keyboard probe, typecheck + build pass.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-16d17496-6b5b-4e12-b600-6933357c2059"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-16d17496-6b5b-4e12-b600-6933357c2059"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved layout sizing across supported browsers, including iOS devices.
  * Reduced viewport-related rendering issues in the application shell and screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->