### PR TITLE
Report silent-export audio diagnostics (decode path + signal peak per clip)

### DIFF
--- a/src/lib/export/index.ts
+++ b/src/lib/export/index.ts
@@ -2,7 +2,12 @@ import type { ClipRecord } from '../types'
 import { exportRealtime } from './encode-realtime'
 import { exportWithWebCodecs, supportsWebCodecsExport } from './encode-webcodecs'
 import { planExport } from './plan'
-import { loadWatermarkImage, type ExportResult } from './shared'
+import {
+  loadWatermarkImage,
+  reportSilentExportAudio,
+  resetAudioDiagnostics,
+  type ExportResult,
+} from './shared'
 
 export type { ExportResult } from './shared'
 export { planExport, type ExportPlan, type PlannedSegment } from './plan'
@@ -40,23 +45,29 @@ export async function exportProject(
 
   const watermarkImage = options.watermark === false ? null : await loadWatermarkImage()
 
+  resetAudioDiagnostics()
   if (supportsWebCodecsExport()) {
     try {
-      return await exportWithWebCodecs(
+      const result = await exportWithWebCodecs(
         plan,
         options.onProgress,
         options.getPreviewCanvas,
         watermarkImage,
       )
+      reportSilentExportAudio({ engine: 'webcodecs', outputMime: result.mimeType })
+      return result
     } catch (error) {
       console.warn('WebCodecs export failed; falling back to realtime stitcher', error)
+      resetAudioDiagnostics()
     }
   }
 
-  return exportRealtime(plan, {
+  const result = await exportRealtime(plan, {
     audioContext: options.audioContext,
     onProgress: options.onProgress,
     getPreviewCanvas: options.getPreviewCanvas,
     watermarkImage,
   })
+  reportSilentExportAudio({ engine: 'realtime', outputMime: result.mimeType })
+  return result
 }

--- a/src/lib/export/shared.ts
+++ b/src/lib/export/shared.ts
@@ -174,6 +174,60 @@ export function pickOutputSize(sourceWidth: number, sourceHeight: number): {
 /** Decode a clip's audio track at the given sample rate. Null when it has none. */
 let audioDecodeFailureReported = false
 
+/** Per-export audio observations, evaluated once by reportSilentExportAudio.
+ * Debugging silent exports remotely needs to know two things per clip: which
+ * decode path ran, and whether the decoded audio carried any actual signal
+ * (a perfect pipeline still exports silence when the mic recorded none). */
+interface ClipAudioObservation {
+  path: 'native' | 'fallback' | 'failed'
+  peak: number
+  mimeType: string
+}
+
+let audioObservations: ClipAudioObservation[] = []
+
+export function resetAudioDiagnostics(): void {
+  audioObservations = []
+}
+
+/** Fires a single tagged Sentry report when an export's audio looks wrong —
+ * every clip failed to decode, or nothing above the near-silence floor. */
+export function reportSilentExportAudio(context: Record<string, unknown>): void {
+  if (audioObservations.length === 0) return
+  const maxPeak = Math.max(...audioObservations.map((o) => o.peak))
+  const allFailed = audioObservations.every((o) => o.path === 'failed')
+  if (!allFailed && maxPeak >= 0.005) return
+  reportError(
+    new Error(
+      allFailed
+        ? 'Export audio: every clip failed to decode'
+        : 'Export audio: decoded clips are silent (mic likely recorded nothing)',
+    ),
+    'export-audio',
+    {
+      ...context,
+      clips: audioObservations.map((o) => ({
+        path: o.path,
+        peak: Number(o.peak.toFixed(4)),
+        mimeType: o.mimeType,
+      })),
+    },
+  )
+}
+
+function audioBufferPeak(buffer: AudioBuffer): number {
+  let peak = 0
+  for (let ch = 0; ch < buffer.numberOfChannels; ch += 1) {
+    const data = buffer.getChannelData(ch)
+    const stride = Math.max(1, Math.floor(data.length / 4000))
+    for (let i = 0; i < data.length; i += stride) {
+      const value = Math.abs(data[i])
+      if (value > peak) peak = value
+    }
+  }
+  return peak
+}
+
 export async function decodeClipAudio(
   blob: Blob,
   sampleRate = 48000,
@@ -181,7 +235,9 @@ export async function decodeClipAudio(
   try {
     const bytes = await blob.arrayBuffer()
     const ctx = new OfflineAudioContext(2, 1, sampleRate)
-    return await ctx.decodeAudioData(bytes)
+    const decoded = await ctx.decodeAudioData(bytes)
+    audioObservations.push({ path: 'native', peak: audioBufferPeak(decoded), mimeType: blob.type })
+    return decoded
   } catch {
     // Safari's MediaRecorder writes fragmented MP4, which decodeAudioData
     // rejects — demux + AudioDecoder covers it (silent export otherwise).
@@ -189,11 +245,19 @@ export async function decodeClipAudio(
       try {
         const { decodeMp4AudioWithWebCodecs } = await import('./mp4-audio')
         const decoded = await decodeMp4AudioWithWebCodecs(blob, sampleRate)
-        if (decoded) return decoded
+        if (decoded) {
+          audioObservations.push({
+            path: 'fallback',
+            peak: audioBufferPeak(decoded),
+            mimeType: blob.type,
+          })
+          return decoded
+        }
       } catch {
         // Fall through to the failure report below.
       }
     }
+    audioObservations.push({ path: 'failed', peak: 0, mimeType: blob.type })
     if (!audioDecodeFailureReported) {
       audioDecodeFailureReported = true
       reportError(new Error('Clip audio decode failed — export audio will be silent'), 'export-audio', {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

The iPhone tester reports audio is *still* missing from exports after #44. Remote investigation has cleared every stage reachable from here: fragmented-MP4 decode works via the new fallback (verified in WebKit and Chromium), and the AAC encode + MP4 mux half produces valid, audible output in WebKit (ffmpeg-verified: 48kHz stereo AAC at the expected level). The remaining suspects can't be distinguished without device data: a stale build on the tester's phone, a real-iOS-only decoder difference, or **clips that are silent at the source** (mic capture producing an empty track — a perfect export pipeline still yields silence).

This ships the telemetry to answer that on the next attempt:

- `decodeClipAudio` records one observation per clip: which decode path ran (`native` / `fallback` / `failed`) and the decoded audio's **signal peak** (sampled, cheap).
- After each export, `reportSilentExportAudio` sends **one tagged Sentry event only when the audio looks wrong** — every clip failed to decode, or nothing exceeded the near-silence floor (peak < 0.005) — including the engine used, output mime, and the per-clip path/peak/mime list. Healthy exports send nothing, keeping the errors-only reporting posture.
- Diagnostics reset per export run (including on WebCodecs → realtime fallback).

The event distinguishes all three hypotheses: `failed` paths → iOS decoder difference to fix; `native`/`fallback` with ~0 peak → mic capture problem (recording-side fix); no event at all → the tester is on a stale build.

## Testing

- 72 unit tests, full smoke suite 32/32 (fake-camera audio has real signal, so no diagnostic fires), typecheck + build pass.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-16d17496-6b5b-4e12-b600-6933357c2059"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-16d17496-6b5b-4e12-b600-6933357c2059"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

