### PR TITLE
Use IconBack on About, Privacy, and Terms pages

### DIFF
--- a/src/pages/about-page.tsx
+++ b/src/pages/about-page.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
 import { Link } from 'react-router-dom'
+import { IconBack } from '../components/icons'
 import { BrandMark } from '../components/brand-mark'
 import { checkForUpdates } from '../lib/app-update'
 import { buildDateLabel, shortVersion } from '../lib/build-info'
@@ -68,7 +69,7 @@ export function AboutPage() {
     <div className="screen about-screen">
       <div className="about-top">
         <Link to="/" className="btn-icon" aria-label="Back to projects">
-          ←
+          <IconBack />
         </Link>
         <strong>About</strong>
         <span className="about-top-spacer" aria-hidden="true" />

--- a/src/pages/privacy-page.tsx
+++ b/src/pages/privacy-page.tsx
@@ -1,4 +1,5 @@
 import { Link } from 'react-router-dom'
+import { IconBack } from '../components/icons'
 
 /** Plain-language privacy policy for on-device Kody Video. */
 export function PrivacyPage() {
@@ -6,7 +7,7 @@ export function PrivacyPage() {
     <div className="screen about-screen">
       <div className="about-top">
         <Link to="/" className="btn-icon" aria-label="Back to projects">
-          ←
+          <IconBack />
         </Link>
         <strong>Privacy</strong>
         <span className="about-top-spacer" aria-hidden="true" />

--- a/src/pages/terms-page.tsx
+++ b/src/pages/terms-page.tsx
@@ -1,4 +1,5 @@
 import { Link } from 'react-router-dom'
+import { IconBack } from '../components/icons'
 
 /** Plain-language terms of use for on-device Kody Video. */
 export function TermsPage() {
@@ -6,7 +7,7 @@ export function TermsPage() {
     <div className="screen about-screen">
       <div className="about-top">
         <Link to="/" className="btn-icon" aria-label="Back to projects">
-          ←
+          <IconBack />
         </Link>
         <strong>Terms</strong>
         <span className="about-top-spacer" aria-hidden="true" />


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

The About page (and the Privacy/Terms pages sharing its header pattern) used a literal `←` character for the back link while the record and editor screens use the `IconBack` SVG chevron from the unified icon set. All three pages now render `IconBack`, matching the rest of the app.

## Testing

- All three pages verified to render the SVG icon in the back link; visual check of the About header matches the app's other back buttons.
- Full smoke suite 32/32, typecheck + build pass.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-16d17496-6b5b-4e12-b600-6933357c2059"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-16d17496-6b5b-4e12-b600-6933357c2059"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

