### PR TITLE
Encode WebCodecs exports from the on-DOM canvas; add black-frame diagnostics

### DIFF
--- a/src/lib/export/encode-realtime.ts
+++ b/src/lib/export/encode-realtime.ts
@@ -8,8 +8,10 @@ import {
   drawWatermark,
   loadClipVideo,
   pickOutputSize,
+  recordVideoLumaSample,
   seekTo,
   wait,
+  waitForPreviewCanvas,
   type ExportResult,
 } from './shared'
 
@@ -264,6 +266,9 @@ async function paintSegment({
         if (frameCounter.count % PREVIEW_EVERY_N_FRAMES === 0) {
           blitPreview(canvas, getPreviewCanvas?.())
         }
+        if (frameCounter.count % 30 === 0) {
+          recordVideoLumaSample(canvas)
+        }
         frameCounter.count += 1
         onElapsedMs(Math.min(segmentSec, elapsed) * 1000)
         raf = requestAnimationFrame(draw)
@@ -285,20 +290,6 @@ async function paintSegment({
       // already ended
     }
     bufferSource?.disconnect()
-  }
-}
-
-/** The export overlay mounts just after the export starts — wait briefly. */
-async function waitForPreviewCanvas(
-  getPreviewCanvas: (() => HTMLCanvasElement | null) | undefined,
-): Promise<HTMLCanvasElement | null> {
-  if (!getPreviewCanvas) return null
-  const deadline = performance.now() + 1500
-  for (;;) {
-    const canvas = getPreviewCanvas()
-    if (canvas?.isConnected) return canvas
-    if (performance.now() > deadline) return null
-    await wait(50)
   }
 }
 

--- a/src/lib/export/encode-webcodecs.ts
+++ b/src/lib/export/encode-webcodecs.ts
@@ -18,7 +18,9 @@ import {
   drawWatermark,
   loadClipVideo,
   pickOutputSize,
+  recordVideoLumaSample,
   seekTo,
+  waitForPreviewCanvas,
   type ExportResult,
 } from './shared'
 
@@ -142,7 +144,15 @@ export async function exportWithWebCodecs(
     throw new Error('No supported export codec')
   }
 
-  const canvas = document.createElement('canvas')
+  // Draw into the on-DOM overlay canvas when available: Safari-family
+  // engines have a history of treating detached canvases as black (see the
+  // realtime engine's captureStream fix) — and it doubles as a per-frame
+  // live preview. Falls back to a detached canvas (fine on Chromium).
+  let canvas = await waitForPreviewCanvas(getPreviewCanvas)
+  const encodingIntoPreview = canvas !== null
+  if (!canvas) {
+    canvas = document.createElement('canvas')
+  }
   canvas.width = width
   canvas.height = height
   const ctx = canvas.getContext('2d', { alpha: false })
@@ -257,7 +267,8 @@ export async function exportWithWebCodecs(
           ctx,
           videoEncoder,
           state,
-          getPreviewCanvas,
+          // No mirroring needed when the encode canvas is the preview.
+          getPreviewCanvas: encodingIntoPreview ? undefined : getPreviewCanvas,
           watermarkImage,
           hasError: () => encoderError !== null,
           onElapsedMs: (elapsed) => {
@@ -403,6 +414,9 @@ async function pumpSegmentVideo({
     state.lastVideoTsUs = tsUs
     if (state.frameCount % PREVIEW_EVERY_N_FRAMES === 0) {
       blitPreview(canvas, getPreviewCanvas?.())
+    }
+    if (state.frameCount % 30 === 0) {
+      recordVideoLumaSample(canvas)
     }
     state.frameCount += 1
   }

--- a/src/lib/export/index.ts
+++ b/src/lib/export/index.ts
@@ -4,8 +4,10 @@ import { exportWithWebCodecs, supportsWebCodecsExport } from './encode-webcodecs
 import { planExport } from './plan'
 import {
   loadWatermarkImage,
+  reportBlackExportVideo,
   reportSilentExportAudio,
   resetAudioDiagnostics,
+  resetVideoDiagnostics,
   type ExportResult,
 } from './shared'
 
@@ -46,6 +48,7 @@ export async function exportProject(
   const watermarkImage = options.watermark === false ? null : await loadWatermarkImage()
 
   resetAudioDiagnostics()
+  resetVideoDiagnostics()
   if (supportsWebCodecsExport()) {
     try {
       const result = await exportWithWebCodecs(
@@ -55,10 +58,12 @@ export async function exportProject(
         watermarkImage,
       )
       reportSilentExportAudio({ engine: 'webcodecs', outputMime: result.mimeType })
+      reportBlackExportVideo({ engine: 'webcodecs', outputMime: result.mimeType })
       return result
     } catch (error) {
       console.warn('WebCodecs export failed; falling back to realtime stitcher', error)
       resetAudioDiagnostics()
+      resetVideoDiagnostics()
     }
   }
 
@@ -69,5 +74,6 @@ export async function exportProject(
     watermarkImage,
   })
   reportSilentExportAudio({ engine: 'realtime', outputMime: result.mimeType })
+  reportBlackExportVideo({ engine: 'realtime', outputMime: result.mimeType })
   return result
 }

--- a/src/lib/export/shared.ts
+++ b/src/lib/export/shared.ts
@@ -215,6 +215,66 @@ export function reportSilentExportAudio(context: Record<string, unknown>): void 
   )
 }
 
+/** The export overlay mounts just after the export starts — wait briefly.
+ * Encoding into the on-DOM overlay canvas (instead of a detached one) is
+ * load-bearing on Safari, which renders detached canvases as black in
+ * captureStream and related paths. */
+export async function waitForPreviewCanvas(
+  getPreviewCanvas: (() => HTMLCanvasElement | null) | undefined,
+): Promise<HTMLCanvasElement | null> {
+  if (!getPreviewCanvas) return null
+  const deadline = performance.now() + 1500
+  for (;;) {
+    const canvas = getPreviewCanvas()
+    if (canvas?.isConnected) return canvas
+    if (performance.now() > deadline) return null
+    await wait(50)
+  }
+}
+
+/** Video-side twin of the audio diagnostics: sampled encode-canvas luma.
+ * A black exported video with no error is otherwise invisible remotely. */
+let videoLumaSamples: number[] = []
+let videoSampleCanvas: HTMLCanvasElement | null = null
+
+export function resetVideoDiagnostics(): void {
+  videoLumaSamples = []
+}
+
+/** Downsample the encode canvas to 8×8 and record the frame's mean luma. */
+export function recordVideoLumaSample(source: HTMLCanvasElement): void {
+  try {
+    if (!videoSampleCanvas) {
+      videoSampleCanvas = document.createElement('canvas')
+      videoSampleCanvas.width = 8
+      videoSampleCanvas.height = 8
+    }
+    const ctx = videoSampleCanvas.getContext('2d', { willReadFrequently: true })
+    if (!ctx) return
+    ctx.drawImage(source, 0, 0, 8, 8)
+    const { data } = ctx.getImageData(0, 0, 8, 8)
+    let total = 0
+    for (let i = 0; i < data.length; i += 4) {
+      total += 0.299 * data[i] + 0.587 * data[i + 1] + 0.114 * data[i + 2]
+    }
+    videoLumaSamples.push(total / (data.length / 4))
+  } catch {
+    // Sampling must never break an export.
+  }
+}
+
+/** One tagged Sentry report when the export's frames were all near-black. */
+export function reportBlackExportVideo(context: Record<string, unknown>): void {
+  if (videoLumaSamples.length < 3) return
+  const maxLuma = Math.max(...videoLumaSamples)
+  if (maxLuma >= 10) return
+  reportError(new Error('Export video: sampled frames are all near-black'), 'export-video', {
+    ...context,
+    samples: videoLumaSamples.length,
+    maxLuma: Number(maxLuma.toFixed(2)),
+  })
+}
+
 function audioBufferPeak(buffer: AudioBuffer): number {
   let peak = 0
   for (let ch = 0; ch < buffer.numberOfChannels; ch += 1) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

New X feedback (Nico, **Android Firefox**): exported video is black — the same symptom class as the earlier iOS report, but on a platform where the export completes with zero Sentry events. Desktop Firefox 153 (full WebCodecs) does **not** reproduce it: A/B-tested production code vs this branch through the complete record → export flow with Firefox's fake camera, both produce healthy frames (ffmpeg YAVG ~144). The failure is Android-Gecko-specific — most plausibly the known hardware-video-decode → canvas readback black-frame behavior, which no desktop engine emulates.

Two changes, one preventive and one evidentiary:

- **WebCodecs engine now draws into the on-DOM overlay canvas** when available (same fix the realtime engine got in #42, via a shared `waitForPreviewCanvas`), falling back to a detached canvas. This eliminates the detached-canvas black-frame class for the WebCodecs path on Safari-family engines, and upgrades the export preview to every frame.
- **Black-frame diagnostics**, mirroring the audio ones: both engines sample the encode canvas's mean luma (8×8 downsample) every 30th frame; after the export, one tagged Sentry event fires **only if every sample was near-black** (max luma < 10), carrying the engine, output mime, and sample stats. Healthy exports send nothing. The next black-export report will say whether frames were black *at draw time* (pointing at video-decode readback) and on which engine — turning guesswork into a targeted fix.

## Testing

- Firefox (fake camera, full flow): WebCodecs encode canvas confirmed to be the connected on-DOM preview (1280×720 backing), export completes, ffmpeg confirms real frames.
- Chromium: full smoke suite 32/32. 72 unit tests, typecheck + build pass.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-16d17496-6b5b-4e12-b600-6933357c2059"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-16d17496-6b5b-4e12-b600-6933357c2059"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

