### PR TITLE
Remove the iOS experimental callout from the home screen

### DIFF
--- a/scripts/probe-webkit.mjs
+++ b/scripts/probe-webkit.mjs
@@ -39,8 +39,8 @@ try {
   await page.goto(BASE, { waitUntil: 'networkidle' })
   check('home renders in WebKit', (await page.locator('.home-screen').count()) > 0)
   check(
-    'iOS experimental note shows',
-    await page.locator('.home-ios-note').isVisible().catch(() => false),
+    'no iOS experimental note (removed by design)',
+    (await page.locator('.home-ios-note').count()) === 0,
   )
 
   // Feature detection matrix the app's code paths depend on.

--- a/src/pages/home-page.tsx
+++ b/src/pages/home-page.tsx
@@ -28,10 +28,6 @@ import { MAX_PROJECTS, formatDuration, type ClipRecord } from '../lib/types'
 /** Android share targets get flaky well below this; bigger backups download. */
 const SHARE_BACKUP_LIMIT_BYTES = 50 * 1024 * 1024
 
-function isIOS(): boolean {
-  return /iPad|iPhone|iPod/.test(navigator.userAgent)
-}
-
 /** The pre-custom-domain deployment; nudge people to migrate to kody.video. */
 function isLegacyOrigin(): boolean {
   return location.hostname === 'kody-video.pages.dev'
@@ -255,13 +251,6 @@ export function HomePage() {
           ),
         )}
       </section>
-
-      {isIOS() ? (
-        <p className="home-ios-note">
-          Heads up: iPhone/iPad support is experimental — Kody Video works best in Chrome on
-          Android.
-        </p>
-      ) : null}
 
       <p className="home-privacy">
         Clips stay on this phone until you share.

--- a/src/styles/home.css
+++ b/src/styles/home.css
@@ -347,16 +347,6 @@
   border-color: color-mix(in srgb, var(--danger) 45%, transparent);
 }
 
-.home-ios-note {
-  margin: 8px 0 0;
-  padding: 8px 12px;
-  border-radius: 12px;
-  background: color-mix(in srgb, #e0a63a 14%, transparent);
-  border: 1px solid color-mix(in srgb, #e0a63a 40%, transparent);
-  font-size: 0.82rem;
-  line-height: 1.4;
-}
-
 .home-privacy .link-button {
   font-size: inherit;
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Drops the "Heads up: iPhone/iPad support is experimental" banner from the home screen (component, `isIOS` helper, CSS, and the WebKit probe expectation — which now asserts the note is absent). The About page's OK Video credit, which legitimately mentions iOS, stays.

## Testing

- Full smoke suite 32/32, WebKit probe green with the inverted assertion, typecheck + build pass.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-16d17496-6b5b-4e12-b600-6933357c2059"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-16d17496-6b5b-4e12-b600-6933357c2059"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed the iOS-specific support notice from the home page.
  * Updated WebKit checks to confirm the notice no longer appears.
  * Removed styling associated with the retired notice.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->