### PR TITLE
Soften the Go button highlight in light mode

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -273,6 +273,17 @@ a {
   transition: transform 160ms ease, opacity 160ms ease;
 }
 
+/* The dark-mode flare uses --bg-elevated (a dark dimple that reads as a
+ * specular). In light mode that token is pure white and painted a harsh
+ * blob — use a soft white highlight instead so the green stays saturated. */
+@media (prefers-color-scheme: light) {
+  .go-button {
+    background:
+      radial-gradient(circle at 34% 28%, rgba(255, 255, 255, 0.32), transparent 18%),
+      linear-gradient(145deg, var(--accent), var(--ok));
+  }
+}
+
 .go-button:active {
   transform: scale(0.95);
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Tester screenshots showed the Go button's specular highlight looking like a harsh flare in light mode. The highlight is painted with `--bg-elevated`, which is a dark slate in dark mode (a subtle dimple that reads well — unchanged) but pure white in light mode, washing out the button's green.

Light mode now overrides just the flare stop with a soft `rgba(255,255,255,0.32)` highlight over the same green gradient — the button stays saturated with a gentle specular instead of a white blob. Dark mode is untouched.

## Testing

- Before/after renders in both color schemes: dark identical, light keeps the saturated green with a subtle highlight.
- Full smoke suite 32/32, typecheck + build pass.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-16d17496-6b5b-4e12-b600-6933357c2059"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-16d17496-6b5b-4e12-b600-6933357c2059"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

