### PR TITLE
Reject non-integer clip byteLength in backup import

### DIFF
--- a/src/lib/project-transfer.test.ts
+++ b/src/lib/project-transfer.test.ts
@@ -102,6 +102,39 @@ describe('project backup round trip', () => {
     await expect(parseProjectBackup(truncated)).rejects.toThrow(/damaged/i)
   })
 
+  it('rejects a manifest with a non-integer clip byteLength', async () => {
+    // A fractional byteLength would pass a Number.isFinite check but make the
+    // clip byte offsets drift, misaligning (and silently corrupting) every
+    // subsequent clip instead of failing cleanly.
+    const manifest = {
+      version: 1,
+      app: 'kody-video',
+      exportedAt: 1,
+      projectName: 'Fractional',
+      clips: [
+        {
+          mimeType: 'video/mp4',
+          durationMs: 1500,
+          trimStartMs: 0,
+          trimEndMs: 1500,
+          createdAt: 1,
+          byteLength: 4.5,
+        },
+      ],
+    }
+    const manifestBytes = new TextEncoder().encode(JSON.stringify(manifest))
+    const magic = new TextEncoder().encode('KODYVID1')
+    const header = new Uint8Array(magic.byteLength + 4)
+    header.set(magic, 0)
+    new DataView(header.buffer).setUint32(magic.byteLength, manifestBytes.byteLength)
+    // Provide plenty of media bytes so the offset + byteLength <= size guard
+    // passes and the integer check is what does the rejecting.
+    const media = new TextEncoder().encode('AAAAAAAA')
+    const backup = new Blob([header, manifestBytes, media])
+
+    await expect(parseProjectBackup(backup)).rejects.toThrow(/damaged/i)
+  })
+
   it('builds a sensible filename', () => {
     expect(projectBackupFilename('Röad Trip!!')).toBe('r-ad-trip.kodyvideo')
     expect(projectBackupFilename('   ')).toBe('project.kodyvideo')

--- a/src/lib/project-transfer.ts
+++ b/src/lib/project-transfer.ts
@@ -119,7 +119,7 @@ export async function parseProjectBackup(file: Blob): Promise<ParsedBackup> {
   const clips: ParsedBackup['clips'] = []
   for (const clip of manifest.clips) {
     if (
-      !Number.isFinite(clip.byteLength) ||
+      !Number.isInteger(clip.byteLength) ||
       clip.byteLength <= 0 ||
       offset + clip.byteLength > file.size
     ) {


### PR DESCRIPTION
Fixes #52.

## Problem

A `.kodyvideo` backup whose manifest has a fractional clip `byteLength` (e.g. `4.5`) passed validation in `parseProjectBackup`, because the guard only checked `Number.isFinite`:

```ts
if (
  !Number.isFinite(clip.byteLength) ||
  clip.byteLength <= 0 ||
  offset + clip.byteLength > file.size
) {
  throw new Error('This backup file is damaged')
}
```

`offset += clip.byteLength` then accumulates fractional drift, so every subsequent clip's `file.slice(offset, offset + clip.byteLength)` is misaligned — the import "succeeds" but produces silently corrupt (unreadable) clips instead of the intended **"This backup file is damaged"** rejection.

## Fix

Tighten the guard to `Number.isInteger(clip.byteLength)`, so a non-integer byte length is rejected up front like any other damaged manifest.

## Test

Adds a regression test (`src/lib/project-transfer.test.ts`) that crafts a backup with a fractional `byteLength` (with enough trailing media bytes that the `offset + byteLength <= size` check still passes, so the integer check is what does the rejecting) and asserts `parseProjectBackup` rejects with `/damaged/i`. Verified the test fails on `main` and passes with this change.

Full suite: `73 passed` (was 72), `tsc -b` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved project backup validation to reject damaged backups containing invalid, non-integer clip sizes.
  * Users now receive a clear damaged-backup error when importing malformed project files.

* **Tests**
  * Added coverage to verify rejection of backups with fractional clip size values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->