### PR TITLE
Don't announce "Share canceled." when the user cancels the share sheet

### DIFF
--- a/src/pages/project-page.tsx
+++ b/src/pages/project-page.tsx
@@ -294,7 +294,9 @@ export function ProjectPage() {
             if (!result || !exportFilename) return
             void shareFile(result.blob, exportFilename)
               .then((outcome) => {
-                setExportNotice(outcome === 'shared' ? 'Shared!' : 'Share canceled.')
+                // A cancel (AbortError → 'cancelled') is a routine user action,
+                // not something worth announcing — only confirm real shares.
+                if (outcome === 'shared') setExportNotice('Shared!')
               })
               .catch(() => {
                 setExportNotice('Sharing failed — try Save instead.')


### PR DESCRIPTION
Fixes #51.

## Problem

`shareFile()` already treats a user cancel (`AbortError`) as a normal outcome and returns `'cancelled'` (`src/lib/media.ts:308-319`). But the export sheet's `onShare` handler surfaced it as a notice:

```js
.then((outcome) => {
  setExportNotice(outcome === 'shared' ? 'Shared!' : 'Share canceled.')
})
```

So opening the OS share sheet and simply backing out — a routine, intentional action — flashes **"Share canceled."** in the export sheet, as if something went wrong.

## Fix

Only surface a notice on a real share; treat cancel as a no-op:

```js
.then((outcome) => {
  if (outcome === 'shared') setExportNotice('Shared!')
})
```

The `.catch` for genuine share failures ("Sharing failed — try Save instead.") is unchanged.

## Notes

UI-layer change in `project-page.tsx`; the repo's tests cover `lib/` rather than page components, so there's no unit test added. `tsc -b` clean, existing suite `72 passed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
