### PR TITLE
Use the white Go button specular in both themes (dark had a murky smudge)

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -260,8 +260,10 @@ a {
   height: 84px;
   min-width: 84px;
   border-radius: 50%;
+  /* White specular in BOTH themes — via --bg-elevated it was white in light
+   * (the look we want) but a murky dark smudge in dark mode. */
   background:
-    radial-gradient(circle at 34% 28%, color-mix(in srgb, var(--bg-elevated) 72%, transparent), transparent 18%),
+    radial-gradient(circle at 34% 28%, rgba(255, 255, 255, 0.72), transparent 18%),
     linear-gradient(145deg, var(--accent), var(--ok));
   color: var(--ink-strong);
   border: 4px solid color-mix(in srgb, var(--bg-elevated) 72%, transparent);
@@ -271,17 +273,6 @@ a {
   font-weight: 700;
   letter-spacing: -0.04em;
   transition: transform 160ms ease, opacity 160ms ease;
-}
-
-/* The dark-mode flare uses --bg-elevated (a dark dimple that reads as a
- * specular). In light mode that token is pure white and painted a harsh
- * blob — use a soft white highlight instead so the green stays saturated. */
-@media (prefers-color-scheme: light) {
-  .go-button {
-    background:
-      radial-gradient(circle at 34% 28%, rgba(255, 255, 255, 0.32), transparent 18%),
-      linear-gradient(145deg, var(--accent), var(--ok));
-  }
 }
 
 .go-button:active {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Correction to #50 — the feedback direction was inverted: the **white** specular (what light mode rendered) is the good look; **dark mode's** `--bg-elevated` dimple was the murky smudge testers saw.

The flare is now painted with white directly (`rgba(255,255,255,0.72)` — byte-identical to what light mode's token resolved to) in the base rule, and #50's light-mode override is removed. Both themes share the same clean highlight; light mode is restored to exactly its original appearance.

## Testing

- Renders in both color schemes: light matches its pre-#50 look, dark shows the same white specular instead of the dark smudge.
- Full smoke suite 32/32, typecheck + build pass.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-16d17496-6b5b-4e12-b600-6933357c2059"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-16d17496-6b5b-4e12-b600-6933357c2059"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

