### PR TITLE
Sheet modality, export-sheet busy guard, and mount-time preview handle

### DIFF
--- a/src/components/blob-video.tsx
+++ b/src/components/blob-video.tsx
@@ -3,10 +3,12 @@ import { bindBlobUrl } from '../lib/blob-url'
 
 type BlobVideoProps = Omit<VideoHTMLAttributes<HTMLVideoElement>, 'src'> & {
   blob: Blob
+  /** Outer ref to the underlying element (mount/unmount, like a plain ref). */
+  videoRef?: RefCallback<HTMLVideoElement>
 }
 
 /** Video element bound to a Blob via ref callback (revokes URL on unmount/blob change). */
-export function BlobVideo({ blob, ...props }: BlobVideoProps) {
+export function BlobVideo({ blob, videoRef, ...props }: BlobVideoProps) {
   const stateRef = useRef<{ current: string | null; blob: Blob | null }>({
     current: null,
     blob: null,
@@ -15,8 +17,9 @@ export function BlobVideo({ blob, ...props }: BlobVideoProps) {
   const setVideoRef = useCallback<RefCallback<HTMLVideoElement>>(
     (element) => {
       bindBlobUrl(element, blob, stateRef.current)
+      videoRef?.(element)
     },
-    [blob],
+    [blob, videoRef],
   )
 
   return <video {...props} ref={setVideoRef} />

--- a/src/components/confirm-sheet.tsx
+++ b/src/components/confirm-sheet.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import { useSheetModal } from '../hooks/use-sheet-modal'
 
 interface ConfirmSheetProps {
   title: string
@@ -19,6 +20,7 @@ export function ConfirmSheet({
   onClose,
 }: ConfirmSheetProps) {
   const [busy, setBusy] = useState(false)
+  const bindSheet = useSheetModal({ onDismiss: onClose, busy })
 
   return (
     <>
@@ -28,11 +30,24 @@ export function ConfirmSheet({
           if (!busy) onClose()
         }}
       />
-      <div className="sheet confirm-sheet" role="dialog" aria-label={title}>
+      <div
+        className="sheet confirm-sheet"
+        role="dialog"
+        aria-modal="true"
+        aria-label={title}
+        ref={bindSheet}
+      >
         <h3>{title}</h3>
         <p className="sheet-lede muted">{message}</p>
         <div className="sheet-actions">
-          <button type="button" className="btn btn-ghost" onClick={onClose} disabled={busy}>
+          {/* Destructive dialog: initial focus lands on the safe action. */}
+          <button
+            type="button"
+            className="btn btn-ghost"
+            onClick={onClose}
+            disabled={busy}
+            data-sheet-focus
+          >
             {cancelLabel}
           </button>
           <button

--- a/src/components/editor-clip-preview.tsx
+++ b/src/components/editor-clip-preview.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState, type MutableRefObject } from 'react'
+import { useCallback, useRef, useState, type MutableRefObject } from 'react'
 import { BlobVideo } from './blob-video'
 import { IconPause, IconPlay } from './icons'
 import type { ClipRecord } from '../lib/types'
@@ -34,34 +34,42 @@ export function EditorClipPreview({ clip, apiRef }: EditorClipPreviewProps) {
   const mediaRef = useRef<HTMLVideoElement | null>(null)
   const [playing, setPlaying] = useState(false)
 
-  const bindVideo = (video: HTMLVideoElement | null) => {
-    mediaRef.current = video
-    if (!apiRef) return
-    if (!video) {
-      apiRef.current = null
-      return
-    }
-    apiRef.current = {
-      seekToMs: (timeMs: number) => {
-        const el = mediaRef.current
-        if (!el) return
-        el.pause()
-        setPlaying(false)
-        const sec = Math.max(0, Math.min(timeMs, clip.durationMs)) / 1000
-        if (Math.abs(el.currentTime - sec) > 0.02) {
-          el.currentTime = sec
-        } else {
-          nudgeFrame(el)
-        }
-      },
-      pause: () => {
-        const el = mediaRef.current
-        if (!el) return
-        el.pause()
-        setPlaying(false)
-      },
-    }
-  }
+  // Bound to the element's mount/unmount (not the first media event) so the
+  // imperative handle works immediately — early pause()/seekToMs() calls on a
+  // still-loading clip must act instead of silently no-oping (#58).
+  const durationMsRef = useRef(clip.durationMs)
+  durationMsRef.current = clip.durationMs
+  const bindVideo = useCallback(
+    (video: HTMLVideoElement | null) => {
+      mediaRef.current = video
+      if (!apiRef) return
+      if (!video) {
+        apiRef.current = null
+        return
+      }
+      apiRef.current = {
+        seekToMs: (timeMs: number) => {
+          const el = mediaRef.current
+          if (!el) return
+          el.pause()
+          setPlaying(false)
+          const sec = Math.max(0, Math.min(timeMs, durationMsRef.current)) / 1000
+          if (Math.abs(el.currentTime - sec) > 0.02) {
+            el.currentTime = sec
+          } else {
+            nudgeFrame(el)
+          }
+        },
+        pause: () => {
+          const el = mediaRef.current
+          if (!el) return
+          el.pause()
+          setPlaying(false)
+        },
+      }
+    },
+    [apiRef],
+  )
 
   const togglePlayback = () => {
     const video = mediaRef.current
@@ -90,12 +98,12 @@ export function EditorClipPreview({ clip, apiRef }: EditorClipPreviewProps) {
       <BlobVideo
         key={remountKey}
         blob={clip.blob}
+        videoRef={bindVideo}
         className="editor-clip-preview"
         playsInline
         preload="auto"
         onLoadedData={(event) => {
           const video = event.currentTarget
-          bindVideo(video)
           if (Math.abs(video.currentTime - startSec) > 0.04) {
             video.currentTime = startSec
             return
@@ -103,12 +111,10 @@ export function EditorClipPreview({ clip, apiRef }: EditorClipPreviewProps) {
           nudgeFrame(video)
         }}
         onSeeked={(event) => {
-          bindVideo(event.currentTarget)
           if (event.currentTarget.paused) nudgeFrame(event.currentTarget)
         }}
         onTimeUpdate={(event) => {
           const video = event.currentTarget
-          bindVideo(video)
           if (!video.paused && video.currentTime >= endSec - 0.02) {
             video.pause()
             video.currentTime = endSec

--- a/src/components/editor-clip-preview.tsx
+++ b/src/components/editor-clip-preview.tsx
@@ -39,9 +39,13 @@ export function EditorClipPreview({ clip, apiRef }: EditorClipPreviewProps) {
   // still-loading clip must act instead of silently no-oping (#58).
   const durationMsRef = useRef(clip.durationMs)
   durationMsRef.current = clip.durationMs
+  /** An explicit seek before loadeddata must not be snapped back to the trim
+   * start when the metadata arrives. */
+  const explicitSeekRef = useRef(false)
   const bindVideo = useCallback(
     (video: HTMLVideoElement | null) => {
       mediaRef.current = video
+      explicitSeekRef.current = false
       if (!apiRef) return
       if (!video) {
         apiRef.current = null
@@ -51,6 +55,7 @@ export function EditorClipPreview({ clip, apiRef }: EditorClipPreviewProps) {
         seekToMs: (timeMs: number) => {
           const el = mediaRef.current
           if (!el) return
+          explicitSeekRef.current = true
           el.pause()
           setPlaying(false)
           const sec = Math.max(0, Math.min(timeMs, durationMsRef.current)) / 1000
@@ -104,6 +109,8 @@ export function EditorClipPreview({ clip, apiRef }: EditorClipPreviewProps) {
         preload="auto"
         onLoadedData={(event) => {
           const video = event.currentTarget
+          // Don't clobber a seek the user already made while loading.
+          if (explicitSeekRef.current) return
           if (Math.abs(video.currentTime - startSec) > 0.04) {
             video.currentTime = startSec
             return

--- a/src/components/export-sheet.tsx
+++ b/src/components/export-sheet.tsx
@@ -1,3 +1,4 @@
+import { useSheetModal } from '../hooks/use-sheet-modal'
 import { BrandMark } from './brand-mark'
 
 export type ExportStatus = 'exporting' | 'ready' | 'error'
@@ -16,6 +17,8 @@ interface ExportSheetProps {
   watermarked: boolean
   /** True when the removal purchase is unlocked (may change mid-sheet). */
   purchased: boolean
+  /** A share/save is in flight — dismissal would drop its result notice. */
+  busy: boolean
   onShare: () => void
   onSave: () => void
   onSaveClips: () => void
@@ -39,6 +42,7 @@ export function ExportSheet({
   notice,
   watermarked,
   purchased,
+  busy,
   onShare,
   onSave,
   onSaveClips,
@@ -47,10 +51,22 @@ export function ExportSheet({
   onRetry,
   onClose,
 }: ExportSheetProps) {
+  const bindSheet = useSheetModal({ onDismiss: onClose, busy })
   return (
     <>
-      <div className="sheet-backdrop" onClick={onClose} />
-      <div className="sheet export-sheet" role="dialog" aria-label="Share project">
+      <div
+        className="sheet-backdrop"
+        onClick={() => {
+          if (!busy) onClose()
+        }}
+      />
+      <div
+        className="sheet export-sheet"
+        role="dialog"
+        aria-modal="true"
+        aria-label="Share project"
+        ref={bindSheet}
+      >
         {status === 'ready' ? (
           <>
             <BrandMark size={84} className="export-celebrate-art" variant="share" />

--- a/src/components/export-sheet.tsx
+++ b/src/components/export-sheet.tsx
@@ -90,7 +90,7 @@ export function ExportSheet({
               >
                 Save
               </button>
-              <button type="button" className="btn btn-ghost" onClick={onClose}>
+              <button type="button" className="btn btn-ghost" onClick={onClose} disabled={busy}>
                 Done
               </button>
             </div>
@@ -126,7 +126,7 @@ export function ExportSheet({
               <button type="button" className="btn btn-secondary" onClick={onSaveClips} disabled={busy}>
                 Save clips instead
               </button>
-              <button type="button" className="btn btn-ghost" onClick={onClose}>
+              <button type="button" className="btn btn-ghost" onClick={onClose} disabled={busy}>
                 Close
               </button>
             </div>

--- a/src/components/export-sheet.tsx
+++ b/src/components/export-sheet.tsx
@@ -78,7 +78,7 @@ export function ExportSheet({
             {notice ? <p className="sheet-message">{notice}</p> : null}
             <div className="sheet-actions">
               {canShare ? (
-                <button type="button" className="btn btn-primary" onClick={onShare}>
+                <button type="button" className="btn btn-primary" onClick={onShare} disabled={busy}>
                   Share
                 </button>
               ) : null}
@@ -86,6 +86,7 @@ export function ExportSheet({
                 type="button"
                 className={`btn ${canShare ? 'btn-secondary' : 'btn-primary'}`}
                 onClick={onSave}
+                disabled={busy}
               >
                 Save
               </button>
@@ -122,7 +123,7 @@ export function ExportSheet({
               <button type="button" className="btn btn-primary" onClick={onRetry}>
                 Try again
               </button>
-              <button type="button" className="btn btn-secondary" onClick={onSaveClips}>
+              <button type="button" className="btn btn-secondary" onClick={onSaveClips} disabled={busy}>
                 Save clips instead
               </button>
               <button type="button" className="btn btn-ghost" onClick={onClose}>

--- a/src/components/export-sheet.tsx
+++ b/src/components/export-sheet.tsx
@@ -120,7 +120,7 @@ export function ExportSheet({
             <p className="sheet-message is-error">{error ?? 'Something went wrong.'}</p>
             {notice ? <p className="sheet-message">{notice}</p> : null}
             <div className="sheet-actions">
-              <button type="button" className="btn btn-primary" onClick={onRetry}>
+              <button type="button" className="btn btn-primary" onClick={onRetry} disabled={busy}>
                 Try again
               </button>
               <button type="button" className="btn btn-secondary" onClick={onSaveClips} disabled={busy}>

--- a/src/components/home-options-sheet.tsx
+++ b/src/components/home-options-sheet.tsx
@@ -1,3 +1,5 @@
+import { useSheetModal } from '../hooks/use-sheet-modal'
+
 interface HomeOptionsSheetProps {
   projectName: string
   onOpen: () => void
@@ -16,10 +18,17 @@ export function HomeOptionsSheet({
   onDelete,
   onClose,
 }: HomeOptionsSheetProps) {
+  const bindSheet = useSheetModal({ onDismiss: onClose })
   return (
     <>
       <div className="sheet-backdrop" onClick={onClose} />
-      <div className="sheet home-options-sheet" role="dialog" aria-label={`Options for ${projectName}`}>
+      <div
+        className="sheet home-options-sheet"
+        role="dialog"
+        aria-modal="true"
+        aria-label={`Options for ${projectName}`}
+        ref={bindSheet}
+      >
         <h3>{projectName}</h3>
         <p className="sheet-lede muted">What do you want to do?</p>
         <div className="home-options-list">

--- a/src/components/rename-sheet.tsx
+++ b/src/components/rename-sheet.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import { useSheetModal } from '../hooks/use-sheet-modal'
 
 interface RenameSheetProps {
   initialName: string
@@ -19,6 +20,7 @@ export function RenameSheet({
   const [name, setName] = useState(initialName)
   const [busy, setBusy] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const bindSheet = useSheetModal({ onDismiss: onClose, busy })
 
   return (
     <>
@@ -28,7 +30,7 @@ export function RenameSheet({
           if (!busy) onClose()
         }}
       />
-      <div className="sheet" role="dialog" aria-label={title}>
+      <div className="sheet" role="dialog" aria-modal="true" aria-label={title} ref={bindSheet}>
         <h3>{title}</h3>
         <div className="field">
           <label htmlFor="project-name">Name</label>

--- a/src/components/restore-sheet.tsx
+++ b/src/components/restore-sheet.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import { useSheetModal } from '../hooks/use-sheet-modal'
 import { extractSessionId, verifyPurchaseSession } from '../lib/entitlement'
 
 interface RestoreSheetProps {
@@ -14,6 +15,7 @@ export function RestoreSheet({ onRestored, onClose }: RestoreSheetProps) {
   const [value, setValue] = useState('')
   const [busy, setBusy] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const bindSheet = useSheetModal({ onDismiss: onClose, busy })
 
   return (
     <>
@@ -23,7 +25,7 @@ export function RestoreSheet({ onRestored, onClose }: RestoreSheetProps) {
           if (!busy) onClose()
         }}
       />
-      <div className="sheet" role="dialog" aria-label="Restore purchase">
+      <div className="sheet" role="dialog" aria-modal="true" aria-label="Restore purchase" ref={bindSheet}>
         <h3>Restore purchase</h3>
         <p className="muted sheet-lede">
           Paste the confirmation link from your Stripe receipt email (or the checkout session id

--- a/src/hooks/use-sheet-modal.ts
+++ b/src/hooks/use-sheet-modal.ts
@@ -36,7 +36,12 @@ export function useSheetModal({ onDismiss, busy }: SheetModalOptions): RefCallba
         'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])',
       ),
     ].filter((candidate) => !candidate.hasAttribute('disabled'))
-    if (focusables.length === 0) return
+    if (focusables.length === 0) {
+      // Everything is disabled mid-action: hold focus in place rather than
+      // letting Tab escape behind the modal.
+      event.preventDefault()
+      return
+    }
     const first = focusables[0]
     const last = focusables[focusables.length - 1]
     const active = document.activeElement instanceof HTMLElement ? document.activeElement : null

--- a/src/hooks/use-sheet-modal.ts
+++ b/src/hooks/use-sheet-modal.ts
@@ -6,6 +6,10 @@ interface SheetModalOptions {
   busy?: boolean
 }
 
+/** Mounted sheets, in stacking order — only the topmost owns the keyboard
+ * (RestoreSheet opens on top of ExportSheet; Escape must peel one layer). */
+const sheetStack: HTMLElement[] = []
+
 /**
  * Modal behavior for bottom sheets: Escape dismisses (unless busy), Tab is
  * trapped inside the sheet, initial focus lands on `[data-sheet-focus]` (or
@@ -23,6 +27,9 @@ export function useSheetModal({ onDismiss, busy }: SheetModalOptions): RefCallba
   const onKeyDown = useCallback((event: KeyboardEvent) => {
     const element = elementRef.current
     if (!element) return
+    // Stacked sheets: only the topmost handles keys (the lower sheet's
+    // listener must neither trap Tab nor dismiss on the same Escape).
+    if (sheetStack[sheetStack.length - 1] !== element) return
     if (event.key === 'Escape') {
       // Capture-phase stop: the sheet's Escape must never also trigger
       // screen-level shortcuts (e.g. the editor's back-to-camera).
@@ -64,6 +71,7 @@ export function useSheetModal({ onDismiss, busy }: SheetModalOptions): RefCallba
     (element: HTMLElement | null) => {
       if (element) {
         elementRef.current = element
+        sheetStack.push(element)
         previousFocusRef.current =
           document.activeElement instanceof HTMLElement ? document.activeElement : null
         window.addEventListener('keydown', onKeyDown, true)
@@ -74,6 +82,8 @@ export function useSheetModal({ onDismiss, busy }: SheetModalOptions): RefCallba
           )
         initial?.focus()
       } else {
+        const index = elementRef.current ? sheetStack.indexOf(elementRef.current) : -1
+        if (index >= 0) sheetStack.splice(index, 1)
         elementRef.current = null
         window.removeEventListener('keydown', onKeyDown, true)
         previousFocusRef.current?.focus()

--- a/src/hooks/use-sheet-modal.ts
+++ b/src/hooks/use-sheet-modal.ts
@@ -1,0 +1,80 @@
+import { useCallback, useLayoutEffect, useRef, type RefCallback } from 'react'
+
+interface SheetModalOptions {
+  onDismiss: () => void
+  /** Blocks Esc dismissal while an action is in flight. */
+  busy?: boolean
+}
+
+/**
+ * Modal behavior for bottom sheets: Escape dismisses (unless busy), Tab is
+ * trapped inside the sheet, initial focus lands on `[data-sheet-focus]` (or
+ * the first focusable), and focus returns to the opener on close. Attach the
+ * returned ref to the sheet's dialog element and add `aria-modal="true"`.
+ */
+export function useSheetModal({ onDismiss, busy }: SheetModalOptions): RefCallback<HTMLElement> {
+  const optionsRef = useRef({ onDismiss, busy })
+  useLayoutEffect(() => {
+    optionsRef.current = { onDismiss, busy }
+  })
+  const elementRef = useRef<HTMLElement | null>(null)
+  const previousFocusRef = useRef<HTMLElement | null>(null)
+
+  const onKeyDown = useCallback((event: KeyboardEvent) => {
+    const element = elementRef.current
+    if (!element) return
+    if (event.key === 'Escape') {
+      // Capture-phase stop: the sheet's Escape must never also trigger
+      // screen-level shortcuts (e.g. the editor's back-to-camera).
+      event.stopPropagation()
+      if (!optionsRef.current.busy) optionsRef.current.onDismiss()
+      return
+    }
+    if (event.key !== 'Tab') return
+    const focusables = [
+      ...element.querySelectorAll<HTMLElement>(
+        'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])',
+      ),
+    ].filter((candidate) => !candidate.hasAttribute('disabled'))
+    if (focusables.length === 0) return
+    const first = focusables[0]
+    const last = focusables[focusables.length - 1]
+    const active = document.activeElement instanceof HTMLElement ? document.activeElement : null
+    const inside = active !== null && element.contains(active)
+    if (!inside) {
+      event.preventDefault()
+      first.focus()
+      return
+    }
+    if (event.shiftKey && active === first) {
+      event.preventDefault()
+      last.focus()
+    } else if (!event.shiftKey && active === last) {
+      event.preventDefault()
+      first.focus()
+    }
+  }, [])
+
+  return useCallback(
+    (element: HTMLElement | null) => {
+      if (element) {
+        elementRef.current = element
+        previousFocusRef.current =
+          document.activeElement instanceof HTMLElement ? document.activeElement : null
+        window.addEventListener('keydown', onKeyDown, true)
+        const initial =
+          element.querySelector<HTMLElement>('[data-sheet-focus]') ??
+          element.querySelector<HTMLElement>(
+            'button:not([disabled]), [href], input, select, textarea',
+          )
+        initial?.focus()
+      } else {
+        elementRef.current = null
+        window.removeEventListener('keydown', onKeyDown, true)
+        previousFocusRef.current?.focus()
+        previousFocusRef.current = null
+      }
+    },
+    [onKeyDown],
+  )
+}

--- a/src/pages/project-page.tsx
+++ b/src/pages/project-page.tsx
@@ -93,8 +93,11 @@ export function ProjectPage() {
   const [toast, setToast] = useState<ToastState | null>(null)
   const [exportState, setExportState] = useState<ExportUiState | null>(null)
   const [restoring, setRestoring] = useState(false)
-  /** A share/save is in flight — the export sheet must not dismiss under it. */
-  const [exportActionBusy, setExportActionBusy] = useState(false)
+  /** In-flight share/save COUNT (concurrent actions must not clear each
+   * other's busy state) — the export sheet must not dismiss while > 0. */
+  const [exportActionCount, setExportActionCount] = useState(0)
+  const beginExportAction = () => setExportActionCount((count) => count + 1)
+  const endExportAction = () => setExportActionCount((count) => Math.max(0, count - 1))
 
   const refresh = useCallback(() => {
     startTransition(() => {
@@ -280,7 +283,7 @@ export function ProjectPage() {
           notice={exportState.notice}
           watermarked={exportState.watermarked}
           purchased={data.watermarkRemoved}
-          busy={exportActionBusy}
+          busy={exportActionCount > 0}
           onRemoveWatermark={() => {
             window.open(REMOVE_WATERMARK_LINK, '_blank', 'noopener')
           }}
@@ -295,7 +298,7 @@ export function ProjectPage() {
           onShare={() => {
             const result = exportState.result
             if (!result || !exportFilename) return
-            setExportActionBusy(true)
+            beginExportAction()
             void shareFile(result.blob, exportFilename)
               .then((outcome) => {
                 // A cancel (AbortError → 'cancelled') is a routine user action,
@@ -305,12 +308,12 @@ export function ProjectPage() {
               .catch(() => {
                 setExportNotice('Sharing failed — try Save instead.')
               })
-              .finally(() => setExportActionBusy(false))
+              .finally(endExportAction)
           }}
           onSave={() => {
             const result = exportState.result
             if (!result || !exportFilename) return
-            setExportActionBusy(true)
+            beginExportAction()
             void downloadBlob(result.blob, exportFilename)
               .then(() => {
                 setExportNotice('Saved — check your downloads.')
@@ -318,10 +321,10 @@ export function ProjectPage() {
               .catch(() => {
                 setExportNotice('Saving failed — try again.')
               })
-              .finally(() => setExportActionBusy(false))
+              .finally(endExportAction)
           }}
           onSaveClips={() => {
-            setExportActionBusy(true)
+            beginExportAction()
             void downloadClipsAsSeparateFiles(clips, project.name)
               .then(() => {
                 setExportNotice('Saving original clips — allow multiple downloads if asked.')
@@ -329,7 +332,7 @@ export function ProjectPage() {
               .catch(() => {
                 setExportNotice('Saving failed — try again.')
               })
-              .finally(() => setExportActionBusy(false))
+              .finally(endExportAction)
           }}
           onRetry={startExport}
           onClose={closeExport}

--- a/src/pages/project-page.tsx
+++ b/src/pages/project-page.tsx
@@ -93,6 +93,8 @@ export function ProjectPage() {
   const [toast, setToast] = useState<ToastState | null>(null)
   const [exportState, setExportState] = useState<ExportUiState | null>(null)
   const [restoring, setRestoring] = useState(false)
+  /** A share/save is in flight — the export sheet must not dismiss under it. */
+  const [exportActionBusy, setExportActionBusy] = useState(false)
 
   const refresh = useCallback(() => {
     startTransition(() => {
@@ -278,6 +280,7 @@ export function ProjectPage() {
           notice={exportState.notice}
           watermarked={exportState.watermarked}
           purchased={data.watermarkRemoved}
+          busy={exportActionBusy}
           onRemoveWatermark={() => {
             window.open(REMOVE_WATERMARK_LINK, '_blank', 'noopener')
           }}
@@ -292,6 +295,7 @@ export function ProjectPage() {
           onShare={() => {
             const result = exportState.result
             if (!result || !exportFilename) return
+            setExportActionBusy(true)
             void shareFile(result.blob, exportFilename)
               .then((outcome) => {
                 // A cancel (AbortError → 'cancelled') is a routine user action,
@@ -301,18 +305,31 @@ export function ProjectPage() {
               .catch(() => {
                 setExportNotice('Sharing failed — try Save instead.')
               })
+              .finally(() => setExportActionBusy(false))
           }}
           onSave={() => {
             const result = exportState.result
             if (!result || !exportFilename) return
-            void downloadBlob(result.blob, exportFilename).then(() => {
-              setExportNotice('Saved — check your downloads.')
-            })
+            setExportActionBusy(true)
+            void downloadBlob(result.blob, exportFilename)
+              .then(() => {
+                setExportNotice('Saved — check your downloads.')
+              })
+              .catch(() => {
+                setExportNotice('Saving failed — try again.')
+              })
+              .finally(() => setExportActionBusy(false))
           }}
           onSaveClips={() => {
-            void downloadClipsAsSeparateFiles(clips, project.name).then(() => {
-              setExportNotice('Saving original clips — allow multiple downloads if asked.')
-            })
+            setExportActionBusy(true)
+            void downloadClipsAsSeparateFiles(clips, project.name)
+              .then(() => {
+                setExportNotice('Saving original clips — allow multiple downloads if asked.')
+              })
+              .catch(() => {
+                setExportNotice('Saving failed — try again.')
+              })
+              .finally(() => setExportActionBusy(false))
           }}
           onRetry={startExport}
           onClose={closeExport}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Fixes the three remaining issues from @iambharathpadhu's review pass (his other two came with PRs, both merged — #55, #56):

**Fixes #54 — bottom-sheet modality.** New `useSheetModal` hook: Escape dismisses (capture-phase with `stopPropagation`, so a sheet's Esc never reaches screen-level shortcuts; honors `busy`), Tab is trapped inside the sheet, initial focus lands on `[data-sheet-focus]` or the first focusable, and focus returns to the opener on close. Applied to `ConfirmSheet`, `RenameSheet`, `RestoreSheet`, `HomeOptionsSheet`, and `ExportSheet`, all now `aria-modal="true"`. The destructive `ConfirmSheet` puts initial focus on **Cancel**.

**Fixes #53 — export sheet during share/save.** The sheet takes a `busy` prop: the backdrop (and Esc) no longer dismiss while a share/save is in flight, matching the sibling sheets. `onSave`/`onSaveClips` gained `.catch` handlers surfacing "Saving failed — try again." instead of an unhandled rejection with zero feedback.

**Fixes #58 — editor preview imperative handle.** `BlobVideo` forwards a `videoRef` to the underlying element, and `EditorClipPreview` binds `apiRef` there — on mount, not on the first media event — so `pause()`/`seekToMs()` work immediately on freshly-selected clips (trim-handle drags and fast keyboard actions on slow-loading clips no longer no-op). The redundant re-binds in the media event handlers are removed; `durationMs` is read through a ref so the handle never captures a stale clamp.

## Testing

- New probe checks: `aria-modal` present, initial focus inside the sheet, Tab wraps from last to first focusable, Escape closes the options sheet, ConfirmSheet focuses Cancel, Escape closes ConfirmSheet — all pass.
- 73 unit tests, full smoke suite 32/32, typecheck + build pass.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-16d17496-6b5b-4e12-b600-6933357c2059"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-16d17496-6b5b-4e12-b600-6933357c2059"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved bottom-sheet accessibility with focus trapping, keyboard navigation, ARIA dialog attributes, and focus restoration.
  * Escape-to-dismiss behavior is now supported when sheets are not busy.
  * Video previews now support reliable external control and preserve explicit seek positions.
  * Added busy-state handling for sharing and saving actions.

* **Bug Fixes**
  * Prevented sheets from closing and action buttons from being triggered while exports are in progress.
  * Improved video playback positioning during initial loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->