### PR TITLE
Add dismissible iOS Add-to-Home-Screen install hint

### DIFF
--- a/manual-test-checklist.md
+++ b/manual-test-checklist.md
@@ -68,6 +68,8 @@ Run locally with HTTPS or `localhost` (`npm run dev`). Camera/mic require a secu
 - [ ] Hard refresh restores projects and clip media
 - [ ] Airplane mode after first visit still loads the app shell (PWA/service worker)
 - [ ] Offline, existing projects open and clips play from IndexedDB
+- [ ] iOS Safari (browser tab): home shows the Share → Add to Home Screen tip; × dismisses it for good
+- [ ] Installed (standalone) and non-iOS browsers never show the iOS install tip
 
 ## Storage
 - [ ] Home shows "X of Y used" in the footer line

--- a/scripts/probe-install-hint.mjs
+++ b/scripts/probe-install-hint.mjs
@@ -1,0 +1,63 @@
+/**
+ * Verifies the iOS Share → Add to Home Screen hint: shows for iPhone Safari
+ * UAs, dismisses permanently, and stays hidden for Android/standalone.
+ * Run: node scripts/probe-install-hint.mjs (needs `npm run build` first)
+ */
+import { chromium } from 'playwright'
+import { preview } from 'vite'
+
+const IOS_SAFARI_UA =
+  'Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.5 Mobile/15E148 Safari/604.1'
+const IOS_WEBVIEW_UA =
+  'Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148'
+const ANDROID_UA =
+  'Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0 Mobile Safari/537.36'
+
+const server = await preview({ preview: { port: 4183 } })
+const base = 'http://localhost:4183'
+const browser = await chromium.launch()
+const failures = []
+
+async function hintVisible(ua, setup) {
+  const context = await browser.newContext({ userAgent: ua, viewport: { width: 390, height: 844 } })
+  const page = await context.newPage()
+  await page.goto(base)
+  if (setup) await setup(page)
+  const visible = await page
+    .locator('.home-install-hint')
+    .isVisible()
+    .catch(() => false)
+  await context.close()
+  return visible
+}
+
+if (!(await hintVisible(IOS_SAFARI_UA))) failures.push('iOS Safari should show the hint')
+if (await hintVisible(ANDROID_UA)) failures.push('Android should not show the hint')
+if (await hintVisible(IOS_WEBVIEW_UA)) failures.push('iOS bare WebView should not show the hint')
+
+{
+  const context = await browser.newContext({
+    userAgent: IOS_SAFARI_UA,
+    viewport: { width: 390, height: 844 },
+  })
+  const page = await context.newPage()
+  await page.goto(base)
+  await page.click('.install-hint-dismiss')
+  if (await page.locator('.home-install-hint').isVisible().catch(() => false)) {
+    failures.push('dismiss should hide the hint immediately')
+  }
+  await page.reload()
+  if (await page.locator('.home-install-hint').isVisible().catch(() => false)) {
+    failures.push('dismissal should persist across reloads')
+  }
+  await context.close()
+}
+
+await browser.close()
+await server.close()
+
+if (failures.length > 0) {
+  console.error('FAIL:\n- ' + failures.join('\n- '))
+  process.exit(1)
+}
+console.log('install hint probe: all checks passed')

--- a/scripts/probe-install-hint.mjs
+++ b/scripts/probe-install-hint.mjs
@@ -18,11 +18,17 @@ const base = 'http://localhost:4183'
 const browser = await chromium.launch()
 const failures = []
 
-async function hintVisible(ua, setup) {
+async function hintVisible(ua, { standalone = false } = {}) {
   const context = await browser.newContext({ userAgent: ua, viewport: { width: 390, height: 844 } })
   const page = await context.newPage()
+  if (standalone) {
+    // Must be registered before navigation: HomePage checks eligibility
+    // during its first render.
+    await page.addInitScript(() => {
+      Object.defineProperty(navigator, 'standalone', { get: () => true })
+    })
+  }
   await page.goto(base)
-  if (setup) await setup(page)
   const visible = await page
     .locator('.home-install-hint')
     .isVisible()
@@ -34,6 +40,9 @@ async function hintVisible(ua, setup) {
 if (!(await hintVisible(IOS_SAFARI_UA))) failures.push('iOS Safari should show the hint')
 if (await hintVisible(ANDROID_UA)) failures.push('Android should not show the hint')
 if (await hintVisible(IOS_WEBVIEW_UA)) failures.push('iOS bare WebView should not show the hint')
+if (await hintVisible(IOS_SAFARI_UA, { standalone: true })) {
+  failures.push('installed (standalone) app should not show the hint')
+}
 
 {
   const context = await browser.newContext({

--- a/src/components/icons.tsx
+++ b/src/components/icons.tsx
@@ -190,6 +190,26 @@ export function IconUndo({ size = 22 }: IconProps) {
   )
 }
 
+/** The iOS share glyph: box with an arrow rising out of it. */
+export function IconShareIos({ size = 22 }: IconProps) {
+  return (
+    <svg {...baseProps(size)}>
+      <path d="M8 8H6a1 1 0 00-1 1v11a1 1 0 001 1h12a1 1 0 001-1V9a1 1 0 00-1-1h-2" />
+      <path d="M12 14V3" />
+      <path d="M8.5 6.5L12 3l3.5 3.5" />
+    </svg>
+  )
+}
+
+export function IconClose({ size = 22 }: IconProps) {
+  return (
+    <svg {...baseProps(size)}>
+      <path d="M6 6l12 12" />
+      <path d="M18 6L6 18" />
+    </svg>
+  )
+}
+
 export function IconLens({ size = 22 }: IconProps) {
   return (
     <svg {...baseProps(size)}>

--- a/src/lib/install-hint.ts
+++ b/src/lib/install-hint.ts
@@ -1,0 +1,39 @@
+/**
+ * iOS never fires `beforeinstallprompt`, so the only way to get Kody Video on
+ * a home screen there is the manual Share → Add to Home Screen flow. This
+ * decides when nudging about that is actually useful.
+ */
+
+const DISMISSED_KEY = 'kody-video:install-hint-dismissed'
+
+function isIosDevice(): boolean {
+  if (/iPhone|iPad|iPod/i.test(navigator.userAgent)) return true
+  // iPadOS masquerades as macOS but is the only "Mac" with touch points.
+  return navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1
+}
+
+function isStandalone(): boolean {
+  if (window.matchMedia('(display-mode: standalone)').matches) return true
+  return (navigator as { standalone?: boolean }).standalone === true
+}
+
+export function shouldShowIosInstallHint(): boolean {
+  if (!isIosDevice()) return false
+  if (isStandalone()) return false
+  // Bare WKWebViews (X, Instagram, …) have no Share → Add to Home Screen and
+  // omit the "Safari" UA token that real browsers (Safari/CriOS/FxiOS) keep.
+  if (!/Safari/i.test(navigator.userAgent)) return false
+  try {
+    return localStorage.getItem(DISMISSED_KEY) === null
+  } catch {
+    return true
+  }
+}
+
+export function dismissIosInstallHint(): void {
+  try {
+    localStorage.setItem(DISMISSED_KEY, String(Date.now()))
+  } catch {
+    // Private mode without storage — the hint just reappears next visit.
+  }
+}

--- a/src/pages/home-page.tsx
+++ b/src/pages/home-page.tsx
@@ -4,7 +4,7 @@ import { BlobImage } from '../components/blob-image'
 import { BrandMark } from '../components/brand-mark'
 import { ConfirmSheet } from '../components/confirm-sheet'
 import { HomeOptionsSheet } from '../components/home-options-sheet'
-import { IconMore, IconPlus } from '../components/icons'
+import { IconClose, IconMore, IconPlus, IconShareIos } from '../components/icons'
 import { RenameSheet } from '../components/rename-sheet'
 import { downloadBlob, shareOrDownload } from '../lib/media'
 import { loadHomePage, type HomeLoaderData, type ProjectSummary } from '../lib/project-actions'
@@ -17,6 +17,7 @@ import {
 import { createProject, deleteProject, getClipsForProject, renameProject } from '../lib/storage'
 import { reportError } from '../lib/error-reporting'
 import { canPromptInstall, promptInstall, subscribeInstallPrompt } from '../lib/install-prompt'
+import { dismissIosInstallHint, shouldShowIosInstallHint } from '../lib/install-hint'
 import {
   formatBytes,
   formatStoragePercent,
@@ -48,6 +49,7 @@ export function HomePage() {
   const [busy, setBusy] = useState(false)
   const [notice, setNotice] = useState<string | null>(null)
   const [importProgress, setImportProgress] = useState<string | null>(null)
+  const [showInstallHint, setShowInstallHint] = useState(shouldShowIosInstallHint)
   // Prefetched when the options sheet opens so the Save-backup tap keeps its
   // user activation (Web Share needs it; an IndexedDB read can outlive it).
   const prefetchedClipsRef = useRef<{ projectId: string; clips: Promise<ClipRecord[]> } | null>(
@@ -191,6 +193,30 @@ export function HomePage() {
               ? ` Free space fast: delete an old project (⋯ on “${oldestProject.name}”, then Delete).`
               : ' Free space by clearing other site data or files on this device.'}
           </span>
+        </div>
+      ) : null}
+
+      {showInstallHint ? (
+        <div className="home-install-hint">
+          <span className="install-hint-icon" aria-hidden="true">
+            <IconShareIos size={18} />
+          </span>
+          <span>
+            Install Kody Video: tap <strong>Share</strong>, then{' '}
+            <strong>Add to Home Screen</strong> — full screen, and your clips are safer from
+            Safari&rsquo;s storage cleanup.
+          </span>
+          <button
+            type="button"
+            className="install-hint-dismiss"
+            aria-label="Dismiss install tip"
+            onClick={() => {
+              dismissIosInstallHint()
+              setShowInstallHint(false)
+            }}
+          >
+            <IconClose size={16} />
+          </button>
         </div>
       ) : null}
 

--- a/src/styles/home.css
+++ b/src/styles/home.css
@@ -284,6 +284,51 @@
   text-underline-offset: 2px;
 }
 
+.home-install-hint {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  margin: 10px 0 0;
+  padding: 10px 12px;
+  border-radius: 12px;
+  background: var(--accent-soft);
+  border: 1px solid color-mix(in srgb, var(--accent) 40%, transparent);
+  font-size: 0.9rem;
+  line-height: 1.45;
+}
+
+.install-hint-icon {
+  flex: none;
+  display: grid;
+  place-items: center;
+  width: 28px;
+  height: 28px;
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--accent) 18%, transparent);
+  color: var(--accent);
+}
+
+.install-hint-dismiss {
+  flex: none;
+  display: grid;
+  place-items: center;
+  width: 28px;
+  height: 28px;
+  margin: 0;
+  padding: 0;
+  border: none;
+  border-radius: 8px;
+  background: transparent;
+  color: inherit;
+  opacity: 0.7;
+  cursor: pointer;
+}
+
+.install-hint-dismiss:active {
+  opacity: 1;
+  background: color-mix(in srgb, var(--accent) 14%, transparent);
+}
+
 /* Options + confirm sheets (home-owned) */
 
 .home-options-list {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

iOS never fires `beforeinstallprompt`, so the existing "Install app" button can't appear there. This adds a dismissible hint on the home screen walking iOS Safari users through Share → Add to Home Screen.

![iOS install hint on the home screen](https://cursor.com/artifacts/c/art-6aab29f0-c366-4e96-887d-6f7457fe7890)

## How

- New `src/lib/install-hint.ts`: shows only on iOS devices (including iPadOS masquerading as macOS), in a real browser (UA must carry the `Safari` token — bare WKWebViews like X's in-app browser have no Add to Home Screen and are excluded), when not already running standalone, and until dismissed (dismissal persists in `localStorage`).
- Home page renders the hint between the storage banner and project slots, with the iOS share glyph and a × dismiss button.
- New `IconShareIos` and `IconClose` in the shared icon set.
- Manual test checklist entries under Persistence / offline.

## Testing

- `tsc`, vitest (73 passing), and production build all green.
- New `scripts/probe-install-hint.mjs` (Playwright): hint shows for iPhone Safari UA, hidden for Android and bare iOS WebView UAs, dismiss hides immediately and persists across reload. All checks pass.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-16d17496-6b5b-4e12-b600-6933357c2059"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-16d17496-6b5b-4e12-b600-6933357c2059"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an iOS Safari “install to Home screen” hint on the home page, with share/close icons and a dismiss button.
  - The hint won’t show in standalone mode, non-iOS browsers, or unsupported embedded browsers, and dismissals persist appropriately.
- **Tests**
  - Added an automated probe to verify hint visibility and dismissal persistence across iOS/Android user agents.
- **Documentation**
  - Updated the manual test checklist with iOS Safari install/share tip timing and dismissal behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->