### PR TITLE
Fix installed iOS app ignoring the top safe area

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -32,6 +32,20 @@
   --tap: 44px;
 }
 
+/* iOS 26.1 WebKit regression (bug #301994): env(safe-area-inset-top) reports
+   0px inside installed home-screen apps, so everything padded by --safe-top
+   slides under the status bar / Dynamic Island. Enforce a status-bar-sized
+   floor there. 59px clears the Dynamic Island; max() defers to the real
+   env() value the moment Apple fixes it. Scoped to iOS (touch-callout) in
+   standalone display so browsers, Android, and desktop PWAs are untouched. */
+@supports (-webkit-touch-callout: none) {
+  @media (display-mode: standalone) and (pointer: coarse) {
+    :root {
+      --safe-top: max(env(safe-area-inset-top, 0px), 59px);
+    }
+  }
+}
+
 @media (prefers-color-scheme: light) {
   :root {
     color-scheme: light;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

ShrekOverflow reported that Kody Video installed to the iOS Home Screen draws content under the status bar / Dynamic Island ("ignores safe area … the area on the top").

## Why

iOS 26.1 shipped a WebKit regression ([bug #301994](https://bugs.webkit.org/show_bug.cgi?id=301994)): `env(safe-area-inset-top)` returns `0px` inside installed (standalone) home-screen web apps. Our entire layout pads with `--safe-top: env(safe-area-inset-top, 0px)`, so in the installed app every screen's top row slides under the status bar. Browser tabs are unaffected, which is why this never showed in Safari testing.

## How

A CSS-only floor, using the pattern other PWAs adopted for this bug:

- `--safe-top` becomes `max(env(safe-area-inset-top, 0px), 59px)` — 59px clears the Dynamic Island; notch devices over-pad by ~12px, which is invisible in practice.
- Scoped to `@supports (-webkit-touch-callout: none)` (iOS only) + `@media (display-mode: standalone) and (pointer: coarse)`, so Safari tabs, Android, and desktop PWAs keep exact `env()` behavior.
- Self-healing: once Apple fixes `env()`, `max()` defers to the real value.

## Testing

- Production build passes. Pure CSS change consuming the existing `--safe-top` variable; no component changes.
- Needs a real-device sanity check by an iOS 26.1 tester with the app installed (ShrekOverflow can confirm).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-16d17496-6b5b-4e12-b600-6933357c2059"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-16d17496-6b5b-4e12-b600-6933357c2059"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

