### PR TITLE
Add desktop screen recording as a clip source

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,10 +132,21 @@ Kody Video is designed as a mobile camera app, but desktop gets first-class
 keyboard support (hints appear automatically on fine-pointer devices):
 
 - **Camera:** hold `Space` to record (release to stop), `F` flip, `T`
-  self-timer, `E` editor, `P` play preview, `Delete` remove last clip.
+  self-timer, `S` screen recording, `E` editor, `P` play preview, `Delete`
+  remove last clip.
 - **Editor:** `←`/`→` select clip, `Alt`+arrows reorder, `T` trim, `D`
   duplicate, `Delete` delete, `P` play, `Esc` back to camera (or exit trim).
 - **Playback:** `←`/`→` skip clips, `Space` pause/resume, `Esc` close.
+
+## Screen recording (desktop)
+
+The monitor button on the camera view (or `S`) records a screen, window, or
+tab as a regular clip — pick the surface, narrate over your mic (mixed with
+shared tab/system audio when you opt in), then tap the preview or the button
+to stop and the take lands on the filmstrip like any camera clip. Desktop
+browsers only: `getDisplayMedia` does not exist on iOS or Android, so on
+phones use the OS screen recorder instead. The button hides itself where the
+API is missing.
 
 ## Remove Watermark purchase
 
@@ -184,5 +195,6 @@ in-app About page has a link that pre-fills device details).
 | `node scripts/probe-export-chrome.mjs` | Export validation in Chrome stable (real codecs) |
 | `node scripts/probe-keyboard.mjs`    | Desktop keyboard flows (record/edit/playback) |
 | `node scripts/probe-rear-lens.mjs`   | Rear lens switching (ultra-wide) with fake cameras |
+| `node scripts/probe-screen-record.mjs` | Desktop screen recording lands as a clip |
 | `node scripts/probe-touch-timeline.mjs` | Touch timeline gestures (scroll, long-press lift) |
 | `node scripts/probe-webkit.mjs`      | WebKit engine sanity + feature matrix (iOS proxy, not a substitute for a real device) |

--- a/manual-test-checklist.md
+++ b/manual-test-checklist.md
@@ -30,6 +30,15 @@ Run locally with HTTPS or `localhost` (`npm run dev`). Camera/mic require a secu
 - [ ] Multiple holds create multiple clips; total duration in the top bar updates
 - [ ] Backspace button deletes the last clip; toast offers Undo
 
+## Screen recording (desktop only)
+- [ ] Monitor button (and `S`) appears on desktop browsers; absent on Android/iOS
+- [ ] Picking a surface starts the take; the "SCREEN — TAP TO STOP" pill shows with elapsed time
+- [ ] Tapping the preview, the monitor button, `S`, or the browser's own "Stop sharing" all save the clip
+- [ ] Mic narration is recorded (and mixed with tab/system audio when shared); a denied mic still records video
+- [ ] Cancelling the surface picker shows no error
+- [ ] Hold-to-record, self-timer, editor, play, and Go are blocked while a screen take runs
+- [ ] Leaving the camera view mid-take saves the clip
+
 ## Editor
 - [ ] Scissors button opens the editor; stage shows the selected clip
 - [ ] Timeline tiles are wider for longer clips and show real thumbnails

--- a/scripts/probe-screen-record.mjs
+++ b/scripts/probe-screen-record.mjs
@@ -1,0 +1,93 @@
+/**
+ * Screen recording probe (desktop Chromium): the monitor button captures the
+ * tab via getDisplayMedia and appends the take as a regular clip.
+ * Run: npm run build && node scripts/probe-screen-record.mjs
+ */
+import { chromium } from 'playwright'
+import { spawn } from 'node:child_process'
+import { setTimeout as sleep } from 'node:timers/promises'
+
+const PORT = 4187
+const BASE = `http://127.0.0.1:${PORT}`
+const preview = spawn(
+  'npm',
+  ['run', 'preview', '--', '--host', '127.0.0.1', '--port', String(PORT)],
+  { cwd: process.cwd(), stdio: ['ignore', 'pipe', 'pipe'] },
+)
+async function waitForServer(url) {
+  for (let i = 0; i < 60; i++) {
+    try {
+      if ((await fetch(url)).ok) return
+    } catch {}
+    await sleep(250)
+  }
+  throw new Error('server not ready')
+}
+const results = []
+const check = (name, ok, detail = '') => {
+  results.push(ok)
+  console.log(`${ok ? 'PASS' : 'FAIL'}  ${name}${detail ? ` — ${detail}` : ''}`)
+}
+try {
+  await waitForServer(BASE)
+  const browser = await chromium.launch({
+    headless: true,
+    args: [
+      '--use-fake-ui-for-media-stream',
+      '--use-fake-device-for-media-stream',
+      // Answers the getDisplayMedia picker without UI.
+      '--auto-select-desktop-capture-source=Entire screen',
+    ],
+  })
+  const context = await browser.newContext({
+    viewport: { width: 1200, height: 900 },
+    permissions: ['camera', 'microphone'],
+  })
+  const page = await context.newPage()
+  const errors = []
+  page.on('pageerror', (err) => errors.push(String(err)))
+
+  await page.goto(BASE, { waitUntil: 'networkidle' })
+  await page.getByRole('button', { name: /new project/i }).first().click()
+  await page.waitForURL(/\/project\//)
+  const ob = page.getByRole('dialog', { name: /quick start/i })
+  if (await ob.count()) await page.getByRole('button', { name: /start recording/i }).click()
+  await page.waitForFunction(() => {
+    const v = document.querySelector('.record-stage video')
+    return v && v.videoWidth > 0
+  })
+
+  const recordButton = page.getByRole('button', { name: /record your screen/i })
+  check('screen record button visible on desktop', await recordButton.isVisible())
+  check('key hints mention S screen', /S.*screen/i.test(await page.locator('.key-hints').innerText()))
+
+  await recordButton.click()
+  await page.waitForSelector('.record-pill', { timeout: 5000 })
+  check(
+    'screen take pill shows',
+    /SCREEN — TAP TO STOP/.test(await page.locator('.record-pill').innerText()),
+  )
+  check('Go blocked during screen take', await page.locator('.go-button').isDisabled())
+
+  await sleep(2500)
+  // The stage doubles as the stop button during a screen take.
+  await page.locator('.record-stage').click()
+  await page.waitForSelector('.toast', { timeout: 8000 })
+  const toast = await page.locator('.toast').innerText()
+  check('stop saves the clip', /Screen clip added/i.test(toast), toast)
+
+  // Let the loader revalidation land before reading the clip list.
+  await sleep(1500)
+  await page.keyboard.press('KeyE')
+  await page.waitForSelector('.editor-screen')
+  const metaText = await page.locator('.editor-meta small').textContent()
+  check('screen take appears as a clip', /1 clip\b/.test(metaText ?? ''), metaText ?? '')
+
+  check('no page errors', errors.length === 0, errors.join(' | '))
+  await browser.close()
+} catch (err) {
+  check('probe crashed', false, String(err))
+} finally {
+  preview.kill()
+}
+process.exit(results.every(Boolean) ? 0 : 1)

--- a/src/components/icons.tsx
+++ b/src/components/icons.tsx
@@ -198,3 +198,14 @@ export function IconLens({ size = 22 }: IconProps) {
     </svg>
   )
 }
+
+/** Monitor with a record dot: screen recording. */
+export function IconScreen({ size = 22, on = false }: IconProps & { on?: boolean }) {
+  return (
+    <svg {...baseProps(size)}>
+      <rect x="3" y="4.5" width="18" height="12.5" rx="2" />
+      <path d="M9 20.5h6" />
+      <circle cx="12" cy="10.75" r="2.4" fill={on ? 'currentColor' : 'none'} />
+    </svg>
+  )
+}

--- a/src/components/record-screen.tsx
+++ b/src/components/record-screen.tsx
@@ -6,6 +6,11 @@ import { getLocationFix, type LocationFix } from '../lib/location'
 import { reportError } from '../lib/error-reporting'
 import { appendRecording, removeClip, undoLastDelete } from '../lib/project-actions'
 import { HoldRecorder } from '../lib/recorder'
+import {
+  isScreenRecordingSupported,
+  startScreenRecording,
+  type ScreenRecordingSession,
+} from '../lib/screen-recorder'
 import { setLocationTaggingEnabled } from '../lib/storage'
 import {
   formatStoragePercent,
@@ -21,6 +26,7 @@ import {
   IconLens,
   IconLocation,
   IconPlay,
+  IconScreen,
   IconTimer,
   IconTorch,
 } from './icons'
@@ -144,13 +150,20 @@ export function RecordScreen({
   const zoomRestoreActiveRef = useRef(false)
   const stageRef = useRef<HTMLDivElement | null>(null)
 
+  const screenSessionRef = useRef<ScreenRecordingSession | null>(null)
+  /** True while the surface picker or a save is in flight. */
+  const screenBusyRef = useRef(false)
+
   const [recording, setRecording] = useState(false)
   const [recordingMode, setRecordingMode] = useState<RecordingMode | null>(null)
   const [recordStartedAt, setRecordStartedAt] = useState(0)
   const [countdown, setCountdown] = useState<number | null>(null)
+  const [screenRecording, setScreenRecording] = useState(false)
+  const [screenRecordStartedAt, setScreenRecordStartedAt] = useState(0)
   const [locationTagging, setLocationTagging] = useState(locationTaggingEnabled)
   locationTaggingRef.current = locationTagging
 
+  const screenRecordingSupported = isScreenRecordingSupported()
   const totalDurationMs = clips.reduce((sum, clip) => sum + effectiveDurationMs(clip), 0)
   const zoomLevels = camera.zoom ? zoomChipLevels(camera.zoom) : []
   const activeZoomLevel =
@@ -213,6 +226,60 @@ export function RecordScreen({
     wakeLockRef.current = null
   }, [])
 
+  /** Stops the active screen capture and appends it as a clip. Idempotent. */
+  const finishScreenRecord = useCallback(async () => {
+    const session = screenSessionRef.current
+    if (!session) return
+    screenSessionRef.current = null
+    screenBusyRef.current = true
+    setScreenRecording(false)
+    try {
+      const result = await session.stop()
+      if (!result) {
+        showToast('Screen take was too short')
+        return
+      }
+      await appendRecording(project.id, result)
+      refresh()
+      showToast('Screen clip added')
+    } catch (err) {
+      reportError(err, 'screen-record')
+      showToast('Could not save the screen recording')
+    } finally {
+      screenBusyRef.current = false
+    }
+  }, [project.id, refresh, showToast])
+
+  const startScreenRecord = useCallback(() => {
+    void (async () => {
+      if (
+        screenSessionRef.current ||
+        screenBusyRef.current ||
+        recorderRef.current.isRecording ||
+        lockedRef.current ||
+        countdown !== null
+      ) {
+        return
+      }
+      screenBusyRef.current = true
+      try {
+        const session = await startScreenRecording()
+        screenSessionRef.current = session
+        setScreenRecordStartedAt(performance.now())
+        setScreenRecording(true)
+        // The browser's own "Stop sharing" control must save too.
+        session.setOnEnded(() => void finishScreenRecord())
+      } catch (err) {
+        // Cancelling the surface picker is a decision, not an error.
+        if (!(err instanceof DOMException && err.name === 'NotAllowedError')) {
+          showToast(err instanceof Error ? err.message : 'Screen recording failed')
+        }
+      } finally {
+        screenBusyRef.current = false
+      }
+    })()
+  }, [countdown, finishScreenRecord, showToast])
+
   const beginRecord = useCallback(
     async (pointerId: number | null, nextRecordingMode: RecordingMode): Promise<boolean> => {
       if (
@@ -222,6 +289,10 @@ export function RecordScreen({
         lockedRef.current ||
         countdown !== null
       ) {
+        return false
+      }
+      if (screenSessionRef.current) {
+        showToast('Stop the screen recording first')
         return false
       }
       if (!camera.getStream() || !camera.isReady) {
@@ -362,6 +433,7 @@ export function RecordScreen({
 
   const startSelfTimer = useCallback(() => {
     if (recording || lockedRef.current || countdown !== null) return
+    if (screenSessionRef.current) return
     if (!camera.getStream() || !camera.isReady) {
       showToast('Camera not ready')
       return
@@ -441,8 +513,10 @@ export function RecordScreen({
     clearCountdown()
     cancelAnimationFrame(zoomRestoreRafRef.current)
     recorderRef.current.cancel()
+    // Leaving the screen mustn't lose an active screen take — save it.
+    void finishScreenRecord()
     releaseWakeLock()
-  }, [clearCountdown, releaseWakeLock])
+  }, [clearCountdown, finishScreenRecord, releaseWakeLock])
 
   // Release the camera whenever the app leaves the foreground — Android keeps
   // the privacy indicator (green dot) lit as long as any track is live. An
@@ -544,6 +618,12 @@ export function RecordScreen({
           if (!recording && countdown === null) startSelfTimer()
           return
         }
+        case 'KeyS': {
+          if (recording || countdown !== null) return
+          if (screenSessionRef.current) void finishScreenRecord()
+          else if (screenRecordingSupported) startScreenRecord()
+          return
+        }
         case 'Backspace':
         case 'Delete': {
           // Without this, Backspace can also trigger history navigation.
@@ -605,6 +685,12 @@ export function RecordScreen({
         className="record-stage"
         onPointerDown={(event) => {
           if (event.button !== 0) return
+          // While recording the screen, the whole stage is the stop button
+          // (matching the hands-free "tap to stop" language).
+          if (screenSessionRef.current) {
+            void finishScreenRecord()
+            return
+          }
           if (countdown !== null) {
             clearCountdown()
             showToast('Timer canceled')
@@ -713,13 +799,23 @@ export function RecordScreen({
           </div>
         ) : null}
 
+        {screenRecording ? (
+          <div className="record-overlay">
+            <div className="record-pill" aria-live="polite">
+              <span className="record-dot" />
+              <span className="record-pill-label">SCREEN — TAP TO STOP</span>
+              <RecordTimer startedAt={screenRecordStartedAt} className="record-elapsed" />
+            </div>
+          </div>
+        ) : null}
+
         {countdown !== null ? (
           <div className="countdown-overlay" aria-live="assertive">
             <span className="countdown-number">{countdown}</span>
           </div>
         ) : null}
 
-        {!recording && countdown === null && camera.isReady ? (
+        {!recording && !screenRecording && countdown === null && camera.isReady ? (
           <div className={`hold-hint${clips.length > 0 ? ' hold-hint-subtle' : ''}`}>
             <strong>Hold anywhere</strong>
             <span>release to stop</span>
@@ -770,6 +866,21 @@ export function RecordScreen({
           ) : null}
         </div>
         <div className="record-top-actions">
+          {screenRecordingSupported ? (
+            <button
+              type="button"
+              className={`btn-icon${screenRecording ? ' is-active' : ''}`}
+              aria-label={screenRecording ? 'Stop screen recording' : 'Record your screen'}
+              aria-pressed={screenRecording}
+              disabled={recording || countdown !== null}
+              onClick={() => {
+                if (screenSessionRef.current) void finishScreenRecord()
+                else startScreenRecord()
+              }}
+            >
+              <IconScreen on={screenRecording} />
+            </button>
+          ) : null}
           {camera.torchAvailable ? (
             <button
               type="button"
@@ -846,8 +957,13 @@ export function RecordScreen({
       ) : null}
 
       <div className="key-hints" aria-hidden="true">
-        Hold <kbd>Space</kbd> record · <kbd>F</kbd> flip · <kbd>T</kbd> timer · <kbd>E</kbd> editor ·{' '}
-        <kbd>P</kbd> play · <kbd>⌫</kbd> delete last
+        Hold <kbd>Space</kbd> record · <kbd>F</kbd> flip · <kbd>T</kbd> timer ·{' '}
+        {screenRecordingSupported ? (
+          <>
+            <kbd>S</kbd> screen ·{' '}
+          </>
+        ) : null}
+        <kbd>E</kbd> editor · <kbd>P</kbd> play · <kbd>⌫</kbd> delete last
       </div>
 
       <div className="record-dock">
@@ -856,7 +972,7 @@ export function RecordScreen({
             type="button"
             className="btn-icon"
             aria-label="Open editor"
-            disabled={recording}
+            disabled={recording || screenRecording}
             onClick={() => {
               camera.releaseMic()
               onOpenEditor()
@@ -868,7 +984,7 @@ export function RecordScreen({
             type="button"
             className="btn-icon"
             aria-label="Self-timer"
-            disabled={recording || countdown !== null}
+            disabled={recording || screenRecording || countdown !== null}
             onClick={startSelfTimer}
           >
             <IconTimer />
@@ -887,7 +1003,7 @@ export function RecordScreen({
             type="button"
             className="btn-icon"
             aria-label="Play project preview"
-            disabled={recording || clips.length === 0}
+            disabled={recording || screenRecording || clips.length === 0}
             onClick={onPlay}
           >
             <IconPlay />
@@ -896,7 +1012,7 @@ export function RecordScreen({
             type="button"
             className="btn-icon"
             aria-label="Delete last clip"
-            disabled={recording || clips.length === 0}
+            disabled={recording || screenRecording || clips.length === 0}
             onClick={deleteLastClip}
           >
             <IconDeleteLast />
@@ -905,7 +1021,7 @@ export function RecordScreen({
         <button
           type="button"
           className="go-button"
-          disabled={clips.length === 0 || recording}
+          disabled={clips.length === 0 || recording || screenRecording}
           onClick={onOpenExport}
         >
           Go

--- a/src/lib/screen-recorder.ts
+++ b/src/lib/screen-recorder.ts
@@ -1,0 +1,105 @@
+/**
+ * Screen recording as a clip source (a much-requested feature). Desktop-only
+ * by platform reality: getDisplayMedia does not exist on iOS Safari or
+ * Android browsers, so mobile users rely on their OS screen recorder instead.
+ *
+ * Captures the picked surface plus, when available, its audio and the
+ * microphone (for narration) mixed into a single track. The result feeds the
+ * exact same recorder + clip pipeline as camera takes.
+ */
+
+import { openMicrophoneTrack } from './media'
+import { HoldRecorder, type RecordingResult } from './recorder'
+
+export function isScreenRecordingSupported(): boolean {
+  return (
+    typeof navigator !== 'undefined' &&
+    typeof navigator.mediaDevices?.getDisplayMedia === 'function' &&
+    typeof MediaRecorder !== 'undefined'
+  )
+}
+
+export interface ScreenRecordingSession {
+  /** Resolves with the finished take (null when too short). Idempotent. */
+  stop(): Promise<RecordingResult | null>
+  /**
+   * Fires once when capture ends outside the app — the browser's own
+   * "Stop sharing" control. The handler should call stop() to save.
+   */
+  setOnEnded(handler: () => void): void
+}
+
+/**
+ * Prompts the surface picker and starts recording immediately.
+ * Rejects with the picker's NotAllowedError when the user cancels.
+ */
+export async function startScreenRecording(): Promise<ScreenRecordingSession> {
+  const display = await navigator.mediaDevices.getDisplayMedia({
+    video: true,
+    // Tab/system audio when the user opts in via the picker; Firefox and
+    // Safari simply return a video-only stream.
+    audio: true,
+  })
+  const videoTrack = display.getVideoTracks()[0]
+  if (!videoTrack) {
+    display.getTracks().forEach((track) => track.stop())
+    throw new Error('No screen video available')
+  }
+
+  // Narration mic — best effort. A denied mic must not kill the capture;
+  // the take just records without narration (or with shared audio only).
+  const micTrack = await openMicrophoneTrack().catch(() => null)
+
+  const audioSources = [...display.getAudioTracks(), ...(micTrack ? [micTrack] : [])]
+  let audioContext: AudioContext | null = null
+  let audioTrack: MediaStreamTrack | null = null
+  if (audioSources.length === 1) {
+    audioTrack = audioSources[0]
+  } else if (audioSources.length > 1) {
+    // Shared audio + mic must merge into one track for MediaRecorder.
+    audioContext = new AudioContext()
+    void audioContext.resume().catch(() => undefined)
+    const destination = audioContext.createMediaStreamDestination()
+    for (const source of audioSources) {
+      audioContext
+        .createMediaStreamSource(new MediaStream([source]))
+        .connect(destination)
+    }
+    audioTrack = destination.stream.getAudioTracks()[0] ?? null
+  }
+
+  const recordStream = new MediaStream([videoTrack, ...(audioTrack ? [audioTrack] : [])])
+  const recorder = new HoldRecorder()
+
+  const releaseTracks = () => {
+    display.getTracks().forEach((track) => track.stop())
+    micTrack?.stop()
+    void audioContext?.close().catch(() => undefined)
+  }
+
+  if (!recorder.start(recordStream)) {
+    releaseTracks()
+    throw new Error('Could not start the screen recording')
+  }
+
+  let onEnded: (() => void) | null = null
+  let endedFired = false
+  videoTrack.addEventListener('ended', () => {
+    if (endedFired) return
+    endedFired = true
+    onEnded?.()
+  })
+
+  let stopPromise: Promise<RecordingResult | null> | null = null
+  return {
+    stop() {
+      // Both the in-app Stop button and the browser's "Stop sharing" ended
+      // event can race here; the first caller owns the actual teardown.
+      stopPromise ??= recorder.stop().finally(releaseTracks)
+      return stopPromise
+    },
+    setOnEnded(handler) {
+      onEnded = handler
+    },
+  }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

ShrekOverflow's feature request: screen recording. A monitor button on the camera view (keyboard: `S`) captures a screen, window, or tab as a regular clip — it lands on the filmstrip and flows through trim/reorder/export exactly like a camera take.

Platform reality check: `getDisplayMedia` exists only on desktop browsers (Chrome/Edge/Firefox/Safari macOS). iOS Safari and every Android browser lack it entirely, so this is a desktop feature and the button hides itself where the API is missing. Phone users' path remains the OS screen recorder.

## How

- New `src/lib/screen-recorder.ts`: prompts the surface picker, best-effort grabs the mic for narration (a denied mic never kills the capture), and when both shared tab/system audio and mic exist, mixes them into one track through an `AudioContext`. Recording reuses the existing `HoldRecorder` (same mime selection, bitrates, real-duration measurement) and the take is appended via the same `appendRecording` path as camera clips.
- `RecordScreen` wiring:
  - Monitor button in the top actions (only when supported); `S` toggles.
  - While a screen take runs, a "SCREEN — TAP TO STOP" pill with elapsed time shows and the whole stage is the stop button (same language as hands-free takes). The browser's own "Stop sharing" control also saves — stop is idempotent, first caller wins.
  - Hold-to-record, self-timer, editor, play, delete-last, and Go are blocked during a screen take; leaving the screen saves the take instead of dropping it.
  - Cancelling the surface picker is treated as a decision, not an error.
- New `IconScreen`; README (feature section + keyboard hints + probe table) and manual checklist updated.

## Testing

- `tsc`, vitest, and production build pass.
- New `scripts/probe-screen-record.mjs` (Chromium + `--auto-select-desktop-capture-source`): button visibility, pill state, Go blocked during take, tap-to-stop saves, and the take appears in the editor as a 2.4s clip. All checks pass, no page errors.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-16d17496-6b5b-4e12-b600-6933357c2059"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-16d17496-6b5b-4e12-b600-6933357c2059"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

