### PR TITLE
Fix iOS silent recordings: combined mic+camera capture, live silent-mic warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ Verified approach: `npm run build && npm run preview`, load once online, then De
 ## Browser limits
 
 - **iOS Safari:** WebCodecs audio support is incomplete; the realtime fallback engine covers it, but Chromium (especially Android) is the primary target.
+- **iOS microphone:** WebKit can deliver muted audio tracks when mic and camera come from separate `getUserMedia` calls, so on iOS the mic is acquired together with the camera and held while the preview is open (everywhere else the mic is grabbed per-take). A live level monitor warns "Mic isn't picking up sound" during silent takes on every platform.
 - **Permissions:** denied camera/mic must be re-enabled in site settings; the UI surfaces this.
 - **Storage quotas:** large projects can hit IndexedDB quotas; the soft 6-project cap helps.
 - **Background tabs:** recording should stay in the foreground; browsers may throttle capture.
@@ -195,6 +196,7 @@ in-app About page has a link that pre-fills device details).
 | `node scripts/probe-export-chrome.mjs` | Export validation in Chrome stable (real codecs) |
 | `node scripts/probe-keyboard.mjs`    | Desktop keyboard flows (record/edit/playback) |
 | `node scripts/probe-rear-lens.mjs`   | Rear lens switching (ultra-wide) with fake cameras |
+| `node scripts/probe-mic-monitor.mjs`  | Silent-mic warning fires (and clears) correctly |
 | `node scripts/probe-screen-record.mjs` | Desktop screen recording lands as a clip |
 | `node scripts/probe-touch-timeline.mjs` | Touch timeline gestures (scroll, long-press lift) |
 | `node scripts/probe-webkit.mjs`      | WebKit engine sanity + feature matrix (iOS proxy, not a substitute for a real device) |

--- a/manual-test-checklist.md
+++ b/manual-test-checklist.md
@@ -8,7 +8,9 @@ Run locally with HTTPS or `localhost` (`npm run dev`). Camera/mic require a secu
 - [ ] Deny → clear denied panel with retry guidance
 - [ ] Allow → live rear-camera preview (or fallback)
 - [ ] Flip camera works when multiple cameras exist
-- [ ] Opening the camera prompts for the microphone too (one-time priming); the mic is NOT held while idle (no OS mic indicator)
+- [ ] Opening the camera prompts for the microphone too (one-time priming); the mic is NOT held while idle (no OS mic indicator) — except iOS, where the mic is acquired with the camera and held while previewing (muted-track workaround)
+- [ ] iOS: recordings have audible sound (mic + camera come from one combined request)
+- [ ] A take with a dead/covered mic shows the red "Mic isn't picking up sound" pill after ~2.5s; a take with sound clears it
 - [ ] If the mic is blocked in site settings, a red "Mic blocked" pill shows on the record screen (Brave/Android regression)
 - [ ] Torch toggle appears on devices with a flash; zoom chips appear when supported
 - [ ] Phones with multiple rear cameras show a lens chip (e.g. "1/3") that switches to the ultra-wide/telephoto; choice sticks across flips and restarts

--- a/scripts/probe-mic-monitor.mjs
+++ b/scripts/probe-mic-monitor.mjs
@@ -1,0 +1,113 @@
+/**
+ * Silent-mic warning probe: recording with a silent fake mic must show the
+ * "Mic isn't picking up sound" pill; Chromium's default fake mic (a tone)
+ * must not. Run: npm run build && node scripts/probe-mic-monitor.mjs
+ */
+import { chromium } from 'playwright'
+import { spawn } from 'node:child_process'
+import { writeFileSync } from 'node:fs'
+import { setTimeout as sleep } from 'node:timers/promises'
+
+const PORT = 4188
+const BASE = `http://127.0.0.1:${PORT}`
+const preview = spawn(
+  'npm',
+  ['run', 'preview', '--', '--host', '127.0.0.1', '--port', String(PORT)],
+  { cwd: process.cwd(), stdio: ['ignore', 'pipe', 'pipe'] },
+)
+async function waitForServer(url) {
+  for (let i = 0; i < 60; i++) {
+    try {
+      if ((await fetch(url)).ok) return
+    } catch {}
+    await sleep(250)
+  }
+  throw new Error('server not ready')
+}
+
+/** 6s mono 48kHz 16-bit PCM WAV: silence, or a clearly audible 440Hz tone.
+ * (Chromium's DEFAULT fake mic peaks at ~0.003 — below the app's real-mic
+ * floor — so the control needs an explicit tone fixture.) */
+function writeWav(path, { tone }) {
+  const sampleRate = 48000
+  const seconds = 6
+  const sampleCount = sampleRate * seconds
+  const buffer = Buffer.alloc(44 + sampleCount * 2)
+  buffer.write('RIFF', 0)
+  buffer.writeUInt32LE(36 + sampleCount * 2, 4)
+  buffer.write('WAVE', 8)
+  buffer.write('fmt ', 12)
+  buffer.writeUInt32LE(16, 16)
+  buffer.writeUInt16LE(1, 20)
+  buffer.writeUInt16LE(1, 22)
+  buffer.writeUInt32LE(sampleRate, 24)
+  buffer.writeUInt32LE(sampleRate * 2, 28)
+  buffer.writeUInt16LE(2, 32)
+  buffer.writeUInt16LE(16, 34)
+  buffer.write('data', 36)
+  buffer.writeUInt32LE(sampleCount * 2, 40)
+  if (tone) {
+    for (let i = 0; i < sampleCount; i++) {
+      const value = Math.round(Math.sin((2 * Math.PI * 440 * i) / sampleRate) * 0.3 * 32767)
+      buffer.writeInt16LE(value, 44 + i * 2)
+    }
+  }
+  writeFileSync(path, buffer)
+}
+
+const results = []
+const check = (name, ok, detail = '') => {
+  results.push(ok)
+  console.log(`${ok ? 'PASS' : 'FAIL'}  ${name}${detail ? ` — ${detail}` : ''}`)
+}
+
+async function pillDuringTake(extraArgs) {
+  const browser = await chromium.launch({
+    headless: true,
+    args: ['--use-fake-ui-for-media-stream', '--use-fake-device-for-media-stream', ...extraArgs],
+  })
+  const context = await browser.newContext({
+    viewport: { width: 1200, height: 900 },
+    permissions: ['camera', 'microphone'],
+  })
+  const page = await context.newPage()
+  await page.goto(BASE, { waitUntil: 'networkidle' })
+  await page.getByRole('button', { name: /new project/i }).first().click()
+  await page.waitForURL(/\/project\//)
+  const ob = page.getByRole('dialog', { name: /quick start/i })
+  if (await ob.count()) await page.getByRole('button', { name: /start recording/i }).click()
+  await page.waitForFunction(() => {
+    const v = document.querySelector('.record-stage video')
+    return v && v.videoWidth > 0
+  })
+  // Hold well past the monitor's 2.5s grace period.
+  await page.keyboard.down('Space')
+  await sleep(4200)
+  const pill = await page
+    .getByText(/mic isn.t picking up sound/i)
+    .isVisible()
+    .catch(() => false)
+  await page.keyboard.up('Space')
+  await sleep(800)
+  await browser.close()
+  return pill
+}
+
+try {
+  await waitForServer(BASE)
+  writeWav('/tmp/kv-silence.wav', { tone: false })
+  writeWav('/tmp/kv-tone.wav', { tone: true })
+
+  const silentPill = await pillDuringTake([
+    '--use-file-for-fake-audio-capture=/tmp/kv-silence.wav',
+  ])
+  check('silent mic shows the warning pill during the take', silentPill)
+
+  const tonePill = await pillDuringTake(['--use-file-for-fake-audio-capture=/tmp/kv-tone.wav'])
+  check('audible mic shows no warning', !tonePill)
+} catch (err) {
+  check('probe crashed', false, String(err))
+} finally {
+  preview.kill()
+}
+process.exit(results.every(Boolean) ? 0 : 1)

--- a/src/components/record-screen.tsx
+++ b/src/components/record-screen.tsx
@@ -544,6 +544,9 @@ export function RecordScreen({
   visibilityActionRef.current = () => {
     if (document.hidden) {
       clearCountdown()
+      // The warning describes takes from the session being left behind;
+      // returning starts fresh with a restarted camera (and mic, on iOS).
+      setMicSilent(false)
       if (recorderRef.current.isRecording || recording) {
         // MediaRecorder.stop() runs synchronously inside endRecord, so the
         // encoder has flushed by the time the tracks are stopped below; the

--- a/src/components/record-screen.tsx
+++ b/src/components/record-screen.tsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom'
 import type { CameraZoomRange, UseCameraResult } from '../hooks/use-camera'
 import { dragZoomValue } from '../lib/drag-zoom'
 import { getLocationFix, type LocationFix } from '../lib/location'
+import { startMicLevelMonitor, type MicLevelMonitor } from '../lib/mic-monitor'
 import { reportError } from '../lib/error-reporting'
 import { appendRecording, removeClip, undoLastDelete } from '../lib/project-actions'
 import { HoldRecorder } from '../lib/recorder'
@@ -133,6 +134,8 @@ export function RecordScreen({
   lockedRef.current = interactionLocked
   /** In-flight GPS fix for the current take; never shared across takes. */
   const pendingFixRef = useRef<Promise<LocationFix | null> | null>(null)
+  /** Live audio-level watch for the current take (silent-mic warning). */
+  const micMonitorRef = useRef<MicLevelMonitor | null>(null)
   const locationTaggingRef = useRef(locationTaggingEnabled)
 
   const dragZoomPressYRef = useRef(0)
@@ -160,6 +163,8 @@ export function RecordScreen({
   const [countdown, setCountdown] = useState<number | null>(null)
   const [screenRecording, setScreenRecording] = useState(false)
   const [screenRecordStartedAt, setScreenRecordStartedAt] = useState(0)
+  /** The current/last take's mic never rose above the silence floor. */
+  const [micSilent, setMicSilent] = useState(false)
   const [locationTagging, setLocationTagging] = useState(locationTaggingEnabled)
   locationTaggingRef.current = locationTagging
 
@@ -338,6 +343,15 @@ export function RecordScreen({
           pendingFixRef.current = getLocationFix()
         }
         acquireWakeLock()
+        // Watch the live mic level: users must learn about a dead mic while
+        // holding, not after sharing a silent video (Sentry: near-zero clip
+        // peaks on iOS). Warning state carries over between takes until a
+        // take actually picks up sound.
+        micMonitorRef.current?.stop()
+        micMonitorRef.current = startMicLevelMonitor(stream, {
+          onSilent: () => setMicSilent(true),
+          onSound: () => setMicSilent(false),
+        })
         setRecording(true)
         setRecordingMode(nextRecordingMode)
         setRecordStartedAt(performance.now())
@@ -384,6 +398,8 @@ export function RecordScreen({
       endInFlightRef.current = true
       pointerIdRef.current = null
       keyboardTakeRef.current = false
+      micMonitorRef.current?.stop()
+      micMonitorRef.current = null
       setRecording(false)
       setRecordingMode(null)
       // Detach this take's fix before any await so a quick next hold can own the ref.
@@ -512,6 +528,8 @@ export function RecordScreen({
   const cleanupOnUnmount = useCallback(() => {
     clearCountdown()
     cancelAnimationFrame(zoomRestoreRafRef.current)
+    micMonitorRef.current?.stop()
+    micMonitorRef.current = null
     recorderRef.current.cancel()
     // Leaving the screen mustn't lose an active screen take — save it.
     void finishScreenRecord()
@@ -829,7 +847,7 @@ export function RecordScreen({
               <p>
                 {camera.error ??
                   camera.permission.message ??
-                  'Allow camera to preview. Microphone is requested only while you record.'}
+                  'Allow camera to preview. Recording needs the microphone too.'}
               </p>
               <button type="button" className="btn btn-primary" onClick={() => void camera.start()}>
                 Try again
@@ -862,6 +880,15 @@ export function RecordScreen({
               aria-label="Microphone blocked — recordings need sound"
             >
               Mic blocked — allow it in site settings
+            </span>
+          ) : null}
+          {micSilent && camera.micPermission !== 'denied' ? (
+            <span
+              className="storage-pill is-critical"
+              role="status"
+              aria-label="Microphone is not picking up sound"
+            >
+              Mic isn&rsquo;t picking up sound
             </span>
           ) : null}
         </div>

--- a/src/hooks/use-camera.ts
+++ b/src/hooks/use-camera.ts
@@ -1,6 +1,7 @@
 import { useCallback, useRef, useState, type RefCallback } from 'react'
 import {
   canFlipCamera,
+  isIosBrowser,
   listRearCameras,
   openCameraStream,
   openMicrophoneTrack,
@@ -11,6 +12,33 @@ import {
   type CameraPermissionState,
   type FacingMode,
 } from '../lib/media'
+
+/**
+ * iOS Safari is known to deliver muted (silent-but-live) audio tracks when
+ * the mic and camera come from separate getUserMedia calls — the exact
+ * two-call pattern the app uses elsewhere (video-only preview, mic per-take,
+ * for Android's voice-to-text). On iOS the mic is acquired WITH the camera
+ * in one combined call and lives as long as the preview, like a native
+ * camera app. Backgrounding still releases everything.
+ */
+const HOLD_MIC_WITH_CAMERA = typeof navigator !== 'undefined' && isIosBrowser()
+
+/** On iOS, camera + mic in one call (see HOLD_MIC_WITH_CAMERA); a combined
+ * failure falls back to video-only so a mic-denied user still gets a
+ * preview. Elsewhere always video-only. */
+async function openCombinedOrVideoStream(
+  facing: FacingMode,
+  deviceId: string | undefined,
+): Promise<MediaStream> {
+  if (HOLD_MIC_WITH_CAMERA) {
+    try {
+      return await openCameraStream(facing, { audio: true, deviceId })
+    } catch {
+      // Fall through to video-only below.
+    }
+  }
+  return openCameraStream(facing, { audio: false, deviceId })
+}
 
 /** Remembered rear lens (e.g. the ultra-wide) across sessions. */
 const REAR_LENS_STORAGE_KEY = 'kodyVideo.rearLens'
@@ -109,8 +137,10 @@ interface ExtendedSettings extends MediaTrackSettings {
 /**
  * Camera lifecycle is event/ref-driven (no useEffect):
  * - Video ref callback attaches/detaches the stream and starts capture when mounted.
- * - Preview is video-only so Android OS voice-to-text can keep the mic.
- * - enableMic/releaseMic attach a mic track only while recording.
+ * - Preview is video-only so Android OS voice-to-text can keep the mic;
+ *   enableMic/releaseMic attach a mic track only while recording.
+ * - Except iOS: mic comes with the camera in one combined call and stays for
+ *   the preview's lifetime (see HOLD_MIC_WITH_CAMERA).
  */
 export function useCamera(): UseCameraResult {
   const streamRef = useRef<MediaStream | null>(null)
@@ -238,10 +268,10 @@ export function useCamera(): UseCameraResult {
       try {
         const rememberedLens =
           facingRef.current === 'environment' ? await resolveRememberedLens() : undefined
-        const next = await openCameraStream(facingRef.current, {
-          audio: false,
-          deviceId: rememberedLens,
-        })
+        const next = await openCombinedOrVideoStream(facingRef.current, rememberedLens)
+        if (HOLD_MIC_WITH_CAMERA) {
+          setMicPermission(next.getAudioTracks().length > 0 ? 'granted' : 'denied')
+        }
         setPermission({ status: 'granted' })
         replaceStream(next)
         setCanFlip(await canFlipCamera())
@@ -251,7 +281,9 @@ export function useCamera(): UseCameraResult {
         // shows the prompt). Prompt now, at a normal moment. The claim is
         // released when the outcome was ambiguous (prompt dismissed or
         // interrupted by backgrounding) so the next camera start retries.
-        if (!micPrimedRef.current) {
+        // Not on iOS: the mic came with the combined camera request, and a
+        // separate audio-only call is the muted-track pattern to avoid.
+        if (!micPrimedRef.current && !HOLD_MIC_WITH_CAMERA) {
           micPrimedRef.current = true
           void primeMicrophonePermission().then((state) => {
             setMicPermission(state)
@@ -283,7 +315,7 @@ export function useCamera(): UseCameraResult {
     try {
       const rememberedLens =
         nextFacing === 'environment' ? await resolveRememberedLens() : undefined
-      const next = await openCameraStream(nextFacing, { audio: false, deviceId: rememberedLens })
+      const next = await openCombinedOrVideoStream(nextFacing, rememberedLens)
       replaceStream(next)
       void syncRearLenses(next)
     } catch (err) {
@@ -329,7 +361,7 @@ export function useCamera(): UseCameraResult {
         return true
       }
       try {
-        const next = await openCameraStream('environment', { audio: false, deviceId: nextId })
+        const next = await openCombinedOrVideoStream('environment', nextId)
         const openedId = next.getVideoTracks()[0]?.getSettings().deviceId ?? ''
         if (!adopt(next)) return
         // Memory must mirror what's actually on screen: the requested lens,
@@ -342,10 +374,7 @@ export function useCamera(): UseCameraResult {
       } catch (err) {
         // Try to restore the lens we just released.
         try {
-          const restored = await openCameraStream('environment', {
-            audio: false,
-            deviceId: activeId || undefined,
-          })
+          const restored = await openCombinedOrVideoStream('environment', activeId || undefined)
           adopt(restored)
         } catch {
           setError(permissionMessage(err))
@@ -387,6 +416,10 @@ export function useCamera(): UseCameraResult {
   }, [])
 
   const releaseMic = useCallback(() => {
+    // iOS: the mic lives and dies with the camera stream (single-call
+    // pattern) — stopping it per-take would force the separate audio-only
+    // getUserMedia that produces muted tracks on the next take.
+    if (HOLD_MIC_WITH_CAMERA) return
     stopAudioTracks(streamRef.current)
   }, [])
 

--- a/src/hooks/use-camera.ts
+++ b/src/hooks/use-camera.ts
@@ -7,6 +7,7 @@ import {
   openMicrophoneTrack,
   primeMicrophonePermission,
   queryCameraPermission,
+  queryMicrophonePermission,
   stopAudioTracks,
   stopStream,
   type CameraPermissionState,
@@ -227,9 +228,12 @@ export function useCamera(): UseCameraResult {
       readTrackCapabilities(next)
       // iOS: every (re)open is a combined request, so the adopted stream's
       // audio presence is the freshest mic-permission signal — including
-      // after flips and lens switches.
+      // after flips and lens switches. A missing track is NOT proof of a
+      // denial though (the combined open also falls back on transient
+      // failures) — only the Permissions API may claim "blocked".
       if (HOLD_MIC_WITH_CAMERA) {
-        setMicPermission(next.getAudioTracks().length > 0 ? 'granted' : 'denied')
+        if (next.getAudioTracks().length > 0) setMicPermission('granted')
+        else void queryMicrophonePermission().then(setMicPermission)
       }
       setIsReady(true)
     },

--- a/src/hooks/use-camera.ts
+++ b/src/hooks/use-camera.ts
@@ -225,6 +225,12 @@ export function useCamera(): UseCameraResult {
       setStream(next)
       attachToVideo(next)
       readTrackCapabilities(next)
+      // iOS: every (re)open is a combined request, so the adopted stream's
+      // audio presence is the freshest mic-permission signal — including
+      // after flips and lens switches.
+      if (HOLD_MIC_WITH_CAMERA) {
+        setMicPermission(next.getAudioTracks().length > 0 ? 'granted' : 'denied')
+      }
       setIsReady(true)
     },
     [attachToVideo, readTrackCapabilities],
@@ -269,9 +275,6 @@ export function useCamera(): UseCameraResult {
         const rememberedLens =
           facingRef.current === 'environment' ? await resolveRememberedLens() : undefined
         const next = await openCombinedOrVideoStream(facingRef.current, rememberedLens)
-        if (HOLD_MIC_WITH_CAMERA) {
-          setMicPermission(next.getAudioTracks().length > 0 ? 'granted' : 'denied')
-        }
         setPermission({ status: 'granted' })
         replaceStream(next)
         setCanFlip(await canFlipCamera())
@@ -432,12 +435,38 @@ export function useCamera(): UseCameraResult {
       return
     }
 
+    /**
+     * iOS-only recovery for a preview that opened without audio (mic was
+     * denied at start, later granted in settings): reopen camera + mic as
+     * one combined request and adopt it. Attaching a separately-acquired
+     * audio track here would recreate the muted-track pattern this module
+     * exists to avoid.
+     */
+    const reopenCombinedStream = async (): Promise<void> => {
+      const current = streamRef.current
+      if (!current) throw new Error('Camera not ready')
+      const epoch = cameraEpochRef.current
+      const deviceId = current.getVideoTracks()[0]?.getSettings().deviceId
+      const next = await openCameraStream(facingRef.current, { audio: true, deviceId })
+      // The camera may have been stopped or swapped while the permission
+      // prompt was open — never adopt into that lifecycle's back.
+      if (cameraEpochRef.current !== epoch || streamRef.current !== current) {
+        stopStream(next)
+        throw new Error('Camera changed while enabling microphone')
+      }
+      replaceStream(next)
+    }
+
     const attachToCurrentStream = async (attempt = 0): Promise<void> => {
       const current = streamRef.current
       if (!current) {
         throw new Error('Camera not ready')
       }
       if (current.getAudioTracks().some((track) => track.readyState === 'live')) return
+      if (HOLD_MIC_WITH_CAMERA) {
+        await reopenCombinedStream()
+        return
+      }
 
       const audioTrack = await openMicrophoneTrack()
       const latest = streamRef.current
@@ -476,7 +505,7 @@ export function useCamera(): UseCameraResult {
     } finally {
       micInFlightRef.current = null
     }
-  }, [])
+  }, [replaceStream])
 
   const stop = useCallback(() => {
     cameraEpochRef.current += 1

--- a/src/lib/error-reporting.ts
+++ b/src/lib/error-reporting.ts
@@ -108,12 +108,56 @@ function reportExportSessionDeath(): void {
   }
 }
 
+/**
+ * Coarse, non-identifying platform tags. Stripping request metadata (see
+ * beforeSend) also strips the user agent, which left events with no platform
+ * signal at all — triage of the iOS silent-mic report was blind to the OS.
+ * Family-level names only; this matches the privacy page's "browser/OS".
+ */
+export function coarsePlatformTags(): Record<string, string> {
+  const ua = navigator.userAgent
+  const isIos =
+    /iPhone|iPad|iPod/i.test(ua) ||
+    (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1)
+  const os = isIos
+    ? 'ios'
+    : /Android/i.test(ua)
+      ? 'android'
+      : /Mac OS X/.test(ua)
+        ? 'macos'
+        : /Windows/i.test(ua)
+          ? 'windows'
+          : /Linux|CrOS/i.test(ua)
+            ? 'linux'
+            : 'other'
+  const browser = /Edg(?:e|A|iOS)?\//.test(ua)
+    ? 'edge'
+    : /SamsungBrowser/i.test(ua)
+      ? 'samsung'
+      : /OPR\/|OPT\//.test(ua)
+        ? 'opera'
+        : /Firefox\/|FxiOS/i.test(ua)
+          ? 'firefox'
+          : /CriOS|Chrome\//.test(ua)
+            ? 'brave' in navigator
+              ? 'brave'
+              : 'chrome'
+            : /Safari/i.test(ua)
+              ? 'safari'
+              : 'other'
+  const installed =
+    window.matchMedia('(display-mode: standalone)').matches ||
+    (navigator as { standalone?: boolean }).standalone === true
+  return { 'app.os': os, 'app.browser': browser, 'app.installed': String(installed) }
+}
+
 export function initErrorReporting(): void {
   if (!REPORTING_HOSTNAMES.has(location.hostname)) return
   Sentry.init({
     dsn: SENTRY_DSN,
     release: COMMIT_SHA,
     environment: location.hostname === 'kody.video' ? 'production' : 'legacy-pages-dev',
+    initialScope: { tags: coarsePlatformTags() },
     // Crash reports only: no tracing, no session replay, no PII. Clips and
     // media never leave the device — this reports errors and stack traces.
     // These settings ENFORCE the privacy-page wording ("error message, stack

--- a/src/lib/install-hint.ts
+++ b/src/lib/install-hint.ts
@@ -4,13 +4,9 @@
  * decides when nudging about that is actually useful.
  */
 
-const DISMISSED_KEY = 'kody-video:install-hint-dismissed'
+import { isIosBrowser } from './media'
 
-function isIosDevice(): boolean {
-  if (/iPhone|iPad|iPod/i.test(navigator.userAgent)) return true
-  // iPadOS masquerades as macOS but is the only "Mac" with touch points.
-  return navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1
-}
+const DISMISSED_KEY = 'kody-video:install-hint-dismissed'
 
 function isStandalone(): boolean {
   if (window.matchMedia('(display-mode: standalone)').matches) return true
@@ -18,7 +14,7 @@ function isStandalone(): boolean {
 }
 
 export function shouldShowIosInstallHint(): boolean {
-  if (!isIosDevice()) return false
+  if (!isIosBrowser()) return false
   if (isStandalone()) return false
   // Bare WKWebViews (X, Instagram, …) have no Share → Add to Home Screen and
   // omit the "Safari" UA token that real browsers (Safari/CriOS/FxiOS) keep.

--- a/src/lib/media.ts
+++ b/src/lib/media.ts
@@ -165,6 +165,20 @@ export async function openMicrophoneTrack(): Promise<MediaStreamTrack> {
  * no microphone entry to flip). Priming at camera startup shows a normal
  * prompt at a normal moment; later per-take requests then resolve silently.
  */
+/** Permission-state lookup only — never prompts, never opens a track. */
+export async function queryMicrophonePermission(): Promise<'granted' | 'denied' | 'unknown'> {
+  try {
+    const status = await navigator.permissions.query({
+      name: 'microphone' as PermissionName,
+    })
+    if (status.state === 'granted') return 'granted'
+    if (status.state === 'denied') return 'denied'
+  } catch {
+    // Permission query unsupported.
+  }
+  return 'unknown'
+}
+
 export async function primeMicrophonePermission(): Promise<'granted' | 'denied' | 'unknown'> {
   try {
     const status = await navigator.permissions.query({

--- a/src/lib/media.ts
+++ b/src/lib/media.ts
@@ -282,6 +282,13 @@ export function isMobileBrowser(): boolean {
   return /Android|iPhone|iPad|iPod|Mobile/i.test(navigator.userAgent)
 }
 
+/** All iOS browsers share WebKit (and its quirks), whatever their brand. */
+export function isIosBrowser(): boolean {
+  if (/iPhone|iPad|iPod/i.test(navigator.userAgent)) return true
+  // iPadOS masquerades as macOS but is the only "Mac" with touch points.
+  return navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1
+}
+
 export async function downloadBlob(blob: Blob, filename: string): Promise<void> {
   const url = URL.createObjectURL(blob)
   const anchor = document.createElement('a')

--- a/src/lib/mic-monitor.ts
+++ b/src/lib/mic-monitor.ts
@@ -1,0 +1,105 @@
+/**
+ * Live mic-level watch during a take. Sentry showed exports whose source
+ * clips peak at ~0.002 — the mic recorded nothing and the user only found
+ * out after sharing. This surfaces that while they're still recording.
+ */
+
+/** Same near-silence floor the export diagnostics use (see export/shared). */
+const SILENT_PEAK = 0.005
+/** Give the mic time to warm up before calling it silent. */
+const GRACE_MS = 2500
+const SAMPLE_INTERVAL_MS = 300
+
+export interface MicLevelMonitor {
+  stop(): void
+}
+
+/**
+ * Watches the stream's audio track through an AnalyserNode (a passive extra
+ * consumer — MediaRecorder is unaffected). Calls onSilent once when the
+ * take has run past the grace period without any signal above the floor,
+ * and onSound if a signal shows up after that (mic recovered / warmed up).
+ * Best-effort: any Web Audio failure just means no warning.
+ */
+export function startMicLevelMonitor(
+  stream: MediaStream,
+  handlers: { onSilent: () => void; onSound: () => void },
+): MicLevelMonitor {
+  const track = stream.getAudioTracks().find((t) => t.readyState === 'live')
+  if (!track || typeof AudioContext === 'undefined') {
+    return { stop: () => undefined }
+  }
+
+  let context: AudioContext | null = null
+  let analyser: AnalyserNode | null = null
+  let timer = 0
+  let startedAt = 0
+
+  const stop = () => {
+    window.clearInterval(timer)
+    timer = 0
+    try {
+      analyser?.disconnect()
+    } catch {
+      // Already torn down.
+    }
+    void context?.close().catch(() => undefined)
+    context = null
+    analyser = null
+  }
+
+  try {
+    context = new AudioContext()
+    void context.resume().catch(() => undefined)
+    // A dedicated audio-only stream keeps Safari's MediaStreamSource happy.
+    const source = context.createMediaStreamSource(new MediaStream([track]))
+    analyser = context.createAnalyser()
+    analyser.fftSize = 2048
+    source.connect(analyser)
+  } catch {
+    stop()
+    return { stop: () => undefined }
+  }
+
+  const samples = new Float32Array(analyser.fftSize)
+  let maxPeak = 0
+  let verdict: 'pending' | 'silent' | 'sound' = 'pending'
+  startedAt = performance.now()
+
+  timer = window.setInterval(() => {
+    if (!analyser) return
+    // A suspended context reads all-zero — indistinguishable from a dead
+    // mic (which, unlike a muted TRACK, is not a condition to warn about).
+    // Never judge silence unless audio is actually flowing.
+    if (context?.state !== 'running') {
+      void context?.resume().catch(() => undefined)
+      startedAt = performance.now()
+      return
+    }
+    try {
+      analyser.getFloatTimeDomainData(samples)
+    } catch {
+      stop()
+      return
+    }
+    for (let i = 0; i < samples.length; i += 4) {
+      const value = Math.abs(samples[i]!)
+      if (value > maxPeak) maxPeak = value
+    }
+    if (maxPeak >= SILENT_PEAK) {
+      // Signal clears immediately — including a warning a previous take set.
+      if (verdict !== 'sound') {
+        verdict = 'sound'
+        handlers.onSound()
+      }
+      return
+    }
+    if (performance.now() - startedAt < GRACE_MS) return
+    if (verdict === 'pending') {
+      verdict = 'silent'
+      handlers.onSilent()
+    }
+  }, SAMPLE_INTERVAL_MS)
+
+  return { stop }
+}

--- a/src/lib/mic-monitor.ts
+++ b/src/lib/mic-monitor.ts
@@ -16,10 +16,10 @@ export interface MicLevelMonitor {
 
 /**
  * Watches the stream's audio track through an AnalyserNode (a passive extra
- * consumer — MediaRecorder is unaffected). Calls onSilent once when the
- * take has run past the grace period without any signal above the floor,
- * and onSound if a signal shows up after that (mic recovered / warmed up).
- * Best-effort: any Web Audio failure just means no warning.
+ * consumer — MediaRecorder is unaffected). Calls onSilent when the take has
+ * gone a full grace period without any signal above the floor — whether from
+ * the start or because the mic died mid-take — and onSound whenever signal
+ * (re)appears. Best-effort: any Web Audio failure just means no warning.
  */
 export function startMicLevelMonitor(
   stream: MediaStream,
@@ -62,7 +62,10 @@ export function startMicLevelMonitor(
   }
 
   const samples = new Float32Array(analyser.fftSize)
-  let maxPeak = 0
+  /** When signal was last heard; silence is judged on a rolling window so a
+   * mic dying mid-take gets flagged too, not just one that was dead at the
+   * start. */
+  let lastSoundAt: number | null = null
   let verdict: 'pending' | 'silent' | 'sound' = 'pending'
   startedAt = performance.now()
 
@@ -82,11 +85,14 @@ export function startMicLevelMonitor(
       stop()
       return
     }
+    let tickPeak = 0
     for (let i = 0; i < samples.length; i += 4) {
       const value = Math.abs(samples[i]!)
-      if (value > maxPeak) maxPeak = value
+      if (value > tickPeak) tickPeak = value
     }
-    if (maxPeak >= SILENT_PEAK) {
+    const now = performance.now()
+    if (tickPeak >= SILENT_PEAK) {
+      lastSoundAt = now
       // Signal clears immediately — including a warning a previous take set.
       if (verdict !== 'sound') {
         verdict = 'sound'
@@ -94,8 +100,8 @@ export function startMicLevelMonitor(
       }
       return
     }
-    if (performance.now() - startedAt < GRACE_MS) return
-    if (verdict === 'pending') {
+    if (now - (lastSoundAt ?? startedAt) < GRACE_MS) return
+    if (verdict !== 'silent') {
       verdict = 'silent'
       handlers.onSilent()
     }

--- a/src/lib/mic-monitor.ts
+++ b/src/lib/mic-monitor.ts
@@ -76,7 +76,10 @@ export function startMicLevelMonitor(
     // Never judge silence unless audio is actually flowing.
     if (context?.state !== 'running') {
       void context?.resume().catch(() => undefined)
+      // Restart the rolling window entirely: a stale lastSoundAt from before
+      // the suspension would otherwise flag silence instantly on resume.
       startedAt = performance.now()
+      lastSoundAt = null
       return
     }
     try {

--- a/src/lib/project-transfer.test.ts
+++ b/src/lib/project-transfer.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 import {
+  BackupFormatError,
   importProjectBackup,
   parseProjectBackup,
   projectBackupFilename,
@@ -94,6 +95,16 @@ describe('project backup round trip', () => {
 
   it('rejects non-backup files', async () => {
     await expect(parseProjectBackup(new Blob(['just a video']))).rejects.toThrow(/not a kody video/i)
+  })
+
+  it('marks validation failures as BackupFormatError (kept out of crash reporting)', async () => {
+    await expect(parseProjectBackup(new Blob(['just a video']))).rejects.toBeInstanceOf(
+      BackupFormatError,
+    )
+    const backup = serializeProject(fakeProject(), [fakeClip('clip_a', 'AAAAAAAAAA')])
+    await expect(parseProjectBackup(backup.slice(0, backup.size - 4))).rejects.toBeInstanceOf(
+      BackupFormatError,
+    )
   })
 
   it('rejects truncated backups', async () => {

--- a/src/lib/project-transfer.ts
+++ b/src/lib/project-transfer.ts
@@ -86,20 +86,28 @@ export interface ParsedBackup {
 }
 
 /**
+ * A file the user picked that isn't a (valid, current) Kody Video backup.
+ * Surfaced in-app as guidance; expected user input, never a crash report.
+ */
+export class BackupFormatError extends Error {
+  override readonly name = 'BackupFormatError'
+}
+
+/**
  * Parse a backup file. Media bytes are sliced lazily per clip (File.slice),
  * so large backups never need the whole file in memory at once.
  */
 export async function parseProjectBackup(file: Blob): Promise<ParsedBackup> {
   const headerLength = MAGIC_BYTES.byteLength + 4
-  if (file.size < headerLength) throw new Error('Not a Kody Video backup file')
+  if (file.size < headerLength) throw new BackupFormatError('Not a Kody Video backup file')
 
   const header = new Uint8Array(await file.slice(0, headerLength).arrayBuffer())
   for (let i = 0; i < MAGIC_BYTES.byteLength; i += 1) {
-    if (header[i] !== MAGIC_BYTES[i]) throw new Error('Not a Kody Video backup file')
+    if (header[i] !== MAGIC_BYTES[i]) throw new BackupFormatError('Not a Kody Video backup file')
   }
   const manifestLength = new DataView(header.buffer).getUint32(MAGIC_BYTES.byteLength)
   if (manifestLength <= 0 || headerLength + manifestLength > file.size) {
-    throw new Error('This backup file is damaged')
+    throw new BackupFormatError('This backup file is damaged')
   }
 
   let manifest: Manifest
@@ -109,10 +117,10 @@ export async function parseProjectBackup(file: Blob): Promise<ParsedBackup> {
       .arrayBuffer()
     manifest = JSON.parse(new TextDecoder().decode(manifestBytes)) as Manifest
   } catch {
-    throw new Error('This backup file is damaged')
+    throw new BackupFormatError('This backup file is damaged')
   }
   if (manifest.app !== 'kody-video' || manifest.version !== 1 || !Array.isArray(manifest.clips)) {
-    throw new Error('This backup was made by a newer app version — update and retry')
+    throw new BackupFormatError('This backup was made by a newer app version — update and retry')
   }
 
   let offset = headerLength + manifestLength
@@ -123,7 +131,7 @@ export async function parseProjectBackup(file: Blob): Promise<ParsedBackup> {
       clip.byteLength <= 0 ||
       offset + clip.byteLength > file.size
     ) {
-      throw new Error('This backup file is damaged')
+      throw new BackupFormatError('This backup file is damaged')
     }
     const mimeType = typeof clip.mimeType === 'string' ? clip.mimeType : 'video/webm'
     clips.push({
@@ -152,7 +160,7 @@ function assertImportableClip(clip: ParsedBackup['clips'][number]): void {
     Number.isFinite(clip.trimEndMs) &&
     Number.isFinite(clip.createdAt)
   if (!finite || clip.durationMs <= 0 || clip.blob.size <= 0) {
-    throw new Error('This backup file is damaged')
+    throw new BackupFormatError('This backup file is damaged')
   }
 }
 

--- a/src/pages/home-page.tsx
+++ b/src/pages/home-page.tsx
@@ -9,6 +9,7 @@ import { RenameSheet } from '../components/rename-sheet'
 import { downloadBlob, shareOrDownload } from '../lib/media'
 import { loadHomePage, type HomeLoaderData, type ProjectSummary } from '../lib/project-actions'
 import {
+  BackupFormatError,
   importProjectBackup,
   parseProjectBackup,
   projectBackupFilename,
@@ -136,7 +137,8 @@ export function HomePage() {
         // no dependence on the list revalidating behind the scenes.
         navigate(`/project/${project.id}`)
       } catch (err) {
-        reportError(err, 'import')
+        // Wrong/damaged file picked = expected user input, not a crash.
+        if (!(err instanceof BackupFormatError)) reportError(err, 'import')
         setError(err instanceof Error ? err.message : 'Could not import that file')
       } finally {
         setImportProgress(null)

--- a/src/pages/privacy-page.tsx
+++ b/src/pages/privacy-page.tsx
@@ -53,8 +53,10 @@ export function PrivacyPage() {
         <section className="about-section">
           <h2>Camera &amp; microphone</h2>
           <p>
-            The camera and microphone are used only while the app is open and you are recording.
-            Backgrounding the app releases them.
+            The camera and microphone are used only while the app is open, on the camera view.
+            On most devices the microphone is held only while you record; on iOS it stays with
+            the camera preview (a WebKit requirement for working audio). Backgrounding the app
+            releases both. Nothing is ever streamed anywhere.
           </p>
         </section>
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Response to Sentry [KODY-VIDEO-8](https://kent-c-dodds-tech-llc.sentry.io/issues/7641293036/): an export on the latest build whose four source clips all peaked at ~0.002 — the export pipeline decoded everything perfectly, but the mic recorded nothing at capture time.

Three changes:

### 1. iOS: mic and camera in one `getUserMedia` call

iOS WebKit is known to deliver muted (live-but-silent) audio tracks when the mic and camera come from separate `getUserMedia` calls — exactly our pattern (video-only preview, mic acquired per-take, which exists so Android voice-to-text keeps the mic while idle). On iOS the camera now opens **with audio in a single combined call**, the mic lives as long as the preview (like a native camera app), and `releaseMic` is a no-op there so the next take never re-enters the two-call pattern. A combined-request failure falls back to video-only so a mic-denied user still gets a preview. Backgrounding still releases everything. Non-iOS behavior is unchanged. Privacy page/README/checklist updated to describe the iOS difference.

### 2. Live silent-mic warning (all platforms)

New `src/lib/mic-monitor.ts`: an `AnalyserNode` passively watches the take's audio. If a take runs 2.5s without any signal above the export diagnostics' near-silence floor (0.005), a red "Mic isn't picking up sound" pill appears during the take — the user learns immediately instead of after sharing a silent video. Any real signal clears it (including a warning left by a previous take). A suspended `AudioContext` reads all-zero, so silence is only ever judged while the context is running (avoids false positives).

### 3. Report hygiene

- New `BackupFormatError` for backup-parse validation failures; the import flow no longer sends "user picked a wrong file" to Sentry (fixes the KODY-VIDEO-7 noise).
- Coarse, non-identifying platform tags (`app.os`, `app.browser`, `app.installed`) on all events — stripping request metadata for privacy also stripped the user agent, leaving triage blind to platform (we can't even confirm KODY-VIDEO-8 is iOS). Family-level names only, consistent with the privacy page's "browser/OS" wording.

## Testing

- `tsc`, vitest (75 tests, incl. new `BackupFormatError` assertions), production build all pass.
- New `scripts/probe-mic-monitor.mjs`: a silent fake mic shows the pill during a take; an audible tone fixture does not. (Found along the way: Chromium's *default* fake mic peaks at ~0.003 — below the real-mic floor, and coincidentally in the same range as the Sentry event's clip peaks.)
- `scripts/probe-keyboard.mjs` full regression pass (recording flow with the monitor active).
- The iOS combined-call path can't be exercised on Linux; needs a real-device check (Peter's retest).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-16d17496-6b5b-4e12-b600-6933357c2059"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-16d17496-6b5b-4e12-b600-6933357c2059"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added live mic-level monitoring during recording with a “Mic isn’t picking up sound” warning that appears after silence and clears when audio resumes.
  - Enhanced iOS camera/microphone flow to keep audio capture consistent during preview.
  - Improved microphone-required messaging during setup.
- **Bug Fixes**
  - Improved project-backup validation by using dedicated “invalid backup” errors and avoiding false error reporting for damaged inputs.
- **Documentation**
  - Updated iOS-specific guidance for browser limits, permissions, manual camera checks, and privacy policy.
- **Tests**
  - Added an end-to-end mic-monitor probe and new backup-format validation coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->