### PR TITLE
Derive AAC chunk timestamps (WebKit zeroes them); report verification blind spots

### DIFF
--- a/src/lib/export/aac.test.ts
+++ b/src/lib/export/aac.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest'
-import { aacAudioSpecificConfig, isAdtsFramed, stripAdtsFrames } from './aac'
+import {
+  aacAudioSpecificConfig,
+  deriveAacChunkTimestampUs,
+  isAdtsFramed,
+  stripAdtsFrames,
+} from './aac'
 
 function adtsFrame(payload: number[], { protectionAbsent = true } = {}): number[] {
   const headerLength = protectionAbsent ? 7 : 9
@@ -64,5 +69,30 @@ describe('ADTS handling', () => {
   it('returns null for truncated frames', () => {
     const frame = adtsFrame([1, 2, 3, 4, 5, 6])
     expect(stripAdtsFrames(new Uint8Array(frame.slice(0, frame.length - 3)))).toBe(null)
+  })
+})
+
+describe('deriveAacChunkTimestampUs', () => {
+  /** Derived per index (not accumulated) so rounding never drifts. */
+  const tsAt = (index: number) => Math.round((index * 1024 * 1_000_000) / 48000)
+
+  it('keeps a conforming encoder timestamp (Chrome)', () => {
+    const result = deriveAacChunkTimestampUs(2, tsAt(2) + 100, 48000)
+    expect(result).toEqual({ timestampUs: tsAt(2) + 100, overridden: false })
+  })
+
+  it('overrides zeroed timestamps (observed WebKit behavior)', () => {
+    // Encoder said 0 for the 10th chunk — the derived position wins.
+    const result = deriveAacChunkTimestampUs(10, 0, 48000)
+    expect(result).toEqual({ timestampUs: tsAt(10), overridden: true })
+  })
+
+  it('tolerates small encoder jitter without overriding', () => {
+    const result = deriveAacChunkTimestampUs(100, tsAt(100) - 20_000, 48000)
+    expect(result.overridden).toBe(false)
+  })
+
+  it('never overrides the first chunk at zero', () => {
+    expect(deriveAacChunkTimestampUs(0, 0, 48000).overridden).toBe(false)
   })
 })

--- a/src/lib/export/aac.ts
+++ b/src/lib/export/aac.ts
@@ -64,6 +64,34 @@ export interface AacChunkDiagnostics {
   describedByEncoder: boolean
   injectedDescription: boolean
   adtsStripped: number
+  timestampOverrides: number
+}
+
+/** Samples per AAC access unit — fixed by the codec. */
+export const AAC_FRAME_SAMPLES = 1024
+
+/** Trust the encoder's timestamp only within this window of the derived
+ * one. WebKit's AudioEncoder has been observed emitting several chunks all
+ * timestamped 0 — a broken sample timeline that strict (Apple) players
+ * render as silence while raw-stream decoders play it fine. */
+const TIMESTAMP_TOLERANCE_US = 25_000
+
+/**
+ * The timestamp the chunk SHOULD have: audio is fed to the encoder as one
+ * contiguous 48kHz timeline (segment offsets included), and every AAC chunk
+ * is one 1024-sample access unit — so position in the sequence fully
+ * determines timing. Prefers the encoder's own stamp when it agrees.
+ */
+export function deriveAacChunkTimestampUs(
+  chunkIndex: number,
+  encoderTimestampUs: number,
+  sampleRate: number,
+): { timestampUs: number; overridden: boolean } {
+  const derivedUs = Math.round((chunkIndex * AAC_FRAME_SAMPLES * 1_000_000) / sampleRate)
+  if (Math.abs(encoderTimestampUs - derivedUs) <= TIMESTAMP_TOLERANCE_US) {
+    return { timestampUs: encoderTimestampUs, overridden: false }
+  }
+  return { timestampUs: derivedUs, overridden: true }
 }
 
 export interface NormalizedAacChunk {
@@ -82,22 +110,25 @@ export function normalizeAacChunk(
 ): NormalizedAacChunk {
   const { sampleRate, channels, diagnostics } = options
   const isFirstChunk = diagnostics.chunks === 0
+  const chunkIndex = diagnostics.chunks
   diagnostics.chunks += 1
 
   let outChunk = chunk
   const data = new Uint8Array(chunk.byteLength)
   chunk.copyTo(data)
-  if (isAdtsFramed(data)) {
-    const raw = stripAdtsFrames(data)
-    if (raw) {
-      diagnostics.adtsStripped += 1
-      outChunk = new EncodedAudioChunk({
-        type: chunk.type,
-        timestamp: chunk.timestamp,
-        ...(typeof chunk.duration === 'number' ? { duration: chunk.duration } : {}),
-        data: raw,
-      })
-    }
+  const raw = isAdtsFramed(data) ? stripAdtsFrames(data) : null
+  if (raw) diagnostics.adtsStripped += 1
+
+  const timing = deriveAacChunkTimestampUs(chunkIndex, chunk.timestamp, sampleRate)
+  if (timing.overridden) diagnostics.timestampOverrides += 1
+
+  if (raw || timing.overridden) {
+    outChunk = new EncodedAudioChunk({
+      type: chunk.type,
+      timestamp: timing.timestampUs,
+      ...(typeof chunk.duration === 'number' ? { duration: chunk.duration } : {}),
+      data: raw ?? data,
+    })
   }
 
   let outMeta = meta

--- a/src/lib/export/encode-webcodecs.ts
+++ b/src/lib/export/encode-webcodecs.ts
@@ -219,6 +219,7 @@ export async function exportWithWebCodecs(
     describedByEncoder: false,
     injectedDescription: false,
     adtsStripped: 0,
+    timestampOverrides: 0,
   }
   const audioEncoder = new AudioEncoder({
     output: (chunk, meta) => {
@@ -347,6 +348,7 @@ export async function exportWithWebCodecs(
       describedByEncoder: aacDiagnostics.describedByEncoder,
       injectedDescription: aacDiagnostics.injectedDescription,
       adtsStripped: aacDiagnostics.adtsStripped,
+      timestampOverrides: aacDiagnostics.timestampOverrides,
     },
   }
 }

--- a/src/lib/export/index.ts
+++ b/src/lib/export/index.ts
@@ -63,11 +63,13 @@ export async function exportProject(
       )
       reportSilentExportAudio({ engine: 'webcodecs', outputMime: result.mimeType })
       reportBlackExportVideo({ engine: 'webcodecs', outputMime: result.mimeType })
-      // A mux fault (e.g. an AAC track written without its decoder config)
+      // A mux fault (broken AAC framing, a mangled sample timeline, …)
       // produces a silent file with no error at any stage. Verify what was
       // actually written; the realtime engine muxes through MediaRecorder
       // and is immune, so silent output here means fall back, not fail.
-      if ((await verifyOutputAudio(result, 'webcodecs')) === 'silent') {
+      const verification = await verifyOutputAudio(result, 'webcodecs')
+      maybeReportAudioSeamDiagnostics(result, verification)
+      if (verification === 'silent') {
         throw new Error('WebCodecs export produced silent audio')
       }
       return result
@@ -103,19 +105,55 @@ async function verifyOutputAudio(
 ): Promise<'ok' | 'silent' | 'unknown'> {
   const inputPeak = decodedAudioMaxPeak()
   if (inputPeak < AUDIO_SILENCE_PEAK) return 'unknown'
-  const outputPeak = await measureBlobAudioPeak(result.blob)
-  if (outputPeak === null) return 'unknown'
-  if (outputPeak >= AUDIO_SILENCE_PEAK) return 'ok'
+  const measured = await measureBlobAudioPeak(result.blob)
+  if (measured.peak === null) {
+    // Verification is blind here — silence would go unnoticed. Report so
+    // remote failures on decode-limited platforms are still attributable.
+    reportError(
+      new Error('Export output audio could not be verified'),
+      'export-audio-verify',
+      {
+        engine,
+        outputMime: result.mimeType,
+        failure: measured.failure ?? 'unknown',
+        inputPeak: Number(inputPeak.toFixed(4)),
+        ...(result.audioDiagnostics ?? {}),
+      },
+    )
+    return 'unknown'
+  }
+  if (measured.peak >= AUDIO_SILENCE_PEAK) return 'ok'
   reportError(
     new Error('Export output audio is silent despite audible clip audio (encode/mux fault)'),
     'export-audio-output',
     {
       engine,
       outputMime: result.mimeType,
-      outputPeak: Number(outputPeak.toFixed(4)),
+      outputPeak: Number(measured.peak.toFixed(4)),
       inputPeak: Number(inputPeak.toFixed(4)),
       ...(result.audioDiagnostics ?? {}),
     },
   )
   return 'silent'
+}
+
+/** One report per session when the AAC seam had to repair encoder output —
+ * WebKit's encoder quirks (ADTS framing, zeroed timestamps) are otherwise
+ * invisible when the repair WORKS, and knowing they fired on a given
+ * platform is what confirms the diagnosis remotely. */
+let audioSeamReported = false
+function maybeReportAudioSeamDiagnostics(
+  result: ExportResult,
+  verification: 'ok' | 'silent' | 'unknown',
+): void {
+  const diagnostics = result.audioDiagnostics
+  if (!diagnostics) return
+  const repaired = diagnostics.adtsStripped > 0 || diagnostics.timestampOverrides > 0
+  if (!repaired || audioSeamReported) return
+  audioSeamReported = true
+  reportError(
+    new Error('Export audio seam repaired encoder output (informational)'),
+    'export-audio-fixup',
+    { verification, outputMime: result.mimeType, ...diagnostics },
+  )
 }

--- a/src/lib/export/shared.ts
+++ b/src/lib/export/shared.ts
@@ -344,25 +344,38 @@ export async function decodeClipAudio(
  * Returns null when the output can't be decoded here (verification unknown,
  * not proof of silence). Never pushes per-clip observations.
  */
-export async function measureBlobAudioPeak(blob: Blob, sampleRate = 48000): Promise<number | null> {
+export interface BlobAudioMeasurement {
+  peak: number | null
+  /** Why the peak is unknown, when it is (for remote diagnosis). */
+  failure?: string
+}
+
+export async function measureBlobAudioPeak(
+  blob: Blob,
+  sampleRate = 48000,
+): Promise<BlobAudioMeasurement> {
   // Whole-file decode: keep memory bounded on long projects.
-  if (blob.size > 120 * 1024 * 1024) return null
+  if (blob.size > 120 * 1024 * 1024) return { peak: null, failure: 'too large to verify' }
   try {
     const bytes = await blob.arrayBuffer()
     const ctx = new OfflineAudioContext(2, 1, sampleRate)
     const decoded = await ctx.decodeAudioData(bytes)
-    return audioBufferPeak(decoded)
-  } catch {
+    return { peak: audioBufferPeak(decoded) }
+  } catch (nativeError) {
     if (/mp4/i.test(blob.type)) {
       try {
         const { decodeMp4AudioWithWebCodecs } = await import('./mp4-audio')
         const decoded = await decodeMp4AudioWithWebCodecs(blob, sampleRate)
-        if (decoded) return audioBufferPeak(decoded)
-      } catch {
-        // Verification unknown.
+        if (decoded) return { peak: audioBufferPeak(decoded) }
+        return { peak: null, failure: 'demux fallback returned nothing' }
+      } catch (fallbackError) {
+        return {
+          peak: null,
+          failure: `native: ${String(nativeError).slice(0, 120)}; fallback: ${String(fallbackError).slice(0, 120)}`,
+        }
       }
     }
-    return null
+    return { peak: null, failure: String(nativeError).slice(0, 160) }
   }
 }
 
@@ -455,5 +468,6 @@ export interface ExportResult {
     describedByEncoder: boolean
     injectedDescription: boolean
     adtsStripped: number
+    timestampOverrides: number
   }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Peter's retest on `6b4f4e2` (the ADTS/description hardening): still silent, and **still zero Sentry events** — the output verification judged his file "ok" or "unknown" and never triggered the fallback. Both halves of that now have an explanation and a fix.

## New evidence

A Playwright WebKit probe of `AudioEncoder` (AAC, fed ten 100ms blocks with correct sequential timestamps) showed WebKit emits raw AAC with a proper decoder description — but **multiple output chunks all timestamped 0**. If iOS behaves the same, `mp4-muxer` builds a garbage sample timeline: Apple's strict player renders that as silence, while raw-stream decoders — including our own verification's `decodeAudioData`, which ignores container timing — hear the audio fine and report "ok". One mechanism explains the silent file *and* the silent telemetry.

## How

- **`deriveAacChunkTimestampUs`** (`aac.ts`): audio is fed to the encoder as one contiguous 48kHz timeline and every AAC chunk is one 1024-sample access unit, so a chunk's position fully determines its timestamp. `normalizeAacChunk` now compares the encoder's stamp with the derived one and overrides when it deviates beyond 25ms — Chrome's conforming timestamps (and small jitter) pass through untouched. Derivation is per-index, so rounding never drifts.
- **Verification blind spot closed** (`index.ts`, `shared.ts`): when inputs are audible but the output can't be decoded for verification, that's now reported (`step: export-audio-verify`, with both decode-failure reasons) instead of silently returning "unknown".
- **Repair telemetry** (`step: export-audio-fixup`, once per session): when the seam actually had to strip ADTS or override timestamps, we hear about it even when the repair *works* — that's what confirms the diagnosis on real iOS remotely.
- `timestampOverrides` added to the audio diagnostics carried by every silent-output report.

## Testing

- New unit tests for the timestamp derivation (conforming passthrough, zeroed-timestamp override, jitter tolerance, first-chunk-at-zero).
- Full suite: 88 tests green; `tsc` and production build pass.
- The definitive test is Peter's next export: whatever happens, one of `export-audio-fixup` / `export-audio-verify` / `export-audio-output` now fires, so the next data point is guaranteed to be attributable.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-16d17496-6b5b-4e12-b600-6933357c2059"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-16d17496-6b5b-4e12-b600-6933357c2059"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

