### PR TITLE
Pin AAC decoder config, capture encoder forensics, fall back on undecodable output

### DIFF
--- a/src/lib/export/aac.ts
+++ b/src/lib/export/aac.ts
@@ -65,6 +65,24 @@ export interface AacChunkDiagnostics {
   injectedDescription: boolean
   adtsStripped: number
   timestampOverrides: number
+  /** Hex of the description the ENCODER provided when it differs from the
+   * synthesized one — evidence of what the platform actually emits. */
+  encoderDescriptionHex: string | null
+  /** Hex prefix of the first chunk's payload (framing forensics: raw AAC
+   * usually starts 0x21/0xDE…, ADTS 0xFFFx, LATM/LOAS 0x56Ex/0x47…). */
+  firstChunkPrefixHex: string | null
+}
+
+function toHex(bytes: Uint8Array, limit: number): string {
+  return [...bytes.subarray(0, limit)].map((b) => b.toString(16).padStart(2, '0')).join('')
+}
+
+function descriptionBytes(description: AllowSharedBufferSource): Uint8Array {
+  if (description instanceof Uint8Array) return description
+  if (ArrayBuffer.isView(description)) {
+    return new Uint8Array(description.buffer, description.byteOffset, description.byteLength)
+  }
+  return new Uint8Array(description as ArrayBuffer)
 }
 
 /** Samples per AAC access unit — fixed by the codec. */
@@ -116,6 +134,7 @@ export function normalizeAacChunk(
   let outChunk = chunk
   const data = new Uint8Array(chunk.byteLength)
   chunk.copyTo(data)
+  if (isFirstChunk) diagnostics.firstChunkPrefixHex = toHex(data, 8)
   const raw = isAdtsFramed(data) ? stripAdtsFrames(data) : null
   if (raw) diagnostics.adtsStripped += 1
 
@@ -131,13 +150,25 @@ export function normalizeAacChunk(
     })
   }
 
+  // ALWAYS pin our own AudioSpecificConfig: the encoder settings (AAC-LC,
+  // rate, channels) fully determine the correct bytes, Chrome's description
+  // matches them exactly, and an encoder-provided description of any other
+  // shape muxed verbatim into esds yields a track Apple's strict decoder
+  // plays as silence (observed from iOS: healthy chunks in, undecodable
+  // audio out). The bytes the platform DID provide are kept as evidence.
   let outMeta = meta
-  const description = meta?.decoderConfig?.description
-  if (description && description.byteLength > 0) {
+  const synthesized = aacAudioSpecificConfig(sampleRate, channels)
+  const provided = meta?.decoderConfig?.description
+  if (provided && provided.byteLength > 0) {
     diagnostics.describedByEncoder = true
-  } else if (isFirstChunk) {
-    // Pin the config explicitly instead of leaving mp4-muxer to guess one
-    // (5.x guesses correctly for AAC-LC; older versions wrote it empty).
+    const bytes = descriptionBytes(provided)
+    const matches =
+      bytes.length === synthesized.length && bytes.every((b, i) => b === synthesized[i])
+    if (!matches && !diagnostics.encoderDescriptionHex) {
+      diagnostics.encoderDescriptionHex = `${bytes.byteLength}:${toHex(bytes, 16)}`
+    }
+  }
+  if (isFirstChunk) {
     diagnostics.injectedDescription = true
     outMeta = {
       ...meta,
@@ -146,7 +177,7 @@ export function normalizeAacChunk(
         sampleRate,
         numberOfChannels: channels,
         ...meta?.decoderConfig,
-        description: aacAudioSpecificConfig(sampleRate, channels),
+        description: synthesized,
       },
     }
   }

--- a/src/lib/export/encode-webcodecs.ts
+++ b/src/lib/export/encode-webcodecs.ts
@@ -220,6 +220,8 @@ export async function exportWithWebCodecs(
     injectedDescription: false,
     adtsStripped: 0,
     timestampOverrides: 0,
+    encoderDescriptionHex: null,
+    firstChunkPrefixHex: null,
   }
   const audioEncoder = new AudioEncoder({
     output: (chunk, meta) => {
@@ -349,6 +351,8 @@ export async function exportWithWebCodecs(
       injectedDescription: aacDiagnostics.injectedDescription,
       adtsStripped: aacDiagnostics.adtsStripped,
       timestampOverrides: aacDiagnostics.timestampOverrides,
+      encoderDescriptionHex: aacDiagnostics.encoderDescriptionHex,
+      firstChunkPrefixHex: aacDiagnostics.firstChunkPrefixHex,
     },
   }
 }

--- a/src/lib/export/index.ts
+++ b/src/lib/export/index.ts
@@ -63,14 +63,18 @@ export async function exportProject(
       )
       reportSilentExportAudio({ engine: 'webcodecs', outputMime: result.mimeType })
       reportBlackExportVideo({ engine: 'webcodecs', outputMime: result.mimeType })
-      // A mux fault (broken AAC framing, a mangled sample timeline, …)
-      // produces a silent file with no error at any stage. Verify what was
-      // actually written; the realtime engine muxes through MediaRecorder
-      // and is immune, so silent output here means fall back, not fail.
+      // A mux fault (broken AAC framing, a mangled sample timeline, a bad
+      // decoder config, …) produces a silent file with no error at any
+      // stage. Verify what was actually written; the realtime engine muxes
+      // through MediaRecorder (platform-native) and is immune, so both a
+      // provably silent output AND an output this device cannot decode at
+      // all (Chrome always decodes its own files; iOS was observed
+      // rejecting ours while playing its own recordings fine) mean fall
+      // back, not fail.
       const verification = await verifyOutputAudio(result, 'webcodecs')
       maybeReportAudioSeamDiagnostics(result, verification)
-      if (verification === 'silent') {
-        throw new Error('WebCodecs export produced silent audio')
+      if (verification === 'silent' || verification === 'undecodable') {
+        throw new Error(`WebCodecs export audio ${verification} — re-exporting`)
       }
       return result
     } catch (error) {
@@ -102,13 +106,15 @@ export async function exportProject(
 async function verifyOutputAudio(
   result: ExportResult,
   engine: 'webcodecs' | 'realtime',
-): Promise<'ok' | 'silent' | 'unknown'> {
+): Promise<'ok' | 'silent' | 'undecodable' | 'unknown'> {
   const inputPeak = decodedAudioMaxPeak()
   if (inputPeak < AUDIO_SILENCE_PEAK) return 'unknown'
   const measured = await measureBlobAudioPeak(result.blob)
   if (measured.peak === null) {
-    // Verification is blind here — silence would go unnoticed. Report so
-    // remote failures on decode-limited platforms are still attributable.
+    // Verification is blind here — report so remote failures on
+    // decode-limited platforms are still attributable. A file too large to
+    // decode is genuinely unknown; a file this very device REFUSES to
+    // decode right after writing it is evidence of a malformed track.
     reportError(
       new Error('Export output audio could not be verified'),
       'export-audio-verify',
@@ -120,7 +126,7 @@ async function verifyOutputAudio(
         ...(result.audioDiagnostics ?? {}),
       },
     )
-    return 'unknown'
+    return measured.failure === 'too large to verify' ? 'unknown' : 'undecodable'
   }
   if (measured.peak >= AUDIO_SILENCE_PEAK) return 'ok'
   reportError(
@@ -144,7 +150,7 @@ async function verifyOutputAudio(
 let audioSeamReported = false
 function maybeReportAudioSeamDiagnostics(
   result: ExportResult,
-  verification: 'ok' | 'silent' | 'unknown',
+  verification: 'ok' | 'silent' | 'undecodable' | 'unknown',
 ): void {
   const diagnostics = result.audioDiagnostics
   if (!diagnostics) return

--- a/src/lib/export/shared.ts
+++ b/src/lib/export/shared.ts
@@ -469,5 +469,7 @@ export interface ExportResult {
     injectedDescription: boolean
     adtsStripped: number
     timestampOverrides: number
+    encoderDescriptionHex: string | null
+    firstChunkPrefixHex: string | null
   }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

The telemetry from [#65](https://github.com/kentcdodds/kody-video/pull/65) worked: Peter's export on `b4a77b0` produced Sentry [KODY-VIDEO-9](https://kent-c-dodds-tech-llc.sentry.io/issues/) (`step: export-audio-verify`, tagged `ios`/`safari`) with the full picture:

- inputs loud and healthy (`inputPeak: 0.4766`), 235 AAC chunks emitted
- **no ADTS framing, no timestamp overrides, encoder provided a description** — all prior theories dead
- yet the finished file's audio is undecodable **on his own device**: native `decodeAudioData` rejects it and the mp4box demux fallback "returned nothing" — while his device happily decodes its own Safari-recorded clips, and ffmpeg/Chrome accept our file

Conclusion: the audio track we mux is malformed in some Apple-strict way. The encoder-provided `decoderConfig.description`, which we embed into `esds` verbatim, is the prime suspect (its content was never validated — everything else in the pipeline now is).

## How

1. **Always pin our own AudioSpecificConfig** (`aac.ts`): the encoder settings (AAC-LC, 48kHz, stereo) fully determine the correct 2 bytes, and Chrome's own description matches them exactly — so overriding unconditionally is a no-op on conforming platforms and removes the last untrusted bytes from the mux.
2. **Byte-level forensics in diagnostics**: when the encoder's description differs from the synthesized one, its length + hex lands in `encoderDescriptionHex`; the first chunk's 8-byte payload prefix lands in `firstChunkPrefixHex` (raw AAC vs ADTS vs LATM framing is identifiable at a glance). Both ride along on every audio report, so Peter's next event shows exactly what iOS emits.
3. **Fall back on undecodable output** (`index.ts`): "this device refuses to decode the file it just wrote" is now distinguished from "file too large to verify". The former triggers the same automatic re-export through the realtime engine as provably-silent output — MediaRecorder muxes platform-natively there, so **the user gets audio even while the WebCodecs-path root cause is still being pinned down**. Chrome always decodes its own output, so this can't misfire there.

## Testing

- `tsc`, 88 unit/integration tests (including the ffmpeg-backed AAC mux suite), and production build all green.
- The decisive test is Peter's next export: worst case it takes longer (auto-fallback) but has sound, and the forensic bytes tell us the true iOS story either way.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-16d17496-6b5b-4e12-b600-6933357c2059"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-16d17496-6b5b-4e12-b600-6933357c2059"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved AAC audio export compatibility by ensuring exported files include the correct decoder configuration.
  * WebCodecs exports now detect undecodable audio and automatically retry using a fallback path.
  * Improved handling of audio verification failures and oversized outputs.

* **Diagnostics**
  * Added more detailed audio export diagnostics to help identify encoding and playback issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->