### PR TITLE
Never pick the WebCodecs WebM path on iOS; try higher AVC levels first

### DIFF
--- a/src/lib/export/encode-webcodecs.ts
+++ b/src/lib/export/encode-webcodecs.ts
@@ -7,6 +7,7 @@ import {
   Muxer as WebmMuxer,
 } from 'webm-muxer'
 import { deriveProjectLocation } from '../geo'
+import { isIosBrowser } from '../media'
 import type { ClipRecord } from '../types'
 import { normalizeAacChunk, type AacChunkDiagnostics } from './aac'
 import { injectMp4Metadata, type Mp4Chapter } from './mp4-metadata'
@@ -87,21 +88,27 @@ function audioEncoderConfig(codec: string): AudioEncoderConfig {
 
 /**
  * Prefer MP4 (H.264 + AAC) because Android share targets accept it
- * universally; fall back to WebM (VP9/VP8 + Opus). A working audio encoder
- * is required — clips carry mic audio, so a silent WebCodecs export would be
- * strictly worse than the realtime fallback engine, which can mix audio.
+ * universally; try higher AVC levels before abandoning MP4 (High@4.0 caps
+ * near 1080p30 — clips from some cameras exceed it). WebM (VP9/VP8 + Opus)
+ * is the last resort, and NEVER on iOS: nothing there shares or plays WebM
+ * properly, and VP8/VP9 encoding is software-slow on iPhones (observed as a
+ * "frozen" export that eventually produced an unusable .webm). A working
+ * audio encoder is required — clips carry mic audio, so a silent WebCodecs
+ * export would be strictly worse than the realtime fallback engine.
  */
 async function pickCodecs(width: number, height: number): Promise<CodecChoice | null> {
-  const avc = 'avc1.640028'
   const aac = 'mp4a.40.2'
   const opus = 'opus'
 
-  if (
-    (await isVideoConfigSupported(videoEncoderConfig(avc, width, height))) &&
-    (await isAudioConfigSupported(audioEncoderConfig(aac)))
-  ) {
-    return { container: 'mp4', videoCodec: avc, audioCodec: aac }
+  if (await isAudioConfigSupported(audioEncoderConfig(aac))) {
+    // High profile at levels 4.0 → 5.1 (≈1080p30 → 4K).
+    for (const avc of ['avc1.640028', 'avc1.640032', 'avc1.640033']) {
+      if (await isVideoConfigSupported(videoEncoderConfig(avc, width, height))) {
+        return { container: 'mp4', videoCodec: avc, audioCodec: aac }
+      }
+    }
   }
+  if (isIosBrowser()) return null
   if (await isAudioConfigSupported(audioEncoderConfig(opus))) {
     for (const vp of ['vp09.00.31.08', 'vp8']) {
       if (await isVideoConfigSupported(videoEncoderConfig(vp, width, height))) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Peter's pre-`d6bce66` messages surfaced two new symptoms on iOS: exports of his **newly recorded clips** appeared frozen ("never seen it do that before"), and one that completed produced **WEBM · 4.4 MB** — on an iPhone.

## Why

`pickCodecs` probes H.264 High@4.0 (`avc1.640028`) and falls through to WebM when the MP4 pair is unsupported. His new clips (captured through the combined mic+camera stream) evidently probe at dimensions beyond what High@4.0 supports, so iOS took the WebM path — meaning **software VP8/VP9 encoding on an iPhone** (the "freeze": it crawls, then finishes) and a `.webm` file that iOS can't share to Photos or reliably play regardless of its audio. His older clip re-exported through MP4 on the same phone minutes earlier (per the Sentry events), which is why the behavior looked inconsistent.

## How

- `pickCodecs` now tries AVC High levels 4.0 → 5.0 → 5.1 (`avc1.640028` / `avc1.640032` / `avc1.640033`, ≈1080p30 → 4K) before abandoning MP4, so larger clips keep hardware H.264.
- On iOS (`isIosBrowser()`), the WebM branch is skipped entirely: no MP4 support means returning null, which routes the export to the **realtime engine** — platform-native MediaRecorder MP4, hardware-encoded, shareable, and (per the [#66](https://github.com/kentcdodds/kody-video/pull/66) work) the engine immune to the strict-decoder audio faults.
- Non-iOS behavior is unchanged apart from the extra AVC level candidates (the WebM fallback still exists for e.g. Chromium builds without proprietary codecs).

## Testing

- `tsc`, 88 tests, production build all green.
- Codec-selection-only change; the export pipeline itself is covered by the existing probes and the ffmpeg-backed mux tests. Real-device confirmation rides on Peter's next round (his new-clip projects should now export via MP4 at speed, or via the realtime engine — never a frozen WebM crawl).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-16d17496-6b5b-4e12-b600-6933357c2059"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-16d17496-6b5b-4e12-b600-6933357c2059"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

