### PR TITLE
Harden iOS export clip load (MEDIA_ERR_SRC_NOT_SUPPORTED)

### DIFF
--- a/src/lib/export/blob-for-playback.test.ts
+++ b/src/lib/export/blob-for-playback.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest'
+import { blobForPlayback } from './shared'
+
+describe('blobForPlayback', () => {
+  it('returns the same blob when mime matches or is omitted', () => {
+    const blob = new Blob(['clip'], { type: 'video/mp4' })
+    expect(blobForPlayback(blob)).toBe(blob)
+    expect(blobForPlayback(blob, 'video/mp4')).toBe(blob)
+    expect(blobForPlayback(blob, '  video/mp4  ')).toBe(blob)
+  })
+
+  it('retypes octet-stream and empty-type blobs with the clip mime', () => {
+    const generic = new Blob(['clip'], { type: 'application/octet-stream' })
+    const retyped = blobForPlayback(generic, 'video/mp4')
+    expect(retyped).not.toBe(generic)
+    expect(retyped.type).toBe('video/mp4')
+
+    const empty = new Blob(['clip'])
+    expect(blobForPlayback(empty, 'video/mp4').type).toBe('video/mp4')
+  })
+
+  it('prefers the clip mime when the blob type disagrees', () => {
+    const mistyped = new Blob(['clip'], { type: 'video/webm' })
+    const fixed = blobForPlayback(mistyped, 'video/mp4')
+    expect(fixed.type).toBe('video/mp4')
+  })
+})

--- a/src/lib/export/encode-realtime.ts
+++ b/src/lib/export/encode-realtime.ts
@@ -37,7 +37,8 @@ export async function exportRealtime(
   plan: ExportPlan,
   options: RealtimeExportOptions = {},
 ): Promise<ExportResult> {
-  const probe = await loadClipVideo(plan.segments[0].clip.blob)
+  const probeClip = plan.segments[0].clip
+  const probe = await loadClipVideo(probeClip.blob, 8000, probeClip.mimeType)
   const { width, height } = pickOutputSize(probe.video.videoWidth, probe.video.videoHeight)
   probe.release()
 
@@ -109,7 +110,7 @@ export async function exportRealtime(
   const frameCounter = { count: 0 }
   try {
     for (const segment of plan.segments) {
-      const loaded = await loadClipVideo(segment.clip.blob)
+      const loaded = await loadClipVideo(segment.clip.blob, 8000, segment.clip.mimeType)
       try {
         const clamped = clampSegmentToMedia(segment, loaded.mediaDurationMs)
         if (!clamped) continue

--- a/src/lib/export/encode-webcodecs.ts
+++ b/src/lib/export/encode-webcodecs.ts
@@ -143,7 +143,8 @@ export async function exportWithWebCodecs(
   }
 
   // Probe the first clip for output dimensions.
-  const probe = await loadClipVideo(plan.segments[0].clip.blob)
+  const probeClip = plan.segments[0].clip
+  const probe = await loadClipVideo(probeClip.blob, 8000, probeClip.mimeType)
   const { width, height } = pickOutputSize(probe.video.videoWidth, probe.video.videoHeight)
   probe.release()
 
@@ -267,7 +268,7 @@ export async function exportWithWebCodecs(
     for (const segment of plan.segments) {
       if (encoderError) throw encoderError
 
-      const loaded = await loadClipVideo(segment.clip.blob)
+      const loaded = await loadClipVideo(segment.clip.blob, 8000, segment.clip.mimeType)
       try {
         const clamped = clampSegmentToMedia(segment, loaded.mediaDurationMs)
         if (!clamped) continue

--- a/src/lib/export/media-error.test.ts
+++ b/src/lib/export/media-error.test.ts
@@ -40,4 +40,12 @@ describe('isMediaElementFailure', () => {
       false,
     )
   })
+
+  it('exposes MediaError.code for remote triage', () => {
+    const error = new MediaElementFailureError('loadedmetadata', {
+      error: { code: 4 },
+    })
+    expect(error.mediaErrorCode).toBe(4)
+    expect(new MediaElementFailureError('loadedmetadata', {}).mediaErrorCode).toBeUndefined()
+  })
 })

--- a/src/lib/export/media-error.ts
+++ b/src/lib/export/media-error.ts
@@ -20,10 +20,14 @@ export const MEDIA_ELEMENT_FAILURE = Symbol('kody.mediaElementFailure')
 
 export class MediaElementFailureError extends Error {
   readonly [MEDIA_ELEMENT_FAILURE] = true as const
+  /** Browser MediaError.code when present (1–4); useful for remote triage. */
+  readonly mediaErrorCode?: number
 
   constructor(event: string, media: MediaElementLike) {
     super(`Media failed while waiting for "${event}"${mediaErrorDetail(media)}`)
     this.name = 'MediaElementFailureError'
+    const code = media.error?.code
+    if (typeof code === 'number') this.mediaErrorCode = code
   }
 }
 

--- a/src/lib/export/shared.ts
+++ b/src/lib/export/shared.ts
@@ -10,25 +10,52 @@ export interface LoadedClipVideo {
   release: () => void
 }
 
-/** Pause briefly so a previous video/camera can release a hardware decoder. */
-const MEDIA_LOAD_RETRY_DELAY_MS = 200
+/**
+ * Backoff between loadClipVideo retries. Hardware decoder slots (camera,
+ * editor preview, a prior failed open) often take a few hundred ms to free
+ * on Android and iOS WebKit — which can report the race as
+ * MEDIA_ERR_SRC_NOT_SUPPORTED even for a blob that played moments earlier.
+ */
+const MEDIA_LOAD_RETRY_DELAYS_MS = [200, 500, 1000]
+
+/**
+ * Prefer the clip's recorded MIME type when the Blob's type is missing,
+ * generic, or disagrees. Safari rejects object URLs typed as
+ * `application/octet-stream` with MEDIA_ERR_SRC_NOT_SUPPORTED.
+ */
+export function blobForPlayback(blob: Blob, mimeType?: string): Blob {
+  const preferred = (mimeType || '').trim()
+  if (!preferred || preferred === blob.type) return blob
+  return new Blob([blob], { type: preferred })
+}
 
 /**
  * Load a clip blob into an off-DOM video element and resolve its real
  * duration. MediaRecorder WebM blobs report `Infinity` until you seek far
  * past the end, so that dance is handled here.
  *
- * Retries once on media-element failure: Android often rejects the first
- * open when a just-unmounted preview/camera still holds a decoder slot.
+ * Retries on media-element failure: Android/iOS often reject the first open
+ * when a just-unmounted preview/camera still holds a decoder slot.
  */
-export async function loadClipVideo(blob: Blob, timeoutMs = 8000): Promise<LoadedClipVideo> {
-  try {
-    return await loadClipVideoOnce(blob, timeoutMs)
-  } catch (error) {
-    if (!isMediaElementFailure(error)) throw error
-    await wait(MEDIA_LOAD_RETRY_DELAY_MS)
-    return loadClipVideoOnce(blob, timeoutMs)
+export async function loadClipVideo(
+  blob: Blob,
+  timeoutMs = 8000,
+  mimeType?: string,
+): Promise<LoadedClipVideo> {
+  const playable = blobForPlayback(blob, mimeType)
+  let lastError: unknown
+  for (let attempt = 0; attempt <= MEDIA_LOAD_RETRY_DELAYS_MS.length; attempt += 1) {
+    try {
+      return await loadClipVideoOnce(playable, timeoutMs)
+    } catch (error) {
+      lastError = error
+      if (!isMediaElementFailure(error)) throw error
+      const delay = MEDIA_LOAD_RETRY_DELAYS_MS[attempt]
+      if (delay === undefined) break
+      await wait(delay)
+    }
   }
+  throw lastError
 }
 
 async function loadClipVideoOnce(blob: Blob, timeoutMs: number): Promise<LoadedClipVideo> {
@@ -51,8 +78,15 @@ async function loadClipVideoOnce(blob: Blob, timeoutMs: number): Promise<LoadedC
   }
 
   try {
+    // Attach the listener before assigning src/load so a synchronous
+    // loadedmetadata cannot slip past (WebKit sometimes fires promptly for
+    // already-buffered blob URLs).
+    const metadataReady = waitForMediaEvent(video, 'loadedmetadata', timeoutMs)
     video.src = url
-    await waitForMediaEvent(video, 'loadedmetadata', timeoutMs)
+    // Explicit load() helps WebKit pick up a freshly assigned blob URL after
+    // a prior media element on the same page was torn down.
+    video.load()
+    await metadataReady
 
     let durationSec = video.duration
     if (!Number.isFinite(durationSec) || durationSec <= 0) {

--- a/src/lib/storage.test.ts
+++ b/src/lib/storage.test.ts
@@ -135,6 +135,13 @@ describe('storage layer', () => {
     expect(await copy.text()).toBe('recorder-bytes')
   })
 
+  it('toStoredBlob falls back to the clip mime when Blob.type is empty', async () => {
+    const original = new Blob(['untyped'], { type: '' })
+    const copy = await toStoredBlob(original, 'video/mp4')
+    expect(copy.type).toBe('video/mp4')
+    expect(await copy.text()).toBe('untyped')
+  })
+
   it('addClip persists a durable copy, not the caller Blob reference', async () => {
     const project = await createProject('Durable')
     const original = fakeBlob('take-1')

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -243,10 +243,13 @@ export interface AddClipInput {
  * MediaRecorder / File-backed blobs can fail Chromium's object-store write
  * with UnknownError ("Error preparing Blob/File data to be stored…") when
  * the original backing store is ephemeral or already released.
+ *
+ * Prefer `mimeType` when the source Blob's type is empty so Safari does not
+ * later reject an `application/octet-stream` object URL at export.
  */
-export async function toStoredBlob(blob: Blob): Promise<Blob> {
+export async function toStoredBlob(blob: Blob, mimeType?: string): Promise<Blob> {
   const buffer = await blob.arrayBuffer()
-  return new Blob([buffer], { type: blob.type || 'application/octet-stream' })
+  return new Blob([buffer], { type: blob.type || mimeType || 'application/octet-stream' })
 }
 
 export async function addClip(input: AddClipInput): Promise<ClipRecord> {
@@ -254,7 +257,7 @@ export async function addClip(input: AddClipInput): Promise<ClipRecord> {
   // Materialize before opening the transaction — awaiting inside a tx lets
   // IndexedDB auto-commit and abort subsequent puts. Re-read the project
   // inside the tx so overlapping saves cannot clobber fresher clipIds.
-  const durableBlob = await toStoredBlob(input.blob)
+  const durableBlob = await toStoredBlob(input.blob, input.mimeType)
 
   const now = Date.now()
   const clip: ClipRecord = {
@@ -384,7 +387,7 @@ export async function duplicateClip(clipId: ClipId): Promise<ClipRecord> {
 
   const now = Date.now()
   const [blob, thumbs, poster] = await Promise.all([
-    toStoredBlob(source.blob),
+    toStoredBlob(source.blob, source.mimeType),
     source.thumbs
       ? Promise.all(source.thumbs.map((thumb) => toStoredBlob(thumb)))
       : Promise.resolve(undefined),

--- a/src/pages/project-page.tsx
+++ b/src/pages/project-page.tsx
@@ -17,10 +17,13 @@ import { RestoreSheet } from '../components/restore-sheet'
 import { REMOVE_WATERMARK_LINK } from '../lib/entitlement'
 import { clearExportMarker, markExportStarted, reportError } from '../lib/error-reporting'
 import { exportProject, type ExportResult } from '../lib/export'
+import { MediaElementFailureError } from '../lib/export/media-error'
+import { wait } from '../lib/export/shared'
 import {
   canShareFile,
   downloadBlob,
   downloadClipsAsSeparateFiles,
+  isIosBrowser,
   projectFilename,
   shareFile,
 } from '../lib/media'
@@ -112,6 +115,7 @@ export function ProjectPage() {
   }, [])
 
   const clips = data.clips
+  const stopCamera = camera.stop
 
   const startExport = useCallback(() => {
     if (clips.length === 0) return
@@ -132,6 +136,11 @@ export function ProjectPage() {
     }
 
     const watermarked = !data.watermarkRemoved
+    // Stop camera/mic immediately rather than waiting on record-screen
+    // unmount. On iOS the combined mic+camera session can hold decoder
+    // slots past the first paints, and WebKit reports that race as
+    // MEDIA_ERR_SRC_NOT_SUPPORTED for an otherwise playable clip.
+    stopCamera()
     setExportState({
       status: 'exporting',
       progress: 0,
@@ -149,6 +158,10 @@ export function ProjectPage() {
         // the wait still closes the tap-created AudioContext.
         await waitForNextPaint()
         await waitForNextPaint()
+        // iOS WebKit frees hardware decoders asynchronously after stop();
+        // two frames alone was enough on Android but not after the combined
+        // mic+camera capture path.
+        if (isIosBrowser()) await wait(400)
         if (exportRunRef.current !== runId) return
 
         // If the page dies mid-export (tab crash / OOM — no JS error fires),
@@ -179,7 +192,13 @@ export function ProjectPage() {
       } catch (err) {
         // Report even when the run was abandoned (closed sheet / retry) —
         // only the UI update is stale, the failure is real.
-        reportError(err, 'export', { clips: clips.length })
+        reportError(err, 'export', {
+          clips: clips.length,
+          clipMimeTypes: clips.map((clip) => clip.mimeType),
+          clipSizes: clips.map((clip) => clip.blob.size),
+          mediaErrorCode:
+            err instanceof MediaElementFailureError ? err.mediaErrorCode : undefined,
+        })
         if (exportRunRef.current !== runId) return
         setExportState({
           status: 'error',
@@ -199,7 +218,7 @@ export function ProjectPage() {
         }
       }
     })()
-  }, [clips, data.watermarkRemoved])
+  }, [clips, data.watermarkRemoved, stopCamera])
 
   const closeExport = useCallback(() => {
     exportRunRef.current += 1


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Sentry [7643113076](https://sentry.io/organizations/kent-c-dodds-tech-llc/issues/7643113076/): handled export error `MediaElementFailureError: Media failed while waiting for "loadedmetadata" (MEDIA_ERR_SRC_NOT_SUPPORTED)` on **iOS Safari**, release `97bb09d` (1 event).

## Why

Same class as KODY-VIDEO-4 (decoder-slot race at export), but on iOS after the combined mic+camera capture path. Clips that measured fine at record time fail when export opens a new `<video>` while camera/preview slots are still releasing — WebKit surfaces that as `MEDIA_ERR_SRC_NOT_SUPPORTED`, not a distinct “busy” code. Two rAF waits + one 200ms retry were enough on Android; not after the iOS combined session.

Separately, a Blob typed `application/octet-stream` (empty `blob.type` at store time) is rejected by Safari the same way, so storage/playback now prefer the clip’s recorded MIME.

## How

- Stop the camera/mic immediately when export starts (don’t wait for record-screen unmount)
- Extra 400ms settle on iOS after the two paint waits
- `loadClipVideo` retries media-element failures with 200/500/1000ms backoff; attaches listeners before `src`/`load()`
- `blobForPlayback` + export engines pass `clip.mimeType`; `toStoredBlob` falls back to it when `Blob.type` is empty
- Export Sentry extras include clip mime/sizes and `mediaErrorCode`

## Testing

- Unit tests for `blobForPlayback`, media-error code exposure, storage mime fallback
- `npm run build`, `npx vitest run` (93), `node scripts/manual-smoke.mjs` (32/32) — all green
- Squash-merged as `4aef31f`; Cloudflare Pages deploy succeeded; Sentry issue resolved in commit

Siblings (silent export audio / verify failures / IndexedDB blob prep) do **not** share this root cause and were left alone.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-84db932d-c790-4422-aaa0-bdb1e312b62e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-84db932d-c790-4422-aaa0-bdb1e312b62e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved video export reliability, including better handling of browser media-loading failures and automatic retries.
  * Preserved clip media types during storage, duplication, and playback to prevent compatibility issues.
  * Improved export behavior on iOS by releasing camera resources before processing begins.
* **Diagnostics**
  * Export error reports now include clip media details and browser media error codes for easier troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->