### PR TITLE
Fix post-take black flash; iOS uses the OS multi-lens camera instead of a 6-way lens chip

### DIFF
--- a/manual-test-checklist.md
+++ b/manual-test-checklist.md
@@ -14,7 +14,7 @@ Run locally with HTTPS or `localhost` (`npm run dev`). Camera/mic require a secu
 - [ ] If the mic is blocked in site settings, a red "Mic blocked" pill shows on the record screen (Brave/Android regression)
 - [ ] Torch toggle appears on devices with a flash; zoom chips appear when supported
 - [ ] Phones with multiple rear cameras show a lens chip (e.g. "1/3") that switches to the ultra-wide/telephoto; choice sticks across flips and restarts (Android only)
-- [ ] iOS: NO lens chip; the camera opens as the virtual multi-lens device (Back Dual Wide/Triple) so zoom spans 0.5× to max seamlessly
+- [ ] iOS: NO lens chip; on multi-lens iPhones the camera opens as the virtual multi-lens device (Back Dual Wide/Triple) so zoom spans 0.5× to max seamlessly (single-lens iPhones use the plain back camera — no 0.5×)
 - [ ] Ending a take does not flash the camera preview black (Android regression check)
 - [ ] Backgrounding the app releases camera/mic (green dot goes out); returning restarts the preview
 - [ ] Backgrounding mid-recording still saves the take

--- a/manual-test-checklist.md
+++ b/manual-test-checklist.md
@@ -13,7 +13,9 @@ Run locally with HTTPS or `localhost` (`npm run dev`). Camera/mic require a secu
 - [ ] A take with a dead/covered mic shows the red "Mic isn't picking up sound" pill after ~2.5s; a take with sound clears it
 - [ ] If the mic is blocked in site settings, a red "Mic blocked" pill shows on the record screen (Brave/Android regression)
 - [ ] Torch toggle appears on devices with a flash; zoom chips appear when supported
-- [ ] Phones with multiple rear cameras show a lens chip (e.g. "1/3") that switches to the ultra-wide/telephoto; choice sticks across flips and restarts
+- [ ] Phones with multiple rear cameras show a lens chip (e.g. "1/3") that switches to the ultra-wide/telephoto; choice sticks across flips and restarts (Android only)
+- [ ] iOS: NO lens chip; the camera opens as the virtual multi-lens device (Back Dual Wide/Triple) so zoom spans 0.5× to max seamlessly
+- [ ] Ending a take does not flash the camera preview black (Android regression check)
 - [ ] Backgrounding the app releases camera/mic (green dot goes out); returning restarts the preview
 - [ ] Backgrounding mid-recording still saves the take
 - [ ] Screen off → on while on the camera view: preview is live again, not frozen; recording works

--- a/src/components/record-screen.tsx
+++ b/src/components/record-screen.tsx
@@ -210,7 +210,18 @@ export function RecordScreen({
     zoomRestoreRafRef.current = requestAnimationFrame(tick)
   }, [camera])
 
+  const releaseWakeLock = useCallback(() => {
+    wakeLockGenRef.current += 1
+    void wakeLockRef.current?.release().catch(() => undefined)
+    wakeLockRef.current = null
+  }, [])
+
   const acquireWakeLock = useCallback(() => {
+    // A successor take can start while the previous take's save is still in
+    // flight (its cleanup defers to us) — release the previous sentinel
+    // before acquiring ours, or it would be overwritten and leak, keeping
+    // the screen awake indefinitely.
+    releaseWakeLock()
     const generation = wakeLockGenRef.current
     void navigator.wakeLock
       ?.request('screen')
@@ -223,13 +234,7 @@ export function RecordScreen({
         wakeLockRef.current = sentinel
       })
       .catch(() => undefined)
-  }, [])
-
-  const releaseWakeLock = useCallback(() => {
-    wakeLockGenRef.current += 1
-    void wakeLockRef.current?.release().catch(() => undefined)
-    wakeLockRef.current = null
-  }, [])
+  }, [releaseWakeLock])
 
   /** Stops the active screen capture and appends it as a clip. Idempotent. */
   const finishScreenRecord = useCallback(async () => {
@@ -360,7 +365,15 @@ export function RecordScreen({
         }
         return true
       } catch (err) {
-        if (!recorderRef.current.isRecording) camera.releaseMic()
+        if (!recorderRef.current.isRecording) {
+          camera.releaseMic()
+          // A previous take whose deferred cleanup we pre-empted (its
+          // finally saw our beginInFlight and skipped) must not leak its
+          // monitor or wake lock when we then fail to start.
+          micMonitorRef.current?.stop()
+          micMonitorRef.current = null
+          releaseWakeLock()
+        }
         showToast(err instanceof Error ? err.message : 'Could not start recording')
         pointerIdRef.current = null
         setRecordingMode(null)
@@ -369,7 +382,7 @@ export function RecordScreen({
         beginInFlightRef.current = false
       }
     },
-    [acquireWakeLock, camera, countdown, recording, showToast, storageState],
+    [acquireWakeLock, camera, countdown, recording, releaseWakeLock, showToast, storageState],
   )
 
   const endRecord = useCallback(

--- a/src/components/record-screen.tsx
+++ b/src/components/record-screen.tsx
@@ -398,8 +398,6 @@ export function RecordScreen({
       endInFlightRef.current = true
       pointerIdRef.current = null
       keyboardTakeRef.current = false
-      micMonitorRef.current?.stop()
-      micMonitorRef.current = null
       setRecording(false)
       setRecordingMode(null)
       // Detach this take's fix before any await so a quick next hold can own the ref.
@@ -437,8 +435,13 @@ export function RecordScreen({
         endInFlightRef.current = false
         // stop() resolves only after the blob's duration is measured, so a
         // quick next hold may already be recording (or acquiring the mic) by
-        // now — never strip the mic or wake lock from that newer session.
+        // now — never strip the mic, monitor, or wake lock from that newer
+        // session. Tearing the monitor down only after the encoder flushed
+        // matters too: audio-graph churn while MediaRecorder still owned
+        // the tracks flashed the preview black on some Androids.
         if (!recorderRef.current.isRecording && !beginInFlightRef.current) {
+          micMonitorRef.current?.stop()
+          micMonitorRef.current = null
           camera.releaseMic()
           releaseWakeLock()
         }

--- a/src/hooks/use-camera.ts
+++ b/src/hooks/use-camera.ts
@@ -286,8 +286,27 @@ export function useCamera(): UseCameraResult {
       try {
         const rememberedLens =
           facingRef.current === 'environment' ? await resolveRearLens() : undefined
-        const next = await openCombinedOrVideoStream(facingRef.current, rememberedLens)
+        let next = await openCombinedOrVideoStream(facingRef.current, rememberedLens)
         setPermission({ status: 'granted' })
+        // iOS first run: device labels are empty before the permission grant,
+        // so the preferred multi-lens camera can't be resolved until now.
+        // Re-resolve and reopen once so 0.5× works from the very first
+        // session, not just after a restart.
+        if (isIosBrowser() && !rememberedLens && facingRef.current === 'environment') {
+          const preferred = await preferredIosRearCameraId()
+          const activeId = next.getVideoTracks()[0]?.getSettings().deviceId
+          if (preferred && preferred !== activeId) {
+            const epoch = cameraEpochRef.current
+            // iOS camera access is exclusive — release before reopening.
+            stopStream(next)
+            const reopened = await openCombinedOrVideoStream(facingRef.current, preferred)
+            if (cameraEpochRef.current !== epoch) {
+              stopStream(reopened)
+              return
+            }
+            next = reopened
+          }
+        }
         replaceStream(next)
         setCanFlip(await canFlipCamera())
         void syncRearLenses(next)

--- a/src/hooks/use-camera.ts
+++ b/src/hooks/use-camera.ts
@@ -5,6 +5,7 @@ import {
   listRearCameras,
   openCameraStream,
   openMicrophoneTrack,
+  preferredIosRearCameraId,
   primeMicrophonePermission,
   queryCameraPermission,
   queryMicrophonePermission,
@@ -73,8 +74,12 @@ function rememberRearLens(lens: RememberedLens | null): void {
 }
 
 /** Resolve a remembered lens against the current enumeration: exact id when
- * still valid, otherwise the same position, otherwise nothing. */
-async function resolveRememberedLens(): Promise<string | undefined> {
+ * still valid, otherwise the same position, otherwise nothing. On iOS the
+ * lens choice belongs to the OS instead (see preferredIosRearCameraId) —
+ * the virtual composite camera covers all lenses through zoom, and any
+ * remembered raw lens from before is ignored. */
+async function resolveRearLens(): Promise<string | undefined> {
+  if (isIosBrowser()) return preferredIosRearCameraId()
   const remembered = rememberedRearLens()
   if (!remembered) return undefined
   const lenses = await listRearCameras()
@@ -240,9 +245,12 @@ export function useCamera(): UseCameraResult {
     [attachToVideo, readTrackCapabilities],
   )
 
-  /** Discover rear lenses and locate the active one (post-permission only). */
+  /** Discover rear lenses and locate the active one (post-permission only).
+   * Not on iOS: the OS handles lens switching through the virtual composite
+   * camera's zoom range, and offering six raw devices (physical lenses plus
+   * composites) as a cycling chip is confusing noise there. */
   const syncRearLenses = useCallback(async (active: MediaStream) => {
-    if (facingRef.current !== 'environment') {
+    if (facingRef.current !== 'environment' || isIosBrowser()) {
       rearLensesRef.current = []
       setRearLensCount(0)
       setRearLensIndex(0)
@@ -277,7 +285,7 @@ export function useCamera(): UseCameraResult {
 
       try {
         const rememberedLens =
-          facingRef.current === 'environment' ? await resolveRememberedLens() : undefined
+          facingRef.current === 'environment' ? await resolveRearLens() : undefined
         const next = await openCombinedOrVideoStream(facingRef.current, rememberedLens)
         setPermission({ status: 'granted' })
         replaceStream(next)
@@ -321,7 +329,7 @@ export function useCamera(): UseCameraResult {
     setError(null)
     try {
       const rememberedLens =
-        nextFacing === 'environment' ? await resolveRememberedLens() : undefined
+        nextFacing === 'environment' ? await resolveRearLens() : undefined
       const next = await openCombinedOrVideoStream(nextFacing, rememberedLens)
       replaceStream(next)
       void syncRearLenses(next)

--- a/src/lib/media.ts
+++ b/src/lib/media.ts
@@ -130,6 +130,39 @@ export async function listRearCameras(): Promise<string[]> {
   }
 }
 
+/**
+ * iOS exposes every physical rear lens AND virtual composites ("Back Dual
+ * Wide Camera", "Back Triple Camera") as separate devices — six on recent
+ * iPhones. The composites hand lens switching to the OS: one device whose
+ * zoom constraint spans 0.5× to max seamlessly, exactly like the native
+ * camera app. Prefer them; cycling raw devices (the Android pattern) is
+ * confusing there and records at surprising resolutions. Labels are only
+ * populated once camera permission is granted; undefined falls back to the
+ * default facing-mode camera.
+ */
+export async function preferredIosRearCameraId(): Promise<string | undefined> {
+  if (!navigator.mediaDevices?.enumerateDevices) return undefined
+  try {
+    const devices = await navigator.mediaDevices.enumerateDevices()
+    const rear = devices.filter(
+      (device) => device.kind === 'videoinput' && /\bback\b/i.test(device.label),
+    )
+    const byPreference = [
+      /back triple camera/i,
+      /back dual wide camera/i,
+      /back dual camera/i,
+      /^back camera$/i,
+    ]
+    for (const pattern of byPreference) {
+      const match = rear.find((device) => pattern.test(device.label))
+      if (match?.deviceId) return match.deviceId
+    }
+  } catch {
+    // Fall through to the default camera.
+  }
+  return undefined
+}
+
 /** Grab a mic track only for the duration of a recording. */
 export async function openMicrophoneTrack(): Promise<MediaStreamTrack> {
   // Camera-app audio, not voice-call audio: echoCancellation/noiseSuppression/

--- a/src/lib/mic-monitor.ts
+++ b/src/lib/mic-monitor.ts
@@ -15,6 +15,25 @@ export interface MicLevelMonitor {
 }
 
 /**
+ * One shared AudioContext for all takes, suspended between them. Creating
+ * and closing a context around every take churns the platform audio graph
+ * while MediaRecorder still owns the tracks — observed on Android as the
+ * camera preview flashing black right after a take ends.
+ */
+let sharedContext: AudioContext | null = null
+
+function acquireContext(): AudioContext | null {
+  if (typeof AudioContext === 'undefined') return null
+  try {
+    sharedContext ??= new AudioContext()
+    void sharedContext.resume().catch(() => undefined)
+    return sharedContext
+  } catch {
+    return null
+  }
+}
+
+/**
  * Watches the stream's audio track through an AnalyserNode (a passive extra
  * consumer — MediaRecorder is unaffected). Calls onSilent when the take has
  * gone a full grace period without any signal above the floor — whether from
@@ -26,11 +45,12 @@ export function startMicLevelMonitor(
   handlers: { onSilent: () => void; onSound: () => void },
 ): MicLevelMonitor {
   const track = stream.getAudioTracks().find((t) => t.readyState === 'live')
-  if (!track || typeof AudioContext === 'undefined') {
+  const context = track ? acquireContext() : null
+  if (!track || !context) {
     return { stop: () => undefined }
   }
 
-  let context: AudioContext | null = null
+  let source: MediaStreamAudioSourceNode | null = null
   let analyser: AnalyserNode | null = null
   let timer = 0
   let startedAt = 0
@@ -39,20 +59,20 @@ export function startMicLevelMonitor(
     window.clearInterval(timer)
     timer = 0
     try {
+      source?.disconnect()
       analyser?.disconnect()
     } catch {
       // Already torn down.
     }
-    void context?.close().catch(() => undefined)
-    context = null
+    source = null
     analyser = null
+    // Suspend (never close) the shared context — see acquireContext.
+    void sharedContext?.suspend().catch(() => undefined)
   }
 
   try {
-    context = new AudioContext()
-    void context.resume().catch(() => undefined)
     // A dedicated audio-only stream keeps Safari's MediaStreamSource happy.
-    const source = context.createMediaStreamSource(new MediaStream([track]))
+    source = context.createMediaStreamSource(new MediaStream([track]))
     analyser = context.createAnalyser()
     analyser.fftSize = 2048
     source.connect(analyser)

--- a/src/lib/mic-monitor.ts
+++ b/src/lib/mic-monitor.ts
@@ -81,6 +81,10 @@ export function startMicLevelMonitor(
     return { stop: () => undefined }
   }
 
+  // A released mic reads all-zero — a leaked monitor sampling a dead track
+  // must never fire a false "mic silent" warning.
+  track.addEventListener('ended', stop)
+
   const samples = new Float32Array(analyser.fftSize)
   /** When signal was last heard; silence is judged on a rolling window so a
    * mic dying mid-take gets flagged too, not just one that was dead at the


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Two field reports:

1. **Kent (Android)**: since the silent-mic monitor shipped, the camera preview flashes black once or twice right after a take ends.
2. **Peter (iOS)**: a mystery "3/6" chip on the record screen that "changes the zoom levels available as you cycle thru all 6 options" — and a suspicion it's how his odd-resolution clip (the WebM-path trigger from #67) got recorded.

## How

### Black flash after takes

The mic-level monitor created and closed an `AudioContext` around every take; tearing down the audio graph while `MediaRecorder` still owned the tracks churns the platform audio pipeline. Now:

- One **shared `AudioContext`**, created once and **suspended** between takes instead of closed; per-take work is just a source + analyser node that get disconnected.
- Monitor teardown moved into `endRecord`'s `finally`, after the encoder has fully flushed — with the same newer-take guard the mic release uses, so a quick next hold never loses its monitor.

### iOS lens handling

iOS exposes every physical rear lens *and* virtual composites ("Back Dual Wide Camera", "Back Triple Camera") as devices — six on recent iPhones. Cycling raw devices is the Android pattern (where it's the only way to reach the ultra-wide); on iOS it's confusing noise, and the composites do the job properly: **one device whose zoom constraint spans 0.5× to max with OS-driven seamless lens switching**, exactly like the native camera app.

- New `preferredIosRearCameraId()`: prefers Back Triple → Back Dual Wide → Back Dual → Back Camera.
- `resolveRearLens()` uses it on iOS (ignoring any remembered raw lens from previous builds); Android behavior unchanged.
- `syncRearLenses` reports zero lenses on iOS, so the cycling chip never renders there and `switchRearLens` no-ops.

This also removes the likely source of surprise-resolution recordings on iOS (raw telephoto/composite devices probing at dimensions that pushed exports off the MP4 path in #67).

## Testing

- `tsc`, 93 tests, production build green.
- `probe-rear-lens.mjs` (Android lens chip behavior, fake cameras): all 6 checks pass — chip advance, persistence across reload/flip, recording on switched lens.
- `probe-mic-monitor.mjs`: silent-mic pill still fires and clears correctly with the shared context.
- `probe-keyboard.mjs`: full record/edit/playback flow regression pass.
- The black flash itself needs Kent's real device to confirm; the iOS lens behavior needs Peter's.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-16d17496-6b5b-4e12-b600-6933357c2059"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-16d17496-6b5b-4e12-b600-6933357c2059"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved iOS rear-camera selection to better match preferred back lenses and multi-lens zoom behavior.
* **Bug Fixes**
  * Prevented brief black flashes in the camera preview on Android when ending a recording.
  * Improved recording teardown to avoid mic-monitoring or power-saver issues impacting new/ongoing sessions.
* **Documentation**
  * Updated the manual test checklist with additional Camera/Android permission and multi-rear-lens edge-case coverage (including preview stability and zoom behavior).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->