### PR TITLE
Fix dead PWA update button: clientsClaim + forced-reload fallback

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -5,7 +5,7 @@ import { router } from './router'
 
 export function App() {
   const {
-    needRefresh: [needRefresh],
+    needRefresh: [needRefresh, setNeedRefresh],
     updateServiceWorker,
   } = useRegisterSW({
     immediate: true,
@@ -15,13 +15,25 @@ export function App() {
     },
   })
 
+  const applyUpdate = () => {
+    setNeedRefresh(false)
+    void updateServiceWorker(true).catch(() => undefined)
+    // clientsClaim + controllerchange normally reload the page. Workers
+    // deployed before clientsClaim never fire controllerchange, so tapping
+    // Update "did nothing" — the forced reload is what rescues those
+    // sessions (the new worker IS active by then; a reload runs under it).
+    window.setTimeout(() => {
+      window.location.reload()
+    }, 1500)
+  }
+
   return (
     <div className="app-shell">
       <RouterProvider router={router} />
       {needRefresh ? (
         <div className="update-toast" role="status">
           <span>A new version of Kody Video is ready</span>
-          <button type="button" onClick={() => void updateServiceWorker(true)}>
+          <button type="button" onClick={applyUpdate}>
             Update
           </button>
         </div>

--- a/src/lib/app-update.ts
+++ b/src/lib/app-update.ts
@@ -58,14 +58,7 @@ export async function checkForUpdates(): Promise<UpdateCheckResult> {
   // Follow the install through to `waiting`, then apply.
   const deadline = Date.now() + 8000
   while (Date.now() < deadline) {
-    if (reg.waiting) {
-      try {
-        await apply(true)
-        return 'updated'
-      } catch {
-        return 'unavailable'
-      }
-    }
+    if (reg.waiting) return applyAndReload(apply)
     if (!reg.installing) {
       // A worker appeared but is neither installing nor waiting anymore:
       // the install failed (worker went redundant). Don't claim "current".
@@ -74,14 +67,25 @@ export async function checkForUpdates(): Promise<UpdateCheckResult> {
     }
     await new Promise((resolve) => setTimeout(resolve, 200))
   }
-  if (reg.waiting) {
-    try {
-      await apply(true)
-      return 'updated'
-    } catch {
-      return 'unavailable'
-    }
-  }
+  if (reg.waiting) return applyAndReload(apply)
   if (reg.installing) return 'downloading'
   return 'current'
+}
+
+async function applyAndReload(
+  apply: (reloadPage?: boolean) => Promise<void>,
+): Promise<UpdateCheckResult> {
+  try {
+    await apply(true)
+  } catch {
+    return 'unavailable'
+  }
+  // Normally clientsClaim + controllerchange reload the page before this
+  // fires; service workers deployed before clientsClaim never emit
+  // controllerchange, which left the button looking dead. The new worker
+  // has been told to activate either way — reload under it.
+  window.setTimeout(() => {
+    window.location.reload()
+  }, 1500)
+  return 'updated'
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -64,6 +64,11 @@ export default defineConfig({
         ],
       },
       workbox: {
+        // Without clientsClaim the updated worker activates after
+        // SKIP_WAITING but never takes over the open client —
+        // `controllerchange` never fires, the update button appears to do
+        // nothing, and the toast sticks until a full app restart.
+        clientsClaim: true,
         globPatterns: ['**/*.{js,css,html,ico,png,svg,webp,woff2}'],
         // Not part of the app shell: the social card is for link scrapers
         // and the icon master is only the source for generated icons.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Kent (installed app, Android): tapping the update toast's Update button does nothing; About → Check for updates also doesn't clear the notice; only force-closing the app gets the new version.

## Why

The generated service worker had **no `clientsClaim()`**. The prompt-update chain is: Update tap → `SKIP_WAITING` message → new worker activates → *claims open clients* → `controllerchange` fires → `vite-plugin-pwa` reloads the page. Without `clientsClaim`, the activated worker never takes over the open client, `controllerchange` never fires, the reload never happens, and `needRefresh` stays truthy — the button looks dead and the toast is immortal until a full process restart (which finally boots under the already-activated new worker).

## How

- `workbox.clientsClaim: true` in the PWA config — fixes the chain for every worker built from now on.
- **Forced-reload fallback** (1.5s) in both the update toast handler and About's `checkForUpdates`: critical for the transition, because every *currently deployed* worker lacks `clientsClaim` — users updating from today's builds would still hit the dead chain. By the time the fallback fires, the new worker has been told to activate, so the reload comes up on the new version. The toast also clears immediately on tap (`setNeedRefresh(false)`).

## Testing

- `tsc`, 93 tests, production build green; `clientsClaim()` verified present in the generated `dist/sw.js`.
- Full verification needs the two-deploy dance on a real installed app (this deploy establishes the new worker; the *next* deploy exercises the new update path). The fallback reload covers the current-to-this-build step.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-16d17496-6b5b-4e12-b600-6933357c2059?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-16d17496-6b5b-4e12-b600-6933357c2059&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

