### PR TITLE
Kody Video Plus: 1 free project, lazy project creation on first clip

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,16 +149,21 @@ browsers only: `getDisplayMedia` does not exist on iOS or Android, so on
 phones use the OS screen recorder instead. The button hides itself where the
 API is missing.
 
-## Remove Watermark purchase
+## Kody Video Plus purchase
 
-Exports carry a small Kody Video mark in the corner. A one-time $0.99 Stripe
-Payment Link removes it: the export sheet links to checkout, Stripe redirects
-back to `/unlocked?session_id=…`, and a single Cloudflare Pages Function
+The free plan includes one project, and exports carry a small Kody Video mark
+in the corner. Kody Video Plus — a one-time $0.99 Stripe Payment Link —
+removes the watermark and unlocks six project slots: the export sheet (or a
+locked home slot) links to checkout, Stripe redirects back to
+`/unlocked?session_id=…`, and a single Cloudflare Pages Function
 (`functions/api/verify-purchase.ts`) verifies the session server-side before
 the entitlement is stored in IndexedDB. 100%-off promotion codes (friends /
 the developer) flow through the exact same verification. Restore on another
-device: paste the Stripe receipt link into "Already paid?" on the export
-sheet.
+device: "Already paid?" on the export sheet or a locked slot's upsell.
+
+Projects are also created lazily — "New project" opens the camera at
+`/project/new` and nothing is persisted until the first clip is recorded, so
+backing out of an untouched project leaves no empty slot behind.
 
 Deployment requirement: set `STRIPE_SECRET_KEY` (a restricted key with
 Checkout Sessions read access is enough) on the Cloudflare Pages project.

--- a/manual-test-checklist.md
+++ b/manual-test-checklist.md
@@ -91,7 +91,10 @@ Run locally with HTTPS or `localhost` (`npm run dev`). Camera/mic require a secu
 - [ ] Watermark (before purchase) shows the mark + domain at 50% opacity
 
 ## Projects
-- [ ] Create up to 6 projects; 7th is blocked with clear UX
+- [ ] Free plan: 1 project; slots 2–6 show a lock and open the Kody Video Plus upsell
+- [ ] After Plus purchase/restore: create up to 6 projects; 7th is blocked with clear UX
+- [ ] "New project" opens the camera without creating anything; backing out without recording leaves no project behind
+- [ ] Recording the first clip creates the project (URL flips from /project/new to the real id); the clip is saved
 - [ ] Slot order is stable (does not shuffle after opening projects)
 - [ ] Slots show poster art from the first clip
 - [ ] ⋯ menu: Open / Rename / Delete (styled confirm, no browser dialog)

--- a/src/components/export-sheet.tsx
+++ b/src/components/export-sheet.tsx
@@ -98,7 +98,7 @@ export function ExportSheet({
               <p className="watermark-note">
                 Includes a small Kody mark in the corner.{' '}
                 <button type="button" className="link-button" onClick={onRemoveWatermark}>
-                  Remove it — $0.99
+                  Get Plus — $0.99 removes it & unlocks 6 projects
                 </button>{' '}
                 ·{' '}
                 <button type="button" className="link-button" onClick={onRestorePurchase}>

--- a/src/components/icons.tsx
+++ b/src/components/icons.tsx
@@ -219,6 +219,15 @@ export function IconLens({ size = 22 }: IconProps) {
   )
 }
 
+export function IconLock({ size = 22 }: IconProps) {
+  return (
+    <svg {...baseProps(size)}>
+      <rect x="5" y="10.5" width="14" height="9.5" rx="2" />
+      <path d="M8 10.5V7.5a4 4 0 018 0v3" />
+    </svg>
+  )
+}
+
 /** Monitor with a record dot: screen recording. */
 export function IconScreen({ size = 22, on = false }: IconProps & { on?: boolean }) {
   return (

--- a/src/components/record-screen.tsx
+++ b/src/components/record-screen.tsx
@@ -18,7 +18,13 @@ import {
   storageSeverity,
   type StorageSpace,
 } from '../lib/storage-space'
-import { effectiveDurationMs, formatDuration, type ClipRecord, type Project } from '../lib/types'
+import {
+  effectiveDurationMs,
+  formatDuration,
+  type ClipRecord,
+  type Project,
+  type ProjectId,
+} from '../lib/types'
 import {
   IconBack,
   IconDeleteLast,
@@ -51,6 +57,9 @@ export interface ToastAction {
 
 interface RecordScreenProps {
   project: Project
+  /** Resolves the persisted project id, creating the project on the first
+   * recorded clip (a "/project/new" project exists only in the URL). */
+  ensureProjectId: () => Promise<ProjectId>
   clips: ClipRecord[]
   camera: UseCameraResult
   /** Device storage estimate for the almost-full warning. */
@@ -107,6 +116,7 @@ function nearestZoomLevel(levels: number[], value: number): number {
 
 export function RecordScreen({
   project,
+  ensureProjectId,
   clips,
   camera,
   storage,
@@ -249,7 +259,7 @@ export function RecordScreen({
         showToast('Screen take was too short')
         return
       }
-      await appendRecording(project.id, result)
+      await appendRecording(await ensureProjectId(), result)
       refresh()
       showToast('Screen clip added')
     } catch (err) {
@@ -258,7 +268,7 @@ export function RecordScreen({
     } finally {
       screenBusyRef.current = false
     }
-  }, [project.id, refresh, showToast])
+  }, [ensureProjectId, refresh, showToast])
 
   const startScreenRecord = useCallback(() => {
     void (async () => {
@@ -432,7 +442,7 @@ export function RecordScreen({
             }),
           ])
         }
-        await appendRecording(project.id, {
+        await appendRecording(await ensureProjectId(), {
           ...result,
           ...(fix
             ? { lat: fix.lat, lng: fix.lng, locationAccuracyM: fix.accuracyM }
@@ -460,7 +470,7 @@ export function RecordScreen({
         }
       }
     },
-    [camera, project.id, recording, refresh, releaseWakeLock, showToast],
+    [camera, ensureProjectId, recording, refresh, releaseWakeLock, showToast],
   )
 
   const startSelfTimer = useCallback(() => {

--- a/src/components/upsell-sheet.tsx
+++ b/src/components/upsell-sheet.tsx
@@ -1,0 +1,52 @@
+import { useSheetModal } from '../hooks/use-sheet-modal'
+import { REMOVE_WATERMARK_LINK } from '../lib/entitlement'
+import { MAX_PROJECTS } from '../lib/types'
+
+interface UpsellSheetProps {
+  onClose: () => void
+  /** Switch to the restore-purchase flow (owner keeps both sheets exclusive). */
+  onRestore: () => void
+}
+
+/** The one-time Kody Video Plus purchase: watermark removal + more projects. */
+export function UpsellSheet({ onClose, onRestore }: UpsellSheetProps) {
+  const bindSheet = useSheetModal({ onDismiss: onClose })
+
+  return (
+    <>
+      <div className="sheet-backdrop" onClick={onClose} />
+      <div
+        className="sheet"
+        role="dialog"
+        aria-modal="true"
+        aria-label="Kody Video Plus"
+        ref={bindSheet}
+      >
+        <h3>Kody Video Plus</h3>
+        <p className="sheet-copy">
+          The free plan includes 1 project. Plus is a one-time $0.99 purchase that unlocks{' '}
+          {MAX_PROJECTS} project slots and removes the watermark from exports — forever, on this
+          device and any device you restore it on.
+        </p>
+        <div className="sheet-actions">
+          <button type="button" className="btn btn-ghost" onClick={onClose}>
+            Not now
+          </button>
+          <button
+            type="button"
+            className="btn btn-primary"
+            onClick={() => {
+              window.open(REMOVE_WATERMARK_LINK, '_blank', 'noopener')
+              onClose()
+            }}
+          >
+            Get Plus — $0.99
+          </button>
+        </div>
+        <button type="button" className="link-button sheet-footnote" onClick={onRestore}>
+          Already paid? Restore your purchase
+        </button>
+      </div>
+    </>
+  )
+}

--- a/src/lib/project-actions.ts
+++ b/src/lib/project-actions.ts
@@ -16,6 +16,7 @@ import {
 import { estimateStorageSpace, type StorageSpace } from './storage-space'
 import { ensureClipThumbs } from './thumbs'
 import {
+  NEW_PROJECT_ID,
   effectiveDurationMs,
   type ClipId,
   type ClipRecord,
@@ -47,11 +48,17 @@ export interface ProjectLoaderData {
 export interface HomeLoaderData {
   projects: ProjectSummary[]
   storage: StorageSpace | null
+  /** True when the one-time Kody Video Plus purchase is unlocked. */
+  plus: boolean
 }
 
 export async function loadHomePage(): Promise<HomeLoaderData> {
-  const [projects, storage] = await Promise.all([loadHomeProjects(), estimateStorageSpace()])
-  return { projects, storage }
+  const [projects, storage, settings] = await Promise.all([
+    loadHomeProjects(),
+    estimateStorageSpace(),
+    getSettings(),
+  ])
+  return { projects, storage, plus: settings.watermarkRemoved === true }
 }
 
 export async function loadHomeProjects(): Promise<ProjectSummary[]> {
@@ -78,6 +85,33 @@ export async function loadHomeProjects(): Promise<ProjectSummary[]> {
 
 export async function loadProjectPage(projectId: ProjectId): Promise<ProjectLoaderData> {
   try {
+    // A "new" project lives only in the URL until the first clip is
+    // recorded — nothing is persisted, so backing out leaves nothing behind.
+    if (projectId === NEW_PROJECT_ID) {
+      const [projects, settings, storage] = await Promise.all([
+        listProjects(),
+        getSettings(),
+        estimateStorageSpace(),
+      ])
+      const now = Date.now()
+      return {
+        project: {
+          id: NEW_PROJECT_ID,
+          name: `Project ${projects.length + 1}`,
+          createdAt: now,
+          updatedAt: now,
+          clipIds: [],
+        },
+        clips: [],
+        canUndo: false,
+        onboardingDismissed: settings.onboardingDismissed,
+        watermarkRemoved: settings.watermarkRemoved === true,
+        storage,
+        locationTaggingEnabled: settings.locationTaggingEnabled === true,
+        error: null,
+      }
+    }
+
     const [project, clips, undo, settings, storage] = await Promise.all([
       getProject(projectId),
       getClipsForProject(projectId),

--- a/src/lib/storage.test.ts
+++ b/src/lib/storage.test.ts
@@ -19,6 +19,7 @@ import {
   undoDeleteLastClip,
   updateClipTrim,
 } from './storage'
+import { markWatermarkRemoved } from './entitlement'
 import { MAX_PROJECTS, effectiveDurationMs } from './types'
 
 function fakeBlob(label: string): Blob {
@@ -39,7 +40,13 @@ describe('storage layer', () => {
     expect((await getSettings()).onboardingDismissed).toBe(true)
   })
 
+  it('gates the second project behind the Plus purchase', async () => {
+    await createProject('Free one')
+    await expect(createProject('Second')).rejects.toThrow(/plus/i)
+  })
+
   it('creates and lists projects newest-first', async () => {
+    await markWatermarkRemoved('cs_test_storage')
     const a = await createProject('Alpha')
     const b = await createProject('Beta')
     const list = await listProjects()
@@ -48,6 +55,7 @@ describe('storage layer', () => {
   })
 
   it('enforces the soft project cap', async () => {
+    await markWatermarkRemoved('cs_test_storage')
     for (let i = 0; i < MAX_PROJECTS; i += 1) {
       await createProject(`P${i + 1}`)
     }

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -1,5 +1,6 @@
 import { openDB, type DBSchema, type IDBPDatabase } from 'idb'
 import {
+  FREE_PROJECTS,
   MAX_PROJECTS,
   newId,
   type AppMeta,
@@ -137,6 +138,14 @@ export async function createProject(name?: string): Promise<Project> {
   const settings = await getSettings()
   if (existing.length >= settings.maxProjects) {
     throw new Error(`Project limit reached (${settings.maxProjects}). Delete a project to create another.`)
+  }
+  // Free tier includes one project; the one-time Kody Video Plus purchase
+  // (the watermark unlock) raises the cap to maxProjects. Enforced here so
+  // every creation path (record, import) hits the same gate.
+  if (settings.watermarkRemoved !== true && existing.length >= FREE_PROJECTS) {
+    throw new Error(
+      'The free plan includes 1 project — Kody Video Plus unlocks 6 (and removes the watermark).',
+    )
   }
 
   const now = Date.now()

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -56,6 +56,13 @@ export interface AppMeta {
 
 export const MAX_PROJECTS = 6
 
+/** Projects included without the Kody Video Plus purchase. */
+export const FREE_PROJECTS = 1
+
+/** Route id for a project that exists only as a URL until the first clip is
+ * recorded — backing out of an empty "new project" leaves nothing behind. */
+export const NEW_PROJECT_ID: ProjectId = 'new'
+
 export function effectiveDurationMs(clip: Pick<ClipMeta, 'durationMs' | 'trimStartMs' | 'trimEndMs'>): number {
   const end = Math.min(clip.trimEndMs, clip.durationMs)
   const start = Math.max(0, Math.min(clip.trimStartMs, end))

--- a/src/pages/home-page.tsx
+++ b/src/pages/home-page.tsx
@@ -4,7 +4,9 @@ import { BlobImage } from '../components/blob-image'
 import { BrandMark } from '../components/brand-mark'
 import { ConfirmSheet } from '../components/confirm-sheet'
 import { HomeOptionsSheet } from '../components/home-options-sheet'
-import { IconClose, IconMore, IconPlus, IconShareIos } from '../components/icons'
+import { IconClose, IconLock, IconMore, IconPlus, IconShareIos } from '../components/icons'
+import { UpsellSheet } from '../components/upsell-sheet'
+import { RestoreSheet } from '../components/restore-sheet'
 import { RenameSheet } from '../components/rename-sheet'
 import { downloadBlob, shareOrDownload } from '../lib/media'
 import { loadHomePage, type HomeLoaderData, type ProjectSummary } from '../lib/project-actions'
@@ -15,7 +17,7 @@ import {
   projectBackupFilename,
   serializeProject,
 } from '../lib/project-transfer'
-import { createProject, deleteProject, getClipsForProject, renameProject } from '../lib/storage'
+import { deleteProject, getClipsForProject, renameProject } from '../lib/storage'
 import { reportError } from '../lib/error-reporting'
 import { canPromptInstall, promptInstall, subscribeInstallPrompt } from '../lib/install-prompt'
 import { dismissIosInstallHint, shouldShowIosInstallHint } from '../lib/install-hint'
@@ -25,7 +27,13 @@ import {
   requestPersistentStorage,
   storageSeverity,
 } from '../lib/storage-space'
-import { MAX_PROJECTS, formatDuration, type ClipRecord } from '../lib/types'
+import {
+  FREE_PROJECTS,
+  MAX_PROJECTS,
+  NEW_PROJECT_ID,
+  formatDuration,
+  type ClipRecord,
+} from '../lib/types'
 
 /** Android share targets get flaky well below this; bigger backups download. */
 const SHARE_BACKUP_LIMIT_BYTES = 50 * 1024 * 1024
@@ -40,7 +48,7 @@ export async function homeLoader(): Promise<HomeLoaderData> {
 }
 
 export function HomePage() {
-  const { projects, storage } = useLoaderData() as HomeLoaderData
+  const { projects, storage, plus } = useLoaderData() as HomeLoaderData
   const revalidator = useRevalidator()
   const navigate = useNavigate()
   const [error, setError] = useState<string | null>(null)
@@ -51,6 +59,8 @@ export function HomePage() {
   const [notice, setNotice] = useState<string | null>(null)
   const [importProgress, setImportProgress] = useState<string | null>(null)
   const [showInstallHint, setShowInstallHint] = useState(shouldShowIosInstallHint)
+  const [upselling, setUpselling] = useState(false)
+  const [restoring, setRestoring] = useState(false)
   // Prefetched when the options sheet opens so the Save-backup tap keeps its
   // user activation (Web Share needs it; an IndexedDB read can outlive it).
   const prefetchedClipsRef = useRef<{ projectId: string; clips: Promise<ClipRecord[]> } | null>(
@@ -65,21 +75,10 @@ export function HomePage() {
 
   const installable = useSyncExternalStore(subscribeInstallPrompt, canPromptInstall)
 
-  const createAndOpenProject = () => {
-    void (async () => {
-      setBusy(true)
-      setError(null)
-      try {
-        const project = await createProject()
-        // Their recordings should survive storage pressure.
-        requestPersistentStorage()
-        navigate(`/project/${project.id}`)
-      } catch (err) {
-        setError(err instanceof Error ? err.message : 'Could not create project')
-      } finally {
-        setBusy(false)
-      }
-    })()
+  // Nothing is persisted until the first clip is recorded — backing out of
+  // an untouched new project leaves no empty project behind.
+  const openNewProject = () => {
+    navigate(`/project/${NEW_PROJECT_ID}`)
   }
 
   const backupProject = (project: ProjectSummary) => {
@@ -148,7 +147,8 @@ export function HomePage() {
   }
 
   const slots = Array.from({ length: MAX_PROJECTS }, (_, index) => projects[index] ?? null)
-  const atCap = projects.length >= MAX_PROJECTS
+  const projectLimit = plus ? MAX_PROJECTS : FREE_PROJECTS
+  const atCap = projects.length >= projectLimit
   const severity = storage ? storageSeverity(storage.ratio) : 'ok'
   const oldestProject = projects[0] ?? null
 
@@ -262,19 +262,32 @@ export function HomePage() {
                 <IconMore />
               </button>
             </article>
-          ) : (
+          ) : index < projectLimit ? (
             <button
               key={`empty-${index}`}
               type="button"
               className="project-slot empty"
-              disabled={busy || atCap}
-              onClick={createAndOpenProject}
+              disabled={busy}
+              onClick={openNewProject}
             >
               <span className="slot-plus" aria-hidden="true">
                 <IconPlus size={26} />
               </span>
               <strong>New project</strong>
-              <small>{atCap ? 'Six-project limit' : `Slot ${index + 1}`}</small>
+              <small>{`Slot ${index + 1}`}</small>
+            </button>
+          ) : (
+            <button
+              key={`locked-${index}`}
+              type="button"
+              className="project-slot empty locked"
+              onClick={() => setUpselling(true)}
+            >
+              <span className="slot-plus" aria-hidden="true">
+                <IconLock size={22} />
+              </span>
+              <strong>Plus slot</strong>
+              <small>Unlock with Kody Video Plus</small>
             </button>
           ),
         )}
@@ -301,23 +314,32 @@ export function HomePage() {
       </p>
 
       <div className="home-footer">
-        <button
-          type="button"
-          className="btn btn-primary"
-          disabled={busy || atCap}
-          onClick={createAndOpenProject}
-        >
-          {atCap ? `Limit ${MAX_PROJECTS}` : 'New project'}
-        </button>
+        {atCap && !plus ? (
+          <button type="button" className="btn btn-primary" onClick={() => setUpselling(true)}>
+            Get more projects
+          </button>
+        ) : (
+          <button
+            type="button"
+            className="btn btn-primary"
+            disabled={busy || atCap}
+            onClick={openNewProject}
+          >
+            {atCap ? `Limit ${MAX_PROJECTS}` : 'New project'}
+          </button>
+        )}
         <label
           className={`btn btn-ghost home-import${busy ? ' is-disabled' : ''}`}
           onClick={(event) => {
-            if (atCap) {
-              event.preventDefault()
-              setError(
-                `Project limit reached (${MAX_PROJECTS}). Delete a project before importing.`,
-              )
+            if (!atCap) return
+            event.preventDefault()
+            if (!plus) {
+              setUpselling(true)
+              return
             }
+            setError(
+              `Project limit reached (${MAX_PROJECTS}). Delete a project before importing.`,
+            )
           }}
         >
           Import
@@ -380,6 +402,27 @@ export function HomePage() {
           onClose={() => setDeleting(null)}
           onConfirm={async () => {
             await deleteProject(deleting.id)
+            refresh()
+          }}
+        />
+      ) : null}
+
+      {upselling ? (
+        <UpsellSheet
+          onClose={() => setUpselling(false)}
+          onRestore={() => {
+            setUpselling(false)
+            setRestoring(true)
+          }}
+        />
+      ) : null}
+
+      {restoring ? (
+        <RestoreSheet
+          onClose={() => setRestoring(false)}
+          onRestored={() => {
+            setRestoring(false)
+            setNotice('Kody Video Plus restored — all project slots are unlocked.')
             refresh()
           }}
         />

--- a/src/pages/project-page.tsx
+++ b/src/pages/project-page.tsx
@@ -3,6 +3,7 @@ import {
   Link,
   Navigate,
   useLoaderData,
+  useNavigate,
   useRevalidator,
   type LoaderFunctionArgs,
 } from 'react-router-dom'
@@ -28,7 +29,9 @@ import {
   shareFile,
 } from '../lib/media'
 import { loadProjectPage, type ProjectLoaderData } from '../lib/project-actions'
-import { setOnboardingDismissed } from '../lib/storage'
+import { createProject, setOnboardingDismissed } from '../lib/storage'
+import { requestPersistentStorage } from '../lib/storage-space'
+import { NEW_PROJECT_ID, type ProjectId } from '../lib/types'
 
 /** Resolve after the next animation frame (or a short timeout when rAF is busy). */
 function waitForNextPaint(): Promise<void> {
@@ -116,6 +119,30 @@ export function ProjectPage() {
 
   const clips = data.clips
   const stopCamera = camera.stop
+  const navigate = useNavigate()
+  const project = data.project
+
+  // Lazy creation: a "/project/new" project is persisted only when the
+  // first clip finishes recording. The promise is memoized so overlapping
+  // takes (or a camera take racing a screen take) create exactly one.
+  const ensureProjectRef = useRef<Promise<ProjectId> | null>(null)
+  const ensureProjectId = useCallback((): Promise<ProjectId> => {
+    if (project && project.id !== NEW_PROJECT_ID) return Promise.resolve(project.id)
+    ensureProjectRef.current ??= (async () => {
+      try {
+        const created = await createProject()
+        // Their recordings should survive storage pressure.
+        requestPersistentStorage()
+        navigate(`/project/${created.id}`, { replace: true })
+        return created.id
+      } catch (err) {
+        // A failed creation must not poison later attempts.
+        ensureProjectRef.current = null
+        throw err
+      }
+    })()
+    return ensureProjectRef.current
+  }, [navigate, project])
 
   const startExport = useCallback(() => {
     if (clips.length === 0) return
@@ -229,7 +256,7 @@ export function ProjectPage() {
     setExportState((current) => (current ? { ...current, notice } : current))
   }, [])
 
-  if (!data.project || data.error) {
+  if (!project || data.error) {
     if (data.error === 'Project not found') {
       return <Navigate to="/" replace />
     }
@@ -245,7 +272,6 @@ export function ProjectPage() {
     )
   }
 
-  const project = data.project
   const exporting = exportState?.status === 'exporting'
   const overlayOpen = playing || exportState !== null || onboardingOpen
   const exportFilename = exportState?.result
@@ -260,6 +286,7 @@ export function ProjectPage() {
       {exporting ? null : mode === 'record' ? (
         <RecordScreen
           project={project}
+          ensureProjectId={ensureProjectId}
           clips={clips}
           camera={camera}
           storage={data.storage}

--- a/src/pages/terms-page.tsx
+++ b/src/pages/terms-page.tsx
@@ -34,12 +34,13 @@ export function TermsPage() {
         </section>
 
         <section className="about-section">
-          <h2>Watermark removal</h2>
+          <h2>Kody Video Plus</h2>
           <p>
-            Watermark removal is a one-time $0.99 purchase that unlocks watermark-free exports for
-            the browser profile where it&rsquo;s verified. You can restore the purchase on another
-            device via the Stripe receipt link. Payments are handled by Stripe. For refunds or
-            purchase trouble, email <a href="mailto:team@kody.video">team@kody.video</a>.
+            Kody Video Plus is a one-time $0.99 purchase that unlocks watermark-free exports and
+            up to six project slots (the free plan includes one project) for the browser profile
+            where it&rsquo;s verified. You can restore the purchase on another device via the
+            Stripe receipt link. Payments are handled by Stripe. For refunds or purchase trouble,
+            email <a href="mailto:team@kody.video">team@kody.video</a>.
           </p>
         </section>
 

--- a/src/pages/unlocked-page.tsx
+++ b/src/pages/unlocked-page.tsx
@@ -25,11 +25,11 @@ export function UnlockedPage() {
         {result.unlocked ? (
           <>
             <p className="eyebrow">Purchase verified</p>
-            <h1>Watermark removed! 🎉</h1>
+            <h1>Kody Video Plus unlocked! 🎉</h1>
             <p className="muted">
               Thank you for supporting Kody Video. Every export from this device is now
-              watermark-free. Keep your Stripe receipt email — its link restores the purchase on
-              another device.
+              watermark-free and all six project slots are open. Keep your Stripe receipt email —
+              its link restores the purchase on another device.
             </p>
           </>
         ) : (

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -495,6 +495,19 @@ a {
   transition: width 160ms linear;
 }
 
+.sheet-copy {
+  margin: 10px 0 0;
+  font-size: 0.92rem;
+  line-height: 1.5;
+  color: var(--ink-muted);
+}
+
+.sheet-footnote {
+  display: block;
+  margin: 14px auto 0;
+  font-size: 0.85rem;
+}
+
 .update-toast {
   position: absolute;
   top: calc(10px + var(--safe-top));

--- a/src/styles/home.css
+++ b/src/styles/home.css
@@ -134,6 +134,14 @@
     color-mix(in srgb, var(--ink) 5%, transparent);
 }
 
+.project-slot.empty.locked {
+  opacity: 0.55;
+}
+
+.project-slot.empty.locked strong {
+  color: var(--ink-muted);
+}
+
 .project-slot.empty:disabled {
   opacity: 0.45;
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Two product changes from Kent:

1. **One project free; more requires the paid upgrade.** The existing one-time $0.99 purchase is now "Kody Video Plus": it removes the watermark *and* unlocks all six project slots.
2. **Projects only exist once something is recorded.** "New project" opens the camera at `/project/new` without persisting anything; backing out of an untouched project leaves no empty slot behind.

## How

### Plus gate

- Enforced in `createProject` itself (`storage.ts`): without the entitlement, a second project throws with upgrade guidance — so the record path and the import path hit the same gate.
- Home: slots beyond the free limit render locked (lock icon, "Unlock with Kody Video Plus") and open a new `UpsellSheet` — price button opens the existing Stripe Payment Link, plus an "Already paid? Restore" path reusing `RestoreSheet` on the home screen. The footer button becomes "Get more projects" at the free cap; Import routes to the upsell too.
- Existing multi-project users are grandfathered: nothing is locked or deleted, only *creating beyond the limit* gates.
- Copy updated everywhere the purchase is described (export sheet upsell, `/unlocked`, `/terms`, README, checklist).

### Lazy creation

- `/project/new` returns a loader stub (`NEW_PROJECT_ID`) — no DB write, correct default name, onboarding/settings intact.
- `ensureProjectId()` (project page) memoizes a create-once promise: the first finished take (camera or screen recording) creates the project, requests persistent storage, and `replace`-navigates to the real id; overlapping takes create exactly one project. Failure resets the memo so retries work.
- `RecordScreen` resolves the id through `ensureProjectId` in both save paths.

## Testing

- New storage unit test: second project rejects without Plus; existing creation tests now enable the entitlement first. 94 tests green; `tsc` + production build green.
- `probe-keyboard.mjs` end-to-end passes **through the lazy-create path** (it clicks New project → records with Space → edits → plays): the project materializes on the first clip and everything downstream works.
- `probe-fast-export.mjs` seeds one project as a free user — passes.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-16d17496-6b5b-4e12-b600-6933357c2059?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-16d17496-6b5b-4e12-b600-6933357c2059&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

