### PR TITLE
Stream exports to OPFS (flat memory); detach the encode canvas off-iOS (full speed)

### DIFF
--- a/scripts/probe-fast-export.mjs
+++ b/scripts/probe-fast-export.mjs
@@ -7,7 +7,7 @@
  * Run: node scripts/probe-fast-export.mjs   (starts its own vite dev server)
  */
 import { chromium } from 'playwright'
-import { spawn, execFileSync } from 'node:child_process'
+import { spawn, spawnSync, execFileSync } from 'node:child_process'
 import { existsSync } from 'node:fs'
 import { setTimeout as sleep } from 'node:timers/promises'
 
@@ -112,6 +112,31 @@ try {
     'decode-driven pump must beat realtime',
   )
   check('no realtime-engine fallback occurred', warnings.length === 0, warnings.join(' | '))
+
+  // The output must be a real, playable file (streamed to OPFS where
+  // available): download it and let ffprobe be the judge.
+  const downloadPromise = page.waitForEvent('download', { timeout: 15_000 })
+  await page.getByRole('button', { name: /^save$/i }).click()
+  const download = await downloadPromise
+  const savedPath = '/tmp/kv-fast-export-out'
+  await download.saveAs(savedPath)
+  const probeOut = spawnSync(
+    'ffprobe',
+    ['-v', 'error', '-show_entries', 'format=duration:stream=codec_type', '-of', 'json', savedPath],
+    { encoding: 'utf8' },
+  )
+  let streams = []
+  let duration = 0
+  try {
+    const parsed = JSON.parse(probeOut.stdout)
+    streams = (parsed.streams ?? []).map((s) => s.codec_type)
+    duration = Number(parsed.format?.duration ?? 0)
+  } catch {}
+  check(
+    `output has video+audio and ~${totalSeconds}s duration`,
+    streams.includes('video') && streams.includes('audio') && Math.abs(duration - totalSeconds) < 1.5,
+    `streams=${streams.join(',')} duration=${duration.toFixed(2)}s`,
+  )
 
   await browser.close()
 } catch (err) {

--- a/src/lib/export/encode-webcodecs.ts
+++ b/src/lib/export/encode-webcodecs.ts
@@ -9,6 +9,7 @@ import {
   Mp4OutputFormat,
   Output,
   Quality,
+  StreamTarget,
   WebMOutputFormat,
   getFirstEncodableAudioCodec,
   getFirstEncodableVideoCodec,
@@ -19,6 +20,7 @@ import { deriveProjectLocation } from '../geo'
 import { isIosBrowser } from '../media'
 import type { ClipRecord } from '../types'
 import { injectMp4Metadata, type Mp4Chapter } from './mp4-metadata'
+import { createOpfsExportFile } from './opfs'
 import { clampSegmentToMedia, type ExportPlan } from './plan'
 import {
   PREVIEW_INTERVAL_MS,
@@ -105,11 +107,13 @@ export async function exportWithWebCodecs(
     throw new Error('No supported export codec')
   }
 
-  // Draw into the on-DOM overlay canvas when available: Safari-family
-  // engines have a history of treating detached canvases as black (see the
-  // realtime engine's captureStream fix) — and it doubles as a per-frame
-  // live preview. Falls back to a detached canvas (fine on Chromium).
-  let canvas = await waitForPreviewCanvas(getPreviewCanvas)
+  // iOS ONLY: encode into the on-DOM overlay canvas — WebKit has a history
+  // of treating detached canvases as black in capture paths (see the
+  // black-export saga). Everywhere else the encode canvas stays DETACHED:
+  // drawing every frame through a visible, compositor-synchronized canvas
+  // rate-limited a 9× export to a constant ~6× on Android. The preview gets
+  // throttled downscaled blits instead — it only shows what's processing.
+  let canvas = isIosBrowser() ? await waitForPreviewCanvas(getPreviewCanvas) : null
   const encodingIntoPreview = canvas !== null
   if (!canvas) {
     canvas = document.createElement('canvas')
@@ -119,6 +123,10 @@ export async function exportWithWebCodecs(
   const ctx = canvas.getContext('2d', { alpha: false })
   if (!ctx) throw new Error('Canvas not available')
 
+  // Stream the mux to disk when OPFS is available: long exports are too
+  // big for an in-memory buffer (a half-hour project is ~1GB — the
+  // BufferTarget path OOM-killed the tab right at 100%).
+  const opfs = await createOpfsExportFile(choice.container)
   const output = new Output({
     format:
       choice.container === 'mp4'
@@ -127,7 +135,7 @@ export async function exportWithWebCodecs(
           // streamed, so faststart matters little here.
           new Mp4OutputFormat({ fastStart: false })
         : new WebMOutputFormat(),
-    target: new BufferTarget(),
+    target: opfs ? new StreamTarget(opfs.writable, { chunked: true }) : new BufferTarget(),
   })
   const videoSource = new CanvasSource(canvas, {
     codec: choice.videoCodec,
@@ -231,25 +239,54 @@ export async function exportWithWebCodecs(
     await output.finalize()
   } catch (error) {
     await output.cancel().catch(() => undefined)
+    await opfs?.discard().catch(() => undefined)
     throw error
   }
 
   onProgress?.(1)
-  let buffer = (output.target as BufferTarget).buffer
-  if (!buffer) {
-    throw new Error('Export produced no data')
+  const mimeType = choice.container === 'mp4' ? 'video/mp4' : 'video/webm'
+  let blob: Blob
+  if (opfs) {
+    const file = await opfs.getFile()
+    if (file.size === 0) throw new Error('Export produced no data')
+    // Blob composition references the disk-backed file — no RAM copy.
+    blob = new Blob([file], { type: mimeType })
+  } else {
+    const buffer = (output.target as BufferTarget).buffer
+    if (!buffer) throw new Error('Export produced no data')
+    blob = new Blob([buffer], { type: mimeType })
   }
   if (choice.container === 'mp4') {
-    buffer = injectMp4Metadata(buffer, {
+    blob = await injectMetadataBestEffort(blob, mimeType, chapters, clipsInPlan)
+  }
+  return {
+    blob,
+    mimeType,
+    fileExtension: choice.container,
+  }
+}
+
+/** Metadata injection needs the whole file in memory (once) — worth it for
+ * chapters/geotags on normal exports, but never worth risking a very long
+ * export over: oversized files skip it, and any failure returns the
+ * perfectly playable un-injected file. */
+const METADATA_INJECT_LIMIT_BYTES = 256 * 1024 * 1024
+
+async function injectMetadataBestEffort(
+  blob: Blob,
+  mimeType: string,
+  chapters: Mp4Chapter[],
+  clipsInPlan: ClipRecord[],
+): Promise<Blob> {
+  if (blob.size > METADATA_INJECT_LIMIT_BYTES) return blob
+  try {
+    const injected = injectMp4Metadata(await blob.arrayBuffer(), {
       chapters,
       location: deriveProjectLocation(clipsInPlan),
     })
-  }
-  const mimeType = choice.container === 'mp4' ? 'video/mp4' : 'video/webm'
-  return {
-    blob: new Blob([buffer], { type: mimeType }),
-    mimeType,
-    fileExtension: choice.container,
+    return new Blob([injected], { type: mimeType })
+  } catch {
+    return blob
   }
 }
 

--- a/src/lib/export/opfs.ts
+++ b/src/lib/export/opfs.ts
@@ -1,0 +1,74 @@
+/**
+ * OPFS-backed export output. A half-hour export is ~1GB of encoded data —
+ * accumulating that in an in-memory ArrayBuffer (then copying it for
+ * metadata injection and Blob creation) OOM-killed the tab right at 100%.
+ * Streaming the mux to an Origin Private File System file keeps memory flat
+ * regardless of duration; the resulting File is disk-backed, so sharing and
+ * saving never load it into RAM either.
+ */
+
+export interface OpfsExportFile {
+  writable: FileSystemWritableFileStream
+  /** The finished, disk-backed file (call after the writer is closed). */
+  getFile(): Promise<File>
+  /** Abort + delete on export failure. */
+  discard(): Promise<void>
+}
+
+const EXPORT_DIR = 'exports'
+
+/**
+ * Returns null when OPFS isn't available (the caller falls back to an
+ * in-memory buffer). Previous export files are cleaned up here — by the
+ * time a new export starts, the UI has discarded any old result.
+ */
+export async function createOpfsExportFile(extension: string): Promise<OpfsExportFile | null> {
+  try {
+    if (!navigator.storage?.getDirectory) return null
+    const root = await navigator.storage.getDirectory()
+    const dir = await root.getDirectoryHandle(EXPORT_DIR, { create: true })
+
+    // Best-effort cleanup of earlier exports (they only exist as temp space
+    // for the share/save step of the export that created them).
+    try {
+      const names: string[] = []
+      for await (const name of (dir as unknown as { keys(): AsyncIterable<string> }).keys()) {
+        names.push(name)
+      }
+      await Promise.all(names.map((name) => dir.removeEntry(name).catch(() => undefined)))
+    } catch {
+      // Cleanup is a nicety.
+    }
+
+    const name = `export-${Date.now()}.${extension}`
+    const handle = await dir.getFileHandle(name, { create: true })
+    const writable = await handle.createWritable()
+    return {
+      writable,
+      getFile: async () => {
+        // Mediabunny closes the stream on finalize; close defensively for
+        // any path that didn't.
+        try {
+          await writable.close()
+        } catch {
+          // Already closed.
+        }
+        return handle.getFile()
+      },
+      discard: async () => {
+        try {
+          await writable.abort()
+        } catch {
+          // Already closed/aborted.
+        }
+        try {
+          await dir.removeEntry(name)
+        } catch {
+          // Already gone.
+        }
+      },
+    }
+  } catch {
+    return null
+  }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Kent's half-hour, 200-clip export on Android: **crashed right at the end**, and ran at a suspiciously **constant ~6×** ("I'd expect it to export as fast as the device is capable... I'm thinking the preview is controlling how fast the export is").

Both diagnoses hold:

1. **The crash is an OOM at the finish line.** `BufferTarget` accumulates the whole output in RAM — a half-hour export is ~1GB — and then metadata injection and `Blob` creation each *copy* it at 100%.
2. **The constant rate is the visible canvas.** The encode canvas was the on-DOM preview canvas everywhere (an iOS black-canvas workaround applied globally). Every frame drawn through a visible, compositor-synchronized canvas gets rate-limited to a vsync multiple — headless (no compositor) ran 9×, Kent's phone pegged at ~6×.

## How

- **`src/lib/export/opfs.ts`**: exports stream to an Origin Private File System file via Mediabunny's `StreamTarget` (chunked writes — its chunk shape is natively compatible with `FileSystemWritableFileStream`). Memory stays flat for any duration; the resulting `File` is disk-backed, so share/save never load it into RAM either. Previous temp exports are cleaned up at the next export's start; failures abort + delete. No OPFS → `BufferTarget` fallback as before.
- **Encode canvas is detached everywhere except iOS** (which keeps the on-DOM canvas for the WebKit black-capture quirk). The preview still gets its throttled ~5fps downscaled blits — per Kent, it exists to show what's being processed, nothing more.
- **Metadata injection is now best-effort and size-capped** (256MB): chapters/geotags need one full in-memory pass, which is fine for normal exports and never worth risking a long one over — oversized files skip it, and any injection failure returns the perfectly playable un-injected file instead of throwing away a half-hour encode.

## Testing

- `probe-fast-export.mjs` extended: after the speed assertions (still **16s in 1.8s**, no fallback), it now downloads the result and **ffprobe-validates it** — video+audio streams, 16.02s duration. Headless Chromium has OPFS, so this exercises the streaming path end to end.
- `tsc`, 80 tests, production build green.
- The real 30-minute Android run is Kent's to confirm — expected outcome: full-device-speed export (no vsync ceiling) and a flat memory profile with no finish-line crash.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-16d17496-6b5b-4e12-b600-6933357c2059?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-16d17496-6b5b-4e12-b600-6933357c2059&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved video export for larger files by streaming output to temporary local storage when supported.
  * Added automatic cleanup of incomplete or failed exports.
  * Export metadata handling now supports large files more reliably.

* **Bug Fixes**
  * Improved export compatibility across browsers, including continued support for iOS preview workflows.
  * Added validation to confirm exported files contain both video and audio with the expected duration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->