### PR TITLE
Recoverable last export (instant Go on unchanged projects) and save-clips-as-ZIP

### DIFF
--- a/manual-test-checklist.md
+++ b/manual-test-checklist.md
@@ -65,6 +65,10 @@ Run locally with HTTPS or `localhost` (`npm run dev`). Camera/mic require a secu
 - [ ] Segmented progress bar tracks clips
 
 ## Go / export
+- [ ] After an export, closing the sheet and tapping Go again restores the same file instantly ("Restored your last export") — no re-encode
+- [ ] Editing clips (trim/reorder/add/delete) or changing watermark state invalidates the restore; Go re-exports
+- [ ] "Re-export from scratch" on the ready sheet renders fresh
+- [ ] "Save original clips (.zip)" downloads one archive containing every clip (works from the error sheet too)
 - [ ] Go starts the export immediately ("Exporting your video…" + progress)
 - [ ] Export completes; sheet shows format + size ("MP4 · x MB" expected on Android)
 - [ ] Share opens the system share sheet (fresh tap, no silent failure)

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@sentry/react": "^10.68.0",
+        "client-zip": "^2.5.0",
         "idb": "^8.0.3",
         "mediabunny": "^1.52.1",
         "react": "^19.1.0",
@@ -3618,6 +3619,12 @@
       "engines": {
         "node": ">= 16"
       }
+    },
+    "node_modules/client-zip": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/client-zip/-/client-zip-2.5.0.tgz",
+      "integrity": "sha512-ydG4nDZesbFurnNq0VVCp/yyomIBh+X/1fZPI/P24zbnG4dtC4tQAfI5uQsomigsUMeiRO2wiTPizLWQh+IAyQ==",
+      "license": "MIT"
     },
     "node_modules/commander": {
       "version": "2.20.3",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@sentry/react": "^10.68.0",
+    "client-zip": "^2.5.0",
     "idb": "^8.0.3",
     "mediabunny": "^1.52.1",
     "react": "^19.1.0",

--- a/scripts/probe-fast-export.mjs
+++ b/scripts/probe-fast-export.mjs
@@ -138,6 +138,32 @@ try {
     `streams=${streams.join(',')} duration=${duration.toFixed(2)}s`,
   )
 
+  // Recovery: close the sheet, tap Go again — the persisted last export
+  // must come back instantly instead of re-encoding.
+  await page.getByRole('button', { name: /^done$/i }).click()
+  const recoverStartedAt = Date.now()
+  await page.locator('.go-button').click()
+  await page.getByText(/restored your last export/i).waitFor({ timeout: 5_000 })
+  const recoverSeconds = (Date.now() - recoverStartedAt) / 1000
+  check(
+    `missed-share recovery is instant (${recoverSeconds.toFixed(1)}s)`,
+    recoverSeconds < 3,
+  )
+
+  // Clips ZIP: one archive with every original clip inside.
+  const zipDownloadPromise = page.waitForEvent('download', { timeout: 30_000 })
+  await page.getByRole('button', { name: /save original clips/i }).click()
+  const zipDownload = await zipDownloadPromise
+  const zipPath = '/tmp/kv-clips-out.zip'
+  await zipDownload.saveAs(zipPath)
+  const zipList = spawnSync('unzip', ['-l', zipPath], { encoding: 'utf8' })
+  const entryCount = (zipList.stdout.match(/\.mp4|\.webm/g) ?? []).length
+  check(
+    `clips zip contains all ${CLIP_COUNT} clips`,
+    zipList.status === 0 && entryCount === CLIP_COUNT,
+    `entries=${entryCount}`,
+  )
+
   await browser.close()
 } catch (err) {
   check('probe crashed', false, String(err))

--- a/src/components/export-sheet.tsx
+++ b/src/components/export-sheet.tsx
@@ -25,6 +25,8 @@ interface ExportSheetProps {
   onRemoveWatermark: () => void
   onRestorePurchase: () => void
   onRetry: () => void
+  /** Fresh render, bypassing the persisted last-export cache. */
+  onReExport: () => void
   onClose: () => void
 }
 
@@ -49,6 +51,7 @@ export function ExportSheet({
   onRemoveWatermark,
   onRestorePurchase,
   onRetry,
+  onReExport,
   onClose,
 }: ExportSheetProps) {
   const bindSheet = useSheetModal({ onDismiss: onClose, busy })
@@ -94,6 +97,15 @@ export function ExportSheet({
                 Done
               </button>
             </div>
+            <p className="sheet-utility-links">
+              <button type="button" className="link-button" onClick={onSaveClips} disabled={busy}>
+                Save original clips (.zip)
+              </button>{' '}
+              ·{' '}
+              <button type="button" className="link-button" onClick={onReExport} disabled={busy}>
+                Re-export from scratch
+              </button>
+            </p>
             {watermarked && !purchased ? (
               <p className="watermark-note">
                 Includes a small Kody mark in the corner.{' '}
@@ -124,7 +136,7 @@ export function ExportSheet({
                 Try again
               </button>
               <button type="button" className="btn btn-secondary" onClick={onSaveClips} disabled={busy}>
-                Save clips instead
+                Save clips (.zip) instead
               </button>
               <button type="button" className="btn btn-ghost" onClick={onClose} disabled={busy}>
                 Close

--- a/src/lib/clips-zip.ts
+++ b/src/lib/clips-zip.ts
@@ -1,0 +1,41 @@
+/**
+ * "Save clips" as one ZIP. Individual downloads were unusable at 200 clips;
+ * a ZIP is one artifact for the share sheet or downloads folder. Clips are
+ * already-compressed video, so client-zip's store-mode (no recompression,
+ * zip64 for huge projects) is exactly right — and the archive streams to
+ * OPFS where available, so even gigabyte projects never sit in RAM.
+ */
+
+import { makeZip } from 'client-zip'
+import { streamToOpfsFile } from './export/opfs'
+import type { ClipRecord } from './types'
+
+function extensionFor(mimeType: string): string {
+  return /mp4/i.test(mimeType) ? 'mp4' : 'webm'
+}
+
+function clipFilename(clip: ClipRecord, index: number): string {
+  const stamp = new Date(clip.createdAt)
+    .toISOString()
+    .slice(0, 19)
+    .replace('T', ' ')
+    .replace(/:/g, '.')
+  return `${String(index + 1).padStart(3, '0')} - ${stamp}.${extensionFor(clip.mimeType)}`
+}
+
+/** Build the archive; disk-backed via OPFS when available, in-memory otherwise. */
+export async function buildClipsZip(clips: ClipRecord[]): Promise<Blob> {
+  // A fresh stream per attempt: a failed OPFS pipe leaves its stream
+  // locked, and makeZip reads clip blobs lazily so re-creation is free.
+  const createStream = () =>
+    makeZip(
+      clips.map((clip, index) => ({
+        name: clipFilename(clip, index),
+        lastModified: new Date(clip.createdAt),
+        input: clip.blob,
+      })),
+    )
+  const file = await streamToOpfsFile('clips.zip', createStream())
+  if (file) return new Blob([file], { type: 'application/zip' })
+  return new Response(createStream()).blob()
+}

--- a/src/lib/export/last-export.ts
+++ b/src/lib/export/last-export.ts
@@ -1,0 +1,85 @@
+/**
+ * Recoverable last export. Missing the share sheet used to mean re-encoding
+ * the whole project (half an hour of video = many minutes of work). After a
+ * successful export, the file is persisted to OPFS with a fingerprint of
+ * exactly what produced it; tapping Go on an unchanged project serves it
+ * instantly, and Retry always forces a fresh encode.
+ */
+
+import { getDb, getSettings } from '../storage'
+import type { ClipRecord, ProjectId } from '../types'
+import { readOpfsFile, streamToOpfsFile } from './opfs'
+import type { ExportResult } from './shared'
+
+const LAST_EXPORT_PREFIX = 'last-export'
+
+/** Anything that changes the rendered output must change the signature. */
+export function exportSignature(clips: ClipRecord[], watermarked: boolean): string {
+  return JSON.stringify({
+    watermarked,
+    clips: clips.map((clip) => [clip.id, clip.trimStartMs, clip.trimEndMs]),
+  })
+}
+
+/**
+ * Persist a finished export (best effort — OPFS may be unavailable, in
+ * which case the feature simply doesn't exist on this browser). The blob
+ * streams to disk, so disk-backed results never occupy RAM twice; the
+ * metadata is committed only after the bytes are safely written.
+ */
+export async function persistLastExport(args: {
+  projectId: ProjectId
+  result: ExportResult
+  signature: string
+  watermarked: boolean
+}): Promise<void> {
+  const { projectId, result, signature, watermarked } = args
+  const opfsName = `${LAST_EXPORT_PREFIX}.${result.fileExtension}`
+  const file = await streamToOpfsFile(opfsName, result.blob.stream())
+  if (!file || file.size !== result.blob.size) return
+
+  const db = await getDb()
+  const settings = await getSettings()
+  await db.put('meta', {
+    ...settings,
+    lastExport: {
+      projectId,
+      opfsName,
+      mimeType: result.mimeType,
+      fileExtension: result.fileExtension,
+      createdAt: Date.now(),
+      signature,
+      watermarked,
+    },
+  })
+}
+
+export interface RecoveredExport {
+  result: ExportResult
+  watermarked: boolean
+  createdAt: number
+}
+
+/**
+ * The stored export for this exact project + signature, or null when it
+ * doesn't exist, doesn't match, or its file has vanished.
+ */
+export async function loadMatchingExport(
+  projectId: ProjectId,
+  signature: string,
+): Promise<RecoveredExport | null> {
+  const settings = await getSettings()
+  const last = settings.lastExport
+  if (!last || last.projectId !== projectId || last.signature !== signature) return null
+  const file = await readOpfsFile(last.opfsName)
+  if (!file || file.size === 0) return null
+  return {
+    result: {
+      blob: new Blob([file], { type: last.mimeType }),
+      mimeType: last.mimeType,
+      fileExtension: last.fileExtension,
+    },
+    watermarked: last.watermarked,
+    createdAt: last.createdAt,
+  }
+}

--- a/src/lib/export/opfs.ts
+++ b/src/lib/export/opfs.ts
@@ -22,18 +22,51 @@ const EXPORT_DIR = 'exports'
  * in-memory buffer). Previous export files are cleaned up here — by the
  * time a new export starts, the UI has discarded any old result.
  */
+/** Write a stream into a named OPFS file (overwriting), returning the
+ * disk-backed File — or null when OPFS is unavailable. */
+export async function streamToOpfsFile(
+  name: string,
+  stream: ReadableStream<Uint8Array>,
+): Promise<File | null> {
+  try {
+    if (!navigator.storage?.getDirectory) return null
+    const root = await navigator.storage.getDirectory()
+    const dir = await root.getDirectoryHandle(EXPORT_DIR, { create: true })
+    const handle = await dir.getFileHandle(name, { create: true })
+    const writable = await handle.createWritable()
+    await stream.pipeTo(writable)
+    return handle.getFile()
+  } catch {
+    return null
+  }
+}
+
+/** Read a previously persisted OPFS file, or null when it's gone. */
+export async function readOpfsFile(name: string): Promise<File | null> {
+  try {
+    if (!navigator.storage?.getDirectory) return null
+    const root = await navigator.storage.getDirectory()
+    const dir = await root.getDirectoryHandle(EXPORT_DIR, { create: true })
+    const handle = await dir.getFileHandle(name)
+    return await handle.getFile()
+  } catch {
+    return null
+  }
+}
+
 export async function createOpfsExportFile(extension: string): Promise<OpfsExportFile | null> {
   try {
     if (!navigator.storage?.getDirectory) return null
     const root = await navigator.storage.getDirectory()
     const dir = await root.getDirectoryHandle(EXPORT_DIR, { create: true })
 
-    // Best-effort cleanup of earlier exports (they only exist as temp space
-    // for the share/save step of the export that created them).
+    // Best-effort cleanup of earlier temp exports. Persisted artifacts
+    // (the recoverable last export, clip zips) are kept — they must survive
+    // a new export attempt that might fail.
     try {
       const names: string[] = []
       for await (const name of (dir as unknown as { keys(): AsyncIterable<string> }).keys()) {
-        names.push(name)
+        if (name.startsWith('export-')) names.push(name)
       }
       await Promise.all(names.map((name) => dir.removeEntry(name).catch(() => undefined)))
     } catch {

--- a/src/lib/media.ts
+++ b/src/lib/media.ts
@@ -387,26 +387,6 @@ export async function shareOrDownload(
   return 'downloaded'
 }
 
-/**
- * Save every original clip as its own file. Downloads are spaced out so the
- * browser's multiple-download prompt has a chance to appear once instead of
- * silently dropping all but the first file.
- */
-export async function downloadClipsAsSeparateFiles(
-  clips: ClipRecord[],
-  projectName: string,
-): Promise<void> {
-  for (let index = 0; index < clips.length; index += 1) {
-    const clip = clips[index]
-    const ext = clip.mimeType.includes('mp4') ? 'mp4' : 'webm'
-    const name = `${slugify(projectName)}-clip-${String(index + 1).padStart(2, '0')}.${ext}`
-    await downloadBlob(clip.blob, name)
-    if (index < clips.length - 1) {
-      await new Promise((resolve) => setTimeout(resolve, 400))
-    }
-  }
-}
-
 /** Share/download a single original clip — most reliable path on mobile. */
 export async function shareClipFile(
   clip: ClipRecord,

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -52,6 +52,19 @@ export interface AppMeta {
   purchaseSessionId?: string | null
   /** Opt-in: tag new clips with device location. */
   locationTaggingEnabled?: boolean
+  /** The persisted last export (OPFS-backed), recoverable after the share
+   * sheet is missed — and served instantly when nothing changed. */
+  lastExport?: {
+    projectId: ProjectId
+    opfsName: string
+    mimeType: string
+    fileExtension: 'mp4' | 'webm'
+    createdAt: number
+    /** Fingerprint of the clips (ids + trims) and watermark state that
+     * produced the file — any difference means a fresh export is needed. */
+    signature: string
+    watermarked: boolean
+  } | null
 }
 
 export const MAX_PROJECTS = 6

--- a/src/pages/project-page.tsx
+++ b/src/pages/project-page.tsx
@@ -16,14 +16,19 @@ import { RecordScreen, type ToastAction } from '../components/record-screen'
 import { useCamera } from '../hooks/use-camera'
 import { RestoreSheet } from '../components/restore-sheet'
 import { REMOVE_WATERMARK_LINK } from '../lib/entitlement'
+import { buildClipsZip } from '../lib/clips-zip'
 import { clearExportMarker, markExportStarted, reportError } from '../lib/error-reporting'
 import { exportProject, type ExportResult } from '../lib/export'
+import {
+  exportSignature,
+  loadMatchingExport,
+  persistLastExport,
+} from '../lib/export/last-export'
 import { MediaElementFailureError } from '../lib/export/media-error'
 import { wait } from '../lib/export/shared'
 import {
   canShareFile,
   downloadBlob,
-  downloadClipsAsSeparateFiles,
   isIosBrowser,
   projectFilename,
   shareFile,
@@ -144,7 +149,7 @@ export function ProjectPage() {
     return ensureProjectRef.current
   }, [navigate, project])
 
-  const startExport = useCallback(() => {
+  const startExport = useCallback((options?: { force?: boolean }) => {
     if (clips.length === 0) return
     const runId = exportRunRef.current + 1
     exportRunRef.current = runId
@@ -163,6 +168,7 @@ export function ProjectPage() {
     }
 
     const watermarked = !data.watermarkRemoved
+    const signature = exportSignature(clips, watermarked)
     // Stop camera/mic immediately rather than waiting on record-screen
     // unmount. On iOS the combined mic+camera session can hold decoder
     // slots past the first paints, and WebKit reports that race as
@@ -196,6 +202,25 @@ export function ProjectPage() {
 
     void (async () => {
       try {
+        // Unchanged project + a persisted last export = instant "ready":
+        // missing the share sheet must never cost a re-encode. Retry
+        // bypasses this (force) and always renders fresh.
+        if (!options?.force && project) {
+          const recovered = await loadMatchingExport(project.id, signature).catch(() => null)
+          if (exportRunRef.current !== runId) return
+          if (recovered) {
+            setExportState({
+              status: 'ready',
+              progress: 1,
+              result: recovered.result,
+              error: null,
+              notice: 'Restored your last export — nothing changed since. Retry re-renders.',
+              watermarked: recovered.watermarked,
+            })
+            return
+          }
+        }
+
         // Export unmounts record/editor so camera + preview video release.
         // Wait two frames so those hardware decoder slots free before we open
         // new ones — otherwise loadClipVideo can fail with a media error on
@@ -225,6 +250,16 @@ export function ProjectPage() {
             )
           },
         })
+        // Persist for recovery/instant reuse — in the background, the sheet
+        // must not wait on a disk copy of a possibly huge file.
+        if (project) {
+          void persistLastExport({
+            projectId: project.id,
+            result,
+            signature,
+            watermarked,
+          }).catch(() => undefined)
+        }
         if (exportRunRef.current !== runId) return
         setExportState({
           status: 'ready',
@@ -266,7 +301,7 @@ export function ProjectPage() {
         }
       }
     })()
-  }, [clips, data.watermarkRemoved, stopCamera])
+  }, [clips, data.watermarkRemoved, project, stopCamera])
 
   const closeExport = useCallback(() => {
     exportRunRef.current += 1
@@ -392,16 +427,21 @@ export function ProjectPage() {
           }}
           onSaveClips={() => {
             beginExportAction()
-            void downloadClipsAsSeparateFiles(clips, project.name)
+            setExportNotice(
+              `Zipping ${clips.length} clip${clips.length === 1 ? '' : 's'}… keep this open.`,
+            )
+            void buildClipsZip(clips)
+              .then((zip) => downloadBlob(zip, projectFilename(`${project.name} clips`, 'zip')))
               .then(() => {
-                setExportNotice('Saving original clips — allow multiple downloads if asked.')
+                setExportNotice('Clips zipped — check your downloads.')
               })
               .catch(() => {
-                setExportNotice('Saving failed — try again.')
+                setExportNotice('Zipping failed — try again.')
               })
               .finally(endExportAction)
           }}
-          onRetry={startExport}
+          onRetry={() => startExport({ force: true })}
+          onReExport={() => startExport({ force: true })}
           onClose={closeExport}
         />
       ) : null}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -508,6 +508,13 @@ a {
   font-size: 0.85rem;
 }
 
+.sheet-utility-links {
+  margin: 12px 0 0;
+  text-align: center;
+  font-size: 0.85rem;
+  color: var(--ink-muted);
+}
+
 .update-toast {
   position: absolute;
   top: calc(10px + var(--safe-top));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Two requests from Kent:

1. **"If I miss the share or save screen I can do it again"** — the finished export is now persisted, and tapping Go on an unchanged project brings the ready sheet back **instantly** with the same file ("Restored your last export"). No more re-encoding half an hour of video because a sheet got dismissed.
2. **"Save all the video clips… in a ZIP"** — "Save original clips (.zip)" produces one archive with every clip (numbered + capture-timestamped filenames), replacing the old one-download-per-clip flow that was unusable at 200 clips.

## How

### Recoverable last export (`src/lib/export/last-export.ts`)

- After any successful export (either engine), the blob streams to a stable OPFS file in the background and `AppMeta.lastExport` records it along with a **signature** — clip ids + trims + watermark state. Metadata commits only after the bytes are written; the temp-export cleanup at new-export start now preserves persisted artifacts.
- On Go, a matching project + signature serves the stored file immediately; **any edit (or a watermark purchase) changes the signature and forces a fresh render**. Retry and the new "Re-export from scratch" link always bypass the cache — without that link, the cache would have made "tap Go again for a clean export" a trap.
- Best-effort by design: no OPFS (rare) → the feature just doesn't exist on that browser; a vanished file → normal export.

### Clips ZIP (`src/lib/clips-zip.ts`)

- `client-zip` (~5KB, streaming, zip64) in store mode — clips are already-compressed video, so no recompression. The archive **streams to OPFS** where available, so a gigabyte project never sits in RAM; in-memory fallback otherwise. Wired into both the ready sheet (new utility link) and the error sheet's existing escape hatch, with a "Zipping N clips…" notice while it builds. The old `downloadClipsAsSeparateFiles` is removed.

## Testing

`probe-fast-export.mjs` now covers the full journey and passes end to end:

- export 16s in 1.8s (no fallback), ffprobe-valid output (video+audio, 16.02s)
- close sheet → Go → **recovery in 0.1s** with the restore notice
- "Save original clips (.zip)" → downloaded archive verified by `unzip` to contain all 4 clips

Plus `tsc`, 80 unit tests, production build green.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-16d17496-6b5b-4e12-b600-6933357c2059?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-16d17496-6b5b-4e12-b600-6933357c2059&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

