### PR TITLE
Fill the screen on iOS installed apps (status bar strip)

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,6 +9,16 @@
     />
     <meta name="theme-color" media="(prefers-color-scheme: dark)" content="#2F3E46" />
     <meta name="theme-color" media="(prefers-color-scheme: light)" content="#EEF5F1" />
+    <!-- iOS home-screen apps only draw under the status bar when asked:
+         black-translucent makes the web view truly full screen (the page
+         background paints behind the clock instead of an opaque system
+         strip). Content clearance comes from the --safe-top padding that
+         every top-anchored element already uses. Status bar text follows
+         the system light/dark mode, which matches our color-scheme theming. -->
+    <meta name="mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
+    <meta name="apple-mobile-web-app-title" content="Kody Video" />
     <meta
       name="description"
       content="Kody Video — hold anywhere to record clips. Privacy-first camera for the web."

--- a/manual-test-checklist.md
+++ b/manual-test-checklist.md
@@ -87,6 +87,7 @@ Run locally with HTTPS or `localhost` (`npm run dev`). Camera/mic require a secu
 - [ ] Offline, existing projects open and clips play from IndexedDB
 - [ ] iOS Safari (browser tab): home shows the Share → Add to Home Screen tip; × dismisses it for good
 - [ ] Installed (standalone) and non-iOS browsers never show the iOS install tip
+- [ ] iOS installed app fills the whole screen: the app background paints behind the status bar clock (no mismatched opaque strip along the top), and no content hides under the Dynamic Island
 
 ## Storage
 - [ ] Home shows "X of Y used" in the footer line


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

ShrekOverflow reported that the installed app on iOS doesn't fill the screen — an opaque bar sits along the top behind the status bar, in a shade that doesn't match the app background.

## Why

iOS home-screen web apps only extend the web view under the status bar when the page opts in with `apple-mobile-web-app-status-bar-style: black-translucent` (plus the `-capable` meta). We already had `viewport-fit=cover` and every top-anchored element already pads by `--safe-top` (including the 59px floor for the iOS 26.1 `env(safe-area-inset-top)` regression) — the app was built for full-bleed but never asked iOS for it, so iOS reserved the status bar strip and painted it itself.

## How

- Added `mobile-web-app-capable`, `apple-mobile-web-app-capable`, `apple-mobile-web-app-status-bar-style: black-translucent`, and `apple-mobile-web-app-title` metas to `index.html`. The app background now paints behind the clock; content clearance is unchanged since `--safe-top` padding was already in place.
- Status bar text follows the system light/dark mode, which matches the app's `prefers-color-scheme` theming, so legibility is consistent in both themes.
- Added a manual-test-checklist entry for iOS standalone full-bleed.

Only affects installed iOS apps — Safari tabs, Android, and desktop ignore these metas. Verified the tags land in the built `dist/index.html`; needs a real-device confirmation from an iOS tester after deploy (reinstalling the home-screen app may be required for iOS to pick up the new metas).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-16d17496-6b5b-4e12-b600-6933357c2059?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-16d17496-6b5b-4e12-b600-6933357c2059&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added mobile web app support for iOS home-screen installation.
  * Enabled standalone display, translucent status-bar rendering, and the “Kody Video” app title.
  * Improved full-screen background coverage and safe content placement around the Dynamic Island.

* **Documentation**
  * Added an iOS installation checklist item for validating status-bar and Dynamic Island layout behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->