### PR TITLE
Storage management: stop export-cache leaks, add one-tap cleanup

### DIFF
--- a/manual-test-checklist.md
+++ b/manual-test-checklist.md
@@ -41,7 +41,11 @@ npm test           # unit tests
   downloads a `.kodyvideo` file and import restores it; import at the plan
   limit is refused with a clear message; slot order is stable
 - **Storage**: footer shows "X of Y used"; ≥80% shows the amber banner, ≥92%
-  turns critical
+  turns critical; the banner offers one-tap "Clear cached exports"; the boot
+  sweep removes orphaned cache files but keeps the referenced last export;
+  deleting a project drops its cached export; the About page shows the cache
+  size with a working Clear button; exactly one recoverable export lives on
+  disk after an export (no temp/zip/duplicate leaks)
 - **Desktop keyboard**: key hints on fine-pointer devices; hold Space
   records and a sub-120ms tap never sticks; E editor / Esc back / P play /
   Delete removes last; editor arrows select, Alt+arrows reorder, D

--- a/src/lib/export/encode-webcodecs.ts
+++ b/src/lib/export/encode-webcodecs.ts
@@ -271,6 +271,7 @@ export async function exportWithWebCodecs(
     if (!buffer) throw new Error('Export produced no data')
     blob = new Blob([buffer], { type: mimeType })
   }
+  const diskBlob = blob
   if (choice.container === 'mp4') {
     blob = await injectMetadataBestEffort(blob, mimeType, chapters, clipsInPlan)
   }
@@ -278,6 +279,10 @@ export async function exportWithWebCodecs(
     blob,
     mimeType,
     fileExtension: choice.container,
+    opfsName: opfs?.name,
+    // Metadata injection returns a NEW in-memory blob; when it ran, the
+    // on-disk file no longer matches what the user gets.
+    opfsBacked: opfs !== null && blob === diskBlob,
   }
 }
 

--- a/src/lib/export/export-cache.ts
+++ b/src/lib/export/export-cache.ts
@@ -1,0 +1,74 @@
+/**
+ * Lifecycle management for the OPFS export cache. Export files are big
+ * (a half-hour project is ~1GB), and three kinds of them live in the
+ * exports directory:
+ *
+ * - `export-<ts>.<ext>` — the streaming target of an in-flight or
+ *   just-finished export (it may back the ExportResult blob on screen)
+ * - the recoverable last export referenced by AppMeta.lastExport (which,
+ *   when the result was file-backed, IS its `export-<ts>` file — no copy)
+ * - `clips.zip` — scratch for the most recent "Save clips" archive
+ *
+ * Left alone these quietly eat gigabytes: users saw "storage full" after
+ * deleting every project. Everything except the referenced last export is
+ * swept at boot and before each new export; users can drop the lot from
+ * the storage UI.
+ */
+
+import { getDb, getSettings, listProjects } from '../storage'
+import { listExportEntries, removeExportEntry } from './opfs'
+
+/** Total bytes sitting in the export cache (0 when OPFS is unavailable). */
+export async function estimateExportCacheBytes(): Promise<number> {
+  const entries = await listExportEntries()
+  return entries.reduce((sum, entry) => sum + entry.sizeBytes, 0)
+}
+
+async function clearLastExportMeta(): Promise<void> {
+  const db = await getDb()
+  const settings = await getSettings()
+  if (!settings.lastExport) return
+  await db.put('meta', { ...settings, lastExport: undefined })
+}
+
+/**
+ * Delete every cached export file, including the recoverable last export
+ * (its meta record goes with it). The user-facing "free up space" action.
+ * Returns the number of bytes freed.
+ */
+export async function clearExportCache(): Promise<number> {
+  const entries = await listExportEntries()
+  await clearLastExportMeta()
+  await Promise.all(entries.map((entry) => removeExportEntry(entry.name)))
+  return entries.reduce((sum, entry) => sum + entry.sizeBytes, 0)
+}
+
+/**
+ * Boot/end-of-export sweep: delete every cache file except a still-valid
+ * last export (its project must still exist). Safe whenever no export is
+ * writing — which is true at app boot and before an export starts.
+ */
+export async function sweepExportCache(): Promise<void> {
+  const entries = await listExportEntries()
+  if (entries.length === 0) return
+
+  const settings = await getSettings()
+  let keep: string | null = null
+  if (settings.lastExport) {
+    const projects = await listProjects()
+    const projectExists = projects.some(
+      (project) => project.id === settings.lastExport?.projectId,
+    )
+    if (projectExists) {
+      keep = settings.lastExport.opfsName
+    } else {
+      await clearLastExportMeta()
+    }
+  }
+
+  await Promise.all(
+    entries
+      .filter((entry) => entry.name !== keep)
+      .map((entry) => removeExportEntry(entry.name)),
+  )
+}

--- a/src/lib/export/export-cache.ts
+++ b/src/lib/export/export-cache.ts
@@ -18,6 +18,33 @@
 import { getDb, getSettings, listProjects } from '../storage'
 import { listExportEntries, removeExportEntry } from './opfs'
 
+/**
+ * Cross-tab coordination: an export in one tab streams into a temp file
+ * that no metadata references yet — a sweep or clear from another tab
+ * (boot, or the "clear cached exports" button) must not delete it out from
+ * under the encoder. Exports hold this lock shared (they can overlap);
+ * deleting operations take it exclusive, and only when free.
+ */
+const CACHE_LOCK = 'kody-video-export-cache'
+
+/** Run `fn` while holding the cache lock shared — sweeps and clears wait
+ * out (or skip) anything inside. No-op wrapper without Web Locks. */
+export async function withExportCacheReserved<T>(fn: () => Promise<T>): Promise<T> {
+  const locks = navigator.locks
+  if (!locks?.request) return fn()
+  return locks.request(CACHE_LOCK, { mode: 'shared' }, fn)
+}
+
+/** Exclusive, non-waiting: deleting cache files is either safe right now or
+ * skipped. Returns null when an export holds the lock. */
+async function tryExclusive<T>(fn: () => Promise<T>): Promise<T | null> {
+  const locks = navigator.locks
+  if (!locks?.request) return fn()
+  return locks.request(CACHE_LOCK, { mode: 'exclusive', ifAvailable: true }, async (lock) =>
+    lock ? fn() : null,
+  )
+}
+
 /** Total bytes sitting in the export cache (0 when OPFS is unavailable). */
 export async function estimateExportCacheBytes(): Promise<number> {
   const entries = await listExportEntries()
@@ -34,41 +61,50 @@ async function clearLastExportMeta(): Promise<void> {
 /**
  * Delete every cached export file, including the recoverable last export
  * (its meta record goes with it). The user-facing "free up space" action.
- * Returns the number of bytes freed.
+ * Returns the number of bytes freed; throws when an export is in flight
+ * (possibly in another tab) so nothing gets deleted mid-stream.
  */
 export async function clearExportCache(): Promise<number> {
-  const entries = await listExportEntries()
-  await clearLastExportMeta()
-  await Promise.all(entries.map((entry) => removeExportEntry(entry.name)))
-  return entries.reduce((sum, entry) => sum + entry.sizeBytes, 0)
+  const freed = await tryExclusive(async () => {
+    const entries = await listExportEntries()
+    await clearLastExportMeta()
+    await Promise.all(entries.map((entry) => removeExportEntry(entry.name)))
+    return entries.reduce((sum, entry) => sum + entry.sizeBytes, 0)
+  })
+  if (freed === null) {
+    throw new Error('An export is in progress — try again when it finishes.')
+  }
+  return freed
 }
 
 /**
- * Boot/end-of-export sweep: delete every cache file except a still-valid
- * last export (its project must still exist). Safe whenever no export is
- * writing — which is true at app boot and before an export starts.
+ * Boot/pre-export sweep: delete every cache file except a still-valid
+ * last export (its project must still exist). Skipped entirely while any
+ * tab is exporting — cleanup is best-effort and gets another chance.
  */
 export async function sweepExportCache(): Promise<void> {
-  const entries = await listExportEntries()
-  if (entries.length === 0) return
+  await tryExclusive(async () => {
+    const entries = await listExportEntries()
+    if (entries.length === 0) return
 
-  const settings = await getSettings()
-  let keep: string | null = null
-  if (settings.lastExport) {
-    const projects = await listProjects()
-    const projectExists = projects.some(
-      (project) => project.id === settings.lastExport?.projectId,
-    )
-    if (projectExists) {
-      keep = settings.lastExport.opfsName
-    } else {
-      await clearLastExportMeta()
+    const settings = await getSettings()
+    let keep: string | null = null
+    if (settings.lastExport) {
+      const projects = await listProjects()
+      const projectExists = projects.some(
+        (project) => project.id === settings.lastExport?.projectId,
+      )
+      if (projectExists) {
+        keep = settings.lastExport.opfsName
+      } else {
+        await clearLastExportMeta()
+      }
     }
-  }
 
-  await Promise.all(
-    entries
-      .filter((entry) => entry.name !== keep)
-      .map((entry) => removeExportEntry(entry.name)),
-  )
+    await Promise.all(
+      entries
+        .filter((entry) => entry.name !== keep)
+        .map((entry) => removeExportEntry(entry.name)),
+    )
+  })
 }

--- a/src/lib/export/export-cache.ts
+++ b/src/lib/export/export-cache.ts
@@ -67,9 +67,12 @@ async function clearLastExportMeta(): Promise<void> {
 export async function clearExportCache(): Promise<number> {
   const freed = await tryExclusive(async () => {
     const entries = await listExportEntries()
+    const beforeBytes = entries.reduce((sum, entry) => sum + entry.sizeBytes, 0)
     await clearLastExportMeta()
     await Promise.all(entries.map((entry) => removeExportEntry(entry.name)))
-    return entries.reduce((sum, entry) => sum + entry.sizeBytes, 0)
+    // Removals are best-effort — report what actually left the disk.
+    const remaining = await listExportEntries()
+    return beforeBytes - remaining.reduce((sum, entry) => sum + entry.sizeBytes, 0)
   })
   if (freed === null) {
     throw new Error('An export is in progress — try again when it finishes.')

--- a/src/lib/export/index.ts
+++ b/src/lib/export/index.ts
@@ -2,6 +2,7 @@ import { reportError } from '../error-reporting'
 import type { ClipRecord } from '../types'
 import { exportRealtime } from './encode-realtime'
 import { exportWithWebCodecs, supportsWebCodecsExport } from './encode-webcodecs'
+import { sweepExportCache } from './export-cache'
 import { planExport } from './plan'
 import {
   AUDIO_SILENCE_PEAK,
@@ -50,6 +51,11 @@ export async function exportProject(
   }
 
   const watermarkImage = options.watermark === false ? null : await loadWatermarkImage()
+
+  // Reclaim stale cache (old temp files, the clips zip, an orphaned last
+  // export) before writing a new potentially-huge file. The current last
+  // export survives — it's still the recovery net if this export fails.
+  await sweepExportCache().catch(() => undefined)
 
   resetAudioDiagnostics()
   resetVideoDiagnostics()

--- a/src/lib/export/index.ts
+++ b/src/lib/export/index.ts
@@ -2,7 +2,7 @@ import { reportError } from '../error-reporting'
 import type { ClipRecord } from '../types'
 import { exportRealtime } from './encode-realtime'
 import { exportWithWebCodecs, supportsWebCodecsExport } from './encode-webcodecs'
-import { sweepExportCache } from './export-cache'
+import { sweepExportCache, withExportCacheReserved } from './export-cache'
 import { planExport } from './plan'
 import {
   AUDIO_SILENCE_PEAK,
@@ -57,6 +57,17 @@ export async function exportProject(
   // export survives — it's still the recovery net if this export fails.
   await sweepExportCache().catch(() => undefined)
 
+  // Reserved for the whole encode: the streaming temp file has no metadata
+  // reference yet, and a sweep or "clear cached exports" from another tab
+  // must not delete it mid-write.
+  return withExportCacheReserved(() => runExport(plan, options, watermarkImage))
+}
+
+async function runExport(
+  plan: ReturnType<typeof planExport>,
+  options: ExportOptions,
+  watermarkImage: Awaited<ReturnType<typeof loadWatermarkImage>> | null,
+): Promise<ExportResult> {
   resetAudioDiagnostics()
   resetVideoDiagnostics()
   if (supportsWebCodecsExport()) {

--- a/src/lib/export/last-export.ts
+++ b/src/lib/export/last-export.ts
@@ -52,8 +52,17 @@ async function persistLastExportInner(args: {
 }): Promise<void> {
   const { projectId, result, signature, watermarked } = args
 
+  // Adoption must verify the file is really there: between the export
+  // finishing and this reservation being acquired there is a microscopic
+  // window where another tab's sweep could have deleted the unreferenced
+  // temp — recording a missing name would leave stale restore metadata.
+  const adoptable =
+    result.opfsBacked && result.opfsName
+      ? await readOpfsFile(result.opfsName).then((file) => file !== null && file.size > 0)
+      : false
+
   let opfsName: string
-  if (result.opfsBacked && result.opfsName) {
+  if (adoptable && result.opfsName) {
     opfsName = result.opfsName
   } else {
     opfsName = `${LAST_EXPORT_PREFIX}.${result.fileExtension}`

--- a/src/lib/export/last-export.ts
+++ b/src/lib/export/last-export.ts
@@ -8,6 +8,7 @@
 
 import { getDb, getSettings } from '../storage'
 import type { ClipRecord, ProjectId } from '../types'
+import { withExportCacheReserved } from './export-cache'
 import { readOpfsFile, removeExportEntry, streamToOpfsFile } from './opfs'
 import type { ExportResult } from './shared'
 
@@ -33,6 +34,17 @@ export function exportSignature(clips: ClipRecord[], watermarked: boolean): stri
  * once the new record is committed.
  */
 export async function persistLastExport(args: {
+  projectId: ProjectId
+  result: ExportResult
+  signature: string
+  watermarked: boolean
+}): Promise<void> {
+  // Reserved against concurrent sweeps: the file being adopted/copied has
+  // no committed metadata reference until the put below lands.
+  await withExportCacheReserved(() => persistLastExportInner(args))
+}
+
+async function persistLastExportInner(args: {
   projectId: ProjectId
   result: ExportResult
   signature: string

--- a/src/lib/export/last-export.ts
+++ b/src/lib/export/last-export.ts
@@ -8,7 +8,7 @@
 
 import { getDb, getSettings } from '../storage'
 import type { ClipRecord, ProjectId } from '../types'
-import { readOpfsFile, streamToOpfsFile } from './opfs'
+import { readOpfsFile, removeExportEntry, streamToOpfsFile } from './opfs'
 import type { ExportResult } from './shared'
 
 const LAST_EXPORT_PREFIX = 'last-export'
@@ -23,9 +23,14 @@ export function exportSignature(clips: ClipRecord[], watermarked: boolean): stri
 
 /**
  * Persist a finished export (best effort — OPFS may be unavailable, in
- * which case the feature simply doesn't exist on this browser). The blob
- * streams to disk, so disk-backed results never occupy RAM twice; the
- * metadata is committed only after the bytes are safely written.
+ * which case the feature simply doesn't exist on this browser).
+ *
+ * File-backed results are adopted in place — the export already lives on
+ * disk, and copying a ~1GB file just to rename it doubled the app's disk
+ * footprint. In-memory results (metadata-injected MP4s, the realtime
+ * engine) stream to a well-known name, and their now-superseded temp file
+ * is removed. Either way, the previously cached export file is dropped
+ * once the new record is committed.
  */
 export async function persistLastExport(args: {
   projectId: ProjectId
@@ -34,12 +39,24 @@ export async function persistLastExport(args: {
   watermarked: boolean
 }): Promise<void> {
   const { projectId, result, signature, watermarked } = args
-  const opfsName = `${LAST_EXPORT_PREFIX}.${result.fileExtension}`
-  const file = await streamToOpfsFile(opfsName, result.blob.stream())
-  if (!file || file.size !== result.blob.size) return
+
+  let opfsName: string
+  if (result.opfsBacked && result.opfsName) {
+    opfsName = result.opfsName
+  } else {
+    opfsName = `${LAST_EXPORT_PREFIX}.${result.fileExtension}`
+    const file = await streamToOpfsFile(opfsName, result.blob.stream())
+    if (!file || file.size !== result.blob.size) return
+    // The streaming temp behind this export (if any) is superseded by the
+    // copy we just wrote — reclaim it now instead of at the next sweep.
+    if (result.opfsName && result.opfsName !== opfsName) {
+      await removeExportEntry(result.opfsName).catch(() => undefined)
+    }
+  }
 
   const db = await getDb()
   const settings = await getSettings()
+  const previousName = settings.lastExport?.opfsName
   await db.put('meta', {
     ...settings,
     lastExport: {
@@ -52,6 +69,9 @@ export async function persistLastExport(args: {
       watermarked,
     },
   })
+  if (previousName && previousName !== opfsName) {
+    await removeExportEntry(previousName).catch(() => undefined)
+  }
 }
 
 export interface RecoveredExport {

--- a/src/lib/export/opfs.ts
+++ b/src/lib/export/opfs.ts
@@ -8,6 +8,8 @@
  */
 
 export interface OpfsExportFile {
+  /** The file's name inside the exports directory. */
+  name: string
   writable: FileSystemWritableFileStream
   /** The finished, disk-backed file (call after the writer is closed). */
   getFile(): Promise<File>
@@ -17,11 +19,49 @@ export interface OpfsExportFile {
 
 const EXPORT_DIR = 'exports'
 
-/**
- * Returns null when OPFS isn't available (the caller falls back to an
- * in-memory buffer). Previous export files are cleaned up here — by the
- * time a new export starts, the UI has discarded any old result.
- */
+async function exportsDir(): Promise<FileSystemDirectoryHandle | null> {
+  try {
+    if (!navigator.storage?.getDirectory) return null
+    const root = await navigator.storage.getDirectory()
+    return await root.getDirectoryHandle(EXPORT_DIR, { create: true })
+  } catch {
+    return null
+  }
+}
+
+export interface OpfsExportEntry {
+  name: string
+  sizeBytes: number
+}
+
+/** Every file in the exports directory with its size (empty when OPFS is
+ * unavailable). */
+export async function listExportEntries(): Promise<OpfsExportEntry[]> {
+  const dir = await exportsDir()
+  if (!dir) return []
+  const entries: OpfsExportEntry[] = []
+  try {
+    for await (const name of (dir as unknown as { keys(): AsyncIterable<string> }).keys()) {
+      const sizeBytes = await dir
+        .getFileHandle(name)
+        .then((handle) => handle.getFile())
+        .then((file) => file.size)
+        .catch(() => 0)
+      entries.push({ name, sizeBytes })
+    }
+  } catch {
+    // Enumeration is best-effort.
+  }
+  return entries
+}
+
+/** Best-effort delete of one exports-directory file. */
+export async function removeExportEntry(name: string): Promise<void> {
+  const dir = await exportsDir()
+  if (!dir) return
+  await dir.removeEntry(name).catch(() => undefined)
+}
+
 /** Write a stream into a named OPFS file (overwriting), returning the
  * disk-backed File — or null when OPFS is unavailable. */
 export async function streamToOpfsFile(
@@ -29,9 +69,8 @@ export async function streamToOpfsFile(
   stream: ReadableStream<Uint8Array>,
 ): Promise<File | null> {
   try {
-    if (!navigator.storage?.getDirectory) return null
-    const root = await navigator.storage.getDirectory()
-    const dir = await root.getDirectoryHandle(EXPORT_DIR, { create: true })
+    const dir = await exportsDir()
+    if (!dir) return null
     const handle = await dir.getFileHandle(name, { create: true })
     const writable = await handle.createWritable()
     await stream.pipeTo(writable)
@@ -44,9 +83,8 @@ export async function streamToOpfsFile(
 /** Read a previously persisted OPFS file, or null when it's gone. */
 export async function readOpfsFile(name: string): Promise<File | null> {
   try {
-    if (!navigator.storage?.getDirectory) return null
-    const root = await navigator.storage.getDirectory()
-    const dir = await root.getDirectoryHandle(EXPORT_DIR, { create: true })
+    const dir = await exportsDir()
+    if (!dir) return null
     const handle = await dir.getFileHandle(name)
     return await handle.getFile()
   } catch {
@@ -54,29 +92,18 @@ export async function readOpfsFile(name: string): Promise<File | null> {
   }
 }
 
+/** Returns null when OPFS isn't available (the caller falls back to an
+ * in-memory buffer). Stale-file cleanup is the export-cache module's job —
+ * it knows which names are still referenced. */
 export async function createOpfsExportFile(extension: string): Promise<OpfsExportFile | null> {
   try {
-    if (!navigator.storage?.getDirectory) return null
-    const root = await navigator.storage.getDirectory()
-    const dir = await root.getDirectoryHandle(EXPORT_DIR, { create: true })
-
-    // Best-effort cleanup of earlier temp exports. Persisted artifacts
-    // (the recoverable last export, clip zips) are kept — they must survive
-    // a new export attempt that might fail.
-    try {
-      const names: string[] = []
-      for await (const name of (dir as unknown as { keys(): AsyncIterable<string> }).keys()) {
-        if (name.startsWith('export-')) names.push(name)
-      }
-      await Promise.all(names.map((name) => dir.removeEntry(name).catch(() => undefined)))
-    } catch {
-      // Cleanup is a nicety.
-    }
-
+    const dir = await exportsDir()
+    if (!dir) return null
     const name = `export-${Date.now()}.${extension}`
     const handle = await dir.getFileHandle(name, { create: true })
     const writable = await handle.createWritable()
     return {
+      name,
       writable,
       getFile: async () => {
         // Mediabunny closes the stream on finalize; close defensively for

--- a/src/lib/export/shared.ts
+++ b/src/lib/export/shared.ts
@@ -551,4 +551,9 @@ export interface ExportResult {
   blob: Blob
   mimeType: string
   fileExtension: 'mp4' | 'webm'
+  /** Name of the OPFS exports-directory file this export streamed into. */
+  opfsName?: string
+  /** True when `blob` is exactly the bytes of the `opfsName` file (false
+   * when metadata injection produced a new in-memory blob). */
+  opfsBacked?: boolean
 }

--- a/src/lib/project-actions.ts
+++ b/src/lib/project-actions.ts
@@ -13,6 +13,7 @@ import {
   undoDeleteLastClip,
   updateClipTrim,
 } from './storage'
+import { estimateExportCacheBytes } from './export/export-cache'
 import { estimateStorageSpace, type StorageSpace } from './storage-space'
 import { ensureClipThumbs } from './thumbs'
 import {
@@ -48,17 +49,20 @@ export interface ProjectLoaderData {
 export interface HomeLoaderData {
   projects: ProjectSummary[]
   storage: StorageSpace | null
+  /** Bytes held by cached export files (recoverable last export, scratch). */
+  exportCacheBytes: number
   /** True when the one-time Kody Video Plus purchase is unlocked. */
   plus: boolean
 }
 
 export async function loadHomePage(): Promise<HomeLoaderData> {
-  const [projects, storage, settings] = await Promise.all([
+  const [projects, storage, exportCacheBytes, settings] = await Promise.all([
     loadHomeProjects(),
     estimateStorageSpace(),
+    estimateExportCacheBytes(),
     getSettings(),
   ])
-  return { projects, storage, plus: settings.watermarkRemoved === true }
+  return { projects, storage, exportCacheBytes, plus: settings.watermarkRemoved === true }
 }
 
 export async function loadHomeProjects(): Promise<ProjectSummary[]> {

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -1,4 +1,5 @@
 import { openDB, type DBSchema, type IDBPDatabase } from 'idb'
+import { removeExportEntry } from './export/opfs'
 import {
   FREE_PROJECTS,
   MAX_PROJECTS,
@@ -191,10 +192,24 @@ export async function deleteProject(id: ProjectId): Promise<void> {
     tx.objectStore('undo').delete(id),
     tx.objectStore('projects').delete(id),
   ]
-  if (settings?.lastOpenedProjectId === id) {
-    ops.push(tx.objectStore('meta').put({ ...settings, lastOpenedProjectId: null }))
+  const dropsCachedExport = settings?.lastExport?.projectId === id
+  if (settings && (settings.lastOpenedProjectId === id || dropsCachedExport)) {
+    ops.push(
+      tx.objectStore('meta').put({
+        ...settings,
+        lastOpenedProjectId:
+          settings.lastOpenedProjectId === id ? null : settings.lastOpenedProjectId,
+        lastExport: dropsCachedExport ? undefined : settings.lastExport,
+      }),
+    )
   }
   await completeTransaction(ops, tx)
+
+  // The cached export can be ~1GB — deleting a project must actually free
+  // its space, not just its clips. Best-effort, after the commit.
+  if (dropsCachedExport && settings?.lastExport) {
+    await removeExportEntry(settings.lastExport.opfsName).catch(() => undefined)
+  }
 }
 
 export async function touchProject(id: ProjectId): Promise<void> {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,6 +2,7 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import { App } from './app'
 import { initErrorReporting, reactRootErrorHandlers } from './lib/error-reporting'
+import { sweepExportCache } from './lib/export/export-cache'
 import './lib/install-prompt'
 import './styles/global.css'
 import './styles/home.css'
@@ -9,6 +10,9 @@ import './styles/record.css'
 import './styles/editor.css'
 
 initErrorReporting()
+// Export temp files and zip scratch can be gigabytes; reclaim anything no
+// longer referenced. No export can be running at boot, so this is safe.
+void sweepExportCache().catch(() => undefined)
 
 createRoot(document.getElementById('root')!, reactRootErrorHandlers).render(
   <StrictMode>

--- a/src/pages/about-page.tsx
+++ b/src/pages/about-page.tsx
@@ -1,9 +1,11 @@
 import { useState } from 'react'
-import { Link } from 'react-router-dom'
+import { Link, useLoaderData, useRevalidator } from 'react-router-dom'
 import { IconBack } from '../components/icons'
 import { BrandMark } from '../components/brand-mark'
 import { checkForUpdates } from '../lib/app-update'
 import { buildDateLabel, shortVersion } from '../lib/build-info'
+import { clearExportCache, estimateExportCacheBytes } from '../lib/export/export-cache'
+import { estimateStorageSpace, formatBytes, type StorageSpace } from '../lib/storage-space'
 
 /** Prefilled GitHub issue so bug reports arrive with device context attached. */
 function reportProblemUrl(): string {
@@ -23,6 +25,19 @@ function reportProblemUrl(): string {
   return `https://github.com/kentcdodds/kody-video/issues/new?${params}`
 }
 
+export interface AboutLoaderData {
+  storage: StorageSpace | null
+  exportCacheBytes: number
+}
+
+export async function aboutLoader(): Promise<AboutLoaderData> {
+  const [storage, exportCacheBytes] = await Promise.all([
+    estimateStorageSpace(),
+    estimateExportCacheBytes(),
+  ])
+  return { storage, exportCacheBytes }
+}
+
 type UpdateStatus = 'idle' | 'checking' | 'current' | 'updating' | 'downloading' | 'unavailable'
 
 const UPDATE_STATUS_LABEL: Record<Exclude<UpdateStatus, 'idle'>, string> = {
@@ -35,7 +50,23 @@ const UPDATE_STATUS_LABEL: Record<Exclude<UpdateStatus, 'idle'>, string> = {
 
 /** Credits, inspiration, and the open-source pointer. */
 export function AboutPage() {
+  const { storage, exportCacheBytes } = useLoaderData() as AboutLoaderData
+  const revalidator = useRevalidator()
   const [updateStatus, setUpdateStatus] = useState<UpdateStatus>('idle')
+  const [cacheStatus, setCacheStatus] = useState<string | null>(null)
+  const [clearingCache, setClearingCache] = useState(false)
+
+  const onClearExportCache = () => {
+    if (clearingCache) return
+    setClearingCache(true)
+    void clearExportCache()
+      .then((freedBytes) => {
+        setCacheStatus(`Freed ${formatBytes(freedBytes)}.`)
+        void revalidator.revalidate()
+      })
+      .catch(() => setCacheStatus('Could not clear cached exports — try again.'))
+      .finally(() => setClearingCache(false))
+  }
 
   const onCheckForUpdates = () => {
     if (updateStatus === 'checking' || updateStatus === 'updating') return
@@ -146,6 +177,39 @@ export function AboutPage() {
             <kbd>Delete</kbd> deletes, and <kbd>Esc</kbd> goes back. During playback the arrows
             skip clips, <kbd>Space</kbd> pauses, and <kbd>Esc</kbd> closes.
           </p>
+        </section>
+
+        <section className="about-section">
+          <h2>Storage</h2>
+          <p>
+            {storage
+              ? `This app uses ${formatBytes(storage.usedBytes)} of the ${formatBytes(storage.quotaBytes)} the browser allows. `
+              : ''}
+            Your recordings are the big consumer — delete old projects from the home screen
+            (⋯ → Delete) to free the most space. The app also keeps your latest export cached so
+            tapping Go on an unchanged project is instant.
+          </p>
+          <p>
+            Cached export files: <strong>{formatBytes(exportCacheBytes)}</strong>
+            {exportCacheBytes > 0 ? (
+              <>
+                {' · '}
+                <button
+                  type="button"
+                  className="link-button"
+                  onClick={onClearExportCache}
+                  disabled={clearingCache}
+                >
+                  Clear
+                </button>
+              </>
+            ) : null}
+          </p>
+          {cacheStatus ? (
+            <p role="status" aria-live="polite">
+              {cacheStatus}
+            </p>
+          ) : null}
         </section>
 
         <section className="about-section">

--- a/src/pages/about-page.tsx
+++ b/src/pages/about-page.tsx
@@ -64,7 +64,11 @@ export function AboutPage() {
         setCacheStatus(`Freed ${formatBytes(freedBytes)}.`)
         void revalidator.revalidate()
       })
-      .catch(() => setCacheStatus('Could not clear cached exports — try again.'))
+      .catch((err) =>
+        setCacheStatus(
+          err instanceof Error ? err.message : 'Could not clear cached exports — try again.',
+        ),
+      )
       .finally(() => setClearingCache(false))
   }
 

--- a/src/pages/home-page.tsx
+++ b/src/pages/home-page.tsx
@@ -86,6 +86,8 @@ export function HomePage() {
   // gigabytes — when storage runs hot, the fix must be one tap away.
   const onClearExportCache = () => {
     setBusy(true)
+    setError(null)
+    setNotice(null)
     void clearExportCache()
       .then((freedBytes) => {
         setNotice(`Cleared cached export files — freed ${formatBytes(freedBytes)}.`)
@@ -93,7 +95,9 @@ export function HomePage() {
       })
       .catch((err) => {
         reportError(err, 'clear-export-cache')
-        setError('Could not clear cached exports — try again.')
+        setError(
+          err instanceof Error ? err.message : 'Could not clear cached exports — try again.',
+        )
       })
       .finally(() => {
         setBusy(false)

--- a/src/pages/home-page.tsx
+++ b/src/pages/home-page.tsx
@@ -18,6 +18,7 @@ import {
   serializeProject,
 } from '../lib/project-transfer'
 import { deleteProject, getClipsForProject, renameProject } from '../lib/storage'
+import { clearExportCache } from '../lib/export/export-cache'
 import { reportError } from '../lib/error-reporting'
 import { canPromptInstall, promptInstall, subscribeInstallPrompt } from '../lib/install-prompt'
 import { dismissIosInstallHint, shouldShowIosInstallHint } from '../lib/install-hint'
@@ -48,7 +49,7 @@ export async function homeLoader(): Promise<HomeLoaderData> {
 }
 
 export function HomePage() {
-  const { projects, storage, plus } = useLoaderData() as HomeLoaderData
+  const { projects, storage, exportCacheBytes, plus } = useLoaderData() as HomeLoaderData
   const revalidator = useRevalidator()
   const navigate = useNavigate()
   const [error, setError] = useState<string | null>(null)
@@ -79,6 +80,24 @@ export function HomePage() {
   // an untouched new project leaves no empty project behind.
   const openNewProject = () => {
     navigate(`/project/${NEW_PROJECT_ID}`)
+  }
+
+  // Cached export files (the recoverable last export + scratch) can hold
+  // gigabytes — when storage runs hot, the fix must be one tap away.
+  const onClearExportCache = () => {
+    setBusy(true)
+    void clearExportCache()
+      .then((freedBytes) => {
+        setNotice(`Cleared cached export files — freed ${formatBytes(freedBytes)}.`)
+        refresh()
+      })
+      .catch((err) => {
+        reportError(err, 'clear-export-cache')
+        setError('Could not clear cached exports — try again.')
+      })
+      .finally(() => {
+        setBusy(false)
+      })
   }
 
   const backupProject = (project: ProjectSummary) => {
@@ -195,6 +214,16 @@ export function HomePage() {
               ? ` Free space fast: delete an old project (⋯ on “${oldestProject.name}”, then Delete).`
               : ' Free space by clearing other site data or files on this device.'}
           </span>
+          {exportCacheBytes > 0 ? (
+            <button
+              type="button"
+              className="btn btn-secondary storage-banner-action"
+              disabled={busy}
+              onClick={onClearExportCache}
+            >
+              Clear cached exports ({formatBytes(exportCacheBytes)})
+            </button>
+          ) : null}
         </div>
       ) : null}
 

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -1,5 +1,5 @@
 import { Navigate, createBrowserRouter } from 'react-router-dom'
-import { AboutPage } from './pages/about-page'
+import { AboutPage, aboutLoader } from './pages/about-page'
 import { HomePage, homeLoader } from './pages/home-page'
 import { PrivacyPage } from './pages/privacy-page'
 import { ProjectPage, projectLoader } from './pages/project-page'
@@ -25,6 +25,7 @@ export const router = createBrowserRouter([
   {
     path: '/about',
     element: <AboutPage />,
+    loader: aboutLoader,
   },
   {
     path: '/privacy',

--- a/src/styles/home.css
+++ b/src/styles/home.css
@@ -400,6 +400,15 @@
   border-color: color-mix(in srgb, var(--danger) 45%, transparent);
 }
 
+.storage-banner-action {
+  margin-top: 8px;
+  align-self: flex-start;
+  min-height: 36px;
+  padding: 0 14px;
+  border-radius: 999px;
+  font-size: 0.88rem;
+}
+
 .home-privacy .link-button {
   font-size: inherit;
 }

--- a/tests/e2e/export.spec.ts
+++ b/tests/e2e/export.spec.ts
@@ -80,5 +80,31 @@ test.describe('Go / export', () => {
     // Nothing left the device: no non-GET requests to any non-local host
     // during recording, export, save, or zip.
     expect(offsiteWrites).toEqual([])
+
+    // Cache hygiene: exactly ONE recoverable export remains on disk after a
+    // boot sweep — no stray temp files, no zip scratch, no duplicate copy of
+    // the export (the double-store was how "storage full" survived deleting
+    // every project).
+    await page.locator('.export-sheet').getByRole('button', { name: 'Done' }).click()
+    await expect
+      .poll(() =>
+        page.evaluate(async () => {
+          const storage = await import('/src/lib/storage.ts')
+          return (await storage.getSettings()).lastExport?.opfsName ?? null
+        }),
+      )
+      .not.toBeNull()
+    await page.reload()
+    await waitForCameraReady(page)
+    const cacheEntries = await page.evaluate(async () => {
+      const root = await navigator.storage.getDirectory()
+      const dir = await root.getDirectoryHandle('exports', { create: true })
+      const names: string[] = []
+      for await (const name of (dir as unknown as { keys(): AsyncIterable<string> }).keys()) {
+        names.push(name)
+      }
+      return names
+    })
+    expect(cacheEntries).toHaveLength(1)
   })
 })

--- a/tests/e2e/storage.spec.ts
+++ b/tests/e2e/storage.spec.ts
@@ -1,0 +1,125 @@
+import { test, expect, type Page } from '@playwright/test'
+import { gotoHome, seedProject } from './helpers'
+
+function listExportCache(page: Page): Promise<string[]> {
+  return page.evaluate(async () => {
+    const root = await navigator.storage.getDirectory()
+    const dir = await root.getDirectoryHandle('exports', { create: true })
+    const names: string[] = []
+    for await (const name of (dir as unknown as { keys(): AsyncIterable<string> }).keys()) {
+      names.push(name)
+    }
+    return names.sort()
+  })
+}
+
+/** A cache entry the boot sweep must respect: a real project referenced by
+ * AppMeta.lastExport, with bytes on disk. */
+async function seedReferencedExportCache(page: Page, sizeBytes: number): Promise<void> {
+  const projectId = await seedProject(page, { clips: 1 })
+  await page.evaluate(
+    async ({ id, size }) => {
+      const root = await navigator.storage.getDirectory()
+      const dir = await root.getDirectoryHandle('exports', { create: true })
+      const handle = await dir.getFileHandle('last-export.mp4', { create: true })
+      const writable = await handle.createWritable()
+      await writable.write(new Uint8Array(size))
+      await writable.close()
+
+      const storage = await import('/src/lib/storage.ts')
+      const db = await storage.getDb()
+      const settings = await storage.getSettings()
+      await db.put('meta', {
+        ...settings,
+        lastExport: {
+          projectId: id,
+          opfsName: 'last-export.mp4',
+          mimeType: 'video/mp4',
+          fileExtension: 'mp4',
+          createdAt: Date.now(),
+          signature: 'e2e-seeded',
+          watermarked: true,
+        },
+      })
+    },
+    { id: projectId, size: sizeBytes },
+  )
+}
+
+test.describe('storage management', () => {
+  test('boot sweep removes orphaned cache files but keeps a referenced export', async ({
+    page,
+  }) => {
+    await seedReferencedExportCache(page, 2048)
+    // Orphans: a stale temp and a zip nothing references.
+    await page.evaluate(async () => {
+      const root = await navigator.storage.getDirectory()
+      const dir = await root.getDirectoryHandle('exports', { create: true })
+      for (const name of ['export-123.mp4', 'clips.zip']) {
+        const handle = await dir.getFileHandle(name, { create: true })
+        const writable = await handle.createWritable()
+        await writable.write(new Uint8Array(1024))
+        await writable.close()
+      }
+    })
+    expect(await listExportCache(page)).toEqual(['clips.zip', 'export-123.mp4', 'last-export.mp4'])
+
+    await page.reload()
+    await expect(page.locator('.home-hero')).toBeVisible()
+    await expect.poll(() => listExportCache(page)).toEqual(['last-export.mp4'])
+  })
+
+  test('storage banner offers one-tap cache clearing when space runs hot', async ({
+    browser,
+  }) => {
+    const context = await browser.newContext()
+    await context.addInitScript(() => {
+      Object.defineProperty(navigator.storage, 'estimate', {
+        value: async () => ({ usage: 0.85 * 1e9, quota: 1e9 }),
+      })
+    })
+    const page = await context.newPage()
+    await gotoHome(page)
+    await seedReferencedExportCache(page, 4096)
+    await page.reload()
+
+    const banner = page.locator('.storage-banner')
+    await expect(banner).toBeVisible()
+    await banner.getByRole('button', { name: /Clear cached exports/ }).click()
+    await expect(page.getByText(/Cleared cached export files — freed/)).toBeVisible()
+    await expect.poll(() => listExportCache(page)).toEqual([])
+    const lastExport = await page.evaluate(async () => {
+      const storage = await import('/src/lib/storage.ts')
+      return (await storage.getSettings()).lastExport ?? null
+    })
+    expect(lastExport).toBeNull()
+    await context.close()
+  })
+
+  test('about page shows cache size and clears it', async ({ page }) => {
+    await seedReferencedExportCache(page, 5 * 1024 * 1024)
+    await page.goto('/about')
+    const section = page.locator('.about-section', { hasText: 'Cached export files' })
+    await expect(section).toContainText('5 MB')
+    await section.getByRole('button', { name: 'Clear' }).click()
+    await expect(section.getByText(/Freed 5 MB/)).toBeVisible()
+    await expect(section).toContainText('Cached export files: 0 MB')
+    await expect.poll(() => listExportCache(page)).toEqual([])
+  })
+
+  test('deleting a project drops its cached export with it', async ({ page }) => {
+    await seedReferencedExportCache(page, 2048)
+    await page.reload()
+    await page.locator('.slot-options').click()
+    await page.getByRole('button', { name: 'Delete' }).click()
+    await page.locator('.confirm-sheet').getByRole('button', { name: 'Delete' }).click()
+    await expect(page.locator('.project-slot.filled')).toHaveCount(0)
+
+    await expect.poll(() => listExportCache(page)).toEqual([])
+    const lastExport = await page.evaluate(async () => {
+      const storage = await import('/src/lib/storage.ts')
+      return (await storage.getSettings()).lastExport ?? null
+    })
+    expect(lastExport).toBeNull()
+  })
+})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Kent deleted a project and storage still read full. Root cause: the OPFS export cache was quietly holding gigabytes that nothing ever reclaimed. This PR fixes the leaks and adds a visible storage-management surface.

## The leaks

For a long project (the half-hour, 200-clip case), after one export + one "Save clips":

- **Cached last export (~1GB)** survived its project's deletion — `deleteProject` freed clips but never touched `AppMeta.lastExport` or its OPFS file
- **Double-store (~1GB more)**: `persistLastExport` *copied* the on-disk export file to `last-export.<ext>`, and the `export-<ts>` temp only got cleaned when the *next* export started
- **`clips.zip` scratch (project-sized)** persisted forever after "Save clips"

## Fixes

- `deleteProject` clears `lastExport` in the same transaction and removes its OPFS file when the cached export belongs to the deleted project
- `persistLastExport` adopts file-backed exports **in place** (records the existing file's name — no copy). The in-memory path (metadata-injected MP4s ≤256MB, realtime engine) still streams a copy, but reclaims the superseded temp immediately; replacing a cached export always deletes the previous file
- A **sweep** at boot (`main.tsx`) and at export start (`exportProject`) deletes every cache file except a still-valid referenced last export; references to deleted projects are cleared. The sweep only runs when no export can be writing
- New `src/lib/export/export-cache.ts` owns estimate/clear/sweep; `opfs.ts` stays pure FS ops (avoids a storage↔opfs import cycle)

## UI

- The home storage banner (≥80%) gains a one-tap **"Clear cached exports (X MB)"** action with a freed-bytes notice
- The About page gets a **Storage** section: browser usage, guidance that projects are the big consumer, cache size, and a Clear button (new `aboutLoader`)

## Verification

- New e2e spec `tests/e2e/storage.spec.ts`: boot sweep keeps referenced/removes orphaned files, banner action clears cache + meta, About page shows and clears the cache, deleting a project drops its cached export
- Export spec now asserts **exactly one recoverable export on disk** after a boot sweep (no temps, no zip, no duplicate)
- Full suite: 42/42 e2e, 80 unit tests, lint, build all pass
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-16d17496-6b5b-4e12-b600-6933357c2059?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-16d17496-6b5b-4e12-b600-6933357c2059&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added storage usage and cached export size information to the Home and About pages.
  * Added controls to clear cached exports and display progress, results, and errors.
* **Bug Fixes**
  * Improved automatic cleanup of orphaned, temporary, duplicate, and project-related export files.
  * Preserved the current recoverable export and protected active exports during cleanup.
* **Tests**
  * Added end-to-end coverage for export cleanup, storage warnings, cache clearing, and project deletion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->