### PR TITLE
Survive stubborn element loads during export (KODY-VIDEO-A)

### DIFF
--- a/src/lib/clips-zip.ts
+++ b/src/lib/clips-zip.ts
@@ -7,6 +7,7 @@
  */
 
 import { makeZip } from 'client-zip'
+import { withExportCacheReserved } from './export/export-cache'
 import { streamToOpfsFile } from './export/opfs'
 import type { ClipRecord } from './types'
 
@@ -35,7 +36,11 @@ export async function buildClipsZip(clips: ClipRecord[]): Promise<Blob> {
         input: clip.blob,
       })),
     )
-  const file = await streamToOpfsFile('clips.zip', createStream())
+  // Reserved against cache sweeps/clears: the archive streams into the
+  // exports directory and must not be deleted mid-write by another tab.
+  const file = await withExportCacheReserved(() =>
+    streamToOpfsFile('clips.zip', createStream()),
+  )
   if (file) return new Blob([file], { type: 'application/zip' })
   return new Response(createStream()).blob()
 }

--- a/src/lib/clips-zip.ts
+++ b/src/lib/clips-zip.ts
@@ -36,10 +36,11 @@ export async function buildClipsZip(clips: ClipRecord[]): Promise<Blob> {
         input: clip.blob,
       })),
     )
-  // Reserved against cache sweeps/clears: the archive streams into the
-  // exports directory and must not be deleted mid-write by another tab.
+  // Reserved against cache sweeps/clears (must not be deleted mid-write by
+  // another tab), and uniquely named so concurrent zips in two tabs can
+  // never interleave into one file. Orphans are reclaimed by the sweep.
   const file = await withExportCacheReserved(() =>
-    streamToOpfsFile('clips.zip', createStream()),
+    streamToOpfsFile(`clips-${Date.now()}.zip`, createStream()),
   )
   if (file) return new Blob([file], { type: 'application/zip' })
   return new Response(createStream()).blob()

--- a/src/lib/export/encode-realtime.ts
+++ b/src/lib/export/encode-realtime.ts
@@ -10,6 +10,7 @@ import {
   pickOutputSize,
   recordVideoLumaSample,
   seekTo,
+  tagExportError,
   wait,
   waitForPreviewCanvas,
   type ExportResult,
@@ -38,9 +39,21 @@ export async function exportRealtime(
   options: RealtimeExportOptions = {},
 ): Promise<ExportResult> {
   const probeClip = plan.segments[0].clip
-  const probe = await loadClipVideo(probeClip.blob, 8000, probeClip.mimeType)
-  const { width, height } = pickOutputSize(probe.video.videoWidth, probe.video.videoHeight)
-  probe.release()
+  let width: number
+  let height: number
+  try {
+    const probe = await loadClipVideo(probeClip.blob, 8000, probeClip.mimeType)
+    ;({ width, height } = pickOutputSize(probe.video.videoWidth, probe.video.videoHeight))
+    probe.release()
+  } catch (error) {
+    // Probing is not worth dying over: recorded clips carry their capture
+    // dimensions, and pickOutputSize has sane defaults for the rest.
+    if ((probeClip.width ?? 0) > 0 && (probeClip.height ?? 0) > 0) {
+      ;({ width, height } = pickOutputSize(probeClip.width!, probeClip.height!))
+    } else {
+      throw tagExportError(error, { engine: 'realtime', where: 'probe-size', clipIndex: 0 })
+    }
+  }
 
   // Encode from the overlay's on-DOM canvas whenever possible: iOS Safari's
   // canvas.captureStream() delivers BLACK frames for canvases that aren't
@@ -109,8 +122,19 @@ export async function exportRealtime(
   let paintedTotalMs = 0
   const frameCounter = { count: 0 }
   try {
-    for (const segment of plan.segments) {
-      const loaded = await loadClipVideo(segment.clip.blob, 8000, segment.clip.mimeType)
+    for (const [segmentIndex, segment] of plan.segments.entries()) {
+      let loaded: Awaited<ReturnType<typeof loadClipVideo>>
+      try {
+        loaded = await loadClipVideo(segment.clip.blob, 8000, segment.clip.mimeType)
+      } catch (error) {
+        // The realtime engine plays clips through elements — this clip is
+        // genuinely unopenable here. Tag which one for the error report.
+        throw tagExportError(error, {
+          engine: 'realtime',
+          where: 'segment-load',
+          clipIndex: segmentIndex,
+        })
+      }
       try {
         const clamped = clampSegmentToMedia(segment, loaded.mediaDurationMs)
         if (!clamped) continue

--- a/src/lib/export/encode-webcodecs.ts
+++ b/src/lib/export/encode-webcodecs.ts
@@ -28,6 +28,7 @@ import {
   decodeClipAudio,
   drawWatermark,
   loadClipVideo,
+  tagExportError,
   pickOutputSize,
   recordVideoLumaSample,
   seekTo,
@@ -178,7 +179,7 @@ export async function exportWithWebCodecs(
   const chapters: Mp4Chapter[] = []
 
   try {
-    for (const segment of plan.segments) {
+    for (const [segmentIndex, segment] of plan.segments.entries()) {
       const input = new Input({
         source: new BlobSource(segment.clip.blob),
         formats: ALL_FORMATS,
@@ -192,8 +193,24 @@ export async function exportWithWebCodecs(
           .catch(() => 0)
         let clamped = mediaDurationMs > 0 ? clampSegmentToMedia(segment, mediaDurationMs) : null
         if (!clamped) {
-          loaded = await loadClipVideo(segment.clip.blob, 8000, segment.clip.mimeType)
-          clamped = clampSegmentToMedia(segment, loaded.mediaDurationMs)
+          try {
+            loaded = await loadClipVideo(segment.clip.blob, 8000, segment.clip.mimeType)
+            clamped = clampSegmentToMedia(segment, loaded.mediaDurationMs)
+          } catch (error) {
+            // A stubborn element load (iOS WebKit can refuse a blob it
+            // recorded itself — KODY-VIDEO-A) must not kill the export when
+            // it was only measuring duration: the recorder already measured
+            // this clip's real media duration at capture time. Only the
+            // element PUMP truly needs the element.
+            clamped = clampSegmentToMedia(segment, segment.clip.durationMs)
+            if (!clamped) {
+              throw tagExportError(error, {
+                engine: 'webcodecs',
+                where: 'clip-duration',
+                clipIndex: segmentIndex,
+              })
+            }
+          }
         }
         if (!clamped) continue
         const segmentMs = clamped.endMs - clamped.startMs
@@ -235,7 +252,15 @@ export async function exportWithWebCodecs(
           // Per-clip fallback: undecodable/unsupported clips play through a
           // video element like before (realtime-paced, but correct).
           console.info('[export] segment video path: element (realtime-paced)')
-          loaded ??= await loadClipVideo(segment.clip.blob, 8000, segment.clip.mimeType)
+          try {
+            loaded ??= await loadClipVideo(segment.clip.blob, 8000, segment.clip.mimeType)
+          } catch (error) {
+            throw tagExportError(error, {
+              engine: 'webcodecs',
+              where: 'element-pump',
+              clipIndex: segmentIndex,
+            })
+          }
           await pumpSegmentVideo({ video: loaded.video, ...pumpShared })
         }
 
@@ -312,9 +337,9 @@ async function injectMetadataBestEffort(
 
 /** Output dimensions from the first clip's real (rotated) display size. */
 async function probeOutputSize(plan: ExportPlan): Promise<{ width: number; height: number }> {
-  const blob = plan.segments[0]!.clip.blob
+  const clip = plan.segments[0]!.clip
   try {
-    const input = new Input({ source: new BlobSource(blob), formats: ALL_FORMATS })
+    const input = new Input({ source: new BlobSource(clip.blob), formats: ALL_FORMATS })
     const track = await input.getPrimaryVideoTrack()
     if (track && track.displayWidth > 0 && track.displayHeight > 0) {
       return pickOutputSize(track.displayWidth, track.displayHeight)
@@ -322,11 +347,20 @@ async function probeOutputSize(plan: ExportPlan): Promise<{ width: number; heigh
   } catch {
     // Fall through to the element probe.
   }
-  const probe = await loadClipVideo(blob, 8000, plan.segments[0]!.clip.mimeType)
   try {
-    return pickOutputSize(probe.video.videoWidth, probe.video.videoHeight)
-  } finally {
-    probe.release()
+    const probe = await loadClipVideo(clip.blob, 8000, clip.mimeType)
+    try {
+      return pickOutputSize(probe.video.videoWidth, probe.video.videoHeight)
+    } finally {
+      probe.release()
+    }
+  } catch (error) {
+    // Recorded clips carry their capture dimensions — probing must never be
+    // the reason an export dies (pickOutputSize also has sane defaults).
+    if ((clip.width ?? 0) > 0 && (clip.height ?? 0) > 0) {
+      return pickOutputSize(clip.width!, clip.height!)
+    }
+    throw tagExportError(error, { engine: 'webcodecs', where: 'probe-size', clipIndex: 0 })
   }
 }
 

--- a/src/lib/export/last-export.ts
+++ b/src/lib/export/last-export.ts
@@ -65,7 +65,11 @@ async function persistLastExportInner(args: {
   if (adoptable && result.opfsName) {
     opfsName = result.opfsName
   } else {
-    opfsName = `${LAST_EXPORT_PREFIX}.${result.fileExtension}`
+    // Unique name per write: reusing one canonical name meant an
+    // interrupted write (tab close mid-stream) could leave OLD metadata
+    // describing NEW bytes — restore would silently serve the wrong file.
+    // With unique names a torn write is just an orphan for the sweep.
+    opfsName = `${LAST_EXPORT_PREFIX}-${Date.now()}.${result.fileExtension}`
     const file = await streamToOpfsFile(opfsName, result.blob.stream())
     if (!file || file.size !== result.blob.size) return
     // The streaming temp behind this export (if any) is superseded by the

--- a/src/lib/export/shared.ts
+++ b/src/lib/export/shared.ts
@@ -17,7 +17,20 @@ export interface LoadedClipVideo {
  * on Android and iOS WebKit — which can report the race as
  * MEDIA_ERR_SRC_NOT_SUPPORTED even for a blob that played moments earlier.
  */
-const MEDIA_LOAD_RETRY_DELAYS_MS = [200, 500, 1000]
+const MEDIA_LOAD_RETRY_DELAYS_MS = [200, 500, 1000, 2000]
+
+/**
+ * Attach diagnostic detail (engine, clip index, load purpose) to an error
+ * on its way up — remote export failures are undebuggable without knowing
+ * WHICH clip and WHICH code path rejected.
+ */
+export function tagExportError(error: unknown, detail: Record<string, unknown>): unknown {
+  if (error && typeof error === 'object') {
+    const target = error as { exportDetail?: Record<string, unknown> }
+    target.exportDetail = { ...target.exportDetail, ...detail }
+  }
+  return error
+}
 
 /**
  * Prefer the clip's recorded MIME type when the Blob's type is missing,

--- a/src/pages/about-page.tsx
+++ b/src/pages/about-page.tsx
@@ -4,6 +4,7 @@ import { IconBack } from '../components/icons'
 import { BrandMark } from '../components/brand-mark'
 import { checkForUpdates } from '../lib/app-update'
 import { buildDateLabel, shortVersion } from '../lib/build-info'
+import { reportError } from '../lib/error-reporting'
 import { clearExportCache, estimateExportCacheBytes } from '../lib/export/export-cache'
 import { estimateStorageSpace, formatBytes, type StorageSpace } from '../lib/storage-space'
 
@@ -64,11 +65,12 @@ export function AboutPage() {
         setCacheStatus(`Freed ${formatBytes(freedBytes)}.`)
         void revalidator.revalidate()
       })
-      .catch((err) =>
+      .catch((err) => {
+        reportError(err, 'clear-export-cache')
         setCacheStatus(
           err instanceof Error ? err.message : 'Could not clear cached exports — try again.',
-        ),
-      )
+        )
+      })
       .finally(() => setClearingCache(false))
   }
 

--- a/src/pages/project-page.tsx
+++ b/src/pages/project-page.tsx
@@ -278,6 +278,9 @@ export function ProjectPage() {
           clipSizes: clips.map((clip) => clip.blob.size),
           mediaErrorCode:
             err instanceof MediaElementFailureError ? err.mediaErrorCode : undefined,
+          // Which engine, which clip, which load purpose — attached at the
+          // failing callsite (KODY-VIDEO-A was undebuggable without it).
+          exportDetail: (err as { exportDetail?: Record<string, unknown> }).exportDetail,
         })
         if (exportRunRef.current !== runId) return
         setExportState({

--- a/src/pages/project-page.tsx
+++ b/src/pages/project-page.tsx
@@ -280,7 +280,10 @@ export function ProjectPage() {
             err instanceof MediaElementFailureError ? err.mediaErrorCode : undefined,
           // Which engine, which clip, which load purpose — attached at the
           // failing callsite (KODY-VIDEO-A was undebuggable without it).
-          exportDetail: (err as { exportDetail?: Record<string, unknown> }).exportDetail,
+          exportDetail:
+            err && typeof err === 'object'
+              ? (err as { exportDetail?: Record<string, unknown> }).exportDetail
+              : undefined,
         })
         if (exportRunRef.current !== runId) return
         setExportState({


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Juri (@juristr) hit "Export hit a snag — Media failed while waiting for loadedmetadata (MEDIA_ERR_SRC_NOT_SUPPORTED)" on iOS Chrome in a browser tab ([KODY-VIDEO-A](https://kent-c-dodds-tech-llc.sentry.io/issues/7643113076/)). The Sentry event shows three healthy fMP4 clips (7.6/5.3/14.9MB, `avc1.640028`) on the latest release — recording and preview worked, then export's `loadClipVideo` failed with media error code 4 **even after the existing four retries**. WebKit can persistently refuse a blob `<video>` it recorded itself.

## Why this fixes it

The export depended on element loads in places that never truly needed an element:

- **Duration measurement** (when mediabunny's `computeDuration` comes up empty): now falls back to the recorder-measured `clip.durationMs` — captured from the actual blob at record time — instead of killing the export. If the decoded (WebCodecs) pump then carries the frames, the whole export completes without ever opening a `<video>`.
- **Output-size probing** (both engines): falls back to the clip's stored capture dimensions before giving up; `pickOutputSize` already has sane defaults beyond that.
- Only the **element pump** (the per-clip fallback for undecodable clips, and the realtime engine's playback) genuinely requires an element — those paths keep failing loudly, but now with context.

## Also

- Retry backoff gains a 2s tail attempt (200/500/1000/2000ms) for slow decoder-slot reclaim.
- Errors that still escape carry `exportDetail` — engine, load purpose (`clip-duration` / `element-pump` / `probe-size` / `segment-load`), and clip index — into the Sentry report. KODY-VIDEO-A couldn't tell us which engine or which clip failed; the next report will.

## Verification

- Full e2e suite green (42/42), fast-export probe green (decode pump, ~30fps decimation, recovery, zip), 80 unit tests, lint, build.
- The specific WebKit refusal isn't reproducible in headless Linux; the fallbacks are exercised as no-regression paths, and the new telemetry confirms the fix (or pinpoints the survivor) from the field.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-16d17496-6b5b-4e12-b600-6933357c2059?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-16d17496-6b5b-4e12-b600-6933357c2059&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added cached export storage visibility and cleanup controls on the Home and About pages.
  * Cached exports are automatically cleaned up while preserving active and valid exports.
  * Deleting a project now removes its associated cached export.
  * Export errors provide clearer engine, clip, and loading-stage details.

* **Bug Fixes**
  * Improved export reliability with dimension and duration fallbacks.
  * Prevented temporary and duplicate export files from accumulating.
  * Added safer coordination during simultaneous export and cleanup operations.

* **Tests**
  * Expanded coverage for storage cleanup, cache controls, project deletion, and export integrity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->