### PR TITLE
Mirror the preview only when the selfie feed actually arrives

### DIFF
--- a/src/hooks/use-camera.ts
+++ b/src/hooks/use-camera.ts
@@ -344,12 +344,17 @@ export function useCamera(): UseCameraResult {
     const previousFacing = facingRef.current
     const nextFacing: FacingMode = previousFacing === 'environment' ? 'user' : 'environment'
     facingRef.current = nextFacing
-    setFacing(nextFacing)
     setError(null)
     try {
       const rememberedLens =
         nextFacing === 'environment' ? await resolveRearLens() : undefined
       const next = await openCombinedOrVideoStream(nextFacing, rememberedLens)
+      // The facing STATE (which drives the preview's mirror transform)
+      // changes only once the new stream is in hand: setting it up front
+      // mirrored the still-showing old feed for the whole camera warm-up.
+      // Both updates land in one React commit, so mirror and feed swap
+      // together.
+      setFacing(nextFacing)
       replaceStream(next)
       void syncRearLenses(next)
     } catch (err) {

--- a/tests/e2e/camera-flip.spec.ts
+++ b/tests/e2e/camera-flip.spec.ts
@@ -1,0 +1,50 @@
+import { test, expect } from '@playwright/test'
+import { openNewProject } from './helpers'
+
+// Two fake cameras so the flip button is enabled at all.
+test.use({
+  launchOptions: {
+    args: [
+      '--use-fake-ui-for-media-stream',
+      '--use-fake-device-for-media-stream=device-count=2',
+      '--autoplay-policy=no-user-gesture-required',
+    ],
+  },
+})
+
+test.describe('camera flip', () => {
+  test('mirror applies only when the selfie feed actually arrives', async ({ page }) => {
+    // Slow down the selfie-camera open so the warm-up window is observable:
+    // the bug was the still-showing REAR feed mirroring the moment flip was
+    // tapped, a full camera warm-up before the selfie feed replaced it.
+    await page.addInitScript(() => {
+      const media = navigator.mediaDevices
+      const original = media.getUserMedia.bind(media)
+      media.getUserMedia = async (constraints?: MediaStreamConstraints) => {
+        const wantsSelfie = JSON.stringify(constraints?.video ?? {}).includes('user')
+        if (wantsSelfie) {
+          await new Promise((resolve) => {
+            setTimeout(resolve, 900)
+          })
+        }
+        return original(constraints)
+      }
+    })
+
+    await openNewProject(page)
+    const video = page.locator('.camera-video')
+    await expect(video).not.toHaveClass(/mirror/)
+
+    await page.getByRole('button', { name: 'Flip camera' }).click()
+    // Mid warm-up: old feed still showing — it must NOT be mirrored.
+    await page.waitForTimeout(300)
+    await expect(video).not.toHaveClass(/mirror/)
+
+    // Once the selfie stream lands, the mirror lands with it.
+    await expect(video).toHaveClass(/mirror/, { timeout: 5_000 })
+
+    // And flipping back eventually unmirrors.
+    await page.getByRole('button', { name: 'Flip camera' }).click()
+    await expect(video).not.toHaveClass(/mirror/, { timeout: 5_000 })
+  })
+})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Kent reported: flipping to the selfie camera mirrors the preview *before* the camera feed switches — the still-showing rear feed flips horizontally for the whole camera warm-up (up to a second), which looks broken.

## Why

The `.mirror` transform keys off the camera hook's `facing` state, which `flip()` set optimistically at the start — before the async `getUserMedia` for the new camera resolved and the stream was adopted.

## How

`flip()` now updates `facingRef` up front (internal adoption guards still need it) but defers the `facing` **state** until the new stream is in hand. `setFacing` and `replaceStream` run in the same synchronous block, so React batches them into one commit — the mirror lands together with the selfie feed. The failure path is unchanged.

## Verification

New e2e spec (`camera-flip.spec.ts`, two fake cameras + an artificially slowed selfie open): asserts no mirror mid-warm-up, mirror once the feed arrives, and unmirror after flipping back. Mutation-tested — the spec fails against the old behavior at exactly the mid-warm-up assertion. Full suite 43/43, unit tests, lint, build all green.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-16d17496-6b5b-4e12-b600-6933357c2059?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-16d17496-6b5b-4e12-b600-6933357c2059&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

