### PR TITLE
Lock onto Android's logical multi-camera for seamless zoom lens hand-off

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ Verified approach: `npm run build && npm run preview`, load once online, then De
   Phones that expose Android's *logical multi-camera* to the browser (zoom range below 1×,
   common on Samsung) get native-style seamless lens hand-off through the zoom gesture instead —
   the app detects such a lens the first time it's opened (cycle the chip once) and locks onto
-  it for future sessions. Switching lenses with the chip afterwards replaces that memory (your
+  it for future sessions. Switching lenses with the chip afterward replaces that memory (your
   explicit choice always wins); opening the seamless lens again re-locks it. iPhones always
   work this way via the OS multi-lens camera.
 

--- a/README.md
+++ b/README.md
@@ -132,7 +132,9 @@ Verified approach: `npm run build && npm run preview`, load once online, then De
   Phones that expose Android's *logical multi-camera* to the browser (zoom range below 1×,
   common on Samsung) get native-style seamless lens hand-off through the zoom gesture instead —
   the app detects such a lens the first time it's opened (cycle the chip once) and locks onto
-  it for future sessions. iPhones always work this way via the OS multi-lens camera.
+  it for future sessions. Switching lenses with the chip afterwards replaces that memory (your
+  explicit choice always wins); opening the seamless lens again re-locks it. iPhones always
+  work this way via the OS multi-lens camera.
 
 ## Desktop keyboard support
 

--- a/README.md
+++ b/README.md
@@ -129,6 +129,10 @@ Verified approach: `npm run build && npm run preview`, load once online, then De
 - **Ultra-wide (0.5×):** Android usually exposes the ultra-wide/telephoto as *separate* rear
   cameras, not as zoom below 1× — the lens chip next to the zoom chips switches between them.
   Some devices don't expose the extra lenses to browsers at all; the chip is hidden there.
+  Phones that expose Android's *logical multi-camera* to the browser (zoom range below 1×,
+  common on Samsung) get native-style seamless lens hand-off through the zoom gesture instead —
+  the app detects such a lens the first time it's opened (cycle the chip once) and locks onto
+  it for future sessions. iPhones always work this way via the OS multi-lens camera.
 
 ## Desktop keyboard support
 

--- a/manual-test-checklist.md
+++ b/manual-test-checklist.md
@@ -84,6 +84,10 @@ see the README) — plain `http://<lan-ip>` fails in most browsers.
 - [ ] Multi-rear-lens Androids show the lens chip (e.g. "1/3"); choice sticks
   across flips and restarts. iOS: NO lens chip; multi-lens iPhones open the
   virtual device so zoom spans 0.5×–max
+- [ ] Android phones exposing a logical multi-camera (a rear lens whose zoom
+  chips include 0.5×/0.6×): after opening that lens once, the app reopens it
+  on every session and drag-zoom hands off between physical lenses
+  seamlessly, including mid-recording
 - [ ] Dragging up/down during a hold zooms; edge presses keep a minimum ramp;
   small tremble (<~14px) doesn't zoom; release eases back to the pre-take level
 - [ ] Camera preview stays smooth while recording (no visible frame drops)

--- a/manual-test-checklist.md
+++ b/manual-test-checklist.md
@@ -87,7 +87,7 @@ see the README) — plain `http://<lan-ip>` fails in most browsers.
 - [ ] Android phones exposing a logical multi-camera (a rear lens whose zoom
   chips include 0.5×/0.6×): after opening that lens once, the app reopens it
   on every session and drag-zoom hands off between physical lenses
-  seamlessly, including mid-recording; a manual chip switch afterwards
+  seamlessly, including mid-recording; a manual chip switch afterward
   overrides the memory until the seamless lens is opened again
 - [ ] Dragging up/down during a hold zooms; edge presses keep a minimum ramp;
   small tremble (<~14px) doesn't zoom; release eases back to the pre-take level

--- a/manual-test-checklist.md
+++ b/manual-test-checklist.md
@@ -87,7 +87,8 @@ see the README) — plain `http://<lan-ip>` fails in most browsers.
 - [ ] Android phones exposing a logical multi-camera (a rear lens whose zoom
   chips include 0.5×/0.6×): after opening that lens once, the app reopens it
   on every session and drag-zoom hands off between physical lenses
-  seamlessly, including mid-recording
+  seamlessly, including mid-recording; a manual chip switch afterwards
+  overrides the memory until the seamless lens is opened again
 - [ ] Dragging up/down during a hold zooms; edge presses keep a minimum ramp;
   small tremble (<~14px) doesn't zoom; release eases back to the pre-take level
 - [ ] Camera preview stays smooth while recording (no visible frame drops)

--- a/src/hooks/use-camera.ts
+++ b/src/hooks/use-camera.ts
@@ -274,11 +274,15 @@ export function useCamera(): UseCameraResult {
     // between physical lenses (ultra-wide/wide/tele) as zoom crosses their
     // boundaries, native-camera style, even mid-recording. Lock onto it as
     // the remembered lens so every future session opens it directly.
-    // A later manual chip switch still overwrites this (the user wins).
+    // A still-valid manual chip choice is never displaced from here: opens
+    // land in this path incidentally too (getUserMedia fallbacks), and the
+    // user's explicit pick must survive those. The chip's own switch
+    // handler re-locks the logical lens when the user returns to it.
     const zoomRange = zoomRangeRef.current
     if (zoomRange && zoomRange.min < 1 && activeId && index >= 0) {
       const remembered = rememberedRearLens()
-      if (remembered?.id !== activeId) {
+      const rememberedValid = remembered !== null && lenses.includes(remembered.id)
+      if (!rememberedValid || remembered.id === activeId) {
         rememberRearLens({ id: activeId, index })
       }
     }

--- a/src/hooks/use-camera.ts
+++ b/src/hooks/use-camera.ts
@@ -268,6 +268,20 @@ export function useCamera(): UseCameraResult {
     const index = lenses.indexOf(activeId)
     rearLensIndexRef.current = index >= 0 ? index : 0
     setRearLensIndex(index >= 0 ? index : 0)
+
+    // Seamless multi-lens discovery: a rear lens whose zoom range reaches
+    // below 1× is Android's logical multi-camera — the HAL hands off
+    // between physical lenses (ultra-wide/wide/tele) as zoom crosses their
+    // boundaries, native-camera style, even mid-recording. Lock onto it as
+    // the remembered lens so every future session opens it directly.
+    // A later manual chip switch still overwrites this (the user wins).
+    const zoomRange = zoomRangeRef.current
+    if (zoomRange && zoomRange.min < 1 && activeId && index >= 0) {
+      const remembered = rememberedRearLens()
+      if (remembered?.id !== activeId) {
+        rememberRearLens({ id: activeId, index })
+      }
+    }
   }, [])
 
   const start = useCallback(async () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Kent asked for native-camera-style automatic lens switching while zooming, instead of manually tapping the lens chip before recording.

## Platform reality

- **iOS**: already seamless — the app deliberately opens the OS virtual multi-lens camera (`preferredIosRearCameraId`), and iOS hands off between ultra-wide/wide/tele through the zoom range, including mid-recording. Nothing to change.
- **Android with a logical multi-camera exposed to the browser** (Camera2 `CONTROL_ZOOM_RATIO`; common on Samsung — zoom ranges like 0.6–10 on one device): the HAL does the same seamless hand-off through the `zoom` constraint, and it survives recording because the MediaStream track never changes. The app's zoom pipeline (chips, log-scale drag math) already handles sub-1× ranges — we just never *preferred* that lens.
- **Android with only separate physical lenses** (Kent's phone, evidently): mid-take switching is physically impossible on the web — swapping `getUserMedia` devices kills the MediaRecorder track. Labels ("camera2 0, facing back") can't rank lenses, so the manual chip (with its persisted memory) remains the mechanism there.

## How

Opportunistic discovery in `syncRearLenses`: whenever a rear stream is adopted and its zoom capability reaches below 1×, that lens is recorded as the remembered rear lens — every future session opens it directly, making the phone behave like an iPhone. Discovery happens the first time the lens is opened (cycling the chip once is enough). A manual chip switch afterwards still overwrites the memory: the user always wins.

README browser-limits and the manual checklist document the behavior tiers.

## Verification

- Type-check, unit tests, camera e2e specs green. The behavior itself needs real hardware with a logical multi-camera (fake devices expose no zoom capability) — hence the new manual checklist entry.
- Zero risk to non-qualifying devices: the new code path only runs when a lens actually reports `zoom.min < 1`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-16d17496-6b5b-4e12-b600-6933357c2059?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-16d17496-6b5b-4e12-b600-6933357c2059&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added seamless sub-1× zoom transitions between rear lenses on compatible Android devices.
  * The app detects supported devices and remembers the selected rear lens between sessions.
  * Manual lens switching overrides the remembered selection.
  * iPhones continue using the operating system’s multi-lens behavior.

* **Documentation**
  * Updated Android multi-camera support documentation and manual testing guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->