### PR TITLE
Camera polish: zoom HUD, clone-based recording, rear-lens fallback, camera inspector

### DIFF
--- a/manual-test-checklist.md
+++ b/manual-test-checklist.md
@@ -91,6 +91,8 @@ see the README) — plain `http://<lan-ip>` fails in most browsers.
   overrides the memory until the seamless lens is opened again
 - [ ] Dragging up/down during a hold zooms; edge presses keep a minimum ramp;
   small tremble (<~14px) doesn't zoom; release eases back to the pre-take level
+- [ ] A zoom readout (e.g. "2.3×") appears near the top of the preview while
+  the zoom changes (drag, chip tap, or ease-back) and fades out ~1s after
 - [ ] Camera preview stays smooth while recording (no visible frame drops)
 - [ ] Ending a take does not flash the preview black (Android regression)
 - [ ] Backgrounding releases camera/mic (green dot goes out); returning

--- a/src/components/record-screen.tsx
+++ b/src/components/record-screen.tsx
@@ -1012,7 +1012,10 @@ export function RecordScreen({
                 cancelAnimationFrame(zoomRestoreRafRef.current)
                 zoomBaselineRef.current = null
                 dragZoomMovedRef.current = false
-                void camera.switchRearLens()
+                void camera.switchRearLens().then(() => {
+                  const range = camera.getZoom()
+                  if (range) showZoomHud(range.value)
+                })
               }}
             >
               <IconLens size={14} />

--- a/src/components/record-screen.tsx
+++ b/src/components/record-screen.tsx
@@ -1012,10 +1012,13 @@ export function RecordScreen({
                 cancelAnimationFrame(zoomRestoreRafRef.current)
                 zoomBaselineRef.current = null
                 dragZoomMovedRef.current = false
-                void camera.switchRearLens().then(() => {
-                  const range = camera.getZoom()
-                  if (range) showZoomHud(range.value)
-                })
+                void camera
+                  .switchRearLens()
+                  .then(() => {
+                    const range = camera.getZoom()
+                    if (range) showZoomHud(range.value)
+                  })
+                  .catch(() => undefined)
               }}
             >
               <IconLens size={14} />

--- a/src/components/record-screen.tsx
+++ b/src/components/record-screen.tsx
@@ -198,6 +198,22 @@ export function RecordScreen({
    * OK Video behavior: drag-to-zoom only lasts for the take. When the finger
    * lifts, ease the lens back to the zoom the user had before recording.
    */
+  // Live zoom readout: updated imperatively (refs, no React state) so
+  // drag-to-zoom mid-recording never causes a re-render. Fades out shortly
+  // after the value stops changing.
+  const zoomHudRef = useRef<HTMLDivElement | null>(null)
+  const zoomHudTimerRef = useRef(0)
+  const showZoomHud = useCallback((value: number) => {
+    const hud = zoomHudRef.current
+    if (!hud) return
+    hud.textContent = formatZoomLabel(value)
+    hud.classList.add('is-visible')
+    window.clearTimeout(zoomHudTimerRef.current)
+    zoomHudTimerRef.current = window.setTimeout(() => {
+      hud.classList.remove('is-visible')
+    }, 900)
+  }, [])
+
   const restoreZoomAfterHold = useCallback(() => {
     if (!dragZoomMovedRef.current) return
     dragZoomMovedRef.current = false
@@ -211,7 +227,9 @@ export function RecordScreen({
     const tick = () => {
       const t = Math.min(1, (performance.now() - started) / durationMs)
       const eased = 1 - (1 - t) * (1 - t)
-      camera.setZoom(from + (to - from) * eased)
+      const value = from + (to - from) * eased
+      camera.setZoom(value)
+      showZoomHud(value)
       if (t < 1) {
         zoomRestoreRafRef.current = requestAnimationFrame(tick)
       } else {
@@ -219,7 +237,7 @@ export function RecordScreen({
       }
     }
     zoomRestoreRafRef.current = requestAnimationFrame(tick)
-  }, [camera])
+  }, [camera, showZoomHud])
 
   const releaseWakeLock = useCallback(() => {
     wakeLockGenRef.current += 1
@@ -811,6 +829,7 @@ export function RecordScreen({
           dragZoomMovedRef.current = true
           dragZoomLastValueRef.current = next
           camera.setZoom(next)
+          showZoomHud(next)
         }}
         onPointerUp={(event) => {
           if (keyboardTakeRef.current) return
@@ -877,6 +896,8 @@ export function RecordScreen({
             <span>release to stop</span>
           </div>
         ) : null}
+
+        <div className="zoom-hud" ref={zoomHudRef} aria-hidden="true" />
 
         {needsPermission ? (
           <div className="permission-panel">
@@ -1012,6 +1033,7 @@ export function RecordScreen({
                   cancelAnimationFrame(zoomRestoreRafRef.current)
                   zoomBaselineRef.current = level
                   camera.setZoom(level)
+                  showZoomHud(level)
                 }}
               >
                 {formatZoomLabel(level)}

--- a/src/hooks/use-camera.ts
+++ b/src/hooks/use-camera.ts
@@ -125,6 +125,8 @@ export interface UseCameraResult {
   getStream: () => MediaStream | null
   /** The live preview element — for zero-cost frame capture at take end. */
   getVideoElement: () => HTMLVideoElement | null
+  /** Latest zoom range from the ref (safe to read right after awaits). */
+  getZoom: () => CameraZoomRange | null
 }
 
 interface ZoomCapability {
@@ -595,6 +597,7 @@ export function useCamera(): UseCameraResult {
 
   const getStream = useCallback(() => streamRef.current, [])
   const getVideoElement = useCallback(() => videoElRef.current, [])
+  const getZoom = useCallback(() => zoomRangeRef.current, [])
 
   return {
     videoRef,
@@ -620,6 +623,7 @@ export function useCamera(): UseCameraResult {
     releaseMic,
     getStream,
     getVideoElement,
+    getZoom,
   }
 }
 

--- a/src/lib/media.ts
+++ b/src/lib/media.ts
@@ -107,25 +107,47 @@ interface InputDeviceWithCapabilities extends MediaDeviceInfo {
  * below 1× on the main one — reaching them requires opening that device.
  * Labels/capabilities are only populated once camera permission is granted.
  */
+function deviceFacing(device: InputDeviceWithCapabilities): string[] {
+  try {
+    const facing = device.getCapabilities?.().facingMode
+    return Array.isArray(facing) ? facing : []
+  } catch {
+    return []
+  }
+}
+
+function looksRear(device: InputDeviceWithCapabilities): boolean {
+  const facing = deviceFacing(device)
+  if (facing.length > 0) return facing.includes('environment')
+  return /\bback\b|\brear\b|environment/i.test(device.label)
+}
+
+function looksFront(device: InputDeviceWithCapabilities): boolean {
+  const facing = deviceFacing(device)
+  if (facing.length > 0) return facing.includes('user')
+  return /\bfront\b|\buser\b|selfie/i.test(device.label)
+}
+
 export async function listRearCameras(): Promise<string[]> {
   if (!navigator.mediaDevices?.enumerateDevices) return []
   try {
     const devices = await navigator.mediaDevices.enumerateDevices()
-    return devices
-      .filter((device): device is InputDeviceWithCapabilities => device.kind === 'videoinput')
-      .filter((device) => {
-        try {
-          const facing = device.getCapabilities?.().facingMode
-          if (Array.isArray(facing) && facing.length > 0) {
-            return facing.includes('environment')
-          }
-        } catch {
-          // Fall through to the label heuristic.
-        }
-        return /\bback\b|\brear\b|environment/i.test(device.label)
-      })
-      .map((device) => device.deviceId)
-      .filter((id) => id.length > 0)
+    const videos = devices.filter(
+      (device): device is InputDeviceWithCapabilities => device.kind === 'videoinput',
+    )
+    let rear = videos.filter(looksRear)
+    // Some Chrome/OS builds label lenses without any facing hint ("Camera
+    // 0") and report no facingMode capability. When the positive heuristics
+    // find NOTHING but at least one device is identifiably front-facing,
+    // treat the rest as rear — better than hiding the lens switcher on
+    // phones that clearly have rear cameras.
+    if (rear.length === 0) {
+      const fronts = videos.filter(looksFront)
+      if (fronts.length > 0 && fronts.length < videos.length) {
+        rear = videos.filter((device) => !looksFront(device))
+      }
+    }
+    return rear.map((device) => device.deviceId).filter((id) => id.length > 0)
   } catch {
     return []
   }

--- a/src/lib/recorder.ts
+++ b/src/lib/recorder.ts
@@ -16,85 +16,106 @@ const MIN_TAKE_MS = 120
  * Hold-to-record helper around MediaRecorder.
  * Starts on press, stops on release; returns a Blob for IndexedDB storage.
  */
-export class HoldRecorder {
-  private recorder: MediaRecorder | null = null
-  private recordStream: MediaStream | null = null
-  private chunks: BlobPart[] = []
-  private startedAt = 0
-  private mimeType = ''
-  private stopping = false
-  private trackWidth: number | undefined
-  private trackHeight: number | undefined
-
-  get isRecording(): boolean {
-    return this.recorder?.state === 'recording'
-  }
-
+/** One take's private state. Handlers close over their own session, so a
+ * stale MediaRecorder event (a canceled take's stop arriving after the next
+ * take began) can only ever touch its own clones and chunks. */
+interface RecordingSession {
+  recorder: MediaRecorder
   /** Recording consumes CLONES of the preview's tracks: MediaRecorder
    * attaching/detaching directly on the live camera track makes some
-   * Android HALs reconfigure the capture pipeline, blanking the preview for
-   * a frame right when the take ends. Clones detach invisibly. */
-  private stopClones(): void {
-    this.recordStream?.getTracks().forEach((track) => {
-      track.stop()
-    })
-    this.recordStream = null
+   * Android HALs reconfigure the capture pipeline, blanking the preview
+   * for a frame right when the take ends. Clones detach invisibly. */
+  stream: MediaStream
+  chunks: BlobPart[]
+  mimeType: string
+  startedAt: number
+  trackWidth: number | undefined
+  trackHeight: number | undefined
+}
+
+function stopSessionTracks(session: RecordingSession): void {
+  session.stream.getTracks().forEach((track) => {
+    track.stop()
+  })
+}
+
+export class HoldRecorder {
+  private session: RecordingSession | null = null
+  private stopping = false
+
+  get isRecording(): boolean {
+    return this.session?.recorder.state === 'recording'
   }
 
   /** @returns true when a new recording actually started */
   start(stream: MediaStream): boolean {
     if (this.isRecording || this.stopping) return false
 
-    this.mimeType = pickRecordingMimeType()
-    this.chunks = []
-    this.startedAt = performance.now()
-
     const settings = stream.getVideoTracks()[0]?.getSettings()
-    this.trackWidth = settings?.width
-    this.trackHeight = settings?.height
+    const clones = stream.getTracks().map((track) => track.clone())
+    const recordStream = new MediaStream(clones)
 
-    this.stopClones()
-    const recordStream = new MediaStream(stream.getTracks().map((track) => track.clone()))
-    this.recordStream = recordStream
+    let recorder: MediaRecorder
+    try {
+      const preferredMime = pickRecordingMimeType()
+      recorder = preferredMime
+        ? new MediaRecorder(recordStream, {
+            mimeType: preferredMime,
+            videoBitsPerSecond: 3_500_000,
+            audioBitsPerSecond: 192_000,
+          })
+        : new MediaRecorder(recordStream)
 
-    const recorder = this.mimeType
-      ? new MediaRecorder(recordStream, {
-          mimeType: this.mimeType,
-          videoBitsPerSecond: 3_500_000,
-          audioBitsPerSecond: 192_000,
-        })
-      : new MediaRecorder(recordStream)
-
-    this.mimeType = recorder.mimeType || this.mimeType || 'video/webm'
-    recorder.ondataavailable = (event) => {
-      if (event.data.size > 0) this.chunks.push(event.data)
+      const session: RecordingSession = {
+        recorder,
+        stream: recordStream,
+        chunks: [],
+        mimeType: recorder.mimeType || preferredMime || 'video/webm',
+        startedAt: performance.now(),
+        trackWidth: settings?.width,
+        trackHeight: settings?.height,
+      }
+      recorder.ondataavailable = (event) => {
+        if (event.data.size > 0) session.chunks.push(event.data)
+      }
+      recorder.start(250)
+      this.session = session
+      return true
+    } catch {
+      // Constructor/start can throw (unsupported params, dead tracks) —
+      // the clones must not outlive the failed attempt.
+      recordStream.getTracks().forEach((track) => {
+        track.stop()
+      })
+      return false
     }
-    this.recorder = recorder
-    recorder.start(250)
-    return true
   }
 
   stop(): Promise<RecordingResult | null> {
-    const recorder = this.recorder
-    if (!recorder || recorder.state === 'inactive') {
-      this.recorder = null
+    const session = this.session
+    if (!session || session.recorder.state === 'inactive') {
+      if (session) stopSessionTracks(session)
+      this.session = null
       this.stopping = false
-      this.stopClones()
       return Promise.resolve(null)
     }
 
     this.stopping = true
-    const wallClockMs = Math.max(0, Math.round(performance.now() - this.startedAt))
+    const wallClockMs = Math.max(0, Math.round(performance.now() - session.startedAt))
+    const finishSession = () => {
+      stopSessionTracks(session)
+      if (this.session === session) {
+        this.session = null
+        this.stopping = false
+      }
+    }
 
     return new Promise((resolve, reject) => {
-      recorder.onstop = () => {
-        this.stopClones()
-        const blob = new Blob(this.chunks, { type: this.mimeType })
-        const width = this.trackWidth
-        const height = this.trackHeight
-        this.recorder = null
-        this.chunks = []
-        this.stopping = false
+      session.recorder.onstop = () => {
+        finishSession()
+        const blob = new Blob(session.chunks, { type: session.mimeType })
+        const width = session.trackWidth
+        const height = session.trackHeight
         if (blob.size === 0 || wallClockMs < MIN_TAKE_MS) {
           resolve(null)
           return
@@ -105,7 +126,7 @@ export class HoldRecorder {
           .then((measuredMs) => {
             resolve({
               blob,
-              mimeType: this.mimeType || blob.type || 'video/webm',
+              mimeType: session.mimeType || blob.type || 'video/webm',
               durationMs: measuredMs > 0 ? measuredMs : wallClockMs,
               width,
               height,
@@ -121,41 +142,38 @@ export class HoldRecorder {
             }
             resolve({
               blob,
-              mimeType: this.mimeType || blob.type || 'video/webm',
+              mimeType: session.mimeType || blob.type || 'video/webm',
               durationMs: wallClockMs,
               width,
               height,
             })
           })
       }
-      recorder.onerror = () => {
-        this.stopClones()
-        this.recorder = null
-        this.stopping = false
+      session.recorder.onerror = () => {
+        finishSession()
         reject(new Error('Recording failed'))
       }
-      recorder.stop()
+      session.recorder.stop()
     })
   }
 
   cancel(): void {
-    const recorder = this.recorder
-    if (!recorder) {
-      this.stopping = false
-      this.stopClones()
-      return
-    }
-    recorder.ondataavailable = null
-    if (recorder.state !== 'inactive') {
+    const session = this.session
+    this.session = null
+    this.stopping = false
+    if (!session) return
+    // Stale events from this session must only clean up after themselves.
+    session.recorder.ondataavailable = null
+    session.recorder.onstop = () => stopSessionTracks(session)
+    session.recorder.onerror = () => stopSessionTracks(session)
+    if (session.recorder.state !== 'inactive') {
       try {
-        recorder.stop()
+        session.recorder.stop()
+        return
       } catch {
-        // ignore
+        // Fall through — stop the clones directly.
       }
     }
-    this.stopClones()
-    this.recorder = null
-    this.chunks = []
-    this.stopping = false
+    stopSessionTracks(session)
   }
 }

--- a/src/lib/recorder.ts
+++ b/src/lib/recorder.ts
@@ -18,6 +18,7 @@ const MIN_TAKE_MS = 120
  */
 export class HoldRecorder {
   private recorder: MediaRecorder | null = null
+  private recordStream: MediaStream | null = null
   private chunks: BlobPart[] = []
   private startedAt = 0
   private mimeType = ''
@@ -27,6 +28,17 @@ export class HoldRecorder {
 
   get isRecording(): boolean {
     return this.recorder?.state === 'recording'
+  }
+
+  /** Recording consumes CLONES of the preview's tracks: MediaRecorder
+   * attaching/detaching directly on the live camera track makes some
+   * Android HALs reconfigure the capture pipeline, blanking the preview for
+   * a frame right when the take ends. Clones detach invisibly. */
+  private stopClones(): void {
+    this.recordStream?.getTracks().forEach((track) => {
+      track.stop()
+    })
+    this.recordStream = null
   }
 
   /** @returns true when a new recording actually started */
@@ -41,13 +53,17 @@ export class HoldRecorder {
     this.trackWidth = settings?.width
     this.trackHeight = settings?.height
 
+    this.stopClones()
+    const recordStream = new MediaStream(stream.getTracks().map((track) => track.clone()))
+    this.recordStream = recordStream
+
     const recorder = this.mimeType
-      ? new MediaRecorder(stream, {
+      ? new MediaRecorder(recordStream, {
           mimeType: this.mimeType,
           videoBitsPerSecond: 3_500_000,
           audioBitsPerSecond: 192_000,
         })
-      : new MediaRecorder(stream)
+      : new MediaRecorder(recordStream)
 
     this.mimeType = recorder.mimeType || this.mimeType || 'video/webm'
     recorder.ondataavailable = (event) => {
@@ -63,6 +79,7 @@ export class HoldRecorder {
     if (!recorder || recorder.state === 'inactive') {
       this.recorder = null
       this.stopping = false
+      this.stopClones()
       return Promise.resolve(null)
     }
 
@@ -71,6 +88,7 @@ export class HoldRecorder {
 
     return new Promise((resolve, reject) => {
       recorder.onstop = () => {
+        this.stopClones()
         const blob = new Blob(this.chunks, { type: this.mimeType })
         const width = this.trackWidth
         const height = this.trackHeight
@@ -111,6 +129,7 @@ export class HoldRecorder {
           })
       }
       recorder.onerror = () => {
+        this.stopClones()
         this.recorder = null
         this.stopping = false
         reject(new Error('Recording failed'))
@@ -123,6 +142,7 @@ export class HoldRecorder {
     const recorder = this.recorder
     if (!recorder) {
       this.stopping = false
+      this.stopClones()
       return
     }
     recorder.ondataavailable = null
@@ -133,6 +153,7 @@ export class HoldRecorder {
         // ignore
       }
     }
+    this.stopClones()
     this.recorder = null
     this.chunks = []
     this.stopping = false

--- a/src/pages/about-page.tsx
+++ b/src/pages/about-page.tsx
@@ -6,6 +6,7 @@ import { checkForUpdates } from '../lib/app-update'
 import { buildDateLabel, shortVersion } from '../lib/build-info'
 import { reportError } from '../lib/error-reporting'
 import { clearExportCache, estimateExportCacheBytes } from '../lib/export/export-cache'
+import { listRearCameras } from '../lib/media'
 import { estimateStorageSpace, formatBytes, type StorageSpace } from '../lib/storage-space'
 
 /** Prefilled GitHub issue so bug reports arrive with device context attached. */
@@ -56,6 +57,58 @@ export function AboutPage() {
   const [updateStatus, setUpdateStatus] = useState<UpdateStatus>('idle')
   const [cacheStatus, setCacheStatus] = useState<string | null>(null)
   const [clearingCache, setClearingCache] = useState(false)
+
+  const [cameraReport, setCameraReport] = useState<string | null>(null)
+  const [inspectingCameras, setInspectingCameras] = useState(false)
+
+  /**
+   * On-device camera diagnostic: what the browser exposes varies wildly by
+   * phone and Chrome build (labels, facingMode capability, zoom ranges),
+   * and remote bug reports about lenses are unresolvable without it.
+   */
+  const onInspectCameras = () => {
+    if (inspectingCameras) return
+    setInspectingCameras(true)
+    void (async () => {
+      let probe: MediaStream | null = null
+      try {
+        probe = await navigator.mediaDevices.getUserMedia({ video: true })
+        const track = probe.getVideoTracks()[0]
+        const caps = track?.getCapabilities?.() as
+          | (MediaTrackCapabilities & { zoom?: { min?: number; max?: number } })
+          | undefined
+        const lines: string[] = [`Active camera: ${track?.label || '(no label)'}`]
+        if (caps?.zoom && typeof caps.zoom.min === 'number') {
+          lines.push(`Active zoom range: ${caps.zoom.min}–${caps.zoom.max}×`)
+        } else {
+          lines.push('Active zoom range: not exposed')
+        }
+        const rear = await listRearCameras()
+        lines.push(`Detected rear lenses: ${rear.length}`)
+        const devices = await navigator.mediaDevices.enumerateDevices()
+        for (const device of devices) {
+          if (device.kind !== 'videoinput') continue
+          const facing = (
+            device as MediaDeviceInfo & { getCapabilities?: () => MediaTrackCapabilities }
+          ).getCapabilities?.()?.facingMode
+          const facingLabel =
+            Array.isArray(facing) && facing.length > 0 ? ` [${facing.join(', ')}]` : ''
+          const rearMark = rear.includes(device.deviceId) ? ' — rear' : ''
+          lines.push(`• ${device.label || '(no label)'}${facingLabel}${rearMark}`)
+        }
+        setCameraReport(lines.join('\n'))
+      } catch (err) {
+        setCameraReport(
+          err instanceof Error ? `Could not inspect: ${err.message}` : 'Could not inspect cameras.',
+        )
+      } finally {
+        probe?.getTracks().forEach((track) => {
+          track.stop()
+        })
+        setInspectingCameras(false)
+      }
+    })()
+  }
 
   const onClearExportCache = () => {
     if (clearingCache) return
@@ -216,6 +269,25 @@ export function AboutPage() {
               {cacheStatus}
             </p>
           ) : null}
+        </section>
+
+        <section className="about-section">
+          <h2>Cameras</h2>
+          <p>
+            Wondering why a lens or zoom level isn&rsquo;t available? Browsers expose cameras
+            very differently across phones —{' '}
+            <button
+              type="button"
+              className="link-button"
+              onClick={onInspectCameras}
+              disabled={inspectingCameras}
+            >
+              {inspectingCameras ? 'Inspecting…' : 'Inspect cameras'}
+            </button>{' '}
+            shows exactly what this browser reports (nothing is sent anywhere — attach it to a
+            bug report if something looks wrong).
+          </p>
+          {cameraReport ? <pre className="camera-report">{cameraReport}</pre> : null}
         </section>
 
         <section className="about-section">

--- a/src/styles/home.css
+++ b/src/styles/home.css
@@ -481,6 +481,19 @@
   line-height: 1.55;
 }
 
+.camera-report {
+  margin: 10px 0 0;
+  padding: 10px 12px;
+  border-radius: 12px;
+  background: color-mix(in srgb, var(--ink) 8%, transparent);
+  border: 1px solid var(--line);
+  color: var(--ink);
+  font-size: 0.78rem;
+  line-height: 1.5;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
 .about-section a {
   color: var(--accent);
   font-weight: 600;

--- a/src/styles/record.css
+++ b/src/styles/record.css
@@ -315,6 +315,29 @@
   cursor: not-allowed;
 }
 
+.zoom-hud {
+  position: absolute;
+  top: 18%;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 3;
+  padding: 6px 14px;
+  border-radius: 999px;
+  background: rgba(0, 0, 0, 0.55);
+  border: 1px solid rgba(255, 255, 255, 0.28);
+  color: #fff;
+  font-weight: 700;
+  font-size: 1.05rem;
+  font-variant-numeric: tabular-nums;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 160ms ease;
+}
+
+.zoom-hud.is-visible {
+  opacity: 1;
+}
+
 .lens-chip {
   display: inline-flex;
   align-items: center;

--- a/tests/e2e/home.spec.ts
+++ b/tests/e2e/home.spec.ts
@@ -114,6 +114,15 @@ test.describe('home & app shell', () => {
     await expect(meta('twitter:card')).toHaveAttribute('content', 'summary_large_image')
   })
 
+  test('camera inspector reports what the browser exposes', async ({ page }) => {
+    await page.goto('/about')
+    await page.getByRole('button', { name: 'Inspect cameras' }).click()
+    const report = page.locator('.camera-report')
+    await expect(report).toBeVisible()
+    await expect(report).toContainText('Active camera:')
+    await expect(report).toContainText(/Detected rear lenses: \d+/)
+  })
+
   test('about, privacy, and terms pages render', async ({ page }) => {
     await gotoHome(page)
     await page.getByRole('link', { name: 'About' }).click()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Three field reports from Kent's Android in one pass:

### 1. One black flash still remains after ending a take
PR #80 removed two of three flashes (both hidden `<video>` decoder opens). The remaining suspect is `MediaRecorder` itself: it attached directly to the live camera track, and some Android HALs reconfigure the capture pipeline when the encoder consumer detaches at stop. **Recording now consumes clones of the preview's tracks** — stopping the recorder never touches the track driving the preview. Clones are reclaimed on stop/cancel/error; the backgrounding path still saves takes (the recorder's stop is synchronous before the camera teardown, and clone cleanup rides the recorder's own lifecycle).

### 2. The lens chip disappeared
The chip requires `listRearCameras()` to find more than one rear device. The positive heuristics (facingMode capability, `back|rear|environment` in the label) find nothing on Chrome/OS builds that label lenses as plain "Camera 0" with no facing capability. Two changes:
- **Fallback detection**: when zero rear lenses are found but at least one device is identifiably front-facing, everything else is treated as rear.
- **"Inspect cameras" on the About page**: prints exactly what the browser exposes — active camera label, its zoom range, per-device labels/facing, and what our rear detection concluded. Remote lens reports are unresolvable without this; nothing leaves the device.

### 3. Zoom readout while zooming
A HUD pill near the top of the preview shows the live value ("2.3×") during drag-zoom, chip taps, and the post-release ease-back, fading ~1s after the value stops changing. Fully imperative (refs + classList) so mid-take zooming still causes zero re-renders.

## Verification

- Full e2e suite green (44/44, including a new About-page inspector test), rear-lens probe (including "recording works on the switched lens", which exercises clone-based recording), keyboard probe, 80 unit tests, lint, build.
- The flash fix and chip fallback need real-device confirmation — the inspector exists precisely to make that conversation data-driven.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-16d17496-6b5b-4e12-b600-6933357c2059?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-16d17496-6b5b-4e12-b600-6933357c2059&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a live zoom indicator during zooming, snap-back animations, and zoom control selection.
  - Added camera diagnostics to the About page, including active camera details, zoom range, and detected rear-camera count.
  - Improved detection and listing of rear-facing cameras.

- **Bug Fixes**
  - Recording now uses independent media tracks, preventing recording actions from disrupting the live preview.

- **Tests**
  - Added end-to-end coverage for camera diagnostics and rear-lens detection.
  - Added a manual check for zoom indicator visibility and fade-out behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->