### PR TITLE
Cap the top zoom chip at 10×; drag-zoom still reaches the camera's true max

### DIFF
--- a/manual-test-checklist.md
+++ b/manual-test-checklist.md
@@ -81,6 +81,8 @@ see the README) — plain `http://<lan-ip>` fails in most browsers.
 - [ ] A take with a dead/covered mic shows "Mic isn't picking up sound" after
   ~2.5s; a take with sound clears it
 - [ ] Torch toggle appears on devices with a flash; zoom chips when supported
+- [ ] Long digital ranges: the top zoom chip caps at 10× but drag-zoom still
+  reaches the camera's true max (e.g. 30×), with the HUD showing real values
 - [ ] Multi-rear-lens Androids show the lens chip (e.g. "1/3"); choice sticks
   across flips and restarts. iOS: NO lens chip; multi-lens iPhones open the
   virtual device so zoom spans 0.5×–max

--- a/src/components/record-screen.tsx
+++ b/src/components/record-screen.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useLayoutEffect, useRef, useState } from 'react'
 import { Link } from 'react-router-dom'
-import type { CameraZoomRange, UseCameraResult } from '../hooks/use-camera'
+import type { UseCameraResult } from '../hooks/use-camera'
 import { dragZoomValue } from '../lib/drag-zoom'
 import { getLocationFix, type LocationFix } from '../lib/location'
 import { startMicLevelMonitor, type MicLevelMonitor } from '../lib/mic-monitor'
@@ -14,6 +14,7 @@ import {
 } from '../lib/screen-recorder'
 import { setLocationTaggingEnabled } from '../lib/storage'
 import { captureLiveThumbs } from '../lib/thumbs'
+import { formatZoomLabel, nearestZoomLevel, zoomChipLevels } from '../lib/zoom-chips'
 import {
   formatStoragePercent,
   storageSeverity,
@@ -74,45 +75,6 @@ interface RecordScreenProps {
   onPlay: () => void
   showToast: (message: string, action?: ToastAction) => void
   refresh: () => void
-}
-
-/** Build a small set of zoom chip levels clamped to device min/max (e.g. 1×, 2×, 5×). */
-function zoomChipLevels(zoom: CameraZoomRange): number[] {
-  const { min, max } = zoom
-  const candidates = [1, 2]
-  if (max > 2.05) {
-    const rounded = Math.round(max)
-    // Prefer a clean integer near max (4×/5×); otherwise use the true max.
-    candidates.push(Math.abs(rounded - max) <= 0.35 ? rounded : Number(max.toFixed(1)))
-  }
-  const levels = candidates
-    .map((level) => Math.min(max, Math.max(min, level)))
-    .filter((level, index, arr) => arr.findIndex((other) => Math.abs(other - level) < 0.05) === index)
-    .sort((a, b) => a - b)
-  // Always include device min when it isn't already represented (ultra-wide lenses).
-  if (levels.every((level) => Math.abs(level - min) > 0.05)) {
-    levels.unshift(min)
-  }
-  return levels
-}
-
-function formatZoomLabel(level: number): string {
-  const rounded = Math.round(level * 10) / 10
-  if (Number.isInteger(rounded)) return `${rounded}×`
-  return `${rounded.toFixed(1)}×`
-}
-
-function nearestZoomLevel(levels: number[], value: number): number {
-  let best = levels[0]!
-  let bestDist = Math.abs(value - best)
-  for (const level of levels) {
-    const dist = Math.abs(value - level)
-    if (dist < bestDist) {
-      best = level
-      bestDist = dist
-    }
-  }
-  return best
 }
 
 export function RecordScreen({

--- a/src/lib/zoom-chips.test.ts
+++ b/src/lib/zoom-chips.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest'
+import { ZOOM_CHIP_MAX, formatZoomLabel, nearestZoomLevel, zoomChipLevels } from './zoom-chips'
+
+describe('zoomChipLevels', () => {
+  it('caps the top chip while long digital ranges stay drag-reachable', () => {
+    // 30× super-res mush: chips stop at the cap; drag-zoom (which reads the
+    // camera range directly, not these chips) still spans the full 30×.
+    expect(zoomChipLevels({ min: 1, max: 30 })).toEqual([1, 2, ZOOM_CHIP_MAX])
+  })
+
+  it('keeps modest ranges unchanged', () => {
+    expect(zoomChipLevels({ min: 1, max: 8 })).toEqual([1, 2, 8])
+    expect(zoomChipLevels({ min: 1, max: 2 })).toEqual([1, 2])
+  })
+
+  it('prefers a clean integer near the top', () => {
+    expect(zoomChipLevels({ min: 1, max: 4.9 })).toEqual([1, 2, 4.9])
+    expect(zoomChipLevels({ min: 1, max: 5.2 })).toEqual([1, 2, 5])
+  })
+
+  it('includes the sub-1× minimum of logical multi-cameras', () => {
+    expect(zoomChipLevels({ min: 0.5, max: 30 })).toEqual([0.5, 1, 2, ZOOM_CHIP_MAX])
+  })
+
+  it('collapses degenerate ranges to a single chip', () => {
+    expect(zoomChipLevels({ min: 1, max: 1 })).toEqual([1])
+  })
+})
+
+describe('formatZoomLabel', () => {
+  it('renders integers plainly and fractions with one decimal', () => {
+    expect(formatZoomLabel(2)).toBe('2×')
+    expect(formatZoomLabel(0.5)).toBe('0.5×')
+    expect(formatZoomLabel(2.34)).toBe('2.3×')
+  })
+})
+
+describe('nearestZoomLevel', () => {
+  it('picks the closest chip to the current value', () => {
+    expect(nearestZoomLevel([1, 2, 10], 2.3)).toBe(2)
+    expect(nearestZoomLevel([1, 2, 10], 25)).toBe(10)
+  })
+})

--- a/src/lib/zoom-chips.test.ts
+++ b/src/lib/zoom-chips.test.ts
@@ -25,6 +25,10 @@ describe('zoomChipLevels', () => {
   it('collapses degenerate ranges to a single chip', () => {
     expect(zoomChipLevels({ min: 1, max: 1 })).toEqual([1])
   })
+
+  it('never emits a chip below a minimum that exceeds the cap', () => {
+    expect(zoomChipLevels({ min: 12, max: 30 })).toEqual([12])
+  })
 })
 
 describe('formatZoomLabel', () => {

--- a/src/lib/zoom-chips.ts
+++ b/src/lib/zoom-chips.ts
@@ -1,0 +1,55 @@
+/** Pure zoom-chip math for the record screen's quick-zoom buttons. */
+
+export interface ZoomRangeLike {
+  min: number
+  max: number
+}
+
+/**
+ * Chips stop here even when the camera's digital zoom goes much further
+ * (phones advertise 30×+ of super-res mush). The full hardware range stays
+ * reachable — drag-to-zoom spans the camera's TRUE max; only the one-tap
+ * presets are capped at a value that still looks good.
+ */
+export const ZOOM_CHIP_MAX = 10
+
+/** Build a small set of zoom chip levels clamped to device min and the
+ * chip cap (e.g. 0.5×, 1×, 2×, 10×). */
+export function zoomChipLevels(zoom: ZoomRangeLike): number[] {
+  const { min, max } = zoom
+  const chipMax = Math.min(max, ZOOM_CHIP_MAX)
+  const candidates = [1, 2]
+  if (chipMax > 2.05) {
+    const rounded = Math.round(chipMax)
+    // Prefer a clean integer near the cap (4×/5×); otherwise the exact value.
+    candidates.push(Math.abs(rounded - chipMax) <= 0.35 ? rounded : Number(chipMax.toFixed(1)))
+  }
+  const levels = candidates
+    .map((level) => Math.min(chipMax, Math.max(min, level)))
+    .filter((level, index, arr) => arr.findIndex((other) => Math.abs(other - level) < 0.05) === index)
+    .sort((a, b) => a - b)
+  // Always include device min when it isn't already represented (ultra-wide lenses).
+  if (levels.every((level) => Math.abs(level - min) > 0.05)) {
+    levels.unshift(min)
+  }
+  return levels
+}
+
+export function formatZoomLabel(level: number): string {
+  const rounded = Math.round(level * 10) / 10
+  if (Number.isInteger(rounded)) return `${rounded}×`
+  return `${rounded.toFixed(1)}×`
+}
+
+export function nearestZoomLevel(levels: number[], value: number): number {
+  let best = levels[0]!
+  let bestDist = Math.abs(value - best)
+  for (const level of levels) {
+    const dist = Math.abs(value - level)
+    if (dist < bestDist) {
+      best = level
+      bestDist = dist
+    }
+  }
+  return best
+}

--- a/src/lib/zoom-chips.ts
+++ b/src/lib/zoom-chips.ts
@@ -17,7 +17,9 @@ export const ZOOM_CHIP_MAX = 10
  * chip cap (e.g. 0.5×, 1×, 2×, 10×). */
 export function zoomChipLevels(zoom: ZoomRangeLike): number[] {
   const { min, max } = zoom
-  const chipMax = Math.min(max, ZOOM_CHIP_MAX)
+  // The cap never dips below the device minimum — a hypothetical 12–30×
+  // range must not produce a 10× chip the camera can't reach.
+  const chipMax = Math.min(max, Math.max(ZOOM_CHIP_MAX, min))
   const candidates = [1, 2]
   if (chipMax > 2.05) {
     const rounded = Math.round(chipMax)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Kent's phone advertises a 1–30× zoom range, which put a one-tap **30×** chip on screen — mostly digital super-res mush at that level. Chips now stop at 10×, while the hardware range stays fully reachable: drag-to-zoom reads the camera's range directly (untouched by this change) and spans the true max, with the zoom HUD showing real values the whole way.

## How

- `zoomChipLevels` now clamps its top preset to `ZOOM_CHIP_MAX` (10×). Modest ranges (≤10×) are byte-for-byte unchanged; sub-1× minimums from logical multi-cameras still get their chip.
- The chip math (`zoomChipLevels`, `formatZoomLabel`, `nearestZoomLevel`) moved from `record-screen.tsx` to a pure `src/lib/zoom-chips.ts` module with unit tests covering the cap, unchanged modest ranges, clean-integer rounding, sub-1× minimums, and degenerate ranges.

## Verification

87 unit tests (7 new), full e2e suite 44/44, lint, build all green.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-16d17496-6b5b-4e12-b600-6933357c2059?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-16d17496-6b5b-4e12-b600-6933357c2059&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved camera zoom controls for devices with extended zoom ranges.
  * Zoom chips now cap at 10×, while drag zoom can reach the camera’s actual maximum.
  * The zoom HUD displays the precise zoom value during extended zooming.

* **Tests**
  * Added coverage for zoom ranges, labels, rounding, minimum values, and maximum zoom behavior.
  * Added a manual test for long-range digital zoom.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->