### PR TITLE
Route iOS capture to external Bluetooth mics (DJI, AirPods, headsets)

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ Verified approach: `npm run build && npm run preview`, load once online, then De
 
 - **iOS Safari:** WebCodecs audio support is incomplete; the realtime fallback engine covers it, but Chromium (especially Android) is the primary target.
 - **iOS microphone:** WebKit can deliver muted audio tracks when mic and camera come from separate `getUserMedia` calls, so on iOS the mic is acquired together with the camera and held while the preview is open (everywhere else the mic is grabbed per-take). A live level monitor warns "Mic isn't picking up sound" during silent takes on every platform.
-- **External mics on iOS (DJI, AirPods, wired):** iOS pins web capture to the built-in mic by
+- **External mics on iOS (DJI transmitters, AirPods, wired headsets):** iOS pins web capture to the built-in mic by
   default. After the camera opens, the app kicks WebKit's `navigator.audioSession` into
   `play-and-record` — the documented nudge that re-routes capture to a connected external mic —
   and restores the session when the camera closes. Best-effort: routing remains OS-controlled.

--- a/README.md
+++ b/README.md
@@ -123,6 +123,10 @@ Verified approach: `npm run build && npm run preview`, load once online, then De
 
 - **iOS Safari:** WebCodecs audio support is incomplete; the realtime fallback engine covers it, but Chromium (especially Android) is the primary target.
 - **iOS microphone:** WebKit can deliver muted audio tracks when mic and camera come from separate `getUserMedia` calls, so on iOS the mic is acquired together with the camera and held while the preview is open (everywhere else the mic is grabbed per-take). A live level monitor warns "Mic isn't picking up sound" during silent takes on every platform.
+- **External mics on iOS (DJI, AirPods, wired):** iOS pins web capture to the built-in mic by
+  default. After the camera opens, the app kicks WebKit's `navigator.audioSession` into
+  `play-and-record` — the documented nudge that re-routes capture to a connected external mic —
+  and restores the session when the camera closes. Best-effort: routing remains OS-controlled.
 - **Permissions:** denied camera/mic must be re-enabled in site settings; the UI surfaces this.
 - **Storage quotas:** large projects can hit IndexedDB quotas; the soft 6-project cap helps.
 - **Background tabs:** recording should stay in the foreground; browsers may throttle capture.

--- a/manual-test-checklist.md
+++ b/manual-test-checklist.md
@@ -78,6 +78,10 @@ see the README) — plain `http://<lan-ip>` fails in most browsers.
   mic is NOT held while idle (no OS mic indicator) — except iOS, where it is
   held while previewing (muted-track workaround)
 - [ ] iOS: recordings have audible sound (mic + camera in one combined request)
+- [ ] iOS with an external Bluetooth mic (DJI, AirPods, wired headset):
+  recordings capture from the external mic, not the built-in one (the
+  audio-session kick after camera open re-routes); playback audio quality is
+  normal after leaving the camera
 - [ ] A take with a dead/covered mic shows "Mic isn't picking up sound" after
   ~2.5s; a take with sound clears it
 - [ ] Torch toggle appears on devices with a flash; zoom chips when supported

--- a/manual-test-checklist.md
+++ b/manual-test-checklist.md
@@ -78,7 +78,7 @@ see the README) — plain `http://<lan-ip>` fails in most browsers.
   mic is NOT held while idle (no OS mic indicator) — except iOS, where it is
   held while previewing (muted-track workaround)
 - [ ] iOS: recordings have audible sound (mic + camera in one combined request)
-- [ ] iOS with an external Bluetooth mic (DJI, AirPods, wired headset):
+- [ ] iOS with an external mic (DJI transmitter, AirPods, wired headset):
   recordings capture from the external mic, not the built-in one (the
   audio-session kick after camera open re-routes); playback audio quality is
   normal after leaving the camera

--- a/src/hooks/use-camera.ts
+++ b/src/hooks/use-camera.ts
@@ -1,4 +1,5 @@
 import { useCallback, useRef, useState, type RefCallback } from 'react'
+import { engageRecordAudioSession, releaseRecordAudioSession } from '../lib/audio-session'
 import {
   canFlipCamera,
   isIosBrowser,
@@ -241,8 +242,15 @@ export function useCamera(): UseCameraResult {
       // denial though (the combined open also falls back on transient
       // failures) — only the Permissions API may claim "blocked".
       if (HOLD_MIC_WITH_CAMERA) {
-        if (next.getAudioTracks().length > 0) setMicPermission('granted')
-        else void queryMicrophonePermission().then(setMicPermission)
+        if (next.getAudioTracks().length > 0) {
+          setMicPermission('granted')
+          // External Bluetooth mics (DJI etc.): iOS only routes capture to
+          // them after this post-grant audio-session kick — see
+          // audio-session.ts. Must run AFTER getUserMedia resolved.
+          engageRecordAudioSession()
+        } else {
+          void queryMicrophonePermission().then(setMicPermission)
+        }
       }
       setIsReady(true)
     },
@@ -567,6 +575,7 @@ export function useCamera(): UseCameraResult {
 
   const stop = useCallback(() => {
     cameraEpochRef.current += 1
+    const hadMic = (streamRef.current?.getAudioTracks().length ?? 0) > 0
     stopStream(streamRef.current)
     streamRef.current = null
     setStream(null)
@@ -577,6 +586,9 @@ export function useCamera(): UseCameraResult {
     if (videoElRef.current) {
       videoElRef.current.srcObject = null
     }
+    // The play-and-record session is sticky after capture ends and degrades
+    // playback output — restore hi-fi routing (no-op off iOS).
+    if (hadMic) releaseRecordAudioSession()
   }, [applyZoomState])
 
   const videoRef = useCallback<RefCallback<HTMLVideoElement>>(

--- a/src/hooks/use-camera.ts
+++ b/src/hooks/use-camera.ts
@@ -231,6 +231,7 @@ export function useCamera(): UseCameraResult {
 
   const replaceStream = useCallback(
     (next: MediaStream) => {
+      const hadMic = (streamRef.current?.getAudioTracks().length ?? 0) > 0
       stopStream(streamRef.current)
       streamRef.current = next
       setStream(next)
@@ -244,11 +245,16 @@ export function useCamera(): UseCameraResult {
       if (HOLD_MIC_WITH_CAMERA) {
         if (next.getAudioTracks().length > 0) {
           setMicPermission('granted')
-          // External Bluetooth mics (DJI etc.): iOS only routes capture to
-          // them after this post-grant audio-session kick — see
-          // audio-session.ts. Must run AFTER getUserMedia resolved.
+          // External mics (DJI transmitters, AirPods, wired headsets): iOS
+          // only routes capture to them after this post-grant audio-session
+          // kick — see audio-session.ts. Must run AFTER getUserMedia
+          // resolved.
           engageRecordAudioSession()
         } else {
+          // A combined reopen can fall back to video-only (mic mid-flip
+          // failure) — a sticky play-and-record session with no mic held
+          // would degrade playback until the camera fully stops.
+          if (hadMic) releaseRecordAudioSession()
           void queryMicrophonePermission().then(setMicPermission)
         }
       }

--- a/src/lib/audio-session.ts
+++ b/src/lib/audio-session.ts
@@ -1,0 +1,50 @@
+import { isIosBrowser } from './media'
+
+/**
+ * iOS external-microphone routing (DJI mics, AirPods, wired headsets).
+ *
+ * WebKit captures from whatever input the audio session routes to, and by
+ * default that pins the BUILT-IN mic even when an external Bluetooth mic is
+ * connected — the native camera app uses it, the web app doesn't. The one
+ * lever the web has is the (WebKit-only) `navigator.audioSession` API:
+ * setting `type = 'play-and-record'` AFTER capture starts kicks iOS into
+ * re-routing input to the connected external device. Setting it BEFORE
+ * capture is 50/50, so the call must follow the getUserMedia grant.
+ *
+ * The session is left sticky after capture ends, which degrades playback
+ * output quality — resetting `'playback'` then `'auto'` on release restores
+ * hi-fi output. Both calls are feature-detected no-ops off iOS.
+ */
+
+interface AudioSessionLike {
+  type: string
+}
+
+function audioSession(): AudioSessionLike | null {
+  if (!isIosBrowser()) return null
+  const session = (navigator as { audioSession?: AudioSessionLike }).audioSession
+  return session ?? null
+}
+
+/** Call right after a mic-carrying stream is adopted. */
+export function engageRecordAudioSession(): void {
+  const session = audioSession()
+  if (!session) return
+  try {
+    session.type = 'play-and-record'
+  } catch {
+    // Unsupported value on this WebKit build — routing stays as-is.
+  }
+}
+
+/** Call after the mic-carrying stream is stopped. */
+export function releaseRecordAudioSession(): void {
+  const session = audioSession()
+  if (!session) return
+  try {
+    session.type = 'playback'
+    session.type = 'auto'
+  } catch {
+    // Best-effort restore.
+  }
+}

--- a/src/lib/audio-session.ts
+++ b/src/lib/audio-session.ts
@@ -1,10 +1,10 @@
 import { isIosBrowser } from './media'
 
 /**
- * iOS external-microphone routing (DJI mics, AirPods, wired headsets).
+ * iOS external-microphone routing (DJI transmitters, AirPods, wired headsets).
  *
  * WebKit captures from whatever input the audio session routes to, and by
- * default that pins the BUILT-IN mic even when an external Bluetooth mic is
+ * default that pins the BUILT-IN mic even when an external microphone is
  * connected — the native camera app uses it, the web app doesn't. The one
  * lever the web has is the (WebKit-only) `navigator.audioSession` API:
  * setting `type = 'play-and-record'` AFTER capture starts kicks iOS into

--- a/tests/e2e/ios-audio-session.spec.ts
+++ b/tests/e2e/ios-audio-session.spec.ts
@@ -1,0 +1,50 @@
+import { test, expect } from '@playwright/test'
+import { IOS_SAFARI_UA, openNewProject } from './helpers'
+
+test.use({ userAgent: IOS_SAFARI_UA })
+
+/**
+ * iOS routes capture to external Bluetooth mics (DJI etc.) only after the
+ * post-getUserMedia audio-session kick — see src/lib/audio-session.ts.
+ * WebKit can't run here, so the navigator.audioSession surface is stubbed
+ * and the assertion is on the exact transition sequence.
+ */
+test.describe('iOS audio session routing', () => {
+  test('capture engages play-and-record; stopping restores playback/auto', async ({ page }) => {
+    await page.addInitScript(() => {
+      const log: string[] = []
+      const session = {}
+      Object.defineProperty(session, 'type', {
+        get: () => log[log.length - 1] ?? 'auto',
+        set: (value: string) => {
+          log.push(value)
+        },
+      })
+      Object.defineProperty(navigator, 'audioSession', { value: session })
+      ;(window as unknown as { __audioSessionLog: string[] }).__audioSessionLog = log
+    })
+
+    // On iOS the mic is acquired WITH the camera, so opening the camera view
+    // is what starts capture.
+    await openNewProject(page)
+    await expect
+      .poll(() =>
+        page.evaluate(
+          () => (window as unknown as { __audioSessionLog: string[] }).__audioSessionLog,
+        ),
+      )
+      .toContain('play-and-record')
+
+    // Leaving the camera stops the stream — the sticky session must be
+    // reset ('playback' then 'auto') or playback quality stays degraded.
+    await page.getByRole('link', { name: 'Back to projects' }).click()
+    await page.waitForURL(/\/$/)
+    await expect
+      .poll(() =>
+        page.evaluate(() =>
+          (window as unknown as { __audioSessionLog: string[] }).__audioSessionLog.slice(-2),
+        ),
+      )
+      .toEqual(['playback', 'auto'])
+  })
+})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Juri reported that with his DJI Bluetooth mic connected, recordings still capture from the iPhone's built-in mic — while the native camera app uses the DJI fine.

## Why

iOS pins web `getUserMedia` capture to the built-in mic regardless of connected external inputs; device enumeration on iOS exposes a single opaque "default" input, so `deviceId` selection is not an option. The one web-side lever is WebKit's non-standard `navigator.audioSession` API: setting `type = 'play-and-record'` **after** the capture grant is the documented community workaround that kicks iOS into re-routing input to the connected external device (setting it before the grant works only ~half the time). The session sticks after capture ends and degrades playback output quality, so it must be reset (`'playback'` then `'auto'`) when capture stops.

## How

- New `src/lib/audio-session.ts`: `engageRecordAudioSession()` / `releaseRecordAudioSession()`, feature-detected and iOS-gated (no-ops everywhere else; harmless when no external mic is connected — the built-in mic stays).
- `use-camera` engages right after a mic-carrying combined stream is adopted (covers start, flips, lens switches, and the mic-recovery reopen), and releases in `stop()` whenever the stopped stream carried a mic — which is exactly when the sticky session would otherwise degrade playback.

## Verification

- New e2e spec (iOS UA + stubbed `navigator.audioSession`) pins the exact transition sequence: `play-and-record` appears once the camera view opens (iOS acquires the mic with the camera), and leaving the camera produces `playback` → `auto`.
- Full suite 45/45, unit tests, lint, build green.
- The actual re-routing needs Juri's DJI hardware to confirm — routing remains OS-controlled and this is explicitly best-effort (README/checklist document it as such).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-16d17496-6b5b-4e12-b600-6933357c2059?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-16d17496-6b5b-4e12-b600-6933357c2059&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved iOS camera recording support for external Bluetooth and wired microphones.
  * Audio routing is adjusted during camera use and restored afterward, where supported by iOS.

* **Bug Fixes**
  * Helps maintain normal audio playback quality after closing the camera.

* **Documentation**
  * Added guidance and manual checks for validating external microphone behavior on iOS.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->