### PR TITLE
Fix the last post-take black flash: capture thumbnails from a detached mirror

### DIFF
--- a/src/components/record-screen.tsx
+++ b/src/components/record-screen.tsx
@@ -160,6 +160,43 @@ export function RecordScreen({
    * OK Video behavior: drag-to-zoom only lasts for the take. When the finger
    * lifts, ease the lens back to the zoom the user had before recording.
    */
+  /**
+   * Thumbnail capture mirror: a DETACHED video element fed by the same
+   * camera stream for the take's duration. Post-take thumbs are drawn from
+   * it instead of the on-screen preview — reading back the on-screen
+   * element kicks it out of Android's zero-copy overlay compositing path
+   * for a frame, which is the post-take black flash. A detached element
+   * was never in the compositor, so its readback can't blink anything.
+   */
+  const thumbMirrorRef = useRef<HTMLVideoElement | null>(null)
+  const stopThumbMirror = useCallback(() => {
+    const mirror = thumbMirrorRef.current
+    thumbMirrorRef.current = null
+    if (mirror) {
+      mirror.srcObject = null
+    }
+  }, [])
+  const startThumbMirror = useCallback(
+    (stream: MediaStream) => {
+      stopThumbMirror()
+      const mirror = document.createElement('video')
+      mirror.muted = true
+      mirror.playsInline = true
+      mirror.srcObject = stream
+      void mirror.play().catch(() => undefined)
+      thumbMirrorRef.current = mirror
+    },
+    [stopThumbMirror],
+  )
+  const captureTakeThumbs = useCallback(async () => {
+    const mirror = thumbMirrorRef.current
+    const fromMirror = mirror ? await captureLiveThumbs(mirror) : null
+    // Ultra-short takes can end before the mirror got its first frame —
+    // the on-screen element is the (blink-risking) fallback, still better
+    // than the loader decoding the fresh blob behind the live preview.
+    return fromMirror ?? captureLiveThumbs(camera.getVideoElement())
+  }, [camera])
+
   // Live zoom readout: updated imperatively (refs, no React state) so
   // drag-to-zoom mid-recording never causes a re-render. Fades out shortly
   // after the value stops changing.
@@ -338,6 +375,7 @@ export function RecordScreen({
         if (locationTaggingRef.current) {
           pendingFixRef.current = getLocationFix()
         }
+        startThumbMirror(stream)
         acquireWakeLock()
         // Watch the live mic level: users must learn about a dead mic while
         // holding, not after sharing a silent video (Sentry: near-zero clip
@@ -407,10 +445,11 @@ export function RecordScreen({
       // Detach this take's fix before any await so a quick next hold can own the ref.
       const pendingForThisTake = pendingFixRef.current
       pendingFixRef.current = null
-      // Grab the poster/thumb straight off the still-live preview NOW —
-      // decoding the recorded blob for thumbnails while the preview runs
-      // blanks it on many Androids (the post-take black flash).
-      const capturedThumbs = captureLiveThumbs(camera.getVideoElement()).catch(() => null)
+      // Grab the poster/thumb from the detached mirror NOW (synchronous
+      // draw at finger-lift) — decoding the recorded blob for thumbnails
+      // while the preview runs blanks it on many Androids, and reading
+      // back the on-screen element blinks its overlay path.
+      const capturedThumbs = captureTakeThumbs().catch(() => null)
       try {
         const result = await recorderRef.current.stop()
         if (!result) {
@@ -456,10 +495,22 @@ export function RecordScreen({
           micMonitorRef.current = null
           camera.releaseMic()
           releaseWakeLock()
+          // A quick next hold already replaced the mirror via
+          // startThumbMirror — only tear it down when this take is the last.
+          stopThumbMirror()
         }
       }
     },
-    [camera, ensureProjectId, recording, refresh, releaseWakeLock, showToast],
+    [
+      camera,
+      captureTakeThumbs,
+      ensureProjectId,
+      recording,
+      refresh,
+      releaseWakeLock,
+      showToast,
+      stopThumbMirror,
+    ],
   )
 
   const startSelfTimer = useCallback(() => {
@@ -546,10 +597,11 @@ export function RecordScreen({
     micMonitorRef.current?.stop()
     micMonitorRef.current = null
     recorderRef.current.cancel()
+    stopThumbMirror()
     // Leaving the screen mustn't lose an active screen take — save it.
     void finishScreenRecord()
     releaseWakeLock()
-  }, [clearCountdown, finishScreenRecord, releaseWakeLock])
+  }, [clearCountdown, finishScreenRecord, releaseWakeLock, stopThumbMirror])
 
   // Release the camera whenever the app leaves the foreground — Android keeps
   // the privacy indicator (green dot) lit as long as any track is live. An

--- a/tests/e2e/record.spec.ts
+++ b/tests/e2e/record.spec.ts
@@ -50,6 +50,27 @@ test.describe('camera & hold-to-record', () => {
         { thumbs: 1, poster: true },
         { thumbs: 1, poster: true },
       ])
+
+    // The poster must carry a real camera frame — a black poster means the
+    // capture path (the detached mirror element) never delivered pixels.
+    const posterLuma = await page.evaluate(async () => {
+      const storage = await import('/src/lib/storage.ts')
+      const projects = await storage.listProjects()
+      const clips = await storage.getClipsForProject(projects[0]!.id)
+      const bitmap = await createImageBitmap(clips[0]!.poster as Blob)
+      const canvas = document.createElement('canvas')
+      canvas.width = bitmap.width
+      canvas.height = bitmap.height
+      const ctx = canvas.getContext('2d')!
+      ctx.drawImage(bitmap, 0, 0)
+      const data = ctx.getImageData(0, 0, canvas.width, canvas.height).data
+      let sum = 0
+      for (let i = 0; i < data.length; i += 4) {
+        sum += 0.299 * data[i]! + 0.587 * data[i + 1]! + 0.114 * data[i + 2]!
+      }
+      return sum / (data.length / 4)
+    })
+    expect(posterLuma).toBeGreaterThan(8)
   })
 
   test('recording shows the REC pill with elapsed time', async ({ page }) => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Kent still sees a single black flash when ending a take, surviving both prior fixes (#80 removed the two hidden-decoder flashes, #83 isolated MediaRecorder onto cloned tracks). The timeline points at the capture we *added* in #80: the post-take poster/thumb is drawn from the on-screen camera `<video>` — a GPU readback that kicks the element out of Android's zero-copy overlay compositing path for a frame. That's one visible blink, exactly at finger-lift, only at stop (capture doesn't run at start). Not reproducible in desktop Chromium (the overlay path is an Android compositor behavior), so this is mechanism-based with a device-verifiable prediction.

## How

- Each take now attaches a **detached** `<video>` element (`thumbMirror`) to the same camera stream for the take's duration. Post-take thumbs are drawn from that mirror — a detached element was never in the compositor, so reading it back can't blink anything on screen.
- Ultra-short takes that end before the mirror's first frame fall back to the on-screen element (still better than letting the loader decode the fresh blob behind the live preview).
- Lifecycle: the mirror starts with the recorder, is torn down in `endRecord`'s guarded finally (a quick next hold replaces it via `startThumbMirror`, so the older take's cleanup never strips the newer take's mirror), and in unmount cleanup.

## Verification

- New e2e assertion: the stored poster must carry a real camera frame (average luma check) — a black poster would mean the mirror path delivered no pixels. Passes with fake camera.
- Full suite 45/45, keyboard probe 19/19, unit tests, lint, build green.
- The flash itself needs Kent's Android to confirm; if it *still* blinks after this, the remaining suspects are the recorder-clone stop at HAL level and the zoom snap-back ramp, and the next step is a device-side bisect toggle.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-16d17496-6b5b-4e12-b600-6933357c2059?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-16d17496-6b5b-4e12-b600-6933357c2059&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved camera recording thumbnails to reliably capture a valid video frame.
  * Added a fallback to the recording preview when the primary thumbnail frame is unavailable.
* **Tests**
  * Added coverage to detect black or invalid poster images in recorded clips.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->