### PR TITLE
Rewrite Kody Video as a Remix 3 client-side application

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,18 +49,24 @@ for what it covers and the remaining real-device-only checks.
 
 ## Architecture
 
+Built with [Remix 3](https://github.com/remix-run/remix) (`remix@3.0.0-beta.5`,
+pinned — v3 is prerelease) as a pure client-side app: `remix/ui` components
+rendered with `createRoot`, no server rendering.
+
 ```
 src/
   lib/storage.ts            IndexedDB (idb) — projects, clip blobs + thumbnails, undo
-  lib/project-actions.ts    Loader/mutation helpers for routes
+  lib/project-actions.ts    Loader/mutation helpers for pages
+  lib/camera.ts             Camera controller (open/flip/zoom/lens/mic lifecycle)
   lib/recorder.ts           Hold-to-record MediaRecorder wrapper (hardware-codec aware)
   lib/media.ts              getUserMedia/permissions/share/download helpers
   lib/thumbs.ts             Filmstrip thumbnail generation (stored per clip)
+  lib/sheet-modal.ts        Bottom-sheet modality (focus trap, Esc, sheet stack)
   lib/export/               Export engines (see below)
   components/record-screen  Camera surface (capture, zoom, timer, dock)
   components/editor-screen  Timeline, trim, clip actions
   pages/                    Home (project slots) + Project (record/editor shell)
-  router.tsx                React Router data routers (loaders)
+  router.tsx                Tiny client router (route-pattern matching + history)
 ```
 
 ### Chapters & optional location
@@ -91,12 +97,17 @@ before this feature simply lack the data and degrade gracefully.
 - The elapsed timer is a leaf component writing `textContent` from rAF; nothing else re-renders during capture.
 - A screen wake lock is held while recording.
 
-### React data flow (no `useEffect` for app logic)
+### Remix data flow (explicit updates, no hooks)
 
-- **Route loaders** (`homeLoader` / `projectLoader`) load IndexedDB state; mutations call `useRevalidator()`.
-- **Camera** attaches via a **video ref callback** (start on mount, stop on unmount).
-- **Blob URLs** bind/revoke in media ref callbacks (`BlobVideo`, `BlobImage`, `TimelineThumbImage`).
-- **Sheets** reset with `key={id}` instead of syncing props → state in an effect.
+- **Components** are Remix 3 setup + render functions: state lives in plain
+  setup-scope variables, re-renders happen only on explicit `handle.update()`.
+- **Pages own their data**: each page loads IndexedDB state in setup and
+  exposes `refresh()`; mutations write storage then call `refresh()`.
+- **Camera** attaches via the **`ref()` mixin** (start on insert, stop when
+  the element's abort signal fires).
+- **Blob URLs** bind/revoke in `ref()` mixins (`BlobVideo`, `BlobImage`,
+  `TimelineThumbImage`), re-synced from render when the blob changes.
+- **Sheets** reset with `key={id}`; modality comes from `lib/sheet-modal.ts`.
 - **Timers / toasts** use `requestAnimationFrame` / `setTimeout` started from event handlers.
 
 ### Storage (refresh-safe + personal)

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,21 +8,16 @@
       "name": "kody-video",
       "version": "0.1.0",
       "dependencies": {
-        "@sentry/react": "^10.68.0",
+        "@sentry/browser": "^10.69.0",
         "client-zip": "^2.5.0",
         "idb": "^8.0.3",
         "mediabunny": "^1.52.1",
-        "react": "^19.1.0",
-        "react-dom": "^19.1.0",
-        "react-router-dom": "^7.6.3"
+        "remix": "3.0.0-beta.5"
       },
       "devDependencies": {
         "@playwright/test": "^1.62.0",
         "@sentry/vite-plugin": "^5.4.0",
         "@types/node": "^26.1.1",
-        "@types/react": "^19.1.8",
-        "@types/react-dom": "^19.1.6",
-        "@vitejs/plugin-react": "^4.6.0",
         "fake-indexeddb": "^6.0.1",
         "playwright": "^1.62.0",
         "typescript": "~5.8.3",
@@ -1234,38 +1229,6 @@
         "@babel/core": "^7.0.0-0"
       }
     },
-    "node_modules/@babel/plugin-transform-react-jsx-self": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.29.7.tgz",
-      "integrity": "sha512-TL0hMc9xzy86VD31nUiwzd5otRAcyEPcsegCxolO0PvcXuH1v0kECe/UIznYFihpkvU5wg/jk4v0TTEFfm53fw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.29.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-react-jsx-source": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.29.7.tgz",
-      "integrity": "sha512-06IyK09H3wi4cGbhDBwp5gUGo0IKtnYa8tyTiephirPCK6fbobVGiXMMI5zLQ4aKEYP3wZ3ArU44o+8KMrSG/Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.29.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
     "node_modules/@babel/plugin-transform-regenerator": {
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.29.7.tgz",
@@ -1620,6 +1583,40 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.3.tgz",
+      "integrity": "sha512-zLpS5asjEb7lq8jYLq37N6XKaE41DIexlY1rF/z4/tIl3wo13Sqm28fRyfIsKZD+NZ8mM5RoKkpW/rBcuoSZSg==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.3",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
+      "integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.3.tgz",
+      "integrity": "sha512-ELEBe8PsLvvJ6QMr0zLt8ffvOHW/dc1m3CEzNMg7aJUv3bMaoDtw2TXyDAwkYBuroxxuHEwhRTLJSe5sya547g==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -2100,7 +2097,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
@@ -2121,18 +2117,1298 @@
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.31",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
       "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.2.2.tgz",
+      "integrity": "sha512-JfB4kuJQjaoHuCTseIINHtHWeJnvgEcxjwA5t/Y00ZgaOO1Crz3fjT/p8kT28zA/Caz7oiUMn3d6H2yOVCVwuw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.3"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=23.5.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1 || ^2.0.0-alpha.3",
+        "@emnapi/runtime": "^1.7.1 || ^2.0.0-alpha.3"
+      }
+    },
+    "node_modules/@oxc-minify/binding-android-arm-eabi": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-minify/binding-android-arm-eabi/-/binding-android-arm-eabi-0.121.0.tgz",
+      "integrity": "sha512-RcQXLj3JLLVm41n80/6+7OUion2PSQWOH5EUvlD9kCWSF1fWLXCNX1A6t/+nFNjeyaCXZ3YbIWwCTiGXhxxHEw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-minify/binding-android-arm64": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-minify/binding-android-arm64/-/binding-android-arm64-0.121.0.tgz",
+      "integrity": "sha512-VnFvB9DgADWpgwQb6LmeRv302xwdgpD/45WlQNWI380YUgWVXmhoZoNOgnaCSbuFEz+ElQDb/iE2U2LADkfu8w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-minify/binding-darwin-arm64": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-minify/binding-darwin-arm64/-/binding-darwin-arm64-0.121.0.tgz",
+      "integrity": "sha512-0EKcroW5oMgJ27DOUWD724nQmLhV1PLArkXW5F4t7cUoRZy81OlFMqS97AOWIrQPlNPaC/1MYfCtIoZIW8OElQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-minify/binding-darwin-x64": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-minify/binding-darwin-x64/-/binding-darwin-x64-0.121.0.tgz",
+      "integrity": "sha512-DvsiLCZQ7KvufItkGuU45ovM4paB99M3/J5ZqpzjSnHpyFmcWUx19gwG9RTDOmHHA+7TPCq3b02aQoCiX6xiaA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-minify/binding-freebsd-x64": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-minify/binding-freebsd-x64/-/binding-freebsd-x64-0.121.0.tgz",
+      "integrity": "sha512-b+ngbloTvuei3HxfOz6nCwWkIl8dhgp42W1TREBUVRRe80iKe4bclrpZHxacFQYmVZ/bDjIV7ePPRSCSKM93RA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-minify/binding-linux-arm-gnueabihf": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-minify/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.121.0.tgz",
+      "integrity": "sha512-Vj1xJ46zDTJlnF4UQgAVqX4xb2uv6hpmtHkypCMiaNbuop7bJ+VbqSfs7SCKvg23fygK530XTUxr+A7YDbkEzQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-minify/binding-linux-arm-musleabihf": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-minify/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.121.0.tgz",
+      "integrity": "sha512-lVhZ/y6Piqi+TlM+VB3UdRWWtqm7ks2He5VrYmZfO0a8A/wBE7KTpIK+RoUFGW3ii3wr4Hc8AEWZNEjU4fs38Q==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-minify/binding-linux-arm64-gnu": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-minify/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.121.0.tgz",
+      "integrity": "sha512-FMEtjwWKVRehcs4ebsmM8nj7F7/kVH54dcFZodNFsk1iUsVdqPrOWhzanMcU55AYrGmXHeKFx7PlrimDOz2ZdA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-minify/binding-linux-arm64-musl": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-minify/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.121.0.tgz",
+      "integrity": "sha512-ZFCqQWU7TP4oCiu9q0q9xg1wg78Et4bRSCv9LzMAn/N9zJezPa+u3kVqKXkQnvAgrA7fBo9VPSaEx0XMpXsPhA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-minify/binding-linux-ppc64-gnu": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-minify/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.121.0.tgz",
+      "integrity": "sha512-WSV2TNT7a6wfwfWHHvpaOoHVKwB0tKyJpMjj3P401k8tFEZpH/xNqDNofdvXQznKqJ3nyYxIC4llvNGCXUtTzQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-minify/binding-linux-riscv64-gnu": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-minify/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.121.0.tgz",
+      "integrity": "sha512-hTToDA4mEd4P4HdwnmULtyyWP6CsNwuxdiToGZ5LjQvznpF5acRi9KEAqF8zmNXQ9r1RbrbGbYHATfRWogEbfw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-minify/binding-linux-riscv64-musl": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-minify/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.121.0.tgz",
+      "integrity": "sha512-zhgxjY8IkVZ2MpuElCiK37DjEwX2uk9r7fawRh0J4yjkYWVQR5kmmMEo5oMPbBMtri61vnSiqLZmD25cTFP1vw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-minify/binding-linux-s390x-gnu": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-minify/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.121.0.tgz",
+      "integrity": "sha512-YruvsabXqUdhtfe9Qjv2F1tb0u1PqqNBnf0jFhC8K4qJLctgveH/2rBYE8WAqdahxfdR59ByFZd0u6dqwDCKPg==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-minify/binding-linux-x64-gnu": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-minify/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.121.0.tgz",
+      "integrity": "sha512-OOUpoGKeGN6D9bP9dr2lczK3SgOFeMLFiJuldPxOcY21VAxlemEiTPFTPXp4VWzw65sy3bCx0k8R6wyE8TA3EQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-minify/binding-linux-x64-musl": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-minify/binding-linux-x64-musl/-/binding-linux-x64-musl-0.121.0.tgz",
+      "integrity": "sha512-ixdrFcKUdRXsavlAe+ttKQHtR6nUyXSrCjLTkB4eiy8U/5f5A1BQXAKDdw9rUNoPkLc4vrKohG8frI0pjg7S6g==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-minify/binding-openharmony-arm64": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-minify/binding-openharmony-arm64/-/binding-openharmony-arm64-0.121.0.tgz",
+      "integrity": "sha512-P52luYhm78qAPjACwHEMWJQag4hgX3InczjXazLqSWJPf5ismBWDmrSiccVWi2B6nPGSuYd4YQVR3j0h2IELyA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-minify/binding-wasm32-wasi": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-minify/binding-wasm32-wasi/-/binding-wasm32-wasi-0.121.0.tgz",
+      "integrity": "sha512-1XDHPrAJa6W8dGqaDnlt+0k5In5JzGE0EOI87cJnOkSGsUAb1Sk8mKNhUe3/PuGiBDDat8eZ0wlq/VcUeOmsoA==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@napi-rs/wasm-runtime": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@oxc-minify/binding-win32-arm64-msvc": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-minify/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.121.0.tgz",
+      "integrity": "sha512-FvUEX7eTfSh1OBB+/AGSWhkNX/8jPFGM2jvMwrrAZ5vj8kTtnETNTkJdkkPMUEiIEVupxoARKc5UFU2/k+3THw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-minify/binding-win32-ia32-msvc": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-minify/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.121.0.tgz",
+      "integrity": "sha512-ZNcMq+yy9QBgekrBP/NxTD4RW1sZKHOWO+aH5SgqRvfU035Bldvns7zHC8VdaY4Sz3PcaChfmSeapfUoUGqT5w==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-minify/binding-win32-x64-msvc": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-minify/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.121.0.tgz",
+      "integrity": "sha512-/0qRGvYnBVhzwSXHcJ6sF+2rb2QpotbJeAr1wmADgq/hm7JjdRukktngmwXQuIILmC+UELYLoVpa0PTBoEqwrg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-android-arm-eabi": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm-eabi/-/binding-android-arm-eabi-0.121.0.tgz",
+      "integrity": "sha512-n07FQcySwOlzap424/PLMtOkbS7xOu8nsJduKL8P3COGHKgKoDYXwoAHCbChfgFpHnviehrLWIPX0lKGtbEk/A==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-android-arm64": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm64/-/binding-android-arm64-0.121.0.tgz",
+      "integrity": "sha512-/Dd1xIXboYAicw+twT2utxPD7bL8qh7d3ej0qvaYIMj3/EgIrGR+tSnjCUkiCT6g6uTC0neSS4JY8LxhdSU/sA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-darwin-arm64": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-arm64/-/binding-darwin-arm64-0.121.0.tgz",
+      "integrity": "sha512-A0jNEvv7QMtCO1yk205t3DWU9sWUjQ2KNF0hSVO5W9R9r/R1BIvzG01UQAfmtC0dQm7sCrs5puixurKSfr2bRQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-darwin-x64": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-x64/-/binding-darwin-x64-0.121.0.tgz",
+      "integrity": "sha512-SsHzipdxTKUs3I9EOAPmnIimEeJOemqRlRDOp9LIj+96wtxZejF51gNibmoGq8KoqbT1ssAI5po/E3J+vEtXGA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-freebsd-x64": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-freebsd-x64/-/binding-freebsd-x64-0.121.0.tgz",
+      "integrity": "sha512-v1APOTkCp+RWOIDAHRoaeW/UoaHF15a60E8eUL6kUQXh+i4K7PBwq2Wi7jm8p0ymID5/m/oC1w3W31Z/+r7HQw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-arm-gnueabihf": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.121.0.tgz",
+      "integrity": "sha512-PmqPQuqHZyFVWA4ycr0eu4VnTMmq9laOHZd+8R359w6kzuNZPvmmunmNJ8ybkm769A0nCoVp3TJ6dUz7B3FYIQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-arm-musleabihf": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.121.0.tgz",
+      "integrity": "sha512-vF24htj+MOH+Q7y9A8NuC6pUZu8t/C2Fr/kDOi2OcNf28oogr2xadBPXAbml802E8wRAVfbta6YLDQTearz+jw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-arm64-gnu": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.121.0.tgz",
+      "integrity": "sha512-wjH8cIG2Lu/3d64iZpbYr73hREMgKAfu7fqpXjgM2S16y2zhTfDIp8EQjxO8vlDtKP5Rc7waZW72lh8nZtWrpA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-arm64-musl": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.121.0.tgz",
+      "integrity": "sha512-qT663J/W8yQFw3dtscbEi9LKJevr20V7uWs2MPGTnvNZ3rm8anhhE16gXGpxDOHeg9raySaSHKhd4IGa3YZvuw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-ppc64-gnu": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.121.0.tgz",
+      "integrity": "sha512-mYNe4NhVvDBbPkAP8JaVS8lC1dsoJZWH5WCjpw5E+sjhk1R08wt3NnXYUzum7tIiWPfgQxbCMcoxgeemFASbRw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-riscv64-gnu": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.121.0.tgz",
+      "integrity": "sha512-+QiFoGxhAbaI/amqX567784cDyyuZIpinBrJNxUzb+/L2aBRX67mN6Jv40pqduHf15yYByI+K5gUEygCuv0z9w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-riscv64-musl": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.121.0.tgz",
+      "integrity": "sha512-9ykEgyTa5JD/Uhv2sttbKnCfl2PieUfOjyxJC/oDL2UO0qtXOtjPLl7H8Kaj5G7p3hIvFgu3YWvAxvE0sqY+hQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-s390x-gnu": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.121.0.tgz",
+      "integrity": "sha512-DB1EW5VHZdc1lIRjOI3bW/wV6R6y0xlfvdVrqj6kKi7Ayu2U3UqUBdq9KviVkcUGd5Oq+dROqvUEEFRXGAM7EQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-x64-gnu": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.121.0.tgz",
+      "integrity": "sha512-s4lfobX9p4kPTclvMiH3gcQUd88VlnkMTF6n2MTMDAyX5FPNRhhRSFZK05Ykhf8Zy5NibV4PbGR6DnK7FGNN6A==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-x64-musl": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-musl/-/binding-linux-x64-musl-0.121.0.tgz",
+      "integrity": "sha512-P9KlyTpuBuMi3NRGpJO8MicuGZfOoqZVRP1WjOecwx8yk4L/+mrCRNc5egSi0byhuReblBF2oVoDSMgV9Bj4Hw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-openharmony-arm64": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-openharmony-arm64/-/binding-openharmony-arm64-0.121.0.tgz",
+      "integrity": "sha512-R+4jrWOfF2OAPPhj3Eb3U5CaKNAH9/btMveMULIrcNW/hjfysFQlF8wE0GaVBr81dWz8JLgQlsxwctoL78JwXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-wasm32-wasi": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-wasm32-wasi/-/binding-wasm32-wasi-0.121.0.tgz",
+      "integrity": "sha512-5TFISkPTymKvsmIlKasPVTPuWxzCcrT8pM+p77+mtQbIZDd1UC8zww4CJcRI46kolmgrEX6QpKO8AvWMVZ+ifw==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@napi-rs/wasm-runtime": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-win32-arm64-msvc": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.121.0.tgz",
+      "integrity": "sha512-V0pxh4mql4XTt3aiEtRNUeBAUFOw5jzZNxPABLaOKAWrVzSr9+XUaB095lY7jqMf5t8vkfh8NManGB28zanYKw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-win32-ia32-msvc": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.121.0.tgz",
+      "integrity": "sha512-4Ob1qvYMPnlF2N9rdmKdkQFdrq16QVcQwBsO8yiPZXof0fHKFF+LmQV501XFbi7lHyrKm8rlJRfQ/M8bZZPVLw==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-win32-x64-msvc": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.121.0.tgz",
+      "integrity": "sha512-BOp1KCzdboB1tPqoCPXgntgFs0jjeSyOXHzgxVFR7B/qfr3F8r4YDacHkTOUNXtDgM8YwKnkf3rE5gwALYX7NA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-project/runtime": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/runtime/-/runtime-0.121.0.tgz",
+      "integrity": "sha512-p0bQukD8OEHxzY4T9OlANBbEFGnOnjo1CYi50HES7OD36UO2yPh6T+uOJKLtlg06eclxroipRCpQGMpeH8EJ/g==",
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.121.0.tgz",
+      "integrity": "sha512-CGtOARQb9tyv7ECgdAlFxi0Fv7lmzvmlm2rpD/RdijOO9rfk/JvB1CjT8EnoD+tjna/IYgKKw3IV7objRb+aYw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@oxc-resolver/binding-android-arm-eabi": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-android-arm-eabi/-/binding-android-arm-eabi-11.24.2.tgz",
+      "integrity": "sha512-y09e0L0SRI2OA2tUIrjBgoV3eH5hvUKXNkJqXmNo5V2WxIjyC7I7aJfRLMEVpA8yi95f90gFDvO0VMgrDw+vwA==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-android-arm64": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-android-arm64/-/binding-android-arm64-11.24.2.tgz",
+      "integrity": "sha512-cl4icWaZFnLdg8m6qtnh5rBMuGbxc/ptStFHLeCNwr+2cZjkjNwQu/jYRS0CHlnPecOJMpuS5M6/BH+0J/YkEg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-darwin-arm64": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-darwin-arm64/-/binding-darwin-arm64-11.24.2.tgz",
+      "integrity": "sha512-At29QEMF6HajbQvgY8K6OXnHD1x9rad74xBEfmCB6ZqCGsdq75aK7tOYcTbOanMy8qdIBrfL3SMr3p/lfSlb9w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-darwin-x64": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-darwin-x64/-/binding-darwin-x64-11.24.2.tgz",
+      "integrity": "sha512-A5Kqr1EUj4oIL5CF4WRssq/o5P0Y11cwoFouMRmQ7YnC/A8V93nv1nb7aSU8HwcgmXropjLNkVTl4MN87cu28Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-freebsd-x64": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-freebsd-x64/-/binding-freebsd-x64-11.24.2.tgz",
+      "integrity": "sha512-R5xkRBRRz7ceH/P5Jrc6G7FmdUdgpLYyESFAUDVTNQ9K0sGPxcp4ljiwEwEqsvNcQ4sYbMRrWcHHBCu7ksAJVw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-arm-gnueabihf": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-11.24.2.tgz",
+      "integrity": "sha512-k/RuYL4L/R58IBn3wT5ma3Wh4k62bp1eYCFRWCmMsasUOqL+H6sW0VGFadEzKWXFFlz+2uIMoeMk9ySSZJHgbg==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-arm-musleabihf": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-11.24.2.tgz",
+      "integrity": "sha512-bnHAak3ujYfH5pKk4NieFNbvYvernfoQDgwLddbZ3OtMYrem87/qjlA+u+aKG0oZcqSLGCful/6/CEA+aeAgaA==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-arm64-gnu": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-11.24.2.tgz",
+      "integrity": "sha512-vDT3KHgzYp47gmtNOqL2VNhCyl5Zv643eyxm//A68J8DeUGXrvD1pZFiaT4jSfe+RInfnn1R2yVHye4enx6RnA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-arm64-musl": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm64-musl/-/binding-linux-arm64-musl-11.24.2.tgz",
+      "integrity": "sha512-+kMlQvbzfyEYtu5FcjE4p+ttBLpKW4d/AsAsuE69BxV6V4twZJeIQZFfD8gh/wqglY0MkPSezWXQH0jBV13MUw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-ppc64-gnu": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-11.24.2.tgz",
+      "integrity": "sha512-shjfMhmZ3gq9fv/w7bi3PnZlgOPG+2QAOFf0BJF0EgBSIGZ6PMLN2zbGEblTUYB/NKVDRyYhE2ff3dJ1QqNPkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-riscv64-gnu": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-11.24.2.tgz",
+      "integrity": "sha512-zGelwFR5oRo+b69k8Lrzun86DyUHzfKN6cnjbR9l7Z7NIRznOE/2ZvPa1IUKqAL2PzAXOdwkfVqNvO1H2RlpAw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-riscv64-musl": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-11.24.2.tgz",
+      "integrity": "sha512-qxZ1SWCXJY0eyhAlP6Lmo9F2Nrtx7EkYj9oCgL8apDPCwXwCEDA2U697bbT81JIc2IrVjxO4KX6WU2N+oN9Z4w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-s390x-gnu": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-11.24.2.tgz",
+      "integrity": "sha512-sGCecF3cx2DFlH4t/z7ApnOnXqN48p5p5mlHDEnHTAukQa2P+qMVE4CwyWE9W+q/m3QJ7kKfGrIjax31f44oFQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-x64-gnu": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-x64-gnu/-/binding-linux-x64-gnu-11.24.2.tgz",
+      "integrity": "sha512-k/VlMMcSzMlahb3/fENM4rTlsJ0s3fFROA0KXPBmKggqmTSaE383sl8F3KCOXPLmVsYfW6hCitMhXCEtNeZxxg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-x64-musl": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-x64-musl/-/binding-linux-x64-musl-11.24.2.tgz",
+      "integrity": "sha512-8hbnZyNi97b/8wapYaIF9+t9GmZKBW2vunaOc3h9HGJptH7b7XpvZqOTBSm/MpTjr7H497BlgOaSfLUdhmy2bw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-openharmony-arm64": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-openharmony-arm64/-/binding-openharmony-arm64-11.24.2.tgz",
+      "integrity": "sha512-MvyGik3a6pVgZ0t/kWlbmFxFLmXQJwgLsY2eYFHLpy0wGwRbfzeIGgDwQ3kXqE30z+kSXennRkCrT7TUvkptNg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-wasm32-wasi": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-wasm32-wasi/-/binding-wasm32-wasi-11.24.2.tgz",
+      "integrity": "sha512-vHcssMPwO08RTvj/c0iOBz90attxyG3wQJ0dTcyEQK43LRpcdLWZlV5feBhv6Isn6ahbQIzHbCgfa81+RiML0Q==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.11.2",
+        "@emnapi/runtime": "1.11.2",
+        "@napi-rs/wasm-runtime": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@oxc-resolver/binding-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.2.tgz",
+      "integrity": "sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@oxc-resolver/binding-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.2.tgz",
+      "integrity": "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@oxc-resolver/binding-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@oxc-resolver/binding-win32-arm64-msvc": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-11.24.2.tgz",
+      "integrity": "sha512-uokJqro2iBqkFvJdKQLP7d8/BUmFwESQFVmIJUQKj1Xn1a/LysJoe1vmeECLF5b3jsV8CAL5sEMJXX6SdK9Nhg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-win32-x64-msvc": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-win32-x64-msvc/-/binding-win32-x64-msvc-11.24.2.tgz",
+      "integrity": "sha512-UqGPmo56KDfLlfXFAFIrNflHT8tFxWGEivWg3Zeyp4Uy2NlKN1FGPr6/BxcLGG3+kZ6Wp14g5Uj+n71boqZfiw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@oxc-transform/binding-android-arm-eabi": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-android-arm-eabi/-/binding-android-arm-eabi-0.121.0.tgz",
+      "integrity": "sha512-NNYkyDjTID7oVW0LUZ04kDShtyY6hgsTakd2u3mz/hN765JviCuyBIi5qT9dDOmgX0t1y74nuS7FwiLgaCcZ4g==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-transform/binding-android-arm64": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-android-arm64/-/binding-android-arm64-0.121.0.tgz",
+      "integrity": "sha512-zO5az3E5JUmF/k7xOOL9TCipqaVn/d8QHK5T8/bcw6qTWAPVFJjQRK8+5MSmp2ItO2Dmxed5DdWMSxG2NNfA5w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-transform/binding-darwin-arm64": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-darwin-arm64/-/binding-darwin-arm64-0.121.0.tgz",
+      "integrity": "sha512-3vcZdmL8OAdYzXfPDeXrO9KagTgUbXPSFXotoww9N0jVNbdCvSpKJHia1aqdltyevrCWF4KqJyOeeUfGcw7AJw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-transform/binding-darwin-x64": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-darwin-x64/-/binding-darwin-x64-0.121.0.tgz",
+      "integrity": "sha512-R63ZXF4Fuer3FEZYX9UmzIKAENSEYQZTglTkzWoyNPyuHDhSfyJIK+X+wgy2Wc1lTad1XquCUq5SDuRSd37fcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-transform/binding-freebsd-x64": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-freebsd-x64/-/binding-freebsd-x64-0.121.0.tgz",
+      "integrity": "sha512-0krk8L6iOJ6fobs3f9XHo4RSgEas0yLq9/xGZMuwxFs+rI/rnpYPX+1LLSmreHqeZM77a7r+UF12WjwI1odVUA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-transform/binding-linux-arm-gnueabihf": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.121.0.tgz",
+      "integrity": "sha512-cNkTaw77UaNiGOCIv2R1kHZ3OkTVlr/059agLCUaeQmZGl76Ad7DrDcDyhC0Iugw0jEdWZ9zeUS5VLmzblnTXQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-transform/binding-linux-arm-musleabihf": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.121.0.tgz",
+      "integrity": "sha512-eDwTIN0UUCQePgFR41doxorzsxoMoUTbXo6bEbvdFH7P4ZoaUXgHYN10Qjd9K6k0x/bBnU6oC4YPSWYKvQDr9Q==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-transform/binding-linux-arm64-gnu": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.121.0.tgz",
+      "integrity": "sha512-UthSp+L23xeV0lIVloiRDU1d3aOvq0KRif3s6vszeSGnWf69+EVcZcondqLuX9optUhKV0/L8xwe2wLr9WkaDA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-transform/binding-linux-arm64-musl": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.121.0.tgz",
+      "integrity": "sha512-J5vKUF8Jml1m9Fl48fKp2/wPl8LhGdjJWZ3PrrT+S16SbW7yEKixq5upzO2arhrky5elRYMXWwfi60ex1tBi6g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-transform/binding-linux-ppc64-gnu": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.121.0.tgz",
+      "integrity": "sha512-ya+/TL/YH/VcfWeRs95pMIgEj1eQgKg3kR/9AkQgSi8i9jIDEXrgrcQ8cwRYSZ3THlT6cxe3KGJa6vwcHG6JEg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-transform/binding-linux-riscv64-gnu": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.121.0.tgz",
+      "integrity": "sha512-XhUBS/6bxL3maLMvkyY5jM23jFCORl+noYc7KkMydpb0Ot08XSu+8c2o7QpGVHWf85eTH/1Tx0aOTrcWek7EAw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-transform/binding-linux-riscv64-musl": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.121.0.tgz",
+      "integrity": "sha512-kAcZZrU2Wxopcpt38D1u5OeLUwV78EXyOu3VfFNkP/vrMiKB4Tbca8ZxBq+XTkpijuKE4DdCQaLZylsFj7L00w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-transform/binding-linux-s390x-gnu": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.121.0.tgz",
+      "integrity": "sha512-jHyHS+NwPAlUEuY6BzFBDoT4LfSBEW/Ne2FeMzdK8LXOvgHFrJiBf6x8FgekatrTGrDpy1hLiACNnPA81Hs2pQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-transform/binding-linux-x64-gnu": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.121.0.tgz",
+      "integrity": "sha512-KedV2jkFxeMvUqfh6SgXjCnO5SBZ+SorTUxSBeql7zp59ONZgAcehWAqDX+YWsK8wEpt23Q8ydC/0d6ebJIAzQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-transform/binding-linux-x64-musl": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-linux-x64-musl/-/binding-linux-x64-musl-0.121.0.tgz",
+      "integrity": "sha512-jFAZwvgjsswiHET2xxxNvxhKCI74yVmewl0F00i3vzt9C088ZVaUvvWlqDS1GRvD4ORBmpJWOYkHdscpIJijEA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-transform/binding-openharmony-arm64": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-openharmony-arm64/-/binding-openharmony-arm64-0.121.0.tgz",
+      "integrity": "sha512-xn9nxaq31f19PUyGh1xKMOSs8MVPImeaESWNOHtAIznckE+qa5/oHtYALzF3z8uvy1EC/eZODWcHrsYOVNaWug==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-transform/binding-wasm32-wasi": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-wasm32-wasi/-/binding-wasm32-wasi-0.121.0.tgz",
+      "integrity": "sha512-7lj6FBMX8zLfTqIY4YHHTE/b6oyCzZaUwqi2n9KX4FkgjtBpfmq5KSUgi/I+YiE7JJHu1g8Bd3uWJq1lbehL8Q==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@napi-rs/wasm-runtime": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@oxc-transform/binding-win32-arm64-msvc": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.121.0.tgz",
+      "integrity": "sha512-+ve3UajNq2ldcCEEmpMVn7Ic3v/qCykPTSx3lZfe0iCW6tisIWvkYiXpf6B5dvwSY7SDyrdt9EyPMS75b41iPA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-transform/binding-win32-ia32-msvc": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.121.0.tgz",
+      "integrity": "sha512-9ZUHa4bXWlPRLzbjYsU3VBSvqwSVHAknQlN+nUO1DVu6j958Ui9ux0I9pZHwxb07I26VMdDhd7AjJyz1ZtZlkg==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-transform/binding-win32-x64-msvc": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@oxc-transform/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.121.0.tgz",
+      "integrity": "sha512-vV/rzJsmJeeXI1q/xuy93PnoL/IYMwCCyYMX9MmIgMx2a4Lu3vIjUNBLJx1R5CqP/NnvAelsuz05sKlO017FmQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
       }
     },
     "node_modules/@playwright/test": {
@@ -2151,12 +3427,944 @@
         "node": ">=20"
       }
     },
-    "node_modules/@rolldown/pluginutils": {
-      "version": "1.0.0-beta.27",
-      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
-      "integrity": "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==",
-      "dev": true,
+    "node_modules/@remix-run/assert": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/assert/-/assert-0.3.0.tgz",
+      "integrity": "sha512-GBA9klvJdG5YSTwRNur54LQcfqDOtir+x1TDbv3dzB9FS2Li9CEiRLp1EpBcaYrj4ByO03WJCWFBiY8bTMy4vQ==",
       "license": "MIT"
+    },
+    "node_modules/@remix-run/assets": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/@remix-run/assets/-/assets-0.4.4.tgz",
+      "integrity": "sha512-RvENzqsz4avj+PuBRy4AarY0JVGzacy7v9VH/LQuP14xpLPjC134hvKcQJNPkc8vV83d7r8WA/5JXcEESqyiUQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/runtime": "^0.121.0",
+        "@remix-run/file-storage": "0.13.7",
+        "@remix-run/headers": "0.21.1",
+        "@remix-run/mime": "0.4.2",
+        "@remix-run/route-pattern": "0.23.0",
+        "chokidar": "^5.0.0",
+        "es-module-lexer": "^2.0.0",
+        "get-tsconfig": "^4.13.6",
+        "lightningcss": "^1.32.0",
+        "magic-string": "^0.30.21",
+        "oxc-minify": "^0.121.0",
+        "oxc-parser": "^0.121.0",
+        "oxc-resolver": "^11.19.1",
+        "oxc-transform": "^0.121.0",
+        "picomatch": "^4.0.4",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/@remix-run/assets/node_modules/es-module-lexer": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+      "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
+      "license": "MIT"
+    },
+    "node_modules/@remix-run/async-context-middleware": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@remix-run/async-context-middleware/-/async-context-middleware-0.3.4.tgz",
+      "integrity": "sha512-AxFFj2z4z7xdSedRIbtD9WUXLlWDeUox1v6d4x/SInbkiUF+C9LoTZyqh4QSI15bOUrpK1NNVCUCTCgfw4LR0A==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/fetch-router": "^0.20.1"
+      }
+    },
+    "node_modules/@remix-run/auth": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/@remix-run/auth/-/auth-0.2.6.tgz",
+      "integrity": "sha512-7oRSZftQPvYN5vSk89vSZlJHR8iWyLLYTO1Hh6DZ4PI7nCO4V3i4WuHBzog3QajLJCCVhQnEt/o2SuPTBOTXGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/fetch-router": "^0.20.1",
+        "@remix-run/session": "^0.4.2"
+      }
+    },
+    "node_modules/@remix-run/auth-middleware": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@remix-run/auth-middleware/-/auth-middleware-0.2.4.tgz",
+      "integrity": "sha512-REesK8+OiX+kVwSvwSnpEzLWxQnekTGASNU049ygfGxDh9ow/2jC5BZ445muHenkV0qcCIsSlQYiUj5dDXIAYw==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/fetch-router": "^0.20.1",
+        "@remix-run/session": "^0.4.2"
+      }
+    },
+    "node_modules/@remix-run/cli": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@remix-run/cli/-/cli-0.3.4.tgz",
+      "integrity": "sha512-1yzvqQyuBLAK+I8oNiY5Vxz5M2+oqUrkFtR2F6aEu45lVI5iSsvSw/XQicuvAHJg970aIpu2FlYUc7ZhZOKylw==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/terminal": "^0.1.1",
+        "@remix-run/test": "^0.5.0",
+        "semver": "^7.7.4"
+      },
+      "engines": {
+        "node": ">=24.3.0"
+      }
+    },
+    "node_modules/@remix-run/cli/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@remix-run/compression-middleware": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/@remix-run/compression-middleware/-/compression-middleware-0.1.12.tgz",
+      "integrity": "sha512-jThJMui3ca0vvXNTOIiozpyeFVTrabU5bhCjIjQuFKevCtMf9BJi3u+MDABzwxxyH+ztW59rv8R+IJ5O4/nMFA==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/fetch-router": "^0.20.1",
+        "@remix-run/mime": "^0.4.2",
+        "@remix-run/response": "^0.3.7"
+      }
+    },
+    "node_modules/@remix-run/cookie": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/@remix-run/cookie/-/cookie-0.5.4.tgz",
+      "integrity": "sha512-QxV2yo0umBXxwMub8kZFC+nOFnGMVpGo3jQ1Gvs4p1n2N7/0LAKhPgKsWbsk5ab6EqVhpr0S+v9gSQON1nuyoA==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/headers": "^0.21.1"
+      }
+    },
+    "node_modules/@remix-run/cop-middleware": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/@remix-run/cop-middleware/-/cop-middleware-0.1.7.tgz",
+      "integrity": "sha512-B3UEE2ob4GNG6eQilEhqUygCK7t7oPqpNfAtCqhoN+R+LBsdi+9+re5wHaT3xNTa4eeT6YqyXnQsQX6A4otzyg==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/fetch-router": "^0.20.1"
+      }
+    },
+    "node_modules/@remix-run/cors-middleware": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/@remix-run/cors-middleware/-/cors-middleware-0.1.7.tgz",
+      "integrity": "sha512-zbjwCFDwtHDSjyt6sgVVPkFiFfSkmkYPT74nrHClbF+pZx1ra+q93Rpcthbok0cv4IH1f0cagLbf8Jh+IEWNwA==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/fetch-router": "^0.20.1",
+        "@remix-run/headers": "^0.21.1"
+      }
+    },
+    "node_modules/@remix-run/csrf-middleware": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/@remix-run/csrf-middleware/-/csrf-middleware-0.1.7.tgz",
+      "integrity": "sha512-+AUUVIlDEEp62JCyLWC6+pQ7BqaZ2lSkxrBFK/l3t3YYsuA30yk6aPpbQXBXLBtHI12eWA2PHAFZxeRrCPHphQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/fetch-router": "^0.20.1",
+        "@remix-run/session": "^0.4.2"
+      }
+    },
+    "node_modules/@remix-run/data-schema": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/data-schema/-/data-schema-0.3.0.tgz",
+      "integrity": "sha512-rjGaFJduzO3iMFOKwA5URpZDuGbUxgBwcX9myBglfqbax8dBlhRcxurydepq+xi+XBE+bPrT9V57Jur6p1igow==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0"
+      }
+    },
+    "node_modules/@remix-run/data-table": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/data-table/-/data-table-0.3.0.tgz",
+      "integrity": "sha512-2Ikjlm3T2qtMTeWm5v/76iXEP2fqqdJGxjTZ6OFre5b5BFoRyaq/iBmDc0lkXPoOGvkeOxNuRo7L0dRkMTXwJQ==",
+      "license": "MIT"
+    },
+    "node_modules/@remix-run/data-table-mysql": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/data-table-mysql/-/data-table-mysql-0.4.0.tgz",
+      "integrity": "sha512-1HUCmQ7mj0tbkzku8X4z7Y7TaaYMf45Eyh5iqnKB4qT9Jb44XEOjAVveALZ1QchIb0T/72cZ2Gx9YXY7okad+A==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/data-table": "^0.3.0"
+      },
+      "peerDependencies": {
+        "mysql2": "^3.15.3"
+      },
+      "peerDependenciesMeta": {
+        "mysql2": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@remix-run/data-table-postgres": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/data-table-postgres/-/data-table-postgres-0.4.0.tgz",
+      "integrity": "sha512-aOcAYhdgJ99J+BUNrgBrD/RapQt43UbzkGUihm5zhK8S0G5I/gd+TBAw1t8vuutvSw0Zjg1cfDCBihkjMJ4uGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/data-table": "^0.3.0"
+      },
+      "peerDependencies": {
+        "pg": "^8.16.3"
+      },
+      "peerDependenciesMeta": {
+        "pg": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@remix-run/data-table-sqlite": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@remix-run/data-table-sqlite/-/data-table-sqlite-0.5.1.tgz",
+      "integrity": "sha512-YgpUz49eeddYHOY3ebWi4Xeu94KWICRPrmsotkWpTIQdnf/sV+Ddx8BS4kUs+y9JJ/efrjAeHl/LNH6swpvM8g==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/data-table": "^0.3.0"
+      }
+    },
+    "node_modules/@remix-run/fetch-proxy": {
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/@remix-run/fetch-proxy/-/fetch-proxy-0.8.4.tgz",
+      "integrity": "sha512-5Vy8EnRgkboQFpGpVL9TNUEFauh94Cq8Vh9pI1g5jQ3C5OnnMuDKtZV0xR0B7plrI3537ZDFbMRaTG8crKAenA==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/headers": "^0.21.1"
+      }
+    },
+    "node_modules/@remix-run/fetch-router": {
+      "version": "0.20.1",
+      "resolved": "https://registry.npmjs.org/@remix-run/fetch-router/-/fetch-router-0.20.1.tgz",
+      "integrity": "sha512-vxlIu4LHY5KyqOdlXFjJeUefUJxgc7499/cSsBl2bzhQnU5DayPHN/dklBOiG+U7GIYQMmObAinmubkwzaXyuw==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/route-pattern": "^0.23.0"
+      }
+    },
+    "node_modules/@remix-run/file-storage": {
+      "version": "0.13.7",
+      "resolved": "https://registry.npmjs.org/@remix-run/file-storage/-/file-storage-0.13.7.tgz",
+      "integrity": "sha512-7tDgyzs1v0dQgfMt+lpbIzEVkrgrcKJLGbBeXrpJITuCeWoc0XgFfDTp6gghS3s8aWQTm5XHbgnldLoQCEU9Mw==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/fs": "^0.4.6",
+        "@remix-run/lazy-file": "^5.0.6"
+      }
+    },
+    "node_modules/@remix-run/file-storage-s3": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@remix-run/file-storage-s3/-/file-storage-s3-0.1.4.tgz",
+      "integrity": "sha512-n1Z97PpaDIE5tOiRBJTy864ieZtWO1laqdz4pvKbr9KdfUxLRaWmk5gj+UaH7nC+e0sB3wBK9QhjfyoFuGOY6A==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/file-storage": "^0.13.7",
+        "aws4fetch": "^1.0.20"
+      }
+    },
+    "node_modules/@remix-run/form-data-middleware": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@remix-run/form-data-middleware/-/form-data-middleware-0.3.4.tgz",
+      "integrity": "sha512-i/bnBzvXl4qkslVjy/h7r7ODuYiGJ548wDqql757p2eaZCW8h+y8T0/NXh+GcRfleBPYBxst0is6XDEHzt+I6w==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/fetch-router": "^0.20.1",
+        "@remix-run/form-data-parser": "^0.17.4"
+      }
+    },
+    "node_modules/@remix-run/form-data-parser": {
+      "version": "0.17.4",
+      "resolved": "https://registry.npmjs.org/@remix-run/form-data-parser/-/form-data-parser-0.17.4.tgz",
+      "integrity": "sha512-mqWVpD2OaJTFEW2i+M49/iWoUp2Cai6WD606/iynZ+NIlzVdkty3bbGb8g7vTjXeV/sQRmPbg3SJypgvQitvJg==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/multipart-parser": "^0.16.3"
+      }
+    },
+    "node_modules/@remix-run/fs": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/@remix-run/fs/-/fs-0.4.6.tgz",
+      "integrity": "sha512-xxvixX/WyufRr6YrjPLGXvyE5Lzb5G/Y4tygk6McJ6nr59f3hO9w3aVc/lvsVPD7liYfM1EyMnmd4qIByJq9bg==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/lazy-file": "^5.0.6",
+        "@remix-run/mime": "^0.4.2"
+      }
+    },
+    "node_modules/@remix-run/headers": {
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/@remix-run/headers/-/headers-0.21.1.tgz",
+      "integrity": "sha512-DRhRveigepAQDUIi0MrOFhpcl3/KTv/fkpIhulv7Asv1pUwM8RpY2ENjdI8lfii6Z3MEsWtYhGt6If8bi6bYpQ==",
+      "license": "MIT"
+    },
+    "node_modules/@remix-run/html-template": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@remix-run/html-template/-/html-template-0.3.1.tgz",
+      "integrity": "sha512-4yhaBtfh1iVC1razTr+ehu1xmKia0zvE4GWQ6JF2IRiA3kmw+DlrdNFEFqx5Wn1eXAM0vxxcJLdLD7e0XMzH5A==",
+      "license": "MIT"
+    },
+    "node_modules/@remix-run/lazy-file": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/@remix-run/lazy-file/-/lazy-file-5.0.6.tgz",
+      "integrity": "sha512-jIeeqkqR+AgTEKls5WMPbiGyXhrkAJugN4ot/K9X74CLzO9uMbcFDKef7CWCfjN1s+551u+5LxNWLJx1nztuVg==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/mime": "^0.4.2"
+      }
+    },
+    "node_modules/@remix-run/logger-middleware": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@remix-run/logger-middleware/-/logger-middleware-0.3.4.tgz",
+      "integrity": "sha512-hHCZKt1mzqm+pxl/TlkFnaMCSbnLRdad6G9ZWsM0V/hpNPvCYuPjL5eEHiHl8QQeio9xXVOpdefL0X6vDpwRAg==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/fetch-router": "^0.20.1",
+        "@remix-run/terminal": "^0.1.1"
+      }
+    },
+    "node_modules/@remix-run/method-override-middleware": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/@remix-run/method-override-middleware/-/method-override-middleware-0.1.12.tgz",
+      "integrity": "sha512-B4bzxpbvNKcr0cAQCWYTqYq1YFujkGP233vousmj9LjKOuz03Svn9pt9kA03Ps8ZFSoW/usTfOPJ3MckAB9BJw==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/fetch-router": "^0.20.1"
+      }
+    },
+    "node_modules/@remix-run/mime": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@remix-run/mime/-/mime-0.4.2.tgz",
+      "integrity": "sha512-KpZZxBYIrLsvUtt2ZdwK+E2ClVmyvW11Nej6fPgwJpohBMpbCHtR78wtCTv0vqvK5ckLZ7ks2q4pV5dMYFypiA==",
+      "license": "MIT"
+    },
+    "node_modules/@remix-run/multipart-parser": {
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@remix-run/multipart-parser/-/multipart-parser-0.16.3.tgz",
+      "integrity": "sha512-XvMYPIyDTuquR7s1YF4wo4CqMPDrBkpWY0zHSa7SpX0F+t9awg7FWd5mJywc6vTn4oWeS7nQYQQarZ9CuoC/RQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/headers": "^0.21.1"
+      }
+    },
+    "node_modules/@remix-run/node-fetch-server": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/node-fetch-server/-/node-fetch-server-0.14.0.tgz",
+      "integrity": "sha512-s46HS2YuZwCJxwXIrcWdKTfIXWf2G2S20bXeYR2BqBoUkmc4RSiC+VRely6pqNvSUIio8piaI+uLN40IvoFN/A==",
+      "license": "MIT"
+    },
+    "node_modules/@remix-run/node-tsx": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@remix-run/node-tsx/-/node-tsx-0.1.1.tgz",
+      "integrity": "sha512-k9Oi2gML1E7c1PLj+kX+Hsumkjg9tpps7+ufpy7ugsiRTe6fDfZOyEmlYOIkfR2K2Nf8D33+967EMlInm9Nvvg==",
+      "license": "MIT",
+      "dependencies": {
+        "get-tsconfig": "^4.13.6",
+        "oxc-transform": "^0.121.0"
+      },
+      "engines": {
+        "node": ">=24.3.0"
+      }
+    },
+    "node_modules/@remix-run/render-middleware": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@remix-run/render-middleware/-/render-middleware-0.1.4.tgz",
+      "integrity": "sha512-v+RL5T5hDEMNjQyrV/UwODu/x6BUUkpt5EHGixXc00j74KP1g07rtPJvFeeZM6/Yq42I0Ej/4OqsMBiLDjt3dA==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/fetch-router": "^0.20.1"
+      }
+    },
+    "node_modules/@remix-run/response": {
+      "version": "0.3.7",
+      "resolved": "https://registry.npmjs.org/@remix-run/response/-/response-0.3.7.tgz",
+      "integrity": "sha512-f3VWP4NNxgBt+oJfRbgqLYaMXonMdeHhbzAyLfqMzZAwe/ukUwwGoTtER2xlRPDxFlr9Tqa3NFC8PrSmp+rfmA==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/headers": "^0.21.1",
+        "@remix-run/html-template": "^0.3.1",
+        "@remix-run/mime": "^0.4.2"
+      }
+    },
+    "node_modules/@remix-run/route-pattern": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/route-pattern/-/route-pattern-0.23.0.tgz",
+      "integrity": "sha512-8eZfG9owfdvC1OqWemjyIqbFTjWbKTW8RrcbppXrnv1GHMIpFOQx9Ly6F1OXNM03aK1c923JypacoRjamyfVEw==",
+      "license": "MIT"
+    },
+    "node_modules/@remix-run/session": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@remix-run/session/-/session-0.4.2.tgz",
+      "integrity": "sha512-NGzu6/gC5xD/tq40W0WqzTt4JhCdSCIwDHM1aa13JBqb4Ml/Mb0kmXqjfOe/gBYfu6AA11nRQ/BJyr+VduTodA==",
+      "license": "MIT"
+    },
+    "node_modules/@remix-run/session-middleware": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@remix-run/session-middleware/-/session-middleware-0.3.4.tgz",
+      "integrity": "sha512-vFZ70F75Zj1o+UhJ9IJrPlaiFoItwGPrNTY4k5bVKpe4KdwNEat/z3HtfNG2NuBeUys8XhCE3yCT13SM50NkiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/cookie": "^0.5.4",
+        "@remix-run/fetch-router": "^0.20.1",
+        "@remix-run/session": "^0.4.2"
+      }
+    },
+    "node_modules/@remix-run/session-storage-memcache": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@remix-run/session-storage-memcache/-/session-storage-memcache-0.1.2.tgz",
+      "integrity": "sha512-VIJnz+DcJFo+vM1SRKy/8kbJHefVQtGyKS+V1AOMCk8OAMGCCyS+f4ERxmu3as48T/L55oBPsTxQX+rcPchDtQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/session": "^0.4.2"
+      }
+    },
+    "node_modules/@remix-run/session-storage-redis": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@remix-run/session-storage-redis/-/session-storage-redis-0.1.1.tgz",
+      "integrity": "sha512-y/dhJq5hs4rs1zCCPbPJp+i0/EBcYkwQLnwQ4mYtJbSjYIUklSqD3Z7+K8V/MJtl7B4fq8RD1m20lLjLSESMLw==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/session": "^0.4.2"
+      },
+      "peerDependencies": {
+        "redis": "^5.10.0"
+      },
+      "peerDependenciesMeta": {
+        "redis": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@remix-run/static-middleware": {
+      "version": "0.4.13",
+      "resolved": "https://registry.npmjs.org/@remix-run/static-middleware/-/static-middleware-0.4.13.tgz",
+      "integrity": "sha512-32oI2hbVR+GN/sduxOZSY1WNaEasKDm7X7o79eBGG5E78dV5mi0ijGLldHfAEazyRQyqeYzvG292RWUfkFJetA==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/fetch-router": "^0.20.1",
+        "@remix-run/fs": "^0.4.6",
+        "@remix-run/html-template": "^0.3.1",
+        "@remix-run/mime": "^0.4.2",
+        "@remix-run/response": "^0.3.7"
+      }
+    },
+    "node_modules/@remix-run/tar-parser": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@remix-run/tar-parser/-/tar-parser-0.7.1.tgz",
+      "integrity": "sha512-NZKTuA66rj0zqpljWAb6v147cNu5BtRCiv8FY5kn64ZPvLmoI62Ehm2hoUh0g0wJHeCNmgS5QZg1xhw6FX67SA==",
+      "license": "MIT"
+    },
+    "node_modules/@remix-run/terminal": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@remix-run/terminal/-/terminal-0.1.1.tgz",
+      "integrity": "sha512-M8JNcsYp/mWZ0yOB12Ir+Ud1eLxodPr8YSKQcG2PTPeiq9p9c59D9gvF9m6EU2Hmd4esJMiTyy6lJHc/VKKvcw==",
+      "license": "MIT"
+    },
+    "node_modules/@remix-run/test": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/test/-/test-0.5.0.tgz",
+      "integrity": "sha512-jaJLJi7+YXFh4JblWe3hjqve8tkiZ1Nzsog1j6EwCEv814bHldCqBbFrajI69DUULd3nNCs3Mk3rz96lt83xYA==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/node-tsx": "^0.1.1",
+        "@remix-run/terminal": "^0.1.1",
+        "es-module-lexer": "^2.0.0",
+        "esbuild": "^0.27.1",
+        "get-tsconfig": "^4.13.6",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magic-string": "^0.30.21",
+        "oxc-resolver": "^11.19.1",
+        "source-map-js": "^1.2.1",
+        "v8-to-istanbul": "^9.3.0"
+      },
+      "bin": {
+        "remix-test": "dist/cli-entry.js"
+      },
+      "engines": {
+        "node": ">=24.3.0"
+      },
+      "peerDependencies": {
+        "playwright": "^1.60.0"
+      },
+      "peerDependenciesMeta": {
+        "playwright": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@remix-run/test/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@remix-run/test/node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@remix-run/test/node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@remix-run/test/node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@remix-run/test/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@remix-run/test/node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@remix-run/test/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@remix-run/test/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@remix-run/test/node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@remix-run/test/node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@remix-run/test/node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@remix-run/test/node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@remix-run/test/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@remix-run/test/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@remix-run/test/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@remix-run/test/node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@remix-run/test/node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@remix-run/test/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@remix-run/test/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@remix-run/test/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@remix-run/test/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@remix-run/test/node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@remix-run/test/node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@remix-run/test/node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@remix-run/test/node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@remix-run/test/node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@remix-run/test/node_modules/es-module-lexer": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+      "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
+      "license": "MIT"
+    },
+    "node_modules/@remix-run/test/node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
+      }
+    },
+    "node_modules/@remix-run/ui": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/ui/-/ui-0.4.0.tgz",
+      "integrity": "sha512-0whpy2s0V5ZHsErcEPESUZ7McmKQ3Nn1Ut5j4CkQVeos5VT3e1z/+osERMywUNTo2nyeUMpEMte5bFmaoleI3g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/dom-navigation": "^1.0.7"
+      }
     },
     "node_modules/@rollup/plugin-babel": {
       "version": "6.1.0",
@@ -2636,30 +4844,54 @@
       ]
     },
     "node_modules/@sentry/browser": {
-      "version": "10.68.0",
-      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-10.68.0.tgz",
-      "integrity": "sha512-8xVgk7oG2lajXnbXF6a7H1xMZ/U6icqSldHGzQu1+bajfrK8Gan9ULG/Xsj1VM1LlNeK6/7znDJ3u1jgvIwznw==",
+      "version": "10.69.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-10.69.0.tgz",
+      "integrity": "sha512-8391tnm96YbR7b8SYfEA/NEIZuyb2r3SZrtAT0bhZtjlujcYWjo7gugQvk8sWLU9cAa/euD00eJoIoJvNfpd7Q==",
       "license": "MIT",
       "dependencies": {
-        "@sentry/browser-utils": "10.68.0",
+        "@sentry/browser-utils": "10.69.0",
         "@sentry/conventions": "^0.16.0",
-        "@sentry/core": "10.68.0",
-        "@sentry/feedback": "10.68.0",
-        "@sentry/replay": "10.68.0",
-        "@sentry/replay-canvas": "10.68.0"
+        "@sentry/core": "10.69.0",
+        "@sentry/feedback": "10.69.0",
+        "@sentry/replay": "10.69.0",
+        "@sentry/replay-canvas": "10.69.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@sentry/browser-utils": {
-      "version": "10.68.0",
-      "resolved": "https://registry.npmjs.org/@sentry/browser-utils/-/browser-utils-10.68.0.tgz",
-      "integrity": "sha512-be8VtdjCngKc77cstJeV+gO15iH+blyXpBDk8yOehmtX4BkFO33mfTMNCWVR2LA0oOxjIHWRAhf77fIUEhzxPg==",
+      "version": "10.69.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser-utils/-/browser-utils-10.69.0.tgz",
+      "integrity": "sha512-e/u1Abj0zRPwR/deGZAP3GOULrsx67/XXnM5Skniqs4uxTsdNtPek1Nef0tpxwaQJYxwh6pWdhswLPPbbPOgBQ==",
       "license": "MIT",
       "dependencies": {
         "@sentry/conventions": "^0.16.0",
-        "@sentry/core": "10.68.0"
+        "@sentry/core": "10.69.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/browser-utils/node_modules/@sentry/core": {
+      "version": "10.69.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.69.0.tgz",
+      "integrity": "sha512-+uuqVEeiDzYuAKjZLqsROKXvRTbl/QeH0gfGRtpYib1cud4rAFWRIkFmcR7Jb7JGFYwmReyQotiTj/hcDszTZg==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/conventions": "^0.16.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/browser/node_modules/@sentry/core": {
+      "version": "10.69.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.69.0.tgz",
+      "integrity": "sha512-+uuqVEeiDzYuAKjZLqsROKXvRTbl/QeH0gfGRtpYib1cud4rAFWRIkFmcR7Jb7JGFYwmReyQotiTj/hcDszTZg==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/conventions": "^0.16.0"
       },
       "engines": {
         "node": ">=18"
@@ -2901,6 +5133,7 @@
       "version": "10.68.0",
       "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.68.0.tgz",
       "integrity": "sha512-5Amhx8ltVz7vb1bRGyf3c4J69/iHW8R/H+SJxTRILHlsSOBrnVVc/IQEYDC6PTRdRdZ3x2u7RVjxZi2Mhe525g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@sentry/conventions": "^0.16.0"
@@ -2910,55 +5143,74 @@
       }
     },
     "node_modules/@sentry/feedback": {
-      "version": "10.68.0",
-      "resolved": "https://registry.npmjs.org/@sentry/feedback/-/feedback-10.68.0.tgz",
-      "integrity": "sha512-XbdcXiBnpC3vgw46eHOPeD/ZQ+XzluP75ubdUcaPDW02hCh2nsdXiwjZ2DBImbpvIpTbJgjHf/sIlHWvcZJ2Mg==",
+      "version": "10.69.0",
+      "resolved": "https://registry.npmjs.org/@sentry/feedback/-/feedback-10.69.0.tgz",
+      "integrity": "sha512-qrGz5Qaw93/IhMjlFN6uIaXeHwgHDaKGa6FkTAP6PonpkvSbGGqan6xfsENxzj9HUVoli1lZ6tMRDnt2qtSPhg==",
       "license": "MIT",
       "dependencies": {
-        "@sentry/core": "10.68.0"
+        "@sentry/core": "10.69.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
-    "node_modules/@sentry/react": {
-      "version": "10.68.0",
-      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-10.68.0.tgz",
-      "integrity": "sha512-rIq4QR4ScMHHx9JJZv7Jgw31bMdUVJMx+ykHIJb7htjY6mj78sjKs+KpCsMDnvJxDhSmvftGM1KfKD4BggL7OQ==",
+    "node_modules/@sentry/feedback/node_modules/@sentry/core": {
+      "version": "10.69.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.69.0.tgz",
+      "integrity": "sha512-+uuqVEeiDzYuAKjZLqsROKXvRTbl/QeH0gfGRtpYib1cud4rAFWRIkFmcR7Jb7JGFYwmReyQotiTj/hcDszTZg==",
       "license": "MIT",
       "dependencies": {
-        "@sentry/browser": "10.68.0",
-        "@sentry/conventions": "^0.16.0",
-        "@sentry/core": "10.68.0"
+        "@sentry/conventions": "^0.16.0"
       },
       "engines": {
         "node": ">=18"
-      },
-      "peerDependencies": {
-        "react": "^16.14.0 || 17.x || 18.x || 19.x"
       }
     },
     "node_modules/@sentry/replay": {
-      "version": "10.68.0",
-      "resolved": "https://registry.npmjs.org/@sentry/replay/-/replay-10.68.0.tgz",
-      "integrity": "sha512-ZoG2n16vbkx4GWSCnLIqUUN9xlUmccQFbQ2US2rhruQeHTUnHl/ukr8NHOQXZaEbwKyMkX9bEMwfmZHJm+wSTQ==",
+      "version": "10.69.0",
+      "resolved": "https://registry.npmjs.org/@sentry/replay/-/replay-10.69.0.tgz",
+      "integrity": "sha512-uRhmNhtFGPOlM0iniVmWKAX3KVXI0le41yYK/iKdPjinT9jA3ZrmykO/Fv1v/KI5znOtwa9D6eHRnDTTMRxFrg==",
       "license": "MIT",
       "dependencies": {
-        "@sentry/browser-utils": "10.68.0",
-        "@sentry/core": "10.68.0"
+        "@sentry/browser-utils": "10.69.0",
+        "@sentry/core": "10.69.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@sentry/replay-canvas": {
-      "version": "10.68.0",
-      "resolved": "https://registry.npmjs.org/@sentry/replay-canvas/-/replay-canvas-10.68.0.tgz",
-      "integrity": "sha512-HusYcr+He+ohnUDHunYrc5St6vdDnBXpUAndnT5ReyUMVSCiWKfY3paXowU/0787HwYfxdcpZgwC5u79+XbEIg==",
+      "version": "10.69.0",
+      "resolved": "https://registry.npmjs.org/@sentry/replay-canvas/-/replay-canvas-10.69.0.tgz",
+      "integrity": "sha512-VF6nXvSninHcc7dC1Zme0RjkC7VgRMCixs6jKaQX5zTNeqTW3dZGSefSOVv+ZteRi3hJvVORq985VjUC9Z/0+A==",
       "license": "MIT",
       "dependencies": {
-        "@sentry/core": "10.68.0",
-        "@sentry/replay": "10.68.0"
+        "@sentry/core": "10.69.0",
+        "@sentry/replay": "10.69.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/replay-canvas/node_modules/@sentry/core": {
+      "version": "10.69.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.69.0.tgz",
+      "integrity": "sha512-+uuqVEeiDzYuAKjZLqsROKXvRTbl/QeH0gfGRtpYib1cud4rAFWRIkFmcR7Jb7JGFYwmReyQotiTj/hcDszTZg==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/conventions": "^0.16.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/replay/node_modules/@sentry/core": {
+      "version": "10.69.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.69.0.tgz",
+      "integrity": "sha512-+uuqVEeiDzYuAKjZLqsROKXvRTbl/QeH0gfGRtpYib1cud4rAFWRIkFmcR7Jb7JGFYwmReyQotiTj/hcDszTZg==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/conventions": "^0.16.0"
       },
       "engines": {
         "node": ">=18"
@@ -2977,6 +5229,12 @@
         "node": ">= 18"
       }
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
+    },
     "node_modules/@trickfilm400/rollup-plugin-off-main-thread": {
       "version": "3.0.0-pre1",
       "resolved": "https://registry.npmjs.org/@trickfilm400/rollup-plugin-off-main-thread/-/rollup-plugin-off-main-thread-3.0.0-pre1.tgz",
@@ -2993,12 +5251,24 @@
         "node": ">=12"
       }
     },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
       "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@babel/parser": "^7.20.7",
         "@babel/types": "^7.20.7",
@@ -3013,6 +5283,8 @@
       "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@babel/types": "^7.0.0"
       }
@@ -3023,6 +5295,8 @@
       "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@babel/parser": "^7.1.0",
         "@babel/types": "^7.0.0"
@@ -3034,6 +5308,8 @@
       "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@babel/types": "^7.28.2"
       }
@@ -3065,6 +5341,12 @@
         "@types/dom-webcodecs": "*"
       }
     },
+    "node_modules/@types/dom-navigation": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@types/dom-navigation/-/dom-navigation-1.0.7.tgz",
+      "integrity": "sha512-Di4W+i2faYquHUnyWUg3bBQp5pTNvjDDA7mIYfD/1WlLgan6sKkeVjGbdL78K0CuNEk5Pfc/c0rfelwkz10mnQ==",
+      "license": "MIT"
+    },
     "node_modules/@types/dom-webcodecs": {
       "version": "0.1.18",
       "resolved": "https://registry.npmjs.org/@types/dom-webcodecs/-/dom-webcodecs-0.1.18.tgz",
@@ -3078,6 +5360,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/istanbul-lib-coverage": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
+      "integrity": "sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==",
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "26.1.1",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.1.tgz",
@@ -3086,26 +5374,6 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~8.3.0"
-      }
-    },
-    "node_modules/@types/react": {
-      "version": "19.2.17",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
-      "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "csstype": "^3.2.2"
-      }
-    },
-    "node_modules/@types/react-dom": {
-      "version": "19.2.3",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
-      "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
-      "dev": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "@types/react": "^19.2.0"
       }
     },
     "node_modules/@types/resolve": {
@@ -3121,27 +5389,6 @@
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@vitejs/plugin-react": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
-      "integrity": "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/core": "^7.28.0",
-        "@babel/plugin-transform-react-jsx-self": "^7.27.1",
-        "@babel/plugin-transform-react-jsx-source": "^7.27.1",
-        "@rolldown/pluginutils": "1.0.0-beta.27",
-        "@types/babel__core": "^7.20.5",
-        "react-refresh": "^0.17.0"
-      },
-      "engines": {
-        "node": "^14.18.0 || >=16.0.0"
-      },
-      "peerDependencies": {
-        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
-      }
     },
     "node_modules/@vitest/expect": {
       "version": "3.2.7",
@@ -3393,6 +5640,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/aws4fetch": {
+      "version": "1.0.20",
+      "resolved": "https://registry.npmjs.org/aws4fetch/-/aws4fetch-1.0.20.tgz",
+      "integrity": "sha512-/djoAN709iY65ETD6LKCtyyEI04XIBP5xVvfmNxsEP0uJB5tyaGBztSryRr4HqMStr9R06PisQE7m9zDTXKu6g==",
+      "license": "MIT"
+    },
     "node_modules/babel-plugin-polyfill-corejs2": {
       "version": "0.4.17",
       "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.17.tgz",
@@ -3620,6 +5873,21 @@
         "node": ">= 16"
       }
     },
+    "node_modules/chokidar": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
+      "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^5.0.0"
+      },
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/client-zip": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/client-zip/-/client-zip-2.5.0.tgz",
@@ -3647,21 +5915,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
-      "dev": true,
       "license": "MIT"
-    },
-    "node_modules/cookie": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
-      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
     },
     "node_modules/core-js-compat": {
       "version": "3.49.0",
@@ -3701,13 +5955,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/csstype": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
-      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/data-view-buffer": {
       "version": "1.0.2",
@@ -3835,6 +6082,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/dotenv": {
@@ -4456,6 +6712,18 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/get-tsconfig": {
+      "version": "4.14.1",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.1.tgz",
+      "integrity": "sha512-Dz/6HxkrxgNehhxLVeyv8sad9UzF2xBVeaKBQNDfJ5XiSXmp2gTR0eO0RWiT2NCKS5aGP9jjkOMggTN90qU50A==",
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
     "node_modules/glob": {
       "version": "11.1.0",
       "resolved": "https://registry.npmjs.org/glob/-/glob-11.1.0.tgz",
@@ -4531,6 +6799,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/has-property-descriptors": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
@@ -4601,6 +6878,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "license": "MIT"
     },
     "node_modules/https-proxy-agent": {
       "version": "5.0.1",
@@ -5066,6 +7349,42 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/jackspeak": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.2.3.tgz",
@@ -5173,6 +7492,255 @@
         "node": ">=6"
       }
     },
+    "node_modules/lightningcss": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.33.0.tgz",
+      "integrity": "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==",
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.33.0",
+        "lightningcss-darwin-arm64": "1.33.0",
+        "lightningcss-darwin-x64": "1.33.0",
+        "lightningcss-freebsd-x64": "1.33.0",
+        "lightningcss-linux-arm-gnueabihf": "1.33.0",
+        "lightningcss-linux-arm64-gnu": "1.33.0",
+        "lightningcss-linux-arm64-musl": "1.33.0",
+        "lightningcss-linux-x64-gnu": "1.33.0",
+        "lightningcss-linux-x64-musl": "1.33.0",
+        "lightningcss-win32-arm64-msvc": "1.33.0",
+        "lightningcss-win32-x64-msvc": "1.33.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.33.0.tgz",
+      "integrity": "sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.33.0.tgz",
+      "integrity": "sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.33.0.tgz",
+      "integrity": "sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.33.0.tgz",
+      "integrity": "sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.33.0.tgz",
+      "integrity": "sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.33.0.tgz",
+      "integrity": "sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.33.0.tgz",
+      "integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.33.0.tgz",
+      "integrity": "sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.33.0.tgz",
+      "integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.33.0.tgz",
+      "integrity": "sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.33.0.tgz",
+      "integrity": "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
     "node_modules/locate-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -5217,10 +7785,36 @@
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
       "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/make-dir/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/math-intrinsics": {
@@ -5403,6 +7997,141 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/oxc-minify": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/oxc-minify/-/oxc-minify-0.121.0.tgz",
+      "integrity": "sha512-XziD0au8etayM2zJnqcSiW+Pn3hEpqHsbwfL7G4Ej0SwqfvbIjiEF1/uNqONuHl0n9LkLI1ez378vSWZRJZWAQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      },
+      "optionalDependencies": {
+        "@oxc-minify/binding-android-arm-eabi": "0.121.0",
+        "@oxc-minify/binding-android-arm64": "0.121.0",
+        "@oxc-minify/binding-darwin-arm64": "0.121.0",
+        "@oxc-minify/binding-darwin-x64": "0.121.0",
+        "@oxc-minify/binding-freebsd-x64": "0.121.0",
+        "@oxc-minify/binding-linux-arm-gnueabihf": "0.121.0",
+        "@oxc-minify/binding-linux-arm-musleabihf": "0.121.0",
+        "@oxc-minify/binding-linux-arm64-gnu": "0.121.0",
+        "@oxc-minify/binding-linux-arm64-musl": "0.121.0",
+        "@oxc-minify/binding-linux-ppc64-gnu": "0.121.0",
+        "@oxc-minify/binding-linux-riscv64-gnu": "0.121.0",
+        "@oxc-minify/binding-linux-riscv64-musl": "0.121.0",
+        "@oxc-minify/binding-linux-s390x-gnu": "0.121.0",
+        "@oxc-minify/binding-linux-x64-gnu": "0.121.0",
+        "@oxc-minify/binding-linux-x64-musl": "0.121.0",
+        "@oxc-minify/binding-openharmony-arm64": "0.121.0",
+        "@oxc-minify/binding-wasm32-wasi": "0.121.0",
+        "@oxc-minify/binding-win32-arm64-msvc": "0.121.0",
+        "@oxc-minify/binding-win32-ia32-msvc": "0.121.0",
+        "@oxc-minify/binding-win32-x64-msvc": "0.121.0"
+      }
+    },
+    "node_modules/oxc-parser": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/oxc-parser/-/oxc-parser-0.121.0.tgz",
+      "integrity": "sha512-ek9o58+SCv6AV7nchiAcUJy1DNE2CC5WRdBcO0mF+W4oRjNQfPO7b3pLjTHSFECpHkKGOZSQxx3hk8viIL5YCg==",
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "^0.121.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      },
+      "optionalDependencies": {
+        "@oxc-parser/binding-android-arm-eabi": "0.121.0",
+        "@oxc-parser/binding-android-arm64": "0.121.0",
+        "@oxc-parser/binding-darwin-arm64": "0.121.0",
+        "@oxc-parser/binding-darwin-x64": "0.121.0",
+        "@oxc-parser/binding-freebsd-x64": "0.121.0",
+        "@oxc-parser/binding-linux-arm-gnueabihf": "0.121.0",
+        "@oxc-parser/binding-linux-arm-musleabihf": "0.121.0",
+        "@oxc-parser/binding-linux-arm64-gnu": "0.121.0",
+        "@oxc-parser/binding-linux-arm64-musl": "0.121.0",
+        "@oxc-parser/binding-linux-ppc64-gnu": "0.121.0",
+        "@oxc-parser/binding-linux-riscv64-gnu": "0.121.0",
+        "@oxc-parser/binding-linux-riscv64-musl": "0.121.0",
+        "@oxc-parser/binding-linux-s390x-gnu": "0.121.0",
+        "@oxc-parser/binding-linux-x64-gnu": "0.121.0",
+        "@oxc-parser/binding-linux-x64-musl": "0.121.0",
+        "@oxc-parser/binding-openharmony-arm64": "0.121.0",
+        "@oxc-parser/binding-wasm32-wasi": "0.121.0",
+        "@oxc-parser/binding-win32-arm64-msvc": "0.121.0",
+        "@oxc-parser/binding-win32-ia32-msvc": "0.121.0",
+        "@oxc-parser/binding-win32-x64-msvc": "0.121.0"
+      }
+    },
+    "node_modules/oxc-resolver": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/oxc-resolver/-/oxc-resolver-11.24.2.tgz",
+      "integrity": "sha512-FY91FiDBj7ls5MsFS9jN3tjz2o0/zsdSsymlakySaBwVJZorHhkWyICLZMKxlu1R9vYo+sd3z1jwb4J8x7bNDw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      },
+      "optionalDependencies": {
+        "@oxc-resolver/binding-android-arm-eabi": "11.24.2",
+        "@oxc-resolver/binding-android-arm64": "11.24.2",
+        "@oxc-resolver/binding-darwin-arm64": "11.24.2",
+        "@oxc-resolver/binding-darwin-x64": "11.24.2",
+        "@oxc-resolver/binding-freebsd-x64": "11.24.2",
+        "@oxc-resolver/binding-linux-arm-gnueabihf": "11.24.2",
+        "@oxc-resolver/binding-linux-arm-musleabihf": "11.24.2",
+        "@oxc-resolver/binding-linux-arm64-gnu": "11.24.2",
+        "@oxc-resolver/binding-linux-arm64-musl": "11.24.2",
+        "@oxc-resolver/binding-linux-ppc64-gnu": "11.24.2",
+        "@oxc-resolver/binding-linux-riscv64-gnu": "11.24.2",
+        "@oxc-resolver/binding-linux-riscv64-musl": "11.24.2",
+        "@oxc-resolver/binding-linux-s390x-gnu": "11.24.2",
+        "@oxc-resolver/binding-linux-x64-gnu": "11.24.2",
+        "@oxc-resolver/binding-linux-x64-musl": "11.24.2",
+        "@oxc-resolver/binding-openharmony-arm64": "11.24.2",
+        "@oxc-resolver/binding-wasm32-wasi": "11.24.2",
+        "@oxc-resolver/binding-win32-arm64-msvc": "11.24.2",
+        "@oxc-resolver/binding-win32-x64-msvc": "11.24.2"
+      }
+    },
+    "node_modules/oxc-transform": {
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/oxc-transform/-/oxc-transform-0.121.0.tgz",
+      "integrity": "sha512-Kf243wJU/vWF/ThV+ZyfLMQIrViVFRSyYO7UPKpZMMPGGMzxxcHgsNGWy0Uy+pcXD78+jdUnxVTR9rYT73Qw3A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      },
+      "optionalDependencies": {
+        "@oxc-transform/binding-android-arm-eabi": "0.121.0",
+        "@oxc-transform/binding-android-arm64": "0.121.0",
+        "@oxc-transform/binding-darwin-arm64": "0.121.0",
+        "@oxc-transform/binding-darwin-x64": "0.121.0",
+        "@oxc-transform/binding-freebsd-x64": "0.121.0",
+        "@oxc-transform/binding-linux-arm-gnueabihf": "0.121.0",
+        "@oxc-transform/binding-linux-arm-musleabihf": "0.121.0",
+        "@oxc-transform/binding-linux-arm64-gnu": "0.121.0",
+        "@oxc-transform/binding-linux-arm64-musl": "0.121.0",
+        "@oxc-transform/binding-linux-ppc64-gnu": "0.121.0",
+        "@oxc-transform/binding-linux-riscv64-gnu": "0.121.0",
+        "@oxc-transform/binding-linux-riscv64-musl": "0.121.0",
+        "@oxc-transform/binding-linux-s390x-gnu": "0.121.0",
+        "@oxc-transform/binding-linux-x64-gnu": "0.121.0",
+        "@oxc-transform/binding-linux-x64-musl": "0.121.0",
+        "@oxc-transform/binding-openharmony-arm64": "0.121.0",
+        "@oxc-transform/binding-wasm32-wasi": "0.121.0",
+        "@oxc-transform/binding-win32-arm64-msvc": "0.121.0",
+        "@oxc-transform/binding-win32-ia32-msvc": "0.121.0",
+        "@oxc-transform/binding-win32-x64-msvc": "0.121.0"
+      }
+    },
     "node_modules/p-limit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -5524,7 +8253,6 @@
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
       "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -5537,7 +8265,7 @@
       "version": "1.62.0",
       "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.0.tgz",
       "integrity": "sha512-Z14dG305dgaLu6foB1TXQagFiW8JfSUIUaUuPaKQ6NtBPKF1P/qXcqfh6c6K/icPqdy37JmjbiBXf6JNg6Sylw==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "playwright-core": "1.62.0"
@@ -5556,7 +8284,7 @@
       "version": "1.62.0",
       "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.0.tgz",
       "integrity": "sha512-nsNRyq0r2zsG8AcRHWknc9QRA5XCueC7gWMrs+Gx2tlZn9hcl8zudfh00lhJPY1DE7NmZ6bDsT9g2yey8mXljA==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"
@@ -5649,73 +8377,17 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/react": {
-      "version": "19.2.8",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.8.tgz",
-      "integrity": "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==",
+    "node_modules/readdirp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
+      "integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
       "license": "MIT",
       "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/react-dom": {
-      "version": "19.2.8",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.8.tgz",
-      "integrity": "sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==",
-      "license": "MIT",
-      "dependencies": {
-        "scheduler": "^0.27.0"
+        "node": ">= 20.19.0"
       },
-      "peerDependencies": {
-        "react": "^19.2.8"
-      }
-    },
-    "node_modules/react-refresh": {
-      "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
-      "integrity": "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/react-router": {
-      "version": "7.18.1",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.1.tgz",
-      "integrity": "sha512-GDLgg3i3uM0aeJO3Fm+TCS+sDQ7gu12T6x0qdTEzcwqEfleci7JwugVNIF3U//0FWKnJT7ptG+20B2jfDqnZAg==",
-      "license": "MIT",
-      "dependencies": {
-        "cookie": "^1.0.1",
-        "set-cookie-parser": "^2.6.0"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=18",
-        "react-dom": ">=18"
-      },
-      "peerDependenciesMeta": {
-        "react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/react-router-dom": {
-      "version": "7.18.1",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.1.tgz",
-      "integrity": "sha512-KaZh+X/6UtEp28x51AUYZDMg9NGoz2ja3dNHa+ta/tk40vCzKhQ/RypCWBMLbmDr6//E24Vv5uPsrqXFozdkAg==",
-      "license": "MIT",
-      "dependencies": {
-        "react-router": "7.18.1"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=18",
-        "react-dom": ">=18"
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/reflect.getprototypeof": {
@@ -5820,6 +8492,84 @@
         "regjsparser": "bin/parser"
       }
     },
+    "node_modules/remix": {
+      "version": "3.0.0-beta.5",
+      "resolved": "https://registry.npmjs.org/remix/-/remix-3.0.0-beta.5.tgz",
+      "integrity": "sha512-X3l2jLV8vQ4PQigVC1GXtvbopFlfPaP56OC1c9xNilJPw/9QN8UCZRHu43IvAeR4sdNW+j72p5AKDFbiUTrvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/assert": "^0.3.0",
+        "@remix-run/assets": "^0.4.4",
+        "@remix-run/async-context-middleware": "^0.3.4",
+        "@remix-run/auth": "^0.2.6",
+        "@remix-run/auth-middleware": "^0.2.4",
+        "@remix-run/cli": "^0.3.4",
+        "@remix-run/compression-middleware": "^0.1.12",
+        "@remix-run/cookie": "^0.5.4",
+        "@remix-run/cop-middleware": "^0.1.7",
+        "@remix-run/cors-middleware": "^0.1.7",
+        "@remix-run/csrf-middleware": "^0.1.7",
+        "@remix-run/data-schema": "^0.3.0",
+        "@remix-run/data-table": "^0.3.0",
+        "@remix-run/data-table-mysql": "^0.4.0",
+        "@remix-run/data-table-postgres": "^0.4.0",
+        "@remix-run/data-table-sqlite": "^0.5.1",
+        "@remix-run/fetch-proxy": "^0.8.4",
+        "@remix-run/fetch-router": "^0.20.1",
+        "@remix-run/file-storage": "^0.13.7",
+        "@remix-run/file-storage-s3": "^0.1.4",
+        "@remix-run/form-data-middleware": "^0.3.4",
+        "@remix-run/form-data-parser": "^0.17.4",
+        "@remix-run/fs": "^0.4.6",
+        "@remix-run/headers": "^0.21.1",
+        "@remix-run/html-template": "^0.3.1",
+        "@remix-run/lazy-file": "^5.0.6",
+        "@remix-run/logger-middleware": "^0.3.4",
+        "@remix-run/method-override-middleware": "^0.1.12",
+        "@remix-run/mime": "^0.4.2",
+        "@remix-run/multipart-parser": "^0.16.3",
+        "@remix-run/node-fetch-server": "^0.14.0",
+        "@remix-run/node-tsx": "^0.1.1",
+        "@remix-run/render-middleware": "^0.1.4",
+        "@remix-run/response": "^0.3.7",
+        "@remix-run/route-pattern": "^0.23.0",
+        "@remix-run/session": "^0.4.2",
+        "@remix-run/session-middleware": "^0.3.4",
+        "@remix-run/session-storage-memcache": "^0.1.2",
+        "@remix-run/session-storage-redis": "^0.1.1",
+        "@remix-run/static-middleware": "^0.4.13",
+        "@remix-run/tar-parser": "^0.7.1",
+        "@remix-run/terminal": "^0.1.1",
+        "@remix-run/test": "^0.5.0",
+        "@remix-run/ui": "^0.4.0"
+      },
+      "bin": {
+        "remix": "dist/cli-entry.js"
+      },
+      "engines": {
+        "node": ">=24.3.0"
+      },
+      "peerDependencies": {
+        "mysql2": "^3.15.3",
+        "pg": "^8.16.3",
+        "playwright": "^1.60.0",
+        "redis": "^5.10.0"
+      },
+      "peerDependenciesMeta": {
+        "mysql2": {
+          "optional": true
+        },
+        "pg": {
+          "optional": true
+        },
+        "playwright": {
+          "optional": true
+        },
+        "redis": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/require-from-string": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
@@ -5850,6 +8600,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
       }
     },
     "node_modules/rollup": {
@@ -5952,12 +8711,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/scheduler": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
-      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
-      "license": "MIT"
-    },
     "node_modules/semver": {
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
@@ -5977,12 +8730,6 @@
       "engines": {
         "node": ">=20.0.0"
       }
-    },
-    "node_modules/set-cookie-parser": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
-      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
-      "license": "MIT"
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",
@@ -6176,7 +8923,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -6364,6 +9110,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/supports-preserve-symlinks-flag": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
@@ -6492,6 +9250,13 @@
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD",
+      "optional": true
     },
     "node_modules/type-fest": {
       "version": "0.16.0",
@@ -6731,6 +9496,20 @@
       },
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/v8-to-istanbul": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.3.0.tgz",
+      "integrity": "sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==",
+      "license": "ISC",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.12",
+        "@types/istanbul-lib-coverage": "^2.0.1",
+        "convert-source-map": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10.12.0"
       }
     },
     "node_modules/vite": {

--- a/package.json
+++ b/package.json
@@ -14,21 +14,16 @@
     "lint": "tsc -b --pretty false"
   },
   "dependencies": {
-    "@sentry/react": "^10.68.0",
+    "@sentry/browser": "^10.69.0",
     "client-zip": "^2.5.0",
     "idb": "^8.0.3",
     "mediabunny": "^1.52.1",
-    "react": "^19.1.0",
-    "react-dom": "^19.1.0",
-    "react-router-dom": "^7.6.3"
+    "remix": "3.0.0-beta.5"
   },
   "devDependencies": {
     "@playwright/test": "^1.62.0",
     "@sentry/vite-plugin": "^5.4.0",
     "@types/node": "^26.1.1",
-    "@types/react": "^19.1.8",
-    "@types/react-dom": "^19.1.6",
-    "@vitejs/plugin-react": "^4.6.0",
     "fake-indexeddb": "^6.0.1",
     "playwright": "^1.62.0",
     "typescript": "~5.8.3",

--- a/scripts/probe-deployed-remix.mjs
+++ b/scripts/probe-deployed-remix.mjs
@@ -1,0 +1,92 @@
+/**
+ * Smoke test against the deployed remix.kody.video preview: boot, create a
+ * project by hold-to-record with the fake camera, verify the clip landed on
+ * the filmstrip, open the editor, and play back.
+ *
+ * Usage: node scripts/probe-deployed-remix.mjs [origin]
+ */
+import { chromium } from 'playwright'
+
+const origin = process.argv[2] ?? 'https://remix.kody.video'
+
+const browser = await chromium.launch({
+  args: [
+    '--use-fake-ui-for-media-stream',
+    '--use-fake-device-for-media-stream',
+    '--autoplay-policy=no-user-gesture-required',
+  ],
+})
+const context = await browser.newContext({
+  viewport: { width: 412, height: 915 },
+  permissions: ['camera', 'microphone'],
+})
+const page = await context.newPage()
+const errors = []
+page.on('pageerror', (error) => errors.push(String(error)))
+
+const fail = (message) => {
+  console.error(`FAIL: ${message}`)
+  process.exitCode = 1
+}
+
+await page.goto(origin, { waitUntil: 'networkidle' })
+
+// Home renders with the brand + a New project slot.
+await page.waitForSelector('.home-screen', { timeout: 15000 })
+console.log('home screen rendered')
+
+await page.click('.project-slot.empty')
+await page.waitForSelector('.record-screen', { timeout: 15000 })
+// Dismiss onboarding if it appears.
+const onboarding = page.locator('.onboarding-overlay button')
+if (await onboarding.count()) {
+  await onboarding.click()
+}
+await page.waitForSelector('.camera-video', { timeout: 15000 })
+await page.waitForFunction(
+  () => document.querySelector('.camera-video')?.readyState >= 2,
+  undefined,
+  { timeout: 15000 },
+)
+console.log('camera preview live')
+
+// Hold to record ~1.4s.
+const stage = page.locator('.record-stage')
+const box = await stage.boundingBox()
+await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2)
+await page.mouse.down()
+await page.waitForSelector('.record-pill', { timeout: 5000 })
+await page.waitForTimeout(1400)
+await page.mouse.up()
+
+// The lazy project persists and the URL leaves /project/new.
+await page.waitForFunction(() => !location.pathname.endsWith('/new'), undefined, {
+  timeout: 15000,
+})
+console.log(`project created at ${await page.evaluate(() => location.pathname)}`)
+
+// Open editor, expect one clip on the timeline.
+await page.click('[aria-label="Open editor"]')
+await page.waitForSelector('.editor-screen', { timeout: 10000 })
+const clipCount = await page.locator('.clip-thumb').count()
+if (clipCount !== 1) fail(`expected 1 clip on the timeline, saw ${clipCount}`)
+else console.log('clip landed on the filmstrip')
+
+// Playback overlay runs.
+await page.click('[aria-label="Play project preview"]')
+await page.waitForSelector('.playback-overlay', { timeout: 10000 })
+console.log('playback overlay opened')
+await page.click('.playback-tap-zones button[aria-label="Stop preview"]')
+
+// Purchase verification function responds (server-side function reachable).
+const verify = await page.evaluate(async () => {
+  const response = await fetch('/api/verify-purchase?session_id=cs_test_bogus')
+  return { status: response.status, body: await response.text() }
+})
+console.log(`verify-purchase: ${verify.status} ${verify.body.slice(0, 120)}`)
+
+if (errors.length > 0) fail(`page errors: ${errors.join(' | ')}`)
+else console.log('no page errors')
+
+await browser.close()
+console.log(process.exitCode ? 'SMOKE FAILED' : 'SMOKE PASSED')

--- a/scripts/probe-deployed-remix.mjs
+++ b/scripts/probe-deployed-remix.mjs
@@ -16,77 +16,84 @@ const browser = await chromium.launch({
     '--autoplay-policy=no-user-gesture-required',
   ],
 })
-const context = await browser.newContext({
-  viewport: { width: 412, height: 915 },
-  permissions: ['camera', 'microphone'],
-})
-const page = await context.newPage()
-const errors = []
-page.on('pageerror', (error) => errors.push(String(error)))
 
 const fail = (message) => {
   console.error(`FAIL: ${message}`)
   process.exitCode = 1
 }
 
-await page.goto(origin, { waitUntil: 'networkidle' })
+try {
+  const context = await browser.newContext({
+    viewport: { width: 412, height: 915 },
+    permissions: ['camera', 'microphone'],
+  })
+  const page = await context.newPage()
+  const errors = []
+  page.on('pageerror', (error) => errors.push(String(error)))
 
-// Home renders with the brand + a New project slot.
-await page.waitForSelector('.home-screen', { timeout: 15000 })
-console.log('home screen rendered')
+  await page.goto(origin, { waitUntil: 'networkidle' })
 
-await page.click('.project-slot.empty')
-await page.waitForSelector('.record-screen', { timeout: 15000 })
-// Dismiss onboarding if it appears.
-const onboarding = page.locator('.onboarding-overlay button')
-if (await onboarding.count()) {
-  await onboarding.click()
+  // Home renders with the brand + a New project slot.
+  await page.waitForSelector('.home-screen', { timeout: 15000 })
+  console.log('home screen rendered')
+
+  await page.click('.project-slot.empty')
+  await page.waitForSelector('.record-screen', { timeout: 15000 })
+  // Dismiss onboarding if it appears.
+  const onboarding = page.locator('.onboarding-overlay button')
+  if (await onboarding.count()) {
+    await onboarding.click()
+  }
+  await page.waitForSelector('.camera-video', { timeout: 15000 })
+  await page.waitForFunction(
+    () => document.querySelector('.camera-video')?.readyState >= 2,
+    undefined,
+    { timeout: 15000 },
+  )
+  console.log('camera preview live')
+
+  // Hold to record ~1.4s.
+  const stage = page.locator('.record-stage')
+  const box = await stage.boundingBox()
+  if (!box) throw new Error('record stage has no bounding box')
+  await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2)
+  await page.mouse.down()
+  await page.waitForSelector('.record-pill', { timeout: 5000 })
+  await page.waitForTimeout(1400)
+  await page.mouse.up()
+
+  // The lazy project persists and the URL leaves /project/new.
+  await page.waitForFunction(() => !location.pathname.endsWith('/new'), undefined, {
+    timeout: 15000,
+  })
+  console.log(`project created at ${await page.evaluate(() => location.pathname)}`)
+
+  // Open editor, expect one clip on the timeline.
+  await page.click('[aria-label="Open editor"]')
+  await page.waitForSelector('.editor-screen', { timeout: 10000 })
+  const clipCount = await page.locator('.clip-thumb').count()
+  if (clipCount !== 1) fail(`expected 1 clip on the timeline, saw ${clipCount}`)
+  else console.log('clip landed on the filmstrip')
+
+  // Playback overlay runs.
+  await page.click('[aria-label="Play project preview"]')
+  await page.waitForSelector('.playback-overlay', { timeout: 10000 })
+  console.log('playback overlay opened')
+  await page.click('.playback-tap-zones button[aria-label="Stop preview"]')
+
+  // Purchase verification function responds (server-side function reachable).
+  const verify = await page.evaluate(async () => {
+    const response = await fetch('/api/verify-purchase?session_id=cs_test_bogus')
+    return { status: response.status, body: await response.text() }
+  })
+  console.log(`verify-purchase: ${verify.status} ${verify.body.slice(0, 120)}`)
+
+  if (errors.length > 0) fail(`page errors: ${errors.join(' | ')}`)
+  else console.log('no page errors')
+} catch (error) {
+  fail(String(error))
+} finally {
+  await browser.close()
 }
-await page.waitForSelector('.camera-video', { timeout: 15000 })
-await page.waitForFunction(
-  () => document.querySelector('.camera-video')?.readyState >= 2,
-  undefined,
-  { timeout: 15000 },
-)
-console.log('camera preview live')
 
-// Hold to record ~1.4s.
-const stage = page.locator('.record-stage')
-const box = await stage.boundingBox()
-await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2)
-await page.mouse.down()
-await page.waitForSelector('.record-pill', { timeout: 5000 })
-await page.waitForTimeout(1400)
-await page.mouse.up()
-
-// The lazy project persists and the URL leaves /project/new.
-await page.waitForFunction(() => !location.pathname.endsWith('/new'), undefined, {
-  timeout: 15000,
-})
-console.log(`project created at ${await page.evaluate(() => location.pathname)}`)
-
-// Open editor, expect one clip on the timeline.
-await page.click('[aria-label="Open editor"]')
-await page.waitForSelector('.editor-screen', { timeout: 10000 })
-const clipCount = await page.locator('.clip-thumb').count()
-if (clipCount !== 1) fail(`expected 1 clip on the timeline, saw ${clipCount}`)
-else console.log('clip landed on the filmstrip')
-
-// Playback overlay runs.
-await page.click('[aria-label="Play project preview"]')
-await page.waitForSelector('.playback-overlay', { timeout: 10000 })
-console.log('playback overlay opened')
-await page.click('.playback-tap-zones button[aria-label="Stop preview"]')
-
-// Purchase verification function responds (server-side function reachable).
-const verify = await page.evaluate(async () => {
-  const response = await fetch('/api/verify-purchase?session_id=cs_test_bogus')
-  return { status: response.status, body: await response.text() }
-})
-console.log(`verify-purchase: ${verify.status} ${verify.body.slice(0, 120)}`)
-
-if (errors.length > 0) fail(`page errors: ${errors.join(' | ')}`)
-else console.log('no page errors')
-
-await browser.close()
 console.log(process.exitCode ? 'SMOKE FAILED' : 'SMOKE PASSED')

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -1,22 +1,32 @@
-import { RouterProvider } from 'react-router-dom'
-import { useRegisterSW } from 'virtual:pwa-register/react'
+import type { Handle } from 'remix/ui'
+import { on } from 'remix/ui'
+import { registerSW } from 'virtual:pwa-register'
 import { registerUpdateHandles } from './lib/app-update'
-import { router } from './router'
+import { Router } from './router'
+import { AboutPage } from './pages/about-page'
+import { HomePage } from './pages/home-page'
+import { PrivacyPage } from './pages/privacy-page'
+import { ProjectPage } from './pages/project-page'
+import { TermsPage } from './pages/terms-page'
+import { UnlockedPage } from './pages/unlocked-page'
 
-export function App() {
-  const {
-    needRefresh: [needRefresh, setNeedRefresh],
-    updateServiceWorker,
-  } = useRegisterSW({
+export function App(handle: Handle) {
+  let needRefresh = false
+
+  const updateServiceWorker = registerSW({
     immediate: true,
+    onNeedRefresh() {
+      needRefresh = true
+      void handle.update()
+    },
     onRegisteredSW(_url, registration) {
-      // Fires async, after this hook call settles — the closure is safe.
       registerUpdateHandles(registration, (reload) => updateServiceWorker(reload))
     },
   })
 
   const applyUpdate = () => {
-    setNeedRefresh(false)
+    needRefresh = false
+    void handle.update()
     void updateServiceWorker(true).catch(() => undefined)
     // clientsClaim + controllerchange normally reload the page. Workers
     // deployed before clientsClaim never fire controllerchange, so tapping
@@ -27,13 +37,22 @@ export function App() {
     }, 1500)
   }
 
-  return (
+  return () => (
     <div className="app-shell">
-      <RouterProvider router={router} />
+      <Router
+        routes={{
+          '/': () => <HomePage />,
+          '/project/:projectId': (params) => <ProjectPage projectId={params.projectId ?? ''} />,
+          '/unlocked': () => <UnlockedPage />,
+          '/about': () => <AboutPage />,
+          '/privacy': () => <PrivacyPage />,
+          '/terms': () => <TermsPage />,
+        }}
+      />
       {needRefresh ? (
         <div className="update-toast" role="status">
           <span>A new version of Kody Video is ready</span>
-          <button type="button" onClick={applyUpdate}>
+          <button type="button" mix={on('click', applyUpdate)}>
             Update
           </button>
         </div>

--- a/src/components/blob-image.tsx
+++ b/src/components/blob-image.tsx
@@ -1,47 +1,28 @@
-import { useCallback, useRef, type ImgHTMLAttributes, type RefCallback } from 'react'
+import type { Handle, MixValue } from 'remix/ui'
+import { ref } from 'remix/ui'
+import { createBlobUrlBinder } from '../lib/blob-url'
 
-type BlobImageProps = Omit<ImgHTMLAttributes<HTMLImageElement>, 'src'> & {
+interface BlobImageProps {
   blob: Blob
+  className?: string
+  alt?: string
+  'aria-hidden'?: boolean | 'true' | 'false'
+  draggable?: boolean
+  mix?: MixValue
 }
 
-type BlobUrlState = { current: string | null; blob: Blob | null }
+/** Image element bound to a Blob via object URL (revoked on unmount/blob change). */
+export function BlobImage(handle: Handle<BlobImageProps>) {
+  const binder = createBlobUrlBinder<HTMLImageElement>(() => handle.props.blob)
 
-function bindBlobImageUrl(element: HTMLImageElement | null, blob: Blob, state: BlobUrlState): void {
-  if (!element) {
-    if (state.current) {
-      URL.revokeObjectURL(state.current)
-    }
-    state.current = null
-    state.blob = null
-    return
+  return () => {
+    const { blob: _blob, mix, ...props } = handle.props
+    binder.sync()
+    return (
+      <img
+        {...props}
+        mix={[mix, ref((node, signal) => binder.attach(node as HTMLImageElement, signal))]}
+      />
+    )
   }
-
-  if (state.blob !== blob || !state.current) {
-    if (state.current) {
-      URL.revokeObjectURL(state.current)
-    }
-    state.current = URL.createObjectURL(blob)
-    state.blob = blob
-  }
-
-  if (element.src !== state.current) {
-    element.src = state.current
-  }
-}
-
-/** Image element bound to a Blob via ref callback (revokes URL on unmount/blob change). */
-export function BlobImage({ blob, ...props }: BlobImageProps) {
-  const stateRef = useRef<BlobUrlState>({
-    current: null,
-    blob: null,
-  })
-
-  const setImageRef = useCallback<RefCallback<HTMLImageElement>>(
-    (element) => {
-      bindBlobImageUrl(element, blob, stateRef.current)
-    },
-    [blob],
-  )
-
-  return <img {...props} ref={setImageRef} />
 }

--- a/src/components/blob-video.tsx
+++ b/src/components/blob-video.tsx
@@ -1,26 +1,37 @@
-import { useCallback, useRef, type RefCallback, type VideoHTMLAttributes } from 'react'
-import { bindBlobUrl } from '../lib/blob-url'
+import type { Handle, MixInput } from 'remix/ui'
+import { ref } from 'remix/ui'
+import { createBlobUrlBinder } from '../lib/blob-url'
 
-type BlobVideoProps = Omit<VideoHTMLAttributes<HTMLVideoElement>, 'src'> & {
+interface BlobVideoProps {
   blob: Blob
-  /** Outer ref to the underlying element (mount/unmount, like a plain ref). */
-  videoRef?: RefCallback<HTMLVideoElement>
+  className?: string
+  playsInline?: boolean
+  preload?: 'none' | 'metadata' | 'auto'
+  muted?: boolean
+  autoPlay?: boolean
+  /** Outer ref to the underlying element (insert + abort on removal). */
+  videoRef?: (element: HTMLVideoElement, signal: AbortSignal) => void
+  mix?: MixInput<HTMLVideoElement>
 }
 
-/** Video element bound to a Blob via ref callback (revokes URL on unmount/blob change). */
-export function BlobVideo({ blob, videoRef, ...props }: BlobVideoProps) {
-  const stateRef = useRef<{ current: string | null; blob: Blob | null }>({
-    current: null,
-    blob: null,
-  })
+/** Video element bound to a Blob via object URL (revoked on unmount/blob change). */
+export function BlobVideo(handle: Handle<BlobVideoProps>) {
+  const binder = createBlobUrlBinder<HTMLVideoElement>(() => handle.props.blob)
 
-  const setVideoRef = useCallback<RefCallback<HTMLVideoElement>>(
-    (element) => {
-      bindBlobUrl(element, blob, stateRef.current)
-      videoRef?.(element)
-    },
-    [blob, videoRef],
-  )
-
-  return <video {...props} ref={setVideoRef} />
+  return () => {
+    const { blob: _blob, videoRef, mix, ...props } = handle.props
+    binder.sync()
+    return (
+      <video
+        {...props}
+        mix={[
+          mix,
+          ref((node, signal) => {
+            binder.attach(node as HTMLVideoElement, signal)
+            videoRef?.(node as HTMLVideoElement, signal)
+          }),
+        ]}
+      />
+    )
+  }
 }

--- a/src/components/brand-mark.tsx
+++ b/src/components/brand-mark.tsx
@@ -1,3 +1,5 @@
+import type { Handle } from 'remix/ui'
+
 interface BrandMarkProps {
   size?: number
   className?: string
@@ -25,22 +27,25 @@ const sources: Record<NonNullable<BrandMarkProps['variant']>, { webp: string; fa
   },
 }
 
-export function BrandMark({ size = 56, className, variant = 'mark' }: BrandMarkProps) {
-  const src = sources[variant]
+export function BrandMark(handle: Handle<BrandMarkProps>) {
+  return () => {
+    const { size = 56, className, variant = 'mark' } = handle.props
+    const src = sources[variant]
 
-  return (
-    <picture className={className ? `${className}-picture` : undefined}>
-      <source srcSet={src.webp} type="image/webp" />
-      <img
-        className={className}
-        width={size}
-        height={size}
-        src={src.fallback}
-        alt=""
-        aria-hidden="true"
-        draggable={false}
-        decoding="async"
-      />
-    </picture>
-  )
+    return (
+      <picture className={className ? `${className}-picture` : undefined}>
+        <source srcSet={src.webp} type="image/webp" />
+        <img
+          className={className}
+          width={size}
+          height={size}
+          src={src.fallback}
+          alt=""
+          aria-hidden="true"
+          draggable={false}
+          decoding="async"
+        />
+      </picture>
+    )
+  }
 }

--- a/src/components/confirm-sheet.tsx
+++ b/src/components/confirm-sheet.tsx
@@ -1,5 +1,6 @@
-import { useState } from 'react'
-import { useSheetModal } from '../hooks/use-sheet-modal'
+import type { Handle } from 'remix/ui'
+import { on, ref } from 'remix/ui'
+import { attachSheetModal } from '../lib/sheet-modal'
 
 interface ConfirmSheetProps {
   title: string
@@ -11,65 +12,67 @@ interface ConfirmSheetProps {
 }
 
 /** Destructive confirmation bottom sheet (replaces window.confirm). */
-export function ConfirmSheet({
-  title,
-  message,
-  confirmLabel = 'Delete',
-  cancelLabel = 'Cancel',
-  onConfirm,
-  onClose,
-}: ConfirmSheetProps) {
-  const [busy, setBusy] = useState(false)
-  const bindSheet = useSheetModal({ onDismiss: onClose, busy })
+export function ConfirmSheet(handle: Handle<ConfirmSheetProps>) {
+  let busy = false
 
-  return (
-    <>
-      <div
-        className="sheet-backdrop"
-        onClick={() => {
-          if (!busy) onClose()
-        }}
-      />
-      <div
-        className="sheet confirm-sheet"
-        role="dialog"
-        aria-modal="true"
-        aria-label={title}
-        ref={bindSheet}
-      >
-        <h3>{title}</h3>
-        <p className="sheet-lede muted">{message}</p>
-        <div className="sheet-actions">
-          {/* Destructive dialog: initial focus lands on the safe action. */}
-          <button
-            type="button"
-            className="btn btn-ghost"
-            onClick={onClose}
-            disabled={busy}
-            data-sheet-focus
-          >
-            {cancelLabel}
-          </button>
-          <button
-            type="button"
-            className="btn btn-primary confirm-sheet-danger"
-            disabled={busy}
-            onClick={() => {
-              void (async () => {
-                setBusy(true)
+  return () => {
+    const { title, message, confirmLabel = 'Delete', cancelLabel = 'Cancel', onConfirm, onClose } =
+      handle.props
+
+    return (
+      <>
+        <div
+          className="sheet-backdrop"
+          mix={on('click', () => {
+            if (!busy) onClose()
+          })}
+        />
+        <div
+          className="sheet confirm-sheet"
+          role="dialog"
+          aria-modal="true"
+          aria-label={title}
+          mix={ref((node, signal) =>
+            attachSheetModal(node as HTMLElement, signal, {
+              onDismiss: () => handle.props.onClose(),
+              busy: () => busy,
+            }),
+          )}
+        >
+          <h3>{title}</h3>
+          <p className="sheet-lede muted">{message}</p>
+          <div className="sheet-actions">
+            {/* Destructive dialog: initial focus lands on the safe action. */}
+            <button
+              type="button"
+              className="btn btn-ghost"
+              disabled={busy}
+              data-sheet-focus
+              mix={on('click', () => onClose())}
+            >
+              {cancelLabel}
+            </button>
+            <button
+              type="button"
+              className="btn btn-primary confirm-sheet-danger"
+              disabled={busy}
+              mix={on('click', async () => {
+                busy = true
+                void handle.update()
                 try {
                   await onConfirm()
-                  onClose()
+                  handle.props.onClose()
                 } finally {
-                  setBusy(false)
+                  busy = false
+                  void handle.update()
                 }
-              })()
-            }}
-          >
-            {busy ? 'Working…' : confirmLabel}
-          </button>
+              })}
+            >
+              {busy ? 'Working…' : confirmLabel}
+            </button>
+          </div>
         </div>
-      </div>
-    </>
-  )
+      </>
+    )
+  }
 }

--- a/src/components/editor-clip-preview.tsx
+++ b/src/components/editor-clip-preview.tsx
@@ -72,6 +72,9 @@ export function EditorClipPreview(handle: Handle<EditorClipPreviewProps>) {
       },
     }
     signal.addEventListener('abort', () => {
+      // A remount (remountKey change) may bind the replacement element
+      // before this abort runs — never null out the live binding.
+      if (media !== video) return
       media = null
       apiRef.current = null
     })

--- a/src/components/editor-clip-preview.tsx
+++ b/src/components/editor-clip-preview.tsx
@@ -1,4 +1,5 @@
-import { useCallback, useRef, useState, type MutableRefObject } from 'react'
+import type { Handle } from 'remix/ui'
+import { on } from 'remix/ui'
 import { BlobVideo } from './blob-video'
 import { IconPause, IconPlay } from './icons'
 import type { ClipRecord } from '../lib/types'
@@ -10,7 +11,7 @@ export interface EditorClipPreviewHandle {
 
 interface EditorClipPreviewProps {
   clip: ClipRecord
-  apiRef?: MutableRefObject<EditorClipPreviewHandle | null>
+  apiRef?: { current: EditorClipPreviewHandle | null }
 }
 
 function nudgeFrame(video: HTMLVideoElement): void {
@@ -27,57 +28,57 @@ function nudgeFrame(video: HTMLVideoElement): void {
  * Stage preview for the selected timeline clip.
  * Tap toggles playback within the trimmed range; expose seek for trim handles.
  */
-export function EditorClipPreview({ clip, apiRef }: EditorClipPreviewProps) {
-  const startSec = clip.trimStartMs / 1000
-  const endSec = clip.trimEndMs / 1000
-  const remountKey = `${clip.id}:${clip.blob.size}:${clip.blob.type}:${clip.trimStartMs}:${clip.trimEndMs}`
-  const mediaRef = useRef<HTMLVideoElement | null>(null)
-  const [playing, setPlaying] = useState(false)
+export function EditorClipPreview(handle: Handle<EditorClipPreviewProps>) {
+  const { props } = handle
+  let media: HTMLVideoElement | null = null
+  let playing = false
+  /** An explicit seek before loadeddata must not be snapped back to the trim
+   * start when the metadata arrives. */
+  let explicitSeek = false
+
+  const setPlaying = (next: boolean) => {
+    if (playing === next) return
+    playing = next
+    void handle.update()
+  }
 
   // Bound to the element's mount/unmount (not the first media event) so the
   // imperative handle works immediately — early pause()/seekToMs() calls on a
   // still-loading clip must act instead of silently no-oping (#58).
-  const durationMsRef = useRef(clip.durationMs)
-  durationMsRef.current = clip.durationMs
-  /** An explicit seek before loadeddata must not be snapped back to the trim
-   * start when the metadata arrives. */
-  const explicitSeekRef = useRef(false)
-  const bindVideo = useCallback(
-    (video: HTMLVideoElement | null) => {
-      mediaRef.current = video
-      explicitSeekRef.current = false
-      if (!apiRef) return
-      if (!video) {
-        apiRef.current = null
-        return
-      }
-      apiRef.current = {
-        seekToMs: (timeMs: number) => {
-          const el = mediaRef.current
-          if (!el) return
-          explicitSeekRef.current = true
-          el.pause()
-          setPlaying(false)
-          const sec = Math.max(0, Math.min(timeMs, durationMsRef.current)) / 1000
-          if (Math.abs(el.currentTime - sec) > 0.02) {
-            el.currentTime = sec
-          } else {
-            nudgeFrame(el)
-          }
-        },
-        pause: () => {
-          const el = mediaRef.current
-          if (!el) return
-          el.pause()
-          setPlaying(false)
-        },
-      }
-    },
-    [apiRef],
-  )
+  const bindVideo = (video: HTMLVideoElement, signal: AbortSignal) => {
+    media = video
+    explicitSeek = false
+    const apiRef = props.apiRef
+    if (!apiRef) return
+    apiRef.current = {
+      seekToMs: (timeMs: number) => {
+        const el = media
+        if (!el) return
+        explicitSeek = true
+        el.pause()
+        setPlaying(false)
+        const sec = Math.max(0, Math.min(timeMs, props.clip.durationMs)) / 1000
+        if (Math.abs(el.currentTime - sec) > 0.02) {
+          el.currentTime = sec
+        } else {
+          nudgeFrame(el)
+        }
+      },
+      pause: () => {
+        const el = media
+        if (!el) return
+        el.pause()
+        setPlaying(false)
+      },
+    }
+    signal.addEventListener('abort', () => {
+      media = null
+      apiRef.current = null
+    })
+  }
 
   const togglePlayback = () => {
-    const video = mediaRef.current
+    const video = media
     if (!video) return
 
     if (!video.paused) {
@@ -86,6 +87,8 @@ export function EditorClipPreview({ clip, apiRef }: EditorClipPreviewProps) {
       return
     }
 
+    const startSec = props.clip.trimStartMs / 1000
+    const endSec = props.clip.trimEndMs / 1000
     const atEnd = video.currentTime >= endSec - 0.04
     const beforeStart = video.currentTime < startSec - 0.04
     if (atEnd || beforeStart) {
@@ -98,48 +101,58 @@ export function EditorClipPreview({ clip, apiRef }: EditorClipPreviewProps) {
       .catch(() => setPlaying(false))
   }
 
-  return (
-    <div className="editor-clip-preview-wrap">
-      <BlobVideo
-        key={remountKey}
-        blob={clip.blob}
-        videoRef={bindVideo}
-        className="editor-clip-preview"
-        playsInline
-        preload="auto"
-        onLoadedData={(event) => {
-          const video = event.currentTarget
-          // Don't clobber a seek the user already made while loading.
-          if (explicitSeekRef.current) return
-          if (Math.abs(video.currentTime - startSec) > 0.04) {
-            video.currentTime = startSec
-            return
-          }
-          nudgeFrame(video)
-        }}
-        onSeeked={(event) => {
-          if (event.currentTarget.paused) nudgeFrame(event.currentTarget)
-        }}
-        onTimeUpdate={(event) => {
-          const video = event.currentTarget
-          if (!video.paused && video.currentTime >= endSec - 0.02) {
-            video.pause()
-            video.currentTime = endSec
-            setPlaying(false)
-          }
-        }}
-        onPause={() => setPlaying(false)}
-        onPlay={() => setPlaying(true)}
-        onClick={togglePlayback}
-      />
-      <button
-        type="button"
-        className="editor-preview-affordance"
-        aria-label={playing ? 'Pause clip preview' : 'Play clip preview'}
-        onClick={togglePlayback}
-      >
-        {playing ? <IconPause size={18} /> : <IconPlay size={18} />}
-      </button>
-    </div>
-  )
+  return () => {
+    const clip = props.clip
+    const startSec = clip.trimStartMs / 1000
+    const endSec = clip.trimEndMs / 1000
+    const remountKey = `${clip.id}:${clip.blob.size}:${clip.blob.type}:${clip.trimStartMs}:${clip.trimEndMs}`
+
+    return (
+      <div className="editor-clip-preview-wrap">
+        <BlobVideo
+          key={remountKey}
+          blob={clip.blob}
+          videoRef={bindVideo}
+          className="editor-clip-preview"
+          playsInline
+          preload="auto"
+          mix={[
+            on('loadeddata', (event) => {
+              const video = event.currentTarget as HTMLVideoElement
+              // Don't clobber a seek the user already made while loading.
+              if (explicitSeek) return
+              if (Math.abs(video.currentTime - startSec) > 0.04) {
+                video.currentTime = startSec
+                return
+              }
+              nudgeFrame(video)
+            }),
+            on('seeked', (event) => {
+              const video = event.currentTarget as HTMLVideoElement
+              if (video.paused) nudgeFrame(video)
+            }),
+            on('timeupdate', (event) => {
+              const video = event.currentTarget as HTMLVideoElement
+              if (!video.paused && video.currentTime >= endSec - 0.02) {
+                video.pause()
+                video.currentTime = endSec
+                setPlaying(false)
+              }
+            }),
+            on('pause', () => setPlaying(false)),
+            on('play', () => setPlaying(true)),
+            on('click', togglePlayback),
+          ]}
+        />
+        <button
+          type="button"
+          className="editor-preview-affordance"
+          aria-label={playing ? 'Pause clip preview' : 'Play clip preview'}
+          mix={on('click', togglePlayback)}
+        >
+          {playing ? <IconPause size={18} /> : <IconPlay size={18} />}
+        </button>
+      </div>
+    )
+  }
 }

--- a/src/components/editor-screen.tsx
+++ b/src/components/editor-screen.tsx
@@ -1,4 +1,5 @@
-import { useCallback, useLayoutEffect, useRef, useState, type ReactNode } from 'react'
+import type { Handle, RemixNode } from 'remix/ui'
+import { on, ref } from 'remix/ui'
 import {
   duplicateSelectedClip,
   moveSelectedClip,
@@ -6,11 +7,14 @@ import {
   trimClip,
   undoLastDelete,
 } from '../lib/project-actions'
-import { effectiveDurationMs, formatDuration, type ClipId, type ClipRecord, type Project } from '../lib/types'
 import {
-  EditorClipPreview,
-  type EditorClipPreviewHandle,
-} from './editor-clip-preview'
+  effectiveDurationMs,
+  formatDuration,
+  type ClipId,
+  type ClipRecord,
+  type Project,
+} from '../lib/types'
+import { EditorClipPreview, type EditorClipPreviewHandle } from './editor-clip-preview'
 import {
   IconBack,
   IconChevronLeft,
@@ -40,67 +44,65 @@ interface EditorScreenProps {
   refresh: () => void
 }
 
-export function EditorScreen({
-  project,
-  clips,
-  canUndo,
-  interactionLocked,
-  onOpenCamera,
-  onOpenExport,
-  onPlay,
-  showToast,
-  refresh,
-}: EditorScreenProps) {
-  const [selectedClipId, setSelectedClipId] = useState<ClipId | null>(
-    () => clips.at(-1)?.id ?? null,
-  )
-  const [trimming, setTrimming] = useState(false)
-  const previewApiRef = useRef<EditorClipPreviewHandle | null>(null)
+export function EditorScreen(handle: Handle<EditorScreenProps>) {
+  const { props } = handle
+  let selectedClipId: ClipId | null = props.clips.at(-1)?.id ?? null
+  let trimming = false
+  const previewApi: { current: EditorClipPreviewHandle | null } = { current: null }
 
-  const totalDurationMs = clips.reduce((sum, clip) => sum + effectiveDurationMs(clip), 0)
-
-  // Derive a valid selection from loader data (avoid syncing with an effect).
-  const resolvedSelectedId =
-    selectedClipId && clips.some((c) => c.id === selectedClipId)
+  // Derive a valid selection from the loaded clips (no state syncing).
+  const resolveSelectedId = (): ClipId | null =>
+    selectedClipId && props.clips.some((c) => c.id === selectedClipId)
       ? selectedClipId
-      : (clips.at(-1)?.id ?? null)
-  const selected = clips.find((c) => c.id === resolvedSelectedId) ?? null
-  const selectedIndex = selected ? clips.findIndex((c) => c.id === selected.id) : -1
+      : (props.clips.at(-1)?.id ?? null)
+
+  const setSelectedClipId = (id: ClipId | null) => {
+    selectedClipId = id
+    void handle.update()
+  }
+  const setTrimming = (next: boolean) => {
+    trimming = next
+    void handle.update()
+  }
 
   const handleDelete = () => {
-    if (!resolvedSelectedId) return
+    const id = resolveSelectedId()
+    if (!id) return
     void (async () => {
-      await removeClip(resolvedSelectedId)
-      setSelectedClipId(null)
-      setTrimming(false)
-      refresh()
-      showToast('Clip deleted', {
+      await removeClip(id)
+      selectedClipId = null
+      trimming = false
+      void handle.update()
+      props.refresh()
+      props.showToast('Clip deleted', {
         actionLabel: 'Undo',
         onAction: () => {
           void (async () => {
-            const restored = await undoLastDelete(project.id)
+            const restored = await undoLastDelete(props.project.id)
             if (restored) setSelectedClipId(restored.id)
-            refresh()
-            showToast('Clip restored')
+            props.refresh()
+            props.showToast('Clip restored')
           })()
         },
       })
     })()
   }
 
-  // Desktop keyboard support; the stable listener reads the latest committed
-  // handler through a ref, re-assigned after every commit.
-  const keyActionRef = useRef<(event: KeyboardEvent) => void>(() => undefined)
-  const keyAction = (event: KeyboardEvent) => {
-    if (interactionLocked) return
+  // Desktop keyboard support. Closures read live state — no re-binding.
+  const onWindowKeyDown = (event: KeyboardEvent) => {
+    if (props.interactionLocked) return
     // Escape stays global; everything else yields to focused controls.
     if (event.code !== 'Escape' && isInteractiveTarget(event)) return
+    const clips = props.clips
+    const resolvedSelectedId = resolveSelectedId()
+    const selected = clips.find((c) => c.id === resolvedSelectedId) ?? null
+    const selectedIndex = selected ? clips.findIndex((c) => c.id === selected.id) : -1
     if (event.code === 'Escape') {
       if (trimming) {
-        previewApiRef.current?.pause()
+        previewApi.current?.pause()
         setTrimming(false)
       } else {
-        onOpenCamera()
+        props.onOpenCamera()
       }
       return
     }
@@ -116,9 +118,11 @@ export function EditorScreen({
           if (!resolvedSelectedId) return
           const atEdge = step < 0 ? selectedIndex <= 0 : selectedIndex >= clips.length - 1
           if (atEdge) return
-          void moveSelectedClip(project.id, resolvedSelectedId, step < 0 ? 'left' : 'right').then(
-            refresh,
-          )
+          void moveSelectedClip(
+            props.project.id,
+            resolvedSelectedId,
+            step < 0 ? 'left' : 'right',
+          ).then(() => props.refresh())
           return
         }
         const nextIndex = Math.min(
@@ -136,7 +140,7 @@ export function EditorScreen({
       }
       case 'KeyT': {
         if (!selected) return
-        previewApiRef.current?.pause()
+        previewApi.current?.pause()
         setTrimming(true)
         return
       }
@@ -144,47 +148,42 @@ export function EditorScreen({
         if (!resolvedSelectedId) return
         void duplicateSelectedClip(resolvedSelectedId).then((copy) => {
           setSelectedClipId(copy.id)
-          refresh()
+          props.refresh()
         })
         return
       }
       case 'KeyP': {
-        if (clips.length > 0) onPlay()
+        if (clips.length > 0) props.onPlay()
         return
       }
       default:
         return
     }
   }
-  useLayoutEffect(() => {
-    keyActionRef.current = keyAction
-  })
-  const onWindowKeyDown = useCallback((event: KeyboardEvent) => {
-    keyActionRef.current(event)
-  }, [])
+
   // New recordings carry a single live-captured frame (decoding for a full
   // filmstrip behind the live camera preview causes the post-take black
   // flash). Here the camera is released, so upgrade them to the real
-  // evenly-spaced strip. Runs after every commit with a per-clip attempted
-  // set — clips can also arrive through later revalidations (duplicates,
-  // stale-then-fresh loader data), not just the mount.
-  const refineAttemptedRef = useRef<Set<string>>(new Set())
-  useLayoutEffect(() => {
+  // evenly-spaced strip. Checked after every render with a per-clip attempted
+  // set — clips can also arrive through later refreshes (duplicates, undo),
+  // not just the mount.
+  const refineAttempted = new Set<string>()
+  const refineFilmstrips = () => {
     // Ids leave the attempted set when their clip leaves the list: a
     // delete + undo restores the clip from a snapshot that may predate the
     // refinement, and it must get another shot. Clips still present keep
     // their entry, so a failed refinement can't refresh-loop.
-    const ids = new Set(clips.map((clip) => clip.id))
-    for (const id of refineAttemptedRef.current) {
-      if (!ids.has(id)) refineAttemptedRef.current.delete(id)
+    const ids = new Set(props.clips.map((clip) => clip.id))
+    for (const id of refineAttempted) {
+      if (!ids.has(id)) refineAttempted.delete(id)
     }
-    const pending = clips.filter((clip) => {
+    const pending = props.clips.filter((clip) => {
       const count = clip.thumbs?.length ?? 0
-      return count > 0 && count < THUMB_COUNT && !refineAttemptedRef.current.has(clip.id)
+      return count > 0 && count < THUMB_COUNT && !refineAttempted.has(clip.id)
     })
     if (pending.length === 0) return
     for (const clip of pending) {
-      refineAttemptedRef.current.add(clip.id)
+      refineAttempted.add(clip.id)
     }
     // Serial, like the loader backfill: Android caps concurrent video
     // decoders hard, and each refinement decodes a clip.
@@ -192,211 +191,228 @@ export function EditorScreen({
       for (const clip of pending) {
         await refineClipFilmstrip(clip)
       }
-      refresh()
+      props.refresh()
     })()
-  })
+  }
 
-  const bindKeyboard = useCallback(
-    (element: HTMLDivElement | null) => {
-      if (element) window.addEventListener('keydown', onWindowKeyDown)
-      else window.removeEventListener('keydown', onWindowKeyDown)
-    },
-    [onWindowKeyDown],
-  )
+  return () => {
+    const { project, clips, canUndo, onOpenCamera, onOpenExport, onPlay } = props
+    const totalDurationMs = clips.reduce((sum, clip) => sum + effectiveDurationMs(clip), 0)
+    const resolvedSelectedId = resolveSelectedId()
+    const selected = clips.find((c) => c.id === resolvedSelectedId) ?? null
+    const selectedIndex = selected ? clips.findIndex((c) => c.id === selected.id) : -1
 
-  return (
-    <div className={`editor-screen${trimming ? ' is-trimming' : ''}`} ref={bindKeyboard}>
-      <div className="editor-top">
-        <button type="button" className="btn-icon" aria-label="Back to camera" onClick={onOpenCamera}>
-          <IconBack />
-        </button>
-        <div className="editor-meta">
-          <strong>{project.name}</strong>
-          <small>
-            {clips.length} clip{clips.length === 1 ? '' : 's'} · {formatDuration(totalDurationMs)}
-          </small>
-        </div>
-        <button
-          type="button"
-          className="btn-icon"
-          aria-label="Play project preview"
-          disabled={clips.length === 0}
-          onClick={onPlay}
-        >
-          <IconPlay />
-        </button>
-      </div>
+    refineFilmstrips()
 
-      <div className="editor-stage">
-        {selected ? (
-          <EditorClipPreview
-            key={selected.id}
-            clip={
-              trimming
-                ? {
-                    ...selected,
-                    // While trimming, show full clip so handle seeks are visible.
-                    trimStartMs: 0,
-                    trimEndMs: selected.durationMs,
-                  }
-                : selected
-            }
-            apiRef={previewApiRef}
-          />
-        ) : (
-          <div className="editor-empty-preview">Select a clip in the timeline</div>
-        )}
-      </div>
-
-      <div className="editor-panel">
-        {trimming && selected ? (
-          <TrimStrip
-            key={selected.id}
-            clip={selected}
-            onSeek={(timeMs) => previewApiRef.current?.seekToMs(timeMs)}
-            onCancel={() => {
-              previewApiRef.current?.pause()
-              setTrimming(false)
-            }}
-            onDone={async (trimStartMs, trimEndMs) => {
-              await trimClip(selected.id, trimStartMs, trimEndMs)
-              refresh()
-              previewApiRef.current?.pause()
-              setTrimming(false)
-            }}
-          />
-        ) : (
-          <Timeline
-            projectId={project.id}
-            clips={clips}
-            selectedClipId={resolvedSelectedId}
-            onSelect={(id) => {
-              setSelectedClipId(id)
-              setTrimming(false)
-            }}
-            refresh={refresh}
-          />
-        )}
-
-        {!trimming ? (
-          <div className="editor-actions" role="toolbar" aria-label="Clip actions">
-            <ActionButton
-              label="Delete"
-              ariaLabel="Delete clip"
-              disabled={!selected}
-              tone="danger"
-              onClick={handleDelete}
-              icon={<IconTrash />}
-            />
-            <ActionButton
-              label="Duplicate"
-              ariaLabel="Duplicate clip"
-              disabled={!selected}
-              onClick={() => {
-                if (!resolvedSelectedId) return
-                void duplicateSelectedClip(resolvedSelectedId).then((copy) => {
-                  setSelectedClipId(copy.id)
-                  refresh()
-                })
-              }}
-              icon={<IconDuplicate />}
-            />
-            <ActionButton
-              label="Trim"
-              disabled={!selected}
-              prominent
-              onClick={() => {
-                previewApiRef.current?.pause()
-                setTrimming(true)
-              }}
-              icon={<IconTrim />}
-            />
-            <ActionButton
-              label="Left"
-              ariaLabel="Move clip left"
-              disabled={!selected || selectedIndex <= 0}
-              onClick={() => {
-                if (!resolvedSelectedId) return
-                void moveSelectedClip(project.id, resolvedSelectedId, 'left').then(refresh)
-              }}
-              icon={<IconChevronLeft />}
-            />
-            <ActionButton
-              label="Right"
-              ariaLabel="Move clip right"
-              disabled={!selected || selectedIndex >= clips.length - 1}
-              onClick={() => {
-                if (!resolvedSelectedId) return
-                void moveSelectedClip(project.id, resolvedSelectedId, 'right').then(refresh)
-              }}
-              icon={<IconChevronRight />}
-            />
+    return (
+      <div
+        className={`editor-screen${trimming ? ' is-trimming' : ''}`}
+        mix={ref((_node, signal) => {
+          window.addEventListener('keydown', onWindowKeyDown)
+          signal.addEventListener('abort', () => {
+            window.removeEventListener('keydown', onWindowKeyDown)
+          })
+        })}
+      >
+        <div className="editor-top">
+          <button
+            type="button"
+            className="btn-icon"
+            aria-label="Back to camera"
+            mix={on('click', () => onOpenCamera())}
+          >
+            <IconBack />
+          </button>
+          <div className="editor-meta">
+            <strong>{project.name}</strong>
+            <small>
+              {clips.length} clip{clips.length === 1 ? '' : 's'} · {formatDuration(totalDurationMs)}
+            </small>
           </div>
-        ) : null}
-
-        <div className="editor-toolbar">
           <button
             type="button"
-            className="btn btn-ghost"
-            disabled={!canUndo}
-            onClick={() => {
-              void (async () => {
-                const restored = await undoLastDelete(project.id)
-                if (restored) setSelectedClipId(restored.id)
-                refresh()
-                showToast('Clip restored')
-              })()
-            }}
-          >
-            <IconUndo size={18} />
-            Undo delete
-          </button>
-          <button
-            type="button"
-            className="go-button compact"
+            className="btn-icon"
+            aria-label="Play project preview"
             disabled={clips.length === 0}
-            onClick={onOpenExport}
+            mix={on('click', () => onPlay())}
           >
-            Go
+            <IconPlay />
           </button>
         </div>
 
-        <div className="key-hints" aria-hidden="true">
-          <kbd>←</kbd>/<kbd>→</kbd> select · <kbd>Alt</kbd>+arrows move · <kbd>T</kbd> trim ·{' '}
-          <kbd>D</kbd> duplicate · <kbd>⌫</kbd> delete · <kbd>P</kbd> play · <kbd>Esc</kbd> camera
+        <div className="editor-stage">
+          {selected ? (
+            <EditorClipPreview
+              key={selected.id}
+              clip={
+                trimming
+                  ? {
+                      ...selected,
+                      // While trimming, show full clip so handle seeks are visible.
+                      trimStartMs: 0,
+                      trimEndMs: selected.durationMs,
+                    }
+                  : selected
+              }
+              apiRef={previewApi}
+            />
+          ) : (
+            <div className="editor-empty-preview">Select a clip in the timeline</div>
+          )}
+        </div>
+
+        <div className="editor-panel">
+          {trimming && selected ? (
+            <TrimStrip
+              key={selected.id}
+              clip={selected}
+              onSeek={(timeMs) => previewApi.current?.seekToMs(timeMs)}
+              onCancel={() => {
+                previewApi.current?.pause()
+                setTrimming(false)
+              }}
+              onDone={async (trimStartMs, trimEndMs) => {
+                await trimClip(selected.id, trimStartMs, trimEndMs)
+                props.refresh()
+                previewApi.current?.pause()
+                setTrimming(false)
+              }}
+            />
+          ) : (
+            <Timeline
+              projectId={project.id}
+              clips={clips}
+              selectedClipId={resolvedSelectedId}
+              onSelect={(id) => {
+                selectedClipId = id
+                trimming = false
+                void handle.update()
+              }}
+              refresh={props.refresh}
+            />
+          )}
+
+          {!trimming ? (
+            <div className="editor-actions" role="toolbar" aria-label="Clip actions">
+              <ActionButton
+                label="Delete"
+                ariaLabel="Delete clip"
+                disabled={!selected}
+                tone="danger"
+                onClick={handleDelete}
+                icon={<IconTrash />}
+              />
+              <ActionButton
+                label="Duplicate"
+                ariaLabel="Duplicate clip"
+                disabled={!selected}
+                onClick={() => {
+                  if (!resolvedSelectedId) return
+                  void duplicateSelectedClip(resolvedSelectedId).then((copy) => {
+                    setSelectedClipId(copy.id)
+                    props.refresh()
+                  })
+                }}
+                icon={<IconDuplicate />}
+              />
+              <ActionButton
+                label="Trim"
+                disabled={!selected}
+                prominent
+                onClick={() => {
+                  previewApi.current?.pause()
+                  setTrimming(true)
+                }}
+                icon={<IconTrim />}
+              />
+              <ActionButton
+                label="Left"
+                ariaLabel="Move clip left"
+                disabled={!selected || selectedIndex <= 0}
+                onClick={() => {
+                  if (!resolvedSelectedId) return
+                  void moveSelectedClip(project.id, resolvedSelectedId, 'left').then(() =>
+                    props.refresh(),
+                  )
+                }}
+                icon={<IconChevronLeft />}
+              />
+              <ActionButton
+                label="Right"
+                ariaLabel="Move clip right"
+                disabled={!selected || selectedIndex >= clips.length - 1}
+                onClick={() => {
+                  if (!resolvedSelectedId) return
+                  void moveSelectedClip(project.id, resolvedSelectedId, 'right').then(() =>
+                    props.refresh(),
+                  )
+                }}
+                icon={<IconChevronRight />}
+              />
+            </div>
+          ) : null}
+
+          <div className="editor-toolbar">
+            <button
+              type="button"
+              className="btn btn-ghost"
+              disabled={!canUndo}
+              mix={on('click', () => {
+                void (async () => {
+                  const restored = await undoLastDelete(project.id)
+                  if (restored) setSelectedClipId(restored.id)
+                  props.refresh()
+                  props.showToast('Clip restored')
+                })()
+              })}
+            >
+              <IconUndo size={18} />
+              Undo delete
+            </button>
+            <button
+              type="button"
+              className="go-button compact"
+              disabled={clips.length === 0}
+              mix={on('click', () => onOpenExport())}
+            >
+              Go
+            </button>
+          </div>
+
+          <div className="key-hints" aria-hidden="true">
+            <kbd>←</kbd>/<kbd>→</kbd> select · <kbd>Alt</kbd>+arrows move · <kbd>T</kbd> trim ·{' '}
+            <kbd>D</kbd> duplicate · <kbd>⌫</kbd> delete · <kbd>P</kbd> play · <kbd>Esc</kbd> camera
+          </div>
         </div>
       </div>
-    </div>
-  )
+    )
+  }
 }
 
-function ActionButton({
-  label,
-  ariaLabel,
-  icon,
-  disabled,
-  onClick,
-  prominent,
-  tone,
-}: {
-  label: string
-  ariaLabel?: string
-  icon: ReactNode
-  disabled?: boolean
-  onClick: () => void
-  prominent?: boolean
-  tone?: 'danger'
-}) {
-  return (
-    <button
-      type="button"
-      className={`editor-action${prominent ? ' prominent' : ''}${tone === 'danger' ? ' danger' : ''}`}
-      disabled={disabled}
-      aria-label={ariaLabel ?? label}
-      onClick={onClick}
-    >
-      <span className="editor-action-icon">{icon}</span>
-      <span className="editor-action-label">{label}</span>
-    </button>
-  )
+function ActionButton(
+  handle: Handle<{
+    label: string
+    ariaLabel?: string
+    icon: RemixNode
+    disabled?: boolean
+    onClick: () => void
+    prominent?: boolean
+    tone?: 'danger'
+  }>,
+) {
+  return () => {
+    const { label, ariaLabel, icon, disabled, prominent, tone } = handle.props
+    return (
+      <button
+        type="button"
+        className={`editor-action${prominent ? ' prominent' : ''}${tone === 'danger' ? ' danger' : ''}`}
+        disabled={disabled}
+        aria-label={ariaLabel ?? label}
+        mix={on('click', () => handle.props.onClick())}
+      >
+        <span className="editor-action-icon">{icon}</span>
+        <span className="editor-action-label">{label}</span>
+      </button>
+    )
+  }
 }

--- a/src/components/export-overlay.tsx
+++ b/src/components/export-overlay.tsx
@@ -1,10 +1,11 @@
-import type { RefCallback } from 'react'
+import type { Handle } from 'remix/ui'
+import { ref } from 'remix/ui'
 
 interface ExportOverlayProps {
   projectName: string
   progress: number
   /** Bound to the canvas the export engines mirror sampled frames onto. */
-  bindPreviewCanvas: RefCallback<HTMLCanvasElement>
+  bindPreviewCanvas: (canvas: HTMLCanvasElement | null) => void
 }
 
 /**
@@ -12,23 +13,32 @@ interface ExportOverlayProps {
  * (and the camera released) while the engines show the frame currently
  * being encoded above a big progress bar.
  */
-export function ExportOverlay({ projectName, progress, bindPreviewCanvas }: ExportOverlayProps) {
-  const percent = Math.round(progress * 100)
-  return (
-    <div className="export-overlay" role="dialog" aria-label="Exporting video">
-      <div className="export-overlay-stage">
-        <canvas ref={bindPreviewCanvas} className="export-preview-canvas" />
-      </div>
-      <div className="export-overlay-info">
-        <h2>Exporting your video…</h2>
-        <p className="muted">{projectName} — keep the app open</p>
-        <div className="progress-bar" aria-label="Export progress">
-          <span style={{ width: `${percent}%` }} />
+export function ExportOverlay(handle: Handle<ExportOverlayProps>) {
+  return () => {
+    const { projectName, progress } = handle.props
+    const percent = Math.round(progress * 100)
+    return (
+      <div className="export-overlay" role="dialog" aria-label="Exporting video">
+        <div className="export-overlay-stage">
+          <canvas
+            className="export-preview-canvas"
+            mix={ref((node, signal) => {
+              handle.props.bindPreviewCanvas(node as HTMLCanvasElement)
+              signal.addEventListener('abort', () => handle.props.bindPreviewCanvas(null))
+            })}
+          />
         </div>
-        <p className="export-percent" aria-live="polite">
-          {percent}%
-        </p>
+        <div className="export-overlay-info">
+          <h2>Exporting your video…</h2>
+          <p className="muted">{projectName} — keep the app open</p>
+          <div className="progress-bar" aria-label="Export progress">
+            <span style={{ width: `${percent}%` }} />
+          </div>
+          <p className="export-percent" aria-live="polite">
+            {percent}%
+          </p>
+        </div>
       </div>
-    </div>
-  )
+    )
+  }
 }

--- a/src/components/export-sheet.tsx
+++ b/src/components/export-sheet.tsx
@@ -1,4 +1,6 @@
-import { useSheetModal } from '../hooks/use-sheet-modal'
+import type { Handle } from 'remix/ui'
+import { on, ref } from 'remix/ui'
+import { attachSheetModal } from '../lib/sheet-modal'
 import { BrandMark } from './brand-mark'
 
 export type ExportStatus = 'exporting' | 'ready' | 'error'
@@ -35,118 +37,169 @@ interface ExportSheetProps {
  * ("Exporting your video…"), then offers Share / Save from fresh taps so the
  * system share sheet always has the user activation it requires.
  */
-export function ExportSheet({
-  status,
-  error,
-  canShare,
-  fileExtension,
-  fileSizeBytes,
-  notice,
-  watermarked,
-  purchased,
-  busy,
-  onShare,
-  onSave,
-  onSaveClips,
-  onRemoveWatermark,
-  onRestorePurchase,
-  onRetry,
-  onReExport,
-  onClose,
-}: ExportSheetProps) {
-  const bindSheet = useSheetModal({ onDismiss: onClose, busy })
-  return (
-    <>
-      <div
-        className="sheet-backdrop"
-        onClick={() => {
-          if (!busy) onClose()
-        }}
-      />
-      <div
-        className="sheet export-sheet"
-        role="dialog"
-        aria-modal="true"
-        aria-label="Share project"
-        ref={bindSheet}
-      >
-        {status === 'ready' ? (
-          <>
-            <BrandMark size={84} className="export-celebrate-art" variant="share" />
-            <h3>Done! Your video is ready</h3>
-            <p className="muted sheet-lede">
-              {formatFileInfo(fileExtension, fileSizeBytes)} — it stays on this device until you
-              share it.
-            </p>
-            {notice ? <p className="sheet-message">{notice}</p> : null}
-            <div className="sheet-actions">
-              {canShare ? (
-                <button type="button" className="btn btn-primary" onClick={onShare} disabled={busy}>
-                  Share
+export function ExportSheet(handle: Handle<ExportSheetProps>) {
+  const { props } = handle
+  return () => {
+    const {
+      status,
+      error,
+      canShare,
+      fileExtension,
+      fileSizeBytes,
+      notice,
+      watermarked,
+      purchased,
+      busy,
+      onShare,
+      onSave,
+      onSaveClips,
+      onRemoveWatermark,
+      onRestorePurchase,
+      onRetry,
+      onReExport,
+      onClose,
+    } = props
+    return (
+      <>
+        <div
+          className="sheet-backdrop"
+          mix={on('click', () => {
+            if (!props.busy) props.onClose()
+          })}
+        />
+        <div
+          className="sheet export-sheet"
+          role="dialog"
+          aria-modal="true"
+          aria-label="Share project"
+          mix={ref((node, signal) =>
+            attachSheetModal(node as HTMLElement, signal, {
+              onDismiss: () => props.onClose(),
+              busy: () => props.busy,
+            }),
+          )}
+        >
+          {status === 'ready' ? (
+            <>
+              <BrandMark size={84} className="export-celebrate-art" variant="share" />
+              <h3>Done! Your video is ready</h3>
+              <p className="muted sheet-lede">
+                {formatFileInfo(fileExtension, fileSizeBytes)} — it stays on this device until you
+                share it.
+              </p>
+              {notice ? <p className="sheet-message">{notice}</p> : null}
+              <div className="sheet-actions">
+                {canShare ? (
+                  <button
+                    type="button"
+                    className="btn btn-primary"
+                    disabled={busy}
+                    mix={on('click', () => onShare())}
+                  >
+                    Share
+                  </button>
+                ) : null}
+                <button
+                  type="button"
+                  className={`btn ${canShare ? 'btn-secondary' : 'btn-primary'}`}
+                  disabled={busy}
+                  mix={on('click', () => onSave())}
+                >
+                  Save
                 </button>
-              ) : null}
-              <button
-                type="button"
-                className={`btn ${canShare ? 'btn-secondary' : 'btn-primary'}`}
-                onClick={onSave}
-                disabled={busy}
-              >
-                Save
-              </button>
-              <button type="button" className="btn btn-ghost" onClick={onClose} disabled={busy}>
-                Done
-              </button>
-            </div>
-            <p className="sheet-utility-links">
-              <button type="button" className="link-button" onClick={onSaveClips} disabled={busy}>
-                Save original clips (.zip)
-              </button>{' '}
-              ·{' '}
-              <button type="button" className="link-button" onClick={onReExport} disabled={busy}>
-                Re-export from scratch
-              </button>
-            </p>
-            {watermarked && !purchased ? (
-              <p className="watermark-note">
-                Includes a small Kody mark in the corner.{' '}
-                <button type="button" className="link-button" onClick={onRemoveWatermark}>
-                  Get Plus — $0.99 removes it & unlocks 6 projects
+                <button
+                  type="button"
+                  className="btn btn-ghost"
+                  disabled={busy}
+                  mix={on('click', () => onClose())}
+                >
+                  Done
+                </button>
+              </div>
+              <p className="sheet-utility-links">
+                <button
+                  type="button"
+                  className="link-button"
+                  disabled={busy}
+                  mix={on('click', () => onSaveClips())}
+                >
+                  Save original clips (.zip)
                 </button>{' '}
                 ·{' '}
-                <button type="button" className="link-button" onClick={onRestorePurchase}>
-                  Already paid?
+                <button
+                  type="button"
+                  className="link-button"
+                  disabled={busy}
+                  mix={on('click', () => onReExport())}
+                >
+                  Re-export from scratch
                 </button>
               </p>
-            ) : null}
-            {watermarked && purchased ? (
-              <p className="watermark-note">
-                This video still includes the Kody mark — tap Go again for a clean export.
-              </p>
-            ) : null}
-          </>
-        ) : null}
+              {watermarked && !purchased ? (
+                <p className="watermark-note">
+                  Includes a small Kody mark in the corner.{' '}
+                  <button
+                    type="button"
+                    className="link-button"
+                    mix={on('click', () => onRemoveWatermark())}
+                  >
+                    Get Plus — $0.99 removes it & unlocks 6 projects
+                  </button>{' '}
+                  ·{' '}
+                  <button
+                    type="button"
+                    className="link-button"
+                    mix={on('click', () => onRestorePurchase())}
+                  >
+                    Already paid?
+                  </button>
+                </p>
+              ) : null}
+              {watermarked && purchased ? (
+                <p className="watermark-note">
+                  This video still includes the Kody mark — tap Go again for a clean export.
+                </p>
+              ) : null}
+            </>
+          ) : null}
 
-        {status === 'error' ? (
-          <>
-            <h3>Export hit a snag</h3>
-            <p className="sheet-message is-error">{error ?? 'Something went wrong.'}</p>
-            {notice ? <p className="sheet-message">{notice}</p> : null}
-            <div className="sheet-actions">
-              <button type="button" className="btn btn-primary" onClick={onRetry} disabled={busy}>
-                Try again
-              </button>
-              <button type="button" className="btn btn-secondary" onClick={onSaveClips} disabled={busy}>
-                Save clips (.zip) instead
-              </button>
-              <button type="button" className="btn btn-ghost" onClick={onClose} disabled={busy}>
-                Close
-              </button>
-            </div>
-          </>
-        ) : null}
-      </div>
-    </>
-  )
+          {status === 'error' ? (
+            <>
+              <h3>Export hit a snag</h3>
+              <p className="sheet-message is-error">{error ?? 'Something went wrong.'}</p>
+              {notice ? <p className="sheet-message">{notice}</p> : null}
+              <div className="sheet-actions">
+                <button
+                  type="button"
+                  className="btn btn-primary"
+                  disabled={busy}
+                  mix={on('click', () => onRetry())}
+                >
+                  Try again
+                </button>
+                <button
+                  type="button"
+                  className="btn btn-secondary"
+                  disabled={busy}
+                  mix={on('click', () => onSaveClips())}
+                >
+                  Save clips (.zip) instead
+                </button>
+                <button
+                  type="button"
+                  className="btn btn-ghost"
+                  disabled={busy}
+                  mix={on('click', () => onClose())}
+                >
+                  Close
+                </button>
+              </div>
+            </>
+          ) : null}
+        </div>
+      </>
+    )
+  }
 }
 
 function formatFileInfo(ext: string | null, bytes: number | null): string {

--- a/src/components/home-options-sheet.tsx
+++ b/src/components/home-options-sheet.tsx
@@ -1,4 +1,6 @@
-import { useSheetModal } from '../hooks/use-sheet-modal'
+import type { Handle } from 'remix/ui'
+import { on, ref } from 'remix/ui'
+import { attachSheetModal } from '../lib/sheet-modal'
 
 interface HomeOptionsSheetProps {
   projectName: string
@@ -10,47 +12,50 @@ interface HomeOptionsSheetProps {
 }
 
 /** Bottom sheet with Open / Rename / Backup / Delete for a filled project slot. */
-export function HomeOptionsSheet({
-  projectName,
-  onOpen,
-  onRename,
-  onBackup,
-  onDelete,
-  onClose,
-}: HomeOptionsSheetProps) {
-  const bindSheet = useSheetModal({ onDismiss: onClose })
-  return (
-    <>
-      <div className="sheet-backdrop" onClick={onClose} />
-      <div
-        className="sheet home-options-sheet"
-        role="dialog"
-        aria-modal="true"
-        aria-label={`Options for ${projectName}`}
-        ref={bindSheet}
-      >
-        <h3>{projectName}</h3>
-        <p className="sheet-lede muted">What do you want to do?</p>
-        <div className="home-options-list">
-          <button type="button" className="home-option-btn" onClick={onOpen}>
-            Open
-          </button>
-          <button type="button" className="home-option-btn" onClick={onRename}>
-            Rename
-          </button>
-          <button type="button" className="home-option-btn" onClick={onBackup}>
-            Save backup
-          </button>
-          <button type="button" className="home-option-btn home-option-danger" onClick={onDelete}>
-            Delete
-          </button>
+export function HomeOptionsSheet(handle: Handle<HomeOptionsSheetProps>) {
+  return () => {
+    const { projectName, onOpen, onRename, onBackup, onDelete, onClose } = handle.props
+    return (
+      <>
+        <div className="sheet-backdrop" mix={on('click', () => onClose())} />
+        <div
+          className="sheet home-options-sheet"
+          role="dialog"
+          aria-modal="true"
+          aria-label={`Options for ${projectName}`}
+          mix={ref((node, signal) =>
+            attachSheetModal(node as HTMLElement, signal, {
+              onDismiss: () => handle.props.onClose(),
+            }),
+          )}
+        >
+          <h3>{projectName}</h3>
+          <p className="sheet-lede muted">What do you want to do?</p>
+          <div className="home-options-list">
+            <button type="button" className="home-option-btn" mix={on('click', () => onOpen())}>
+              Open
+            </button>
+            <button type="button" className="home-option-btn" mix={on('click', () => onRename())}>
+              Rename
+            </button>
+            <button type="button" className="home-option-btn" mix={on('click', () => onBackup())}>
+              Save backup
+            </button>
+            <button
+              type="button"
+              className="home-option-btn home-option-danger"
+              mix={on('click', () => onDelete())}
+            >
+              Delete
+            </button>
+          </div>
+          <div className="sheet-actions">
+            <button type="button" className="btn btn-ghost" mix={on('click', () => onClose())}>
+              Cancel
+            </button>
+          </div>
         </div>
-        <div className="sheet-actions">
-          <button type="button" className="btn btn-ghost" onClick={onClose}>
-            Cancel
-          </button>
-        </div>
-      </div>
-    </>
-  )
+      </>
+    )
+  }
 }

--- a/src/components/icons.tsx
+++ b/src/components/icons.tsx
@@ -1,5 +1,7 @@
 /** Cohesive stroke icon set (24×24 viewBox, ~2–3px padding, optical balance). */
 
+import type { Handle } from 'remix/ui'
+
 interface IconProps {
   size?: number
 }
@@ -15,21 +17,21 @@ function baseProps(size: number) {
     strokeLinecap: 'round' as const,
     strokeLinejoin: 'round' as const,
     'aria-hidden': true as const,
-    focusable: false as const,
+    focusable: false,
   }
 }
 
-export function IconBack({ size = 22 }: IconProps) {
-  return (
-    <svg {...baseProps(size)}>
+export function IconBack(handle: Handle<IconProps>) {
+  return () => (
+    <svg {...baseProps(handle.props.size ?? 22)}>
       <path d="M15 18l-6-6 6-6" />
     </svg>
   )
 }
 
-export function IconFlip({ size = 22 }: IconProps) {
-  return (
-    <svg {...baseProps(size)}>
+export function IconFlip(handle: Handle<IconProps>) {
+  return () => (
+    <svg {...baseProps(handle.props.size ?? 22)}>
       <path d="M16 4l3 3-3 3" />
       <path d="M4 11V9a4 4 0 014-4h11" />
       <path d="M8 20l-3-3 3-3" />
@@ -38,20 +40,20 @@ export function IconFlip({ size = 22 }: IconProps) {
   )
 }
 
-export function IconTorch({ size = 22, on = false }: IconProps & { on?: boolean }) {
-  return (
-    <svg {...baseProps(size)}>
+export function IconTorch(handle: Handle<IconProps & { on?: boolean }>) {
+  return () => (
+    <svg {...baseProps(handle.props.size ?? 22)}>
       <path
         d="M13 3L7 13h5l-1 8 6-10h-5l1-8z"
-        fill={on ? 'currentColor' : 'none'}
+        fill={handle.props.on ? 'currentColor' : 'none'}
       />
     </svg>
   )
 }
 
-export function IconTimer({ size = 22 }: IconProps) {
-  return (
-    <svg {...baseProps(size)}>
+export function IconTimer(handle: Handle<IconProps>) {
+  return () => (
+    <svg {...baseProps(handle.props.size ?? 22)}>
       <circle cx="12" cy="13" r="7" />
       <path d="M12 10v3.5l2 1.2" />
       <path d="M9 3.5h6" />
@@ -61,35 +63,35 @@ export function IconTimer({ size = 22 }: IconProps) {
 }
 
 /** Map-pin outline for location tagging. */
-export function IconLocation({ size = 22 }: IconProps) {
-  return (
-    <svg {...baseProps(size)}>
+export function IconLocation(handle: Handle<IconProps>) {
+  return () => (
+    <svg {...baseProps(handle.props.size ?? 22)}>
       <path d="M12 20.5s6.5-4.4 6.5-10a6.5 6.5 0 10-13 0c0 5.6 6.5 10 6.5 10z" />
       <circle cx="12" cy="10.5" r="2.25" />
     </svg>
   )
 }
 
-export function IconPlay({ size = 22 }: IconProps) {
-  return (
-    <svg {...baseProps(size)}>
+export function IconPlay(handle: Handle<IconProps>) {
+  return () => (
+    <svg {...baseProps(handle.props.size ?? 22)}>
       <path d="M8 6.5v11L18 12 8 6.5z" />
     </svg>
   )
 }
 
-export function IconPause({ size = 22 }: IconProps) {
-  return (
-    <svg {...baseProps(size)}>
+export function IconPause(handle: Handle<IconProps>) {
+  return () => (
+    <svg {...baseProps(handle.props.size ?? 22)}>
       <path d="M9 6.5v11" />
       <path d="M15 6.5v11" />
     </svg>
   )
 }
 
-export function IconEditor({ size = 22 }: IconProps) {
-  return (
-    <svg {...baseProps(size)}>
+export function IconEditor(handle: Handle<IconProps>) {
+  return () => (
+    <svg {...baseProps(handle.props.size ?? 22)}>
       <circle cx="6.5" cy="6.5" r="2.25" />
       <circle cx="6.5" cy="17.5" r="2.25" />
       <path d="M19.5 4.5L8.7 15.3" />
@@ -100,9 +102,9 @@ export function IconEditor({ size = 22 }: IconProps) {
 }
 
 /** Backspace-style control for deleting the last recorded clip. */
-export function IconDeleteLast({ size = 22 }: IconProps) {
-  return (
-    <svg {...baseProps(size)}>
+export function IconDeleteLast(handle: Handle<IconProps>) {
+  return () => (
+    <svg {...baseProps(handle.props.size ?? 22)}>
       <path d="M18.5 6H9.2L4.5 12l4.7 6H18.5a2 2 0 002-2V8a2 2 0 00-2-2z" />
       <path d="M11.5 10l5 5" />
       <path d="M16.5 10l-5 5" />
@@ -110,9 +112,9 @@ export function IconDeleteLast({ size = 22 }: IconProps) {
   )
 }
 
-export function IconTrash({ size = 22 }: IconProps) {
-  return (
-    <svg {...baseProps(size)}>
+export function IconTrash(handle: Handle<IconProps>) {
+  return () => (
+    <svg {...baseProps(handle.props.size ?? 22)}>
       <path d="M5 7h14" />
       <path d="M9 7V5.5A1.5 1.5 0 0110.5 4h3A1.5 1.5 0 0115 5.5V7" />
       <path d="M8 7l.7 11.2A1.5 1.5 0 0010.2 19.5h3.6a1.5 1.5 0 001.5-1.3L16 7" />
@@ -122,9 +124,9 @@ export function IconTrash({ size = 22 }: IconProps) {
   )
 }
 
-export function IconDuplicate({ size = 22 }: IconProps) {
-  return (
-    <svg {...baseProps(size)}>
+export function IconDuplicate(handle: Handle<IconProps>) {
+  return () => (
+    <svg {...baseProps(handle.props.size ?? 22)}>
       <rect x="8.5" y="8.5" width="11" height="11" rx="2" />
       <path d="M15.5 8.5V6.5A2 2 0 0013.5 4.5h-7a2 2 0 00-2 2v7a2 2 0 002 2h2" />
     </svg>
@@ -132,9 +134,9 @@ export function IconDuplicate({ size = 22 }: IconProps) {
 }
 
 /** Bracket / I-beam handles that read as “trim”. */
-export function IconTrim({ size = 22 }: IconProps) {
-  return (
-    <svg {...baseProps(size)}>
+export function IconTrim(handle: Handle<IconProps>) {
+  return () => (
+    <svg {...baseProps(handle.props.size ?? 22)}>
       <path d="M5 6v12" />
       <path d="M3.5 6h3" />
       <path d="M3.5 18h3" />
@@ -146,34 +148,34 @@ export function IconTrim({ size = 22 }: IconProps) {
   )
 }
 
-export function IconChevronLeft({ size = 22 }: IconProps) {
-  return (
-    <svg {...baseProps(size)}>
+export function IconChevronLeft(handle: Handle<IconProps>) {
+  return () => (
+    <svg {...baseProps(handle.props.size ?? 22)}>
       <path d="M14.5 6l-6 6 6 6" />
     </svg>
   )
 }
 
-export function IconChevronRight({ size = 22 }: IconProps) {
-  return (
-    <svg {...baseProps(size)}>
+export function IconChevronRight(handle: Handle<IconProps>) {
+  return () => (
+    <svg {...baseProps(handle.props.size ?? 22)}>
       <path d="M9.5 6l6 6-6 6" />
     </svg>
   )
 }
 
-export function IconPlus({ size = 22 }: IconProps) {
-  return (
-    <svg {...baseProps(size)}>
+export function IconPlus(handle: Handle<IconProps>) {
+  return () => (
+    <svg {...baseProps(handle.props.size ?? 22)}>
       <path d="M12 6v12" />
       <path d="M6 12h12" />
     </svg>
   )
 }
 
-export function IconMore({ size = 22 }: IconProps) {
-  return (
-    <svg {...baseProps(size)}>
+export function IconMore(handle: Handle<IconProps>) {
+  return () => (
+    <svg {...baseProps(handle.props.size ?? 22)}>
       <circle cx="6" cy="12" r="1.75" fill="currentColor" stroke="none" />
       <circle cx="12" cy="12" r="1.75" fill="currentColor" stroke="none" />
       <circle cx="18" cy="12" r="1.75" fill="currentColor" stroke="none" />
@@ -181,9 +183,9 @@ export function IconMore({ size = 22 }: IconProps) {
   )
 }
 
-export function IconUndo({ size = 22 }: IconProps) {
-  return (
-    <svg {...baseProps(size)}>
+export function IconUndo(handle: Handle<IconProps>) {
+  return () => (
+    <svg {...baseProps(handle.props.size ?? 22)}>
       <path d="M7 5L4 8l3 3" />
       <path d="M4 8h7a5 5 0 110 10H9" />
     </svg>
@@ -191,9 +193,9 @@ export function IconUndo({ size = 22 }: IconProps) {
 }
 
 /** The iOS share glyph: box with an arrow rising out of it. */
-export function IconShareIos({ size = 22 }: IconProps) {
-  return (
-    <svg {...baseProps(size)}>
+export function IconShareIos(handle: Handle<IconProps>) {
+  return () => (
+    <svg {...baseProps(handle.props.size ?? 22)}>
       <path d="M8 8H6a1 1 0 00-1 1v11a1 1 0 001 1h12a1 1 0 001-1V9a1 1 0 00-1-1h-2" />
       <path d="M12 14V3" />
       <path d="M8.5 6.5L12 3l3.5 3.5" />
@@ -201,27 +203,27 @@ export function IconShareIos({ size = 22 }: IconProps) {
   )
 }
 
-export function IconClose({ size = 22 }: IconProps) {
-  return (
-    <svg {...baseProps(size)}>
+export function IconClose(handle: Handle<IconProps>) {
+  return () => (
+    <svg {...baseProps(handle.props.size ?? 22)}>
       <path d="M6 6l12 12" />
       <path d="M18 6L6 18" />
     </svg>
   )
 }
 
-export function IconLens({ size = 22 }: IconProps) {
-  return (
-    <svg {...baseProps(size)}>
+export function IconLens(handle: Handle<IconProps>) {
+  return () => (
+    <svg {...baseProps(handle.props.size ?? 22)}>
       <circle cx="12" cy="12" r="8.5" />
       <circle cx="12" cy="12" r="3.5" />
     </svg>
   )
 }
 
-export function IconLock({ size = 22 }: IconProps) {
-  return (
-    <svg {...baseProps(size)}>
+export function IconLock(handle: Handle<IconProps>) {
+  return () => (
+    <svg {...baseProps(handle.props.size ?? 22)}>
       <rect x="5" y="10.5" width="14" height="9.5" rx="2" />
       <path d="M8 10.5V7.5a4 4 0 018 0v3" />
     </svg>
@@ -229,12 +231,12 @@ export function IconLock({ size = 22 }: IconProps) {
 }
 
 /** Monitor with a record dot: screen recording. */
-export function IconScreen({ size = 22, on = false }: IconProps & { on?: boolean }) {
-  return (
-    <svg {...baseProps(size)}>
+export function IconScreen(handle: Handle<IconProps & { on?: boolean }>) {
+  return () => (
+    <svg {...baseProps(handle.props.size ?? 22)}>
       <rect x="3" y="4.5" width="18" height="12.5" rx="2" />
       <path d="M9 20.5h6" />
-      <circle cx="12" cy="10.75" r="2.4" fill={on ? 'currentColor' : 'none'} />
+      <circle cx="12" cy="10.75" r="2.4" fill={handle.props.on ? 'currentColor' : 'none'} />
     </svg>
   )
 }

--- a/src/components/onboarding-overlay.tsx
+++ b/src/components/onboarding-overlay.tsx
@@ -1,3 +1,5 @@
+import type { Handle } from 'remix/ui'
+import { on } from 'remix/ui'
 import { BrandMark } from './brand-mark'
 
 interface OnboardingOverlayProps {
@@ -23,8 +25,8 @@ const steps = [
   },
 ]
 
-export function OnboardingOverlay({ onDismiss }: OnboardingOverlayProps) {
-  return (
+export function OnboardingOverlay(handle: Handle<OnboardingOverlayProps>) {
+  return () => (
     <div className="onboarding-overlay" role="dialog" aria-label="Kody Video quick start">
       <div className="onboarding-card">
         <div className="onboarding-card-top">
@@ -45,7 +47,11 @@ export function OnboardingOverlay({ onDismiss }: OnboardingOverlayProps) {
             </li>
           ))}
         </ol>
-        <button type="button" className="btn btn-primary" onClick={onDismiss}>
+        <button
+          type="button"
+          className="btn btn-primary"
+          mix={on('click', () => handle.props.onDismiss())}
+        >
           Start recording
         </button>
       </div>

--- a/src/components/playback-overlay.tsx
+++ b/src/components/playback-overlay.tsx
@@ -55,17 +55,21 @@ export function PlaybackOverlay(handle: Handle<PlaybackOverlayProps>) {
     return segment ? segment.endMs - segment.startMs : 0
   }
 
-  /** Bind the current segment's blob to the persistent video element. */
-  const syncVideoSrc = () => {
+  /** Bind the current segment's blob to the persistent video element.
+   * Returns whether a new source was assigned (i.e. `loadedmetadata` will
+   * fire and drive playback). */
+  const syncVideoSrc = (): boolean => {
     const el = videoEl
     const segment = currentSegment()
-    if (!el || !segment) return
+    if (!el || !segment) return false
     if (urlState.blob !== segment.clip.blob) {
       if (urlState.url) URL.revokeObjectURL(urlState.url)
       urlState.url = URL.createObjectURL(segment.clip.blob)
       urlState.blob = segment.clip.blob
       el.src = urlState.url
+      return true
     }
+    return false
   }
 
   const goTo = (nextIndex: number) => {
@@ -201,7 +205,13 @@ export function PlaybackOverlay(handle: Handle<PlaybackOverlayProps>) {
       )
     }
 
-    syncVideoSrc()
+    // Same blob as the previous segment = no new source, so `loadedmetadata`
+    // never re-fires (adjacent duplicated clips) — start this segment
+    // directly. Still-loading media (readyState 0) is left to loadedmetadata.
+    if (!syncVideoSrc() && videoEl && videoEl.readyState >= 1 && loadedIndex !== index) {
+      loadedIndex = index
+      startPlayback(videoEl)
+    }
 
     return (
       <div

--- a/src/components/playback-overlay.tsx
+++ b/src/components/playback-overlay.tsx
@@ -1,4 +1,5 @@
-import { useCallback, useLayoutEffect, useMemo, useRef, useState } from 'react'
+import type { Handle } from 'remix/ui'
+import { on, ref } from 'remix/ui'
 import { planExport } from '../lib/export'
 import type { ClipRecord } from '../lib/types'
 import { IconPlay } from './icons'
@@ -14,74 +15,113 @@ interface PlaybackOverlayProps {
  * (so unmuted playback stays allowed across clips), tap the left/right edges
  * for previous/next clip, tap the middle to stop.
  */
-export function PlaybackOverlay({ clips, onClose }: PlaybackOverlayProps) {
-  // Memoized so segment identity is stable across progress re-renders —
-  // otherwise the video ref callback re-binds (revoking and reassigning the
-  // blob URL) on every tick and playback restarts.
-  const plan = useMemo(() => planExport(clips), [clips])
-  const segments = plan.segments
+export function PlaybackOverlay(handle: Handle<PlaybackOverlayProps>) {
+  const { props } = handle
 
-  const [index, setIndex] = useState(0)
-  const [needsTap, setNeedsTap] = useState(false)
-  const [segmentProgress, setSegmentProgress] = useState(0)
-  const videoRef = useRef<HTMLVideoElement | null>(null)
-  const urlStateRef = useRef<{ url: string | null; blob: Blob | null }>({ url: null, blob: null })
-  const advancedForRef = useRef(-1)
+  // Cached per clips identity so segment identity is stable across progress
+  // re-renders — otherwise the video source would rebind (revoking and
+  // reassigning the blob URL) on every tick and playback would restart.
+  let planFor: ClipRecord[] | null = null
+  let segments: ReturnType<typeof planExport>['segments'] = []
+  const resolveSegments = () => {
+    if (planFor !== props.clips) {
+      planFor = props.clips
+      segments = planExport(props.clips).segments
+    }
+    return segments
+  }
+
+  let index = 0
+  let needsTap = false
+  let segmentProgress = 0
+  let videoEl: HTMLVideoElement | null = null
+  const urlState: { url: string | null; blob: Blob | null } = { url: null, blob: null }
+  let advancedFor = -1
   /** Index whose media has actually loaded — gates stale timeupdate/ended
    * events from the previous clip that fire before the new source is ready. */
-  const loadedIndexRef = useRef(-1)
+  let loadedIndex = -1
 
-  const segment = segments[index] ?? null
+  const currentSegment = () => resolveSegments()[index] ?? null
+  const startSec = () => {
+    const segment = currentSegment()
+    return segment ? segment.startMs / 1000 : 0
+  }
+  const endSec = () => {
+    const segment = currentSegment()
+    return segment ? segment.endMs / 1000 : 0
+  }
+  const segmentMs = () => {
+    const segment = currentSegment()
+    return segment ? segment.endMs - segment.startMs : 0
+  }
 
-  const startSec = segment ? segment.startMs / 1000 : 0
-  const endSec = segment ? segment.endMs / 1000 : 0
-  const segmentMs = segment ? segment.endMs - segment.startMs : 0
+  /** Bind the current segment's blob to the persistent video element. */
+  const syncVideoSrc = () => {
+    const el = videoEl
+    const segment = currentSegment()
+    if (!el || !segment) return
+    if (urlState.blob !== segment.clip.blob) {
+      if (urlState.url) URL.revokeObjectURL(urlState.url)
+      urlState.url = URL.createObjectURL(segment.clip.blob)
+      urlState.blob = segment.clip.blob
+      el.src = urlState.url
+    }
+  }
 
   const goTo = (nextIndex: number) => {
-    advancedForRef.current = -1
-    setSegmentProgress(0)
-    setNeedsTap(false)
+    advancedFor = -1
+    segmentProgress = 0
+    needsTap = false
     if (nextIndex === index) {
-      const video = videoRef.current
+      const video = videoEl
       if (video) {
-        video.currentTime = startSec
-        void video.play().catch(() => setNeedsTap(true))
+        video.currentTime = startSec()
+        void video.play().catch(() => {
+          needsTap = true
+          void handle.update()
+        })
       }
+      void handle.update()
       return
     }
-    setIndex(Math.max(0, Math.min(segments.length - 1, nextIndex)))
+    index = Math.max(0, Math.min(resolveSegments().length - 1, nextIndex))
+    void handle.update()
   }
 
   const advance = () => {
-    if (advancedForRef.current === index) return
-    advancedForRef.current = index
-    if (index >= segments.length - 1) {
-      onClose()
+    if (advancedFor === index) return
+    advancedFor = index
+    if (index >= resolveSegments().length - 1) {
+      props.onClose()
       return
     }
-    setSegmentProgress(0)
-    setIndex(index + 1)
+    segmentProgress = 0
+    index = index + 1
+    void handle.update()
   }
 
   const startPlayback = (video: HTMLVideoElement) => {
-    video.currentTime = startSec
+    video.currentTime = startSec()
     void video
       .play()
-      .then(() => setNeedsTap(false))
-      .catch(() => setNeedsTap(true))
+      .then(() => {
+        needsTap = false
+        void handle.update()
+      })
+      .catch(() => {
+        needsTap = true
+        void handle.update()
+      })
   }
 
   // Desktop keyboard support: arrows skip clips, Space pauses, Esc closes.
-  // The stable listener reads the latest committed handler through a ref,
-  // re-assigned after every commit.
-  const keyActionRef = useRef<(event: KeyboardEvent) => void>(() => undefined)
-  const keyAction = (event: KeyboardEvent) => {
+  const onWindowKeyDown = (event: KeyboardEvent) => {
     // Escape stays global; everything else yields to focused controls
     // (e.g. Space on a tab-focused skip button must click it).
     if (event.code !== 'Escape' && isInteractiveTarget(event)) return
     switch (event.code) {
       case 'Escape':
-        onClose()
+        props.onClose()
         return
       case 'ArrowLeft':
         event.preventDefault()
@@ -95,10 +135,19 @@ export function PlaybackOverlay({ clips, onClose }: PlaybackOverlayProps) {
         event.preventDefault()
         // Auto-repeat while held must not rapid-toggle pause/resume.
         if (event.repeat) return
-        const video = videoRef.current
+        const video = videoEl
         if (!video) return
         if (video.paused) {
-          void video.play().then(() => setNeedsTap(false)).catch(() => setNeedsTap(true))
+          void video
+            .play()
+            .then(() => {
+              needsTap = false
+              void handle.update()
+            })
+            .catch(() => {
+              needsTap = true
+              void handle.update()
+            })
         } else {
           video.pause()
         }
@@ -108,130 +157,143 @@ export function PlaybackOverlay({ clips, onClose }: PlaybackOverlayProps) {
         return
     }
   }
-  useLayoutEffect(() => {
-    keyActionRef.current = keyAction
-  })
-  const onWindowKeyDown = useCallback((event: KeyboardEvent) => {
-    keyActionRef.current(event)
-  }, [])
-  // The empty state has no video element, but Escape must still dismiss.
-  const bindEmptyState = useCallback(
-    (element: HTMLDivElement | null) => {
-      if (element) window.addEventListener('keydown', onWindowKeyDown)
-      else window.removeEventListener('keydown', onWindowKeyDown)
-    },
-    [onWindowKeyDown],
-  )
 
-  const bindVideo = useCallback(
-    (el: HTMLVideoElement | null) => {
-      videoRef.current = el
-      const state = urlStateRef.current
-      if (!el) {
-        window.removeEventListener('keydown', onWindowKeyDown)
-        if (state.url) URL.revokeObjectURL(state.url)
-        state.url = null
-        state.blob = null
-        return
-      }
-      window.addEventListener('keydown', onWindowKeyDown)
-      if (!segment) return
-      if (state.blob !== segment.clip.blob) {
-        if (state.url) URL.revokeObjectURL(state.url)
-        state.url = URL.createObjectURL(segment.clip.blob)
-        state.blob = segment.clip.blob
-        el.src = state.url
-      }
-    },
-    [onWindowKeyDown, segment],
-  )
+  const bindKeyboard = (_node: Element, signal: AbortSignal) => {
+    window.addEventListener('keydown', onWindowKeyDown)
+    signal.addEventListener('abort', () => {
+      window.removeEventListener('keydown', onWindowKeyDown)
+    })
+  }
 
-  if (!segment) {
+  const bindVideo = (el: HTMLVideoElement, signal: AbortSignal) => {
+    videoEl = el
+    syncVideoSrc()
+    signal.addEventListener('abort', () => {
+      videoEl = null
+      if (urlState.url) URL.revokeObjectURL(urlState.url)
+      urlState.url = null
+      urlState.blob = null
+    })
+  }
+
+  return () => {
+    const segs = resolveSegments()
+    const segment = segs[index] ?? null
+
+    if (!segment) {
+      return (
+        <div
+          key="playback-empty"
+          className="playback-overlay"
+          role="dialog"
+          aria-label="Project preview"
+          mix={ref(bindKeyboard)}
+        >
+          <p className="playback-empty">Nothing to play yet — record a clip first.</p>
+          <button
+            type="button"
+            className="btn btn-secondary"
+            mix={on('click', () => props.onClose())}
+          >
+            Close
+          </button>
+        </div>
+      )
+    }
+
+    syncVideoSrc()
+
     return (
       <div
+        key="playback-active"
         className="playback-overlay"
         role="dialog"
         aria-label="Project preview"
-        ref={bindEmptyState}
+        mix={ref(bindKeyboard)}
       >
-        <p className="playback-empty">Nothing to play yet — record a clip first.</p>
-        <button type="button" className="btn btn-secondary" onClick={onClose}>
-          Close
-        </button>
+        <div className="playback-progress" aria-hidden="true">
+          {segs.map((seg, i) => (
+            <span
+              key={`${seg.clip.id}:${i}`}
+              style={{ flexGrow: Math.max(1, seg.endMs - seg.startMs) }}
+            >
+              <i
+                style={{
+                  width:
+                    i < index
+                      ? '100%'
+                      : i === index
+                        ? `${Math.round(segmentProgress * 100)}%`
+                        : '0%',
+                }}
+              />
+            </span>
+          ))}
+        </div>
+
+        <video
+          className="playback-video"
+          playsInline
+          preload="auto"
+          mix={[
+            ref((node, signal) => bindVideo(node as HTMLVideoElement, signal)),
+            on('loadedmetadata', (event) => {
+              loadedIndex = index
+              startPlayback(event.currentTarget as HTMLVideoElement)
+            }),
+            on('ended', () => {
+              if (loadedIndex !== index) return
+              advance()
+            }),
+            on('timeupdate', (event) => {
+              if (loadedIndex !== index) return
+              const video = event.currentTarget as HTMLVideoElement
+              const elapsed = video.currentTime - startSec()
+              segmentProgress = segmentMs() > 0 ? Math.min(1, (elapsed * 1000) / segmentMs()) : 0
+              void handle.update()
+              if (video.currentTime >= endSec() - 0.03) {
+                video.pause()
+                advance()
+              }
+            }),
+          ]}
+        />
+
+        <div className="playback-tap-zones">
+          <button
+            type="button"
+            aria-label="Previous clip"
+            disabled={index === 0}
+            mix={on('click', () => goTo(index - 1))}
+          />
+          <button type="button" aria-label="Stop preview" mix={on('click', () => props.onClose())} />
+          <button type="button" aria-label="Next clip" mix={on('click', () => goTo(index + 1))} />
+        </div>
+
+        {needsTap ? (
+          <button
+            type="button"
+            className="playback-resume"
+            mix={on('click', () => {
+              const video = videoEl
+              if (video)
+                void video
+                  .play()
+                  .then(() => {
+                    needsTap = false
+                    void handle.update()
+                  })
+                  .catch(() => undefined)
+            })}
+          >
+            <IconPlay size={18} /> Tap to play
+          </button>
+        ) : null}
+
+        <div className="playback-caption">
+          Clip {index + 1} / {segs.length} · tap edges to skip · tap middle to stop
+        </div>
       </div>
     )
   }
-
-  return (
-    <div className="playback-overlay" role="dialog" aria-label="Project preview">
-      <div className="playback-progress" aria-hidden="true">
-        {segments.map((seg, i) => (
-          <span
-            key={`${seg.clip.id}:${i}`}
-            style={{ flexGrow: Math.max(1, seg.endMs - seg.startMs) }}
-          >
-            <i
-              style={{
-                width:
-                  i < index ? '100%' : i === index ? `${Math.round(segmentProgress * 100)}%` : '0%',
-              }}
-            />
-          </span>
-        ))}
-      </div>
-
-      <video
-        ref={bindVideo}
-        className="playback-video"
-        playsInline
-        preload="auto"
-        onLoadedMetadata={(event) => {
-          loadedIndexRef.current = index
-          startPlayback(event.currentTarget)
-        }}
-        onEnded={() => {
-          if (loadedIndexRef.current !== index) return
-          advance()
-        }}
-        onTimeUpdate={(event) => {
-          if (loadedIndexRef.current !== index) return
-          const video = event.currentTarget
-          const elapsed = video.currentTime - startSec
-          setSegmentProgress(segmentMs > 0 ? Math.min(1, (elapsed * 1000) / segmentMs) : 0)
-          if (video.currentTime >= endSec - 0.03) {
-            video.pause()
-            advance()
-          }
-        }}
-      />
-
-      <div className="playback-tap-zones">
-        <button
-          type="button"
-          aria-label="Previous clip"
-          onClick={() => goTo(index - 1)}
-          disabled={index === 0}
-        />
-        <button type="button" aria-label="Stop preview" onClick={onClose} />
-        <button type="button" aria-label="Next clip" onClick={() => goTo(index + 1)} />
-      </div>
-
-      {needsTap ? (
-        <button
-          type="button"
-          className="playback-resume"
-          onClick={() => {
-            const video = videoRef.current
-            if (video) void video.play().then(() => setNeedsTap(false)).catch(() => undefined)
-          }}
-        >
-          <IconPlay size={18} /> Tap to play
-        </button>
-      ) : null}
-
-      <div className="playback-caption">
-        Clip {index + 1} / {segments.length} · tap edges to skip · tap middle to stop
-      </div>
-    </div>
-  )
 }

--- a/src/components/record-screen.tsx
+++ b/src/components/record-screen.tsx
@@ -1,6 +1,6 @@
-import { useCallback, useLayoutEffect, useRef, useState } from 'react'
-import { Link } from 'react-router-dom'
-import type { UseCameraResult } from '../hooks/use-camera'
+import type { Handle } from 'remix/ui'
+import { on, ref } from 'remix/ui'
+import type { Camera } from '../lib/camera'
 import { dragZoomValue } from '../lib/drag-zoom'
 import { getLocationFix, type LocationFix } from '../lib/location'
 import { startMicLevelMonitor, type MicLevelMonitor } from '../lib/mic-monitor'
@@ -47,11 +47,6 @@ type RecordingMode = 'hold' | 'hands-free'
 /** Finger tremble tolerance before drag-to-zoom engages. */
 const DRAG_ZOOM_DEADZONE_PX = 14
 
-interface KeyActions {
-  down: (e: KeyboardEvent) => void
-  up: (e: KeyboardEvent) => void
-}
-
 export interface ToastAction {
   actionLabel: string
   onAction: () => void
@@ -63,7 +58,7 @@ interface RecordScreenProps {
    * recorded clip (a "/project/new" project exists only in the URL). */
   ensureProjectId: () => Promise<ProjectId>
   clips: ClipRecord[]
-  camera: UseCameraResult
+  camera: Camera
   /** Device storage estimate for the almost-full warning. */
   storage: StorageSpace | null
   /** True while an overlay (export, preview, onboarding) should block capture. */
@@ -77,89 +72,66 @@ interface RecordScreenProps {
   refresh: () => void
 }
 
-export function RecordScreen({
-  project,
-  ensureProjectId,
-  clips,
-  camera,
-  storage,
-  interactionLocked,
-  locationTaggingEnabled = false,
-  onOpenEditor,
-  onOpenExport,
-  onPlay,
-  showToast,
-  refresh,
-}: RecordScreenProps) {
-  const storageState = storage ? storageSeverity(storage.ratio) : 'ok'
-  const recorderRef = useRef(new HoldRecorder())
-  const pointerIdRef = useRef<number | null>(null)
-  const spaceHeldRef = useRef(false)
+export function RecordScreen(handle: Handle<RecordScreenProps>) {
+  const { props } = handle
+  const camera = props.camera
+
+  const recorder = new HoldRecorder()
+  let pointerId: number | null = null
+  let spaceHeld = false
   /** True while a Space-started take is active: only keyup may end it, and
    * stray pointer events must not end the take or reset drag-zoom state. */
-  const keyboardTakeRef = useRef(false)
-  const beginInFlightRef = useRef(false)
-  const endInFlightRef = useRef(false)
-  const countdownTimerRef = useRef(0)
-  const wakeLockRef = useRef<WakeLockSentinel | null>(null)
-  const wakeLockGenRef = useRef(0)
-  const lockedRef = useRef(interactionLocked)
-  lockedRef.current = interactionLocked
+  let keyboardTake = false
+  let beginInFlight = false
+  let endInFlight = false
+  let countdownTimer = 0
+  let wakeLock: WakeLockSentinel | null = null
+  let wakeLockGen = 0
   /** In-flight GPS fix for the current take; never shared across takes. */
-  const pendingFixRef = useRef<Promise<LocationFix | null> | null>(null)
+  let pendingFix: Promise<LocationFix | null> | null = null
   /** Live audio-level watch for the current take (silent-mic warning). */
-  const micMonitorRef = useRef<MicLevelMonitor | null>(null)
-  const locationTaggingRef = useRef(locationTaggingEnabled)
+  let micMonitor: MicLevelMonitor | null = null
 
-  const dragZoomPressYRef = useRef(0)
-  const dragZoomStartValueRef = useRef(0)
-  const dragZoomStageHeightRef = useRef(0)
-  const dragZoomStageTopRef = useRef(0)
+  let dragZoomPressY = 0
+  let dragZoomStartValue = 0
+  let dragZoomStageHeight = 0
+  let dragZoomStageTop = 0
   /** Whether the current hold actually changed zoom (gates the snap-back). */
-  const dragZoomMovedRef = useRef(false)
+  let dragZoomMoved = false
   /** Last zoom value applied during the drag (ramp start for the snap-back). */
-  const dragZoomLastValueRef = useRef(0)
+  let dragZoomLastValue = 0
   /** Zoom the user chose deliberately (chips) — what a take restores to. */
-  const zoomBaselineRef = useRef<number | null>(null)
-  const zoomRestoreRafRef = useRef(0)
+  let zoomBaseline: number | null = null
+  let zoomRestoreRaf = 0
   /** True while the snap-back ramp is still easing toward the baseline. */
-  const zoomRestoreActiveRef = useRef(false)
-  const stageRef = useRef<HTMLDivElement | null>(null)
+  let zoomRestoreActive = false
+  let stageEl: HTMLDivElement | null = null
 
-  const screenSessionRef = useRef<ScreenRecordingSession | null>(null)
+  let screenSession: ScreenRecordingSession | null = null
   /** True while the surface picker or a save is in flight. */
-  const screenBusyRef = useRef(false)
+  let screenBusy = false
 
-  const [recording, setRecording] = useState(false)
-  const [recordingMode, setRecordingMode] = useState<RecordingMode | null>(null)
-  const [recordStartedAt, setRecordStartedAt] = useState(0)
-  const [countdown, setCountdown] = useState<number | null>(null)
-  const [screenRecording, setScreenRecording] = useState(false)
-  const [screenRecordStartedAt, setScreenRecordStartedAt] = useState(0)
+  let recording = false
+  let recordingMode: RecordingMode | null = null
+  let recordStartedAt = 0
+  let countdown: number | null = null
+  let screenRecording = false
+  let screenRecordStartedAt = 0
   /** The current/last take's mic never rose above the silence floor. */
-  const [micSilent, setMicSilent] = useState(false)
-  const [locationTagging, setLocationTagging] = useState(locationTaggingEnabled)
-  locationTaggingRef.current = locationTagging
+  let micSilent = false
+  let locationTagging = props.locationTaggingEnabled ?? false
 
   const screenRecordingSupported = isScreenRecordingSupported()
-  const totalDurationMs = clips.reduce((sum, clip) => sum + effectiveDurationMs(clip), 0)
-  const zoomLevels = camera.zoom ? zoomChipLevels(camera.zoom) : []
-  const activeZoomLevel =
-    camera.zoom && zoomLevels.length > 0 ? nearestZoomLevel(zoomLevels, camera.zoom.value) : null
-  // Ultra-wide/telephoto are usually separate rear cameras on Android — a
-  // lens chip is the only way to reach 0.5× when zoom can't go below 1×.
-  const showLensChip = camera.facing === 'environment' && camera.rearLensCount > 1
 
-  const clearCountdown = useCallback(() => {
-    window.clearTimeout(countdownTimerRef.current)
-    countdownTimerRef.current = 0
-    setCountdown(null)
-  }, [])
+  const storageState = () => (props.storage ? storageSeverity(props.storage.ratio) : 'ok')
 
-  /**
-   * OK Video behavior: drag-to-zoom only lasts for the take. When the finger
-   * lifts, ease the lens back to the zoom the user had before recording.
-   */
+  const clearCountdown = () => {
+    window.clearTimeout(countdownTimer)
+    countdownTimer = 0
+    countdown = null
+    void handle.update()
+  }
+
   /**
    * Thumbnail capture mirror: a DETACHED video element fed by the same
    * camera stream for the take's duration. Post-take thumbs are drawn from
@@ -168,61 +140,62 @@ export function RecordScreen({
    * for a frame, which is the post-take black flash. A detached element
    * was never in the compositor, so its readback can't blink anything.
    */
-  const thumbMirrorRef = useRef<HTMLVideoElement | null>(null)
-  const stopThumbMirror = useCallback(() => {
-    const mirror = thumbMirrorRef.current
-    thumbMirrorRef.current = null
+  let thumbMirror: HTMLVideoElement | null = null
+  const stopThumbMirror = () => {
+    const mirror = thumbMirror
+    thumbMirror = null
     if (mirror) {
       mirror.srcObject = null
     }
-  }, [])
-  const startThumbMirror = useCallback(
-    (stream: MediaStream) => {
-      stopThumbMirror()
-      const mirror = document.createElement('video')
-      mirror.muted = true
-      mirror.playsInline = true
-      mirror.srcObject = stream
-      void mirror.play().catch(() => undefined)
-      thumbMirrorRef.current = mirror
-    },
-    [stopThumbMirror],
-  )
-  const captureTakeThumbs = useCallback(async () => {
-    const mirror = thumbMirrorRef.current
+  }
+  const startThumbMirror = (stream: MediaStream) => {
+    stopThumbMirror()
+    const mirror = document.createElement('video')
+    mirror.muted = true
+    mirror.playsInline = true
+    mirror.srcObject = stream
+    void mirror.play().catch(() => undefined)
+    thumbMirror = mirror
+  }
+  const captureTakeThumbs = async () => {
+    const mirror = thumbMirror
     const fromMirror = mirror ? await captureLiveThumbs(mirror) : null
     // Ultra-short takes can end before the mirror got its first frame —
     // the on-screen element is the (blink-risking) fallback, still better
     // than the loader decoding the fresh blob behind the live preview.
     return fromMirror ?? captureLiveThumbs(camera.getVideoElement())
-  }, [camera])
+  }
 
-  // Live zoom readout: updated imperatively (refs, no React state) so
+  // Live zoom readout: updated imperatively (no component update) so
   // drag-to-zoom mid-recording never causes a re-render. Fades out shortly
   // after the value stops changing.
-  const zoomHudRef = useRef<HTMLDivElement | null>(null)
-  const zoomHudTimerRef = useRef(0)
-  const showZoomHud = useCallback((value: number) => {
-    const hud = zoomHudRef.current
+  let zoomHudEl: HTMLDivElement | null = null
+  let zoomHudTimer = 0
+  const showZoomHud = (value: number) => {
+    const hud = zoomHudEl
     if (!hud) return
     hud.textContent = formatZoomLabel(value)
     hud.classList.add('is-visible')
-    window.clearTimeout(zoomHudTimerRef.current)
-    zoomHudTimerRef.current = window.setTimeout(() => {
+    window.clearTimeout(zoomHudTimer)
+    zoomHudTimer = window.setTimeout(() => {
       hud.classList.remove('is-visible')
     }, 900)
-  }, [])
+  }
 
-  const restoreZoomAfterHold = useCallback(() => {
-    if (!dragZoomMovedRef.current) return
-    dragZoomMovedRef.current = false
-    const from = dragZoomLastValueRef.current
-    const to = dragZoomStartValueRef.current
-    cancelAnimationFrame(zoomRestoreRafRef.current)
+  /**
+   * OK Video behavior: drag-to-zoom only lasts for the take. When the finger
+   * lifts, ease the lens back to the zoom the user had before recording.
+   */
+  const restoreZoomAfterHold = () => {
+    if (!dragZoomMoved) return
+    dragZoomMoved = false
+    const from = dragZoomLastValue
+    const to = dragZoomStartValue
+    cancelAnimationFrame(zoomRestoreRaf)
     if (Math.abs(from - to) < 0.01) return
     const started = performance.now()
     const durationMs = 220
-    zoomRestoreActiveRef.current = true
+    zoomRestoreActive = true
     const tick = () => {
       const t = Math.min(1, (performance.now() - started) / durationMs)
       const eased = 1 - (1 - t) * (1 - t)
@@ -230,350 +203,347 @@ export function RecordScreen({
       camera.setZoom(value)
       showZoomHud(value)
       if (t < 1) {
-        zoomRestoreRafRef.current = requestAnimationFrame(tick)
+        zoomRestoreRaf = requestAnimationFrame(tick)
       } else {
-        zoomRestoreActiveRef.current = false
+        zoomRestoreActive = false
       }
     }
-    zoomRestoreRafRef.current = requestAnimationFrame(tick)
-  }, [camera, showZoomHud])
+    zoomRestoreRaf = requestAnimationFrame(tick)
+  }
 
-  const releaseWakeLock = useCallback(() => {
-    wakeLockGenRef.current += 1
-    void wakeLockRef.current?.release().catch(() => undefined)
-    wakeLockRef.current = null
-  }, [])
+  const releaseWakeLock = () => {
+    wakeLockGen += 1
+    void wakeLock?.release().catch(() => undefined)
+    wakeLock = null
+  }
 
-  const acquireWakeLock = useCallback(() => {
+  const acquireWakeLock = () => {
     // A successor take can start while the previous take's save is still in
     // flight (its cleanup defers to us) — release the previous sentinel
     // before acquiring ours, or it would be overwritten and leak, keeping
     // the screen awake indefinitely.
     releaseWakeLock()
-    const generation = wakeLockGenRef.current
+    const generation = wakeLockGen
     void navigator.wakeLock
       ?.request('screen')
       .then((sentinel) => {
-        if (wakeLockGenRef.current !== generation) {
+        if (wakeLockGen !== generation) {
           // Released before the sentinel arrived (very short take).
           void sentinel.release().catch(() => undefined)
           return
         }
-        wakeLockRef.current = sentinel
+        wakeLock = sentinel
       })
       .catch(() => undefined)
-  }, [releaseWakeLock])
+  }
 
   /** Stops the active screen capture and appends it as a clip. Idempotent. */
-  const finishScreenRecord = useCallback(async () => {
-    const session = screenSessionRef.current
+  const finishScreenRecord = async () => {
+    const session = screenSession
     if (!session) return
-    screenSessionRef.current = null
-    screenBusyRef.current = true
-    setScreenRecording(false)
+    screenSession = null
+    screenBusy = true
+    screenRecording = false
+    void handle.update()
     try {
       const result = await session.stop()
       if (!result) {
-        showToast('Screen take was too short')
+        props.showToast('Screen take was too short')
         return
       }
-      await appendRecording(await ensureProjectId(), result)
-      refresh()
-      showToast('Screen clip added')
+      await appendRecording(await props.ensureProjectId(), result)
+      props.refresh()
+      props.showToast('Screen clip added')
     } catch (err) {
       reportError(err, 'screen-record')
-      showToast('Could not save the screen recording')
+      props.showToast('Could not save the screen recording')
     } finally {
-      screenBusyRef.current = false
+      screenBusy = false
     }
-  }, [ensureProjectId, refresh, showToast])
+  }
 
-  const startScreenRecord = useCallback(() => {
+  const startScreenRecord = () => {
     void (async () => {
       if (
-        screenSessionRef.current ||
-        screenBusyRef.current ||
-        recorderRef.current.isRecording ||
-        lockedRef.current ||
+        screenSession ||
+        screenBusy ||
+        recorder.isRecording ||
+        props.interactionLocked ||
         countdown !== null
       ) {
         return
       }
-      screenBusyRef.current = true
+      screenBusy = true
       try {
         const session = await startScreenRecording()
-        screenSessionRef.current = session
-        setScreenRecordStartedAt(performance.now())
-        setScreenRecording(true)
+        screenSession = session
+        screenRecordStartedAt = performance.now()
+        screenRecording = true
+        void handle.update()
         // The browser's own "Stop sharing" control must save too.
         session.setOnEnded(() => void finishScreenRecord())
       } catch (err) {
         // Cancelling the surface picker is a decision, not an error.
         if (!(err instanceof DOMException && err.name === 'NotAllowedError')) {
-          showToast(err instanceof Error ? err.message : 'Screen recording failed')
+          props.showToast(err instanceof Error ? err.message : 'Screen recording failed')
         }
       } finally {
-        screenBusyRef.current = false
+        screenBusy = false
       }
     })()
-  }, [countdown, finishScreenRecord, showToast])
+  }
 
-  const beginRecord = useCallback(
-    async (pointerId: number | null, nextRecordingMode: RecordingMode): Promise<boolean> => {
-      if (
-        beginInFlightRef.current ||
-        recording ||
-        recorderRef.current.isRecording ||
-        lockedRef.current ||
-        countdown !== null
-      ) {
-        return false
-      }
-      if (screenSessionRef.current) {
-        showToast('Stop the screen recording first')
-        return false
-      }
-      if (!camera.getStream() || !camera.isReady) {
-        showToast('Camera not ready')
-        return false
-      }
-
-      beginInFlightRef.current = true
-      pointerIdRef.current = pointerId
-      try {
-        // Grab the mic only for this take so Brave/Android voice-to-text stays free while idle.
-        await camera.enableMic()
-        if (pointerId !== null && pointerIdRef.current !== pointerId) {
-          camera.releaseMic()
-          return false
-        }
-        if (nextRecordingMode === 'hold' && pointerId !== null && pointerIdRef.current === null) {
-          camera.releaseMic()
-          return false
-        }
-        // Re-check after the mic await — an overlay may have opened meanwhile.
-        if (lockedRef.current) {
-          camera.releaseMic()
-          return false
-        }
-
-        const stream = camera.getStream()
-        if (!stream?.getAudioTracks().some((track) => track.readyState === 'live')) {
-          throw new Error('Microphone unavailable')
-        }
-
-        const startedOk = recorderRef.current.start(stream)
-        if (!startedOk) {
-          pointerIdRef.current = null
-          // Never strip mic from an already-active recording owned by another start.
-          if (!recorderRef.current.isRecording) camera.releaseMic()
-          showToast('Still finishing the last clip')
-          return false
-        }
-        // Fire-and-forget GPS for this take — must not delay recording start.
-        pendingFixRef.current = null
-        if (locationTaggingRef.current) {
-          pendingFixRef.current = getLocationFix()
-        }
-        startThumbMirror(stream)
-        acquireWakeLock()
-        // Watch the live mic level: users must learn about a dead mic while
-        // holding, not after sharing a silent video (Sentry: near-zero clip
-        // peaks on iOS). Warning state carries over between takes until a
-        // take actually picks up sound.
-        micMonitorRef.current?.stop()
-        micMonitorRef.current = startMicLevelMonitor(stream, {
-          onSilent: () => setMicSilent(true),
-          onSound: () => setMicSilent(false),
-        })
-        setRecording(true)
-        setRecordingMode(nextRecordingMode)
-        setRecordStartedAt(performance.now())
-        if (storageState === 'critical') {
-          showToast('Storage almost full — delete an old project soon')
-        }
-        return true
-      } catch (err) {
-        if (!recorderRef.current.isRecording) {
-          camera.releaseMic()
-          // A previous take whose deferred cleanup we pre-empted (its
-          // finally saw our beginInFlight and skipped) must not leak its
-          // monitor or wake lock when we then fail to start.
-          micMonitorRef.current?.stop()
-          micMonitorRef.current = null
-          releaseWakeLock()
-        }
-        showToast(err instanceof Error ? err.message : 'Could not start recording')
-        pointerIdRef.current = null
-        setRecordingMode(null)
-        return false
-      } finally {
-        beginInFlightRef.current = false
-      }
-    },
-    [acquireWakeLock, camera, countdown, recording, releaseWakeLock, showToast, storageState],
-  )
-
-  const endRecord = useCallback(
-    async (pointerId?: number) => {
-      // Pointer events never end a Space-owned take (keyup does, and it
-      // clears the flag before calling in).
-      if (pointerId !== undefined && keyboardTakeRef.current) return
-      if (
-        pointerId !== undefined &&
-        pointerIdRef.current !== null &&
-        pointerIdRef.current !== pointerId
-      ) {
-        return
-      }
-      // One end per take: stop() resolves asynchronously (duration is
-      // measured), so a second caller (e.g. hide + return in quick
-      // succession) must not re-enter and double-save the clip.
-      if (endInFlightRef.current) return
-      if (!recorderRef.current.isRecording && !recording) {
-        // Pointer released while mic grant was still in flight.
-        pointerIdRef.current = null
-        keyboardTakeRef.current = false
-        camera.releaseMic()
-        return
-      }
-      endInFlightRef.current = true
-      pointerIdRef.current = null
-      keyboardTakeRef.current = false
-      setRecording(false)
-      setRecordingMode(null)
-      // Detach this take's fix before any await so a quick next hold can own the ref.
-      const pendingForThisTake = pendingFixRef.current
-      pendingFixRef.current = null
-      // Grab the poster/thumb from the detached mirror NOW (synchronous
-      // draw at finger-lift) — decoding the recorded blob for thumbnails
-      // while the preview runs blanks it on many Androids, and reading
-      // back the on-screen element blinks its overlay path.
-      const capturedThumbs = captureTakeThumbs().catch(() => null)
-      try {
-        const result = await recorderRef.current.stop()
-        if (!result) {
-          showToast('Hold a bit longer')
-          return
-        }
-        // Recording already elapsed while the fix ran; wait at most ~1.5s more.
-        let fix: LocationFix | null = null
-        if (pendingForThisTake) {
-          fix = await Promise.race([
-            pendingForThisTake,
-            new Promise<null>((resolve) => {
-              window.setTimeout(() => resolve(null), 1500)
-            }),
-          ])
-        }
-        await appendRecording(
-          await ensureProjectId(),
-          {
-            ...result,
-            ...(fix
-              ? { lat: fix.lat, lng: fix.lng, locationAccuracyM: fix.accuracyM }
-              : {}),
-          },
-          { capturedThumbs: await capturedThumbs },
-        )
-        refresh()
-      } catch (err) {
-        // Real store failures (quota, bad blob) must still reach Sentry as
-        // handled exceptions — without the twin unhandled AbortError from tx.done.
-        reportError(err, 'save-clip')
-        showToast(err instanceof Error ? err.message : 'Save failed')
-      } finally {
-        endInFlightRef.current = false
-        // stop() resolves only after the blob's duration is measured, so a
-        // quick next hold may already be recording (or acquiring the mic) by
-        // now — never strip the mic, monitor, or wake lock from that newer
-        // session. Tearing the monitor down only after the encoder flushed
-        // matters too: audio-graph churn while MediaRecorder still owned
-        // the tracks flashed the preview black on some Androids.
-        if (!recorderRef.current.isRecording && !beginInFlightRef.current) {
-          micMonitorRef.current?.stop()
-          micMonitorRef.current = null
-          camera.releaseMic()
-          releaseWakeLock()
-          // A quick next hold already replaced the mirror via
-          // startThumbMirror — only tear it down when this take is the last.
-          stopThumbMirror()
-        }
-      }
-    },
-    [
-      camera,
-      captureTakeThumbs,
-      ensureProjectId,
-      recording,
-      refresh,
-      releaseWakeLock,
-      showToast,
-      stopThumbMirror,
-    ],
-  )
-
-  const startSelfTimer = useCallback(() => {
-    if (recording || lockedRef.current || countdown !== null) return
-    if (screenSessionRef.current) return
+  const beginRecord = async (
+    nextPointerId: number | null,
+    nextRecordingMode: RecordingMode,
+  ): Promise<boolean> => {
+    if (
+      beginInFlight ||
+      recording ||
+      recorder.isRecording ||
+      props.interactionLocked ||
+      countdown !== null
+    ) {
+      return false
+    }
+    if (screenSession) {
+      props.showToast('Stop the screen recording first')
+      return false
+    }
     if (!camera.getStream() || !camera.isReady) {
-      showToast('Camera not ready')
+      props.showToast('Camera not ready')
+      return false
+    }
+
+    beginInFlight = true
+    pointerId = nextPointerId
+    try {
+      // Grab the mic only for this take so Brave/Android voice-to-text stays free while idle.
+      await camera.enableMic()
+      if (nextPointerId !== null && pointerId !== nextPointerId) {
+        camera.releaseMic()
+        return false
+      }
+      if (nextRecordingMode === 'hold' && nextPointerId !== null && pointerId === null) {
+        camera.releaseMic()
+        return false
+      }
+      // Re-check after the mic await — an overlay may have opened meanwhile.
+      if (props.interactionLocked) {
+        camera.releaseMic()
+        return false
+      }
+
+      const stream = camera.getStream()
+      if (!stream?.getAudioTracks().some((track) => track.readyState === 'live')) {
+        throw new Error('Microphone unavailable')
+      }
+
+      const startedOk = recorder.start(stream)
+      if (!startedOk) {
+        pointerId = null
+        // Never strip mic from an already-active recording owned by another start.
+        if (!recorder.isRecording) camera.releaseMic()
+        props.showToast('Still finishing the last clip')
+        return false
+      }
+      // Fire-and-forget GPS for this take — must not delay recording start.
+      pendingFix = null
+      if (locationTagging) {
+        pendingFix = getLocationFix()
+      }
+      startThumbMirror(stream)
+      acquireWakeLock()
+      // Watch the live mic level: users must learn about a dead mic while
+      // holding, not after sharing a silent video (Sentry: near-zero clip
+      // peaks on iOS). Warning state carries over between takes until a
+      // take actually picks up sound.
+      micMonitor?.stop()
+      micMonitor = startMicLevelMonitor(stream, {
+        onSilent: () => {
+          micSilent = true
+          void handle.update()
+        },
+        onSound: () => {
+          micSilent = false
+          void handle.update()
+        },
+      })
+      recording = true
+      recordingMode = nextRecordingMode
+      recordStartedAt = performance.now()
+      void handle.update()
+      if (storageState() === 'critical') {
+        props.showToast('Storage almost full — delete an old project soon')
+      }
+      return true
+    } catch (err) {
+      if (!recorder.isRecording) {
+        camera.releaseMic()
+        // A previous take whose deferred cleanup we pre-empted (its
+        // finally saw our beginInFlight and skipped) must not leak its
+        // monitor or wake lock when we then fail to start.
+        micMonitor?.stop()
+        micMonitor = null
+        releaseWakeLock()
+      }
+      props.showToast(err instanceof Error ? err.message : 'Could not start recording')
+      pointerId = null
+      recordingMode = null
+      void handle.update()
+      return false
+    } finally {
+      beginInFlight = false
+    }
+  }
+
+  const endRecord = async (endPointerId?: number) => {
+    // Pointer events never end a Space-owned take (keyup does, and it
+    // clears the flag before calling in).
+    if (endPointerId !== undefined && keyboardTake) return
+    if (endPointerId !== undefined && pointerId !== null && pointerId !== endPointerId) {
+      return
+    }
+    // One end per take: stop() resolves asynchronously (duration is
+    // measured), so a second caller (e.g. hide + return in quick
+    // succession) must not re-enter and double-save the clip.
+    if (endInFlight) return
+    if (!recorder.isRecording && !recording) {
+      // Pointer released while mic grant was still in flight.
+      pointerId = null
+      keyboardTake = false
+      camera.releaseMic()
+      return
+    }
+    endInFlight = true
+    pointerId = null
+    keyboardTake = false
+    recording = false
+    recordingMode = null
+    void handle.update()
+    // Detach this take's fix before any await so a quick next hold can own it.
+    const pendingForThisTake = pendingFix
+    pendingFix = null
+    // Grab the poster/thumb from the detached mirror NOW (synchronous
+    // draw at finger-lift) — decoding the recorded blob for thumbnails
+    // while the preview runs blanks it on many Androids, and reading
+    // back the on-screen element blinks its overlay path.
+    const capturedThumbs = captureTakeThumbs().catch(() => null)
+    try {
+      const result = await recorder.stop()
+      if (!result) {
+        props.showToast('Hold a bit longer')
+        return
+      }
+      // Recording already elapsed while the fix ran; wait at most ~1.5s more.
+      let fix: LocationFix | null = null
+      if (pendingForThisTake) {
+        fix = await Promise.race([
+          pendingForThisTake,
+          new Promise<null>((resolve) => {
+            window.setTimeout(() => resolve(null), 1500)
+          }),
+        ])
+      }
+      await appendRecording(
+        await props.ensureProjectId(),
+        {
+          ...result,
+          ...(fix ? { lat: fix.lat, lng: fix.lng, locationAccuracyM: fix.accuracyM } : {}),
+        },
+        { capturedThumbs: await capturedThumbs },
+      )
+      props.refresh()
+    } catch (err) {
+      // Real store failures (quota, bad blob) must still reach Sentry as
+      // handled exceptions — without the twin unhandled AbortError from tx.done.
+      reportError(err, 'save-clip')
+      props.showToast(err instanceof Error ? err.message : 'Save failed')
+    } finally {
+      endInFlight = false
+      // stop() resolves only after the blob's duration is measured, so a
+      // quick next hold may already be recording (or acquiring the mic) by
+      // now — never strip the mic, monitor, or wake lock from that newer
+      // session. Tearing the monitor down only after the encoder flushed
+      // matters too: audio-graph churn while MediaRecorder still owned
+      // the tracks flashed the preview black on some Androids.
+      if (!recorder.isRecording && !beginInFlight) {
+        micMonitor?.stop()
+        micMonitor = null
+        camera.releaseMic()
+        releaseWakeLock()
+        // A quick next hold already replaced the mirror via
+        // startThumbMirror — only tear it down when this take is the last.
+        stopThumbMirror()
+      }
+    }
+  }
+
+  const startSelfTimer = () => {
+    if (recording || props.interactionLocked || countdown !== null) return
+    if (screenSession) return
+    if (!camera.getStream() || !camera.isReady) {
+      props.showToast('Camera not ready')
       return
     }
 
     let next = 3
-    setCountdown(next)
+    countdown = next
+    void handle.update()
     const tick = () => {
       next -= 1
       if (next <= 0) {
-        countdownTimerRef.current = 0
-        setCountdown(null)
+        countdownTimer = 0
+        countdown = null
+        void handle.update()
         void (async () => {
           const started = await beginRecord(null, 'hands-free')
           if (started) {
-            showToast('Recording hands-free — tap the preview to stop')
+            props.showToast('Recording hands-free — tap the preview to stop')
           }
         })()
         return
       }
-      setCountdown(next)
-      countdownTimerRef.current = window.setTimeout(tick, 1000)
+      countdown = next
+      void handle.update()
+      countdownTimer = window.setTimeout(tick, 1000)
     }
-    countdownTimerRef.current = window.setTimeout(tick, 1000)
-  }, [beginRecord, camera, countdown, recording, showToast])
+    countdownTimer = window.setTimeout(tick, 1000)
+  }
 
-  const deleteLastClip = useCallback(() => {
-    const lastClip = clips.at(-1)
+  const deleteLastClip = () => {
+    const lastClip = props.clips.at(-1)
     if (!lastClip) {
-      showToast('No clips yet')
+      props.showToast('No clips yet')
       return
     }
     void (async () => {
       await removeClip(lastClip.id)
-      refresh()
-      showToast('Last clip deleted', {
+      props.refresh()
+      props.showToast('Last clip deleted', {
         actionLabel: 'Undo',
         onAction: () => {
           void (async () => {
-            await undoLastDelete(project.id)
-            refresh()
-            showToast('Clip restored')
+            await undoLastDelete(props.project.id)
+            props.refresh()
+            props.showToast('Clip restored')
           })()
         },
       })
     })()
-  }, [clips, project.id, refresh, showToast])
+  }
 
-  const toggleLocationTagging = useCallback(() => {
+  const toggleLocationTagging = () => {
     if (recording || countdown !== null) return
     if (locationTagging) {
       void (async () => {
         try {
           await setLocationTaggingEnabled(false)
-          setLocationTagging(false)
-          showToast('Location tagging off')
+          locationTagging = false
+          void handle.update()
+          props.showToast('Location tagging off')
         } catch {
-          showToast('Could not save the setting — try again')
+          props.showToast('Could not save the setting — try again')
         }
       })()
       return
@@ -582,39 +552,41 @@ export function RecordScreen({
     void (async () => {
       const fix = await getLocationFix()
       if (!fix) {
-        showToast("Location unavailable — check the site's location permission")
+        props.showToast("Location unavailable — check the site's location permission")
         return
       }
       await setLocationTaggingEnabled(true)
-      setLocationTagging(true)
-      showToast('Location tagging on — new clips will be geotagged')
+      locationTagging = true
+      void handle.update()
+      props.showToast('Location tagging on — new clips will be geotagged')
     })()
-  }, [countdown, locationTagging, recording, showToast])
+  }
 
-  const cleanupOnUnmount = useCallback(() => {
-    clearCountdown()
-    cancelAnimationFrame(zoomRestoreRafRef.current)
-    micMonitorRef.current?.stop()
-    micMonitorRef.current = null
-    recorderRef.current.cancel()
+  const cleanupOnUnmount = () => {
+    window.clearTimeout(countdownTimer)
+    countdownTimer = 0
+    cancelAnimationFrame(zoomRestoreRaf)
+    micMonitor?.stop()
+    micMonitor = null
+    recorder.cancel()
     stopThumbMirror()
     // Leaving the screen mustn't lose an active screen take — save it.
     void finishScreenRecord()
     releaseWakeLock()
-  }, [clearCountdown, finishScreenRecord, releaseWakeLock, stopThumbMirror])
+  }
 
   // Release the camera whenever the app leaves the foreground — Android keeps
   // the privacy indicator (green dot) lit as long as any track is live. An
   // in-progress take is finished and saved first; the preview restarts when
   // the app becomes visible again.
-  const visibilityActionRef = useRef<() => void>(() => undefined)
-  visibilityActionRef.current = () => {
+  const onVisibilityChange = () => {
     if (document.hidden) {
       clearCountdown()
       // The warning describes takes from the session being left behind;
       // returning starts fresh with a restarted camera (and mic, on iOS).
-      setMicSilent(false)
-      if (recorderRef.current.isRecording || recording) {
+      micSilent = false
+      void handle.update()
+      if (recorder.isRecording || recording) {
         // MediaRecorder.stop() runs synchronously inside endRecord, so the
         // encoder has flushed by the time the tracks are stopped below; the
         // save itself continues in the background.
@@ -629,7 +601,7 @@ export function RecordScreen({
     // keep previewing (and recording!) a single stale frame forever. If a
     // take was somehow still running on that frozen stream, save it first.
     void (async () => {
-      if (recorderRef.current.isRecording || recording) {
+      if (recorder.isRecording || recording) {
         await endRecord()
       }
       camera.stop()
@@ -641,499 +613,514 @@ export function RecordScreen({
     })()
   }
 
-  const onVisibilityChange = useCallback(() => {
-    visibilityActionRef.current()
-  }, [])
-
   // Desktop keyboard support (the app is designed for phones; this keeps the
-  // desktop experience respectable). Stable listeners read the latest
-  // committed handlers through a ref, re-assigned after every commit.
-  const keyActionsRef = useRef<KeyActions>({ down: () => undefined, up: () => undefined })
-  const keyActions: KeyActions = {
-    down: (event) => {
-      if (event.repeat || lockedRef.current) return
-      if (isInteractiveTarget(event)) return
-      switch (event.code) {
-        case 'Space': {
-          event.preventDefault()
-          if (countdown !== null) {
-            clearCountdown()
-            showToast('Timer canceled')
+  // desktop experience respectable). Closures read live setup-scope state, so
+  // no re-binding is ever needed.
+  const onWindowKeyDown = (event: KeyboardEvent) => {
+    if (event.repeat || props.interactionLocked) return
+    if (isInteractiveTarget(event)) return
+    switch (event.code) {
+      case 'Space': {
+        event.preventDefault()
+        if (countdown !== null) {
+          clearCountdown()
+          props.showToast('Timer canceled')
+          return
+        }
+        if (recording) {
+          // Hands-free (or a stuck keyboard hold): stop on press.
+          if (recordingMode === 'hands-free') void endRecord()
+          return
+        }
+        // Like a pointer hold: interrupt any zoom snap-back still easing
+        // and record from the deliberate baseline, not a mid-ramp value.
+        cancelAnimationFrame(zoomRestoreRaf)
+        if (zoomRestoreActive) {
+          zoomRestoreActive = false
+          camera.setZoom(zoomBaseline ?? camera.zoom?.value ?? 1)
+        }
+        spaceHeld = true
+        keyboardTake = true
+        void beginRecord(null, 'hold').then((started) => {
+          if (!started) {
+            keyboardTake = false
             return
           }
-          if (recording) {
-            // Hands-free (or a stuck keyboard hold): stop on press.
-            if (recordingMode === 'hands-free') void endRecord()
-            return
-          }
-          // Like a pointer hold: interrupt any zoom snap-back still easing
-          // and record from the deliberate baseline, not a mid-ramp value.
-          cancelAnimationFrame(zoomRestoreRafRef.current)
-          if (zoomRestoreActiveRef.current) {
-            zoomRestoreActiveRef.current = false
-            camera.setZoom(zoomBaselineRef.current ?? camera.zoom?.value ?? 1)
-          }
-          spaceHeldRef.current = true
-          keyboardTakeRef.current = true
-          void beginRecord(null, 'hold').then((started) => {
-            if (!started) {
-              keyboardTakeRef.current = false
-              return
-            }
-            // Space was released while the mic grant was in flight.
-            if (!spaceHeldRef.current) {
-              keyboardTakeRef.current = false
-              void endRecord()
-            }
-          })
-          return
-        }
-        case 'KeyE': {
-          if (recording) return
-          camera.releaseMic()
-          onOpenEditor()
-          return
-        }
-        case 'KeyP': {
-          if (!recording && clips.length > 0) onPlay()
-          return
-        }
-        case 'KeyF': {
-          if (!recording && camera.canFlip && countdown === null) void camera.flip()
-          return
-        }
-        case 'KeyT': {
-          if (!recording && countdown === null) startSelfTimer()
-          return
-        }
-        case 'KeyS': {
-          if (recording || countdown !== null) return
-          if (screenSessionRef.current) void finishScreenRecord()
-          else if (screenRecordingSupported) startScreenRecord()
-          return
-        }
-        case 'Backspace':
-        case 'Delete': {
-          // Without this, Backspace can also trigger history navigation.
-          event.preventDefault()
-          if (!recording && clips.length > 0) deleteLastClip()
-          return
-        }
-        default:
-          return
-      }
-    },
-    up: (event) => {
-      if (event.code !== 'Space') return
-      spaceHeldRef.current = false
-      // Only a keyboard-started hold (no owning pointer) ends on keyup.
-      if (recording && recordingMode === 'hold' && pointerIdRef.current === null) {
-        keyboardTakeRef.current = false
-        void endRecord()
-      }
-    },
-  }
-  useLayoutEffect(() => {
-    keyActionsRef.current = keyActions
-  })
-  const onWindowKeyDown = useCallback((event: KeyboardEvent) => {
-    keyActionsRef.current.down(event)
-  }, [])
-  const onWindowKeyUp = useCallback((event: KeyboardEvent) => {
-    keyActionsRef.current.up(event)
-  }, [])
-
-  const attachCameraVideo = camera.videoRef
-  const bindCameraVideo = useCallback(
-    (element: HTMLVideoElement | null) => {
-      if (!element) {
-        document.removeEventListener('visibilitychange', onVisibilityChange)
-        window.removeEventListener('keydown', onWindowKeyDown)
-        window.removeEventListener('keyup', onWindowKeyUp)
-        cleanupOnUnmount()
-      } else {
-        document.addEventListener('visibilitychange', onVisibilityChange)
-        window.addEventListener('keydown', onWindowKeyDown)
-        window.addEventListener('keyup', onWindowKeyUp)
-      }
-      attachCameraVideo(element)
-    },
-    [attachCameraVideo, cleanupOnUnmount, onVisibilityChange, onWindowKeyDown, onWindowKeyUp],
-  )
-
-  const needsPermission =
-    camera.permission.status === 'denied' ||
-    camera.permission.status === 'unsupported' ||
-    (!!camera.error && !camera.isReady)
-
-  return (
-    <div className={`record-screen${recording ? ' is-recording' : ''}`}>
-      <div
-        ref={stageRef}
-        className="record-stage"
-        onPointerDown={(event) => {
-          if (event.button !== 0) return
-          // While recording the screen, the whole stage is the stop button
-          // (matching the hands-free "tap to stop" language).
-          if (screenSessionRef.current) {
-            void finishScreenRecord()
-            return
-          }
-          if (countdown !== null) {
-            clearCountdown()
-            showToast('Timer canceled')
-            return
-          }
-          if (recording && recordingMode === 'hands-free') {
+          // Space was released while the mic grant was in flight.
+          if (!spaceHeld) {
+            keyboardTake = false
             void endRecord()
-            return
           }
-          // A Space-owned take ends on Space keyup only; taps must not
-          // disturb it or its zoom state.
-          if (keyboardTakeRef.current) return
-          // A second finger landing during an active hold must not reset the
-          // drag-zoom state or start another take.
-          if (pointerIdRef.current !== null) return
-          // A new hold interrupts any snap-back still easing; the take starts
-          // from the user's deliberate baseline zoom, not a mid-ramp value.
-          cancelAnimationFrame(zoomRestoreRafRef.current)
-          dragZoomMovedRef.current = false
-          dragZoomPressYRef.current = event.clientY
-          dragZoomStartValueRef.current = zoomBaselineRef.current ?? camera.zoom?.value ?? 1
-          if (zoomRestoreActiveRef.current) {
-            // Finish the interrupted ramp instantly so a motionless hold
-            // still records from the baseline, not a mid-ramp zoom.
-            zoomRestoreActiveRef.current = false
-            camera.setZoom(dragZoomStartValueRef.current)
-          }
-          const stageRect = event.currentTarget.getBoundingClientRect()
-          dragZoomStageHeightRef.current = stageRect.height
-          dragZoomStageTopRef.current = stageRect.top
-          event.currentTarget.setPointerCapture(event.pointerId)
-          void beginRecord(event.pointerId, 'hold')
-        }}
-        onPointerMove={(event) => {
-          if (recordingMode !== 'hold') return
-          if (pointerIdRef.current === null || pointerIdRef.current !== event.pointerId) return
-          const zoom = camera.zoom
-          if (!zoom) return
-          if (zoom.max - zoom.min <= 0) return
-          // Dead zone: natural finger tremble while holding to record must
-          // not start zooming. Once crossed, re-anchor so zoom ramps from
-          // the current finger position without a jump.
-          if (!dragZoomMovedRef.current) {
-            if (Math.abs(event.clientY - dragZoomPressYRef.current) < DRAG_ZOOM_DEADZONE_PX) {
-              return
-            }
-            dragZoomPressYRef.current = event.clientY
-          }
-          // Range-anchored mapping (see dragZoomValue's contract): dragging
-          // to the top of the stage reaches MAX zoom, to the bottom reaches
-          // MIN — except presses within ~20% of an edge, which keep a
-          // minimum ramp for control and cap partway at that edge.
-          const next = dragZoomValue({
-            anchorY: dragZoomPressYRef.current,
-            clientY: event.clientY,
-            stageTop: dragZoomStageTopRef.current,
-            stageHeight: dragZoomStageHeightRef.current || stageRef.current?.clientHeight || 1,
-            start: dragZoomStartValueRef.current,
-            min: zoom.min,
-            max: zoom.max,
-          })
-          dragZoomMovedRef.current = true
-          dragZoomLastValueRef.current = next
-          camera.setZoom(next)
-          showZoomHud(next)
-        }}
-        onPointerUp={(event) => {
-          if (keyboardTakeRef.current) return
-          if (recordingMode !== 'hands-free') {
-            // Only the pointer that owns the hold may end the take and start
-            // the snap-back — a stray second finger lifting must not zoom
-            // out mid-recording.
-            const ownsHold =
-              pointerIdRef.current === null || pointerIdRef.current === event.pointerId
-            void endRecord(event.pointerId)
-            if (ownsHold) restoreZoomAfterHold()
-          }
-        }}
-        onPointerCancel={(event) => {
-          if (keyboardTakeRef.current) return
-          if (recordingMode !== 'hands-free') {
-            const ownsHold =
-              pointerIdRef.current === null || pointerIdRef.current === event.pointerId
-            void endRecord(event.pointerId)
-            if (ownsHold) restoreZoomAfterHold()
-          }
-        }}
-        onContextMenu={(event) => event.preventDefault()}
-      >
-        <video
-          ref={bindCameraVideo}
-          className={`camera-video${camera.facing === 'user' ? ' mirror' : ''}`}
-          muted
-          playsInline
-          autoPlay
-        />
+        })
+        return
+      }
+      case 'KeyE': {
+        if (recording) return
+        camera.releaseMic()
+        props.onOpenEditor()
+        return
+      }
+      case 'KeyP': {
+        if (!recording && props.clips.length > 0) props.onPlay()
+        return
+      }
+      case 'KeyF': {
+        if (!recording && camera.canFlip && countdown === null) void camera.flip()
+        return
+      }
+      case 'KeyT': {
+        if (!recording && countdown === null) startSelfTimer()
+        return
+      }
+      case 'KeyS': {
+        if (recording || countdown !== null) return
+        if (screenSession) void finishScreenRecord()
+        else if (screenRecordingSupported) startScreenRecord()
+        return
+      }
+      case 'Backspace':
+      case 'Delete': {
+        // Without this, Backspace can also trigger history navigation.
+        event.preventDefault()
+        if (!recording && props.clips.length > 0) deleteLastClip()
+        return
+      }
+      default:
+        return
+    }
+  }
+  const onWindowKeyUp = (event: KeyboardEvent) => {
+    if (event.code !== 'Space') return
+    spaceHeld = false
+    // Only a keyboard-started hold (no owning pointer) ends on keyup.
+    if (recording && recordingMode === 'hold' && pointerId === null) {
+      keyboardTake = false
+      void endRecord()
+    }
+  }
 
-        {recording ? (
-          <div className="record-overlay">
-            <div className="record-pill" aria-live="polite">
-              <span className="record-dot" />
-              <span className="record-pill-label">
-                {recordingMode === 'hands-free' ? 'TAP TO STOP' : 'REC'}
-              </span>
-              <RecordTimer startedAt={recordStartedAt} className="record-elapsed" />
-            </div>
-          </div>
-        ) : null}
+  const bindCameraVideo = (element: HTMLVideoElement, signal: AbortSignal) => {
+    document.addEventListener('visibilitychange', onVisibilityChange)
+    window.addEventListener('keydown', onWindowKeyDown)
+    window.addEventListener('keyup', onWindowKeyUp)
+    // Registered before camera.attachVideo's own abort listener so an active
+    // take is finished/saved before the camera stream is stopped.
+    signal.addEventListener('abort', () => {
+      document.removeEventListener('visibilitychange', onVisibilityChange)
+      window.removeEventListener('keydown', onWindowKeyDown)
+      window.removeEventListener('keyup', onWindowKeyUp)
+      cleanupOnUnmount()
+    })
+    camera.attachVideo(element, signal)
+  }
 
-        {screenRecording ? (
-          <div className="record-overlay">
-            <div className="record-pill" aria-live="polite">
-              <span className="record-dot" />
-              <span className="record-pill-label">SCREEN — TAP TO STOP</span>
-              <RecordTimer startedAt={screenRecordStartedAt} className="record-elapsed" />
-            </div>
-          </div>
-        ) : null}
+  return () => {
+    const { project, clips, storage, onOpenEditor, onOpenExport, onPlay } = props
+    const totalDurationMs = clips.reduce((sum, clip) => sum + effectiveDurationMs(clip), 0)
+    const zoomLevels = camera.zoom ? zoomChipLevels(camera.zoom) : []
+    const activeZoomLevel =
+      camera.zoom && zoomLevels.length > 0 ? nearestZoomLevel(zoomLevels, camera.zoom.value) : null
+    // Ultra-wide/telephoto are usually separate rear cameras on Android — a
+    // lens chip is the only way to reach 0.5× when zoom can't go below 1×.
+    const showLensChip = camera.facing === 'environment' && camera.rearLensCount > 1
+    const severity = storageState()
 
-        {countdown !== null ? (
-          <div className="countdown-overlay" aria-live="assertive">
-            <span className="countdown-number">{countdown}</span>
-          </div>
-        ) : null}
+    const needsPermission =
+      camera.permission.status === 'denied' ||
+      camera.permission.status === 'unsupported' ||
+      (!!camera.error && !camera.isReady)
 
-        {!recording && !screenRecording && countdown === null && camera.isReady ? (
-          <div className={`hold-hint${clips.length > 0 ? ' hold-hint-subtle' : ''}`}>
-            <strong>Hold anywhere</strong>
-            <span>release to stop</span>
-          </div>
-        ) : null}
-
-        <div className="zoom-hud" ref={zoomHudRef} aria-hidden="true" />
-
-        {needsPermission ? (
-          <div className="permission-panel">
-            <div>
-              <h2>Camera access</h2>
-              <p>
-                {camera.error ??
-                  camera.permission.message ??
-                  'Allow camera to preview. Recording needs the microphone too.'}
-              </p>
-              <button type="button" className="btn btn-primary" onClick={() => void camera.start()}>
-                Try again
-              </button>
-            </div>
-          </div>
-        ) : null}
-      </div>
-
-      <div className="record-top">
-        <Link to="/" className="btn-icon" aria-label="Back to projects" onClick={cleanupOnUnmount}>
-          <IconBack />
-        </Link>
-        <div className="record-meta">
-          <strong>{project.name}</strong>
-          <span className="record-total">{formatDuration(totalDurationMs)}</span>
-          {storage && storageState !== 'ok' && !recording ? (
-            <Link
-              to="/"
-              className={`storage-pill${storageState === 'critical' ? ' is-critical' : ''}`}
-              aria-label="Device storage almost full — manage projects"
-            >
-              Storage {formatStoragePercent(storage.ratio)} full
-            </Link>
-          ) : null}
-          {camera.micPermission === 'denied' && !recording ? (
-            <span
-              className="storage-pill is-critical"
-              role="status"
-              aria-label="Microphone blocked — recordings need sound"
-            >
-              Mic blocked — allow it in site settings
-            </span>
-          ) : null}
-          {micSilent && camera.micPermission !== 'denied' ? (
-            <span
-              className="storage-pill is-critical"
-              role="status"
-              aria-label="Microphone is not picking up sound"
-            >
-              Mic isn&rsquo;t picking up sound
-            </span>
-          ) : null}
-        </div>
-        <div className="record-top-actions">
-          {screenRecordingSupported ? (
-            <button
-              type="button"
-              className={`btn-icon${screenRecording ? ' is-active' : ''}`}
-              aria-label={screenRecording ? 'Stop screen recording' : 'Record your screen'}
-              aria-pressed={screenRecording}
-              disabled={recording || countdown !== null}
-              onClick={() => {
-                if (screenSessionRef.current) void finishScreenRecord()
-                else startScreenRecord()
-              }}
-            >
-              <IconScreen on={screenRecording} />
-            </button>
-          ) : null}
-          {camera.torchAvailable ? (
-            <button
-              type="button"
-              className={`btn-icon${camera.torchOn ? ' is-active' : ''}`}
-              aria-label="Toggle flash"
-              aria-pressed={camera.torchOn}
-              disabled={recording || countdown !== null}
-              onClick={() => void camera.setTorch(!camera.torchOn)}
-            >
-              <IconTorch on={camera.torchOn} />
-            </button>
-          ) : null}
-          <button
-            type="button"
-            className="btn-icon"
-            aria-label="Flip camera"
-            disabled={!camera.canFlip || recording || countdown !== null}
-            onClick={() => {
-              // The baseline belongs to the previous lens; the new camera
-              // starts from its own default zoom.
-              cancelAnimationFrame(zoomRestoreRafRef.current)
-              zoomBaselineRef.current = null
-              dragZoomMovedRef.current = false
-              void camera.flip()
-            }}
-          >
-            <IconFlip />
-          </button>
-        </div>
-      </div>
-
-      {(camera.zoom && zoomLevels.length > 0) || showLensChip ? (
-        <div className="record-zoom" role="group" aria-label="Zoom and lens">
-          {showLensChip ? (
-            <button
-              type="button"
-              className="zoom-chip lens-chip"
-              aria-label={`Switch rear lens (${camera.rearLensIndex + 1} of ${camera.rearLensCount})`}
-              disabled={recording || countdown !== null || !camera.isReady}
-              onClick={(event) => {
-                event.stopPropagation()
-                // Each lens has its own zoom range and default.
-                cancelAnimationFrame(zoomRestoreRafRef.current)
-                zoomBaselineRef.current = null
-                dragZoomMovedRef.current = false
-                void camera
-                  .switchRearLens()
-                  .then(() => {
-                    const range = camera.getZoom()
-                    if (range) showZoomHud(range.value)
-                  })
-                  .catch(() => undefined)
-              }}
-            >
-              <IconLens size={14} />
-              {camera.rearLensIndex + 1}/{camera.rearLensCount}
-            </button>
-          ) : null}
-          {zoomLevels.map((level) => {
-            const isActive = activeZoomLevel !== null && Math.abs(activeZoomLevel - level) < 0.05
-            return (
-              <button
-                key={level}
-                type="button"
-                className={`zoom-chip${isActive ? ' is-active' : ''}`}
-                aria-pressed={isActive}
-                disabled={countdown !== null}
-                onClick={(event) => {
-                  event.stopPropagation()
-                  cancelAnimationFrame(zoomRestoreRafRef.current)
-                  zoomBaselineRef.current = level
-                  camera.setZoom(level)
-                  showZoomHud(level)
-                }}
-              >
-                {formatZoomLabel(level)}
-              </button>
-            )
-          })}
-        </div>
-      ) : null}
-
-      <div className="key-hints" aria-hidden="true">
-        Hold <kbd>Space</kbd> record · <kbd>F</kbd> flip · <kbd>T</kbd> timer ·{' '}
-        {screenRecordingSupported ? (
-          <>
-            <kbd>S</kbd> screen ·{' '}
-          </>
-        ) : null}
-        <kbd>E</kbd> editor · <kbd>P</kbd> play · <kbd>⌫</kbd> delete last
-      </div>
-
-      <div className="record-dock">
-        <div className="record-tools">
-          <button
-            type="button"
-            className="btn-icon"
-            aria-label="Open editor"
-            disabled={recording || screenRecording}
-            onClick={() => {
-              camera.releaseMic()
-              onOpenEditor()
-            }}
-          >
-            <IconEditor />
-          </button>
-          <button
-            type="button"
-            className="btn-icon"
-            aria-label="Self-timer"
-            disabled={recording || screenRecording || countdown !== null}
-            onClick={startSelfTimer}
-          >
-            <IconTimer />
-          </button>
-          <button
-            type="button"
-            className={`btn-icon${locationTagging ? ' is-active' : ''}`}
-            aria-label="Toggle location tagging"
-            aria-pressed={locationTagging}
-            disabled={recording || countdown !== null}
-            onClick={toggleLocationTagging}
-          >
-            <IconLocation />
-          </button>
-          <button
-            type="button"
-            className="btn-icon"
-            aria-label="Play project preview"
-            disabled={recording || screenRecording || clips.length === 0}
-            onClick={onPlay}
-          >
-            <IconPlay />
-          </button>
-          <button
-            type="button"
-            className="btn-icon"
-            aria-label="Delete last clip"
-            disabled={recording || screenRecording || clips.length === 0}
-            onClick={deleteLastClip}
-          >
-            <IconDeleteLast />
-          </button>
-        </div>
-        <button
-          type="button"
-          className="go-button"
-          disabled={clips.length === 0 || recording || screenRecording}
-          onClick={onOpenExport}
+    return (
+      <div className={`record-screen${recording ? ' is-recording' : ''}`}>
+        <div
+          className="record-stage"
+          mix={[
+            ref((node) => {
+              stageEl = node as HTMLDivElement
+            }),
+            on('pointerdown', (event) => {
+              if (event.button !== 0) return
+              // While recording the screen, the whole stage is the stop button
+              // (matching the hands-free "tap to stop" language).
+              if (screenSession) {
+                void finishScreenRecord()
+                return
+              }
+              if (countdown !== null) {
+                clearCountdown()
+                props.showToast('Timer canceled')
+                return
+              }
+              if (recording && recordingMode === 'hands-free') {
+                void endRecord()
+                return
+              }
+              // A Space-owned take ends on Space keyup only; taps must not
+              // disturb it or its zoom state.
+              if (keyboardTake) return
+              // A second finger landing during an active hold must not reset the
+              // drag-zoom state or start another take.
+              if (pointerId !== null) return
+              // A new hold interrupts any snap-back still easing; the take starts
+              // from the user's deliberate baseline zoom, not a mid-ramp value.
+              cancelAnimationFrame(zoomRestoreRaf)
+              dragZoomMoved = false
+              dragZoomPressY = event.clientY
+              dragZoomStartValue = zoomBaseline ?? camera.zoom?.value ?? 1
+              if (zoomRestoreActive) {
+                // Finish the interrupted ramp instantly so a motionless hold
+                // still records from the baseline, not a mid-ramp zoom.
+                zoomRestoreActive = false
+                camera.setZoom(dragZoomStartValue)
+              }
+              const stage = event.currentTarget as HTMLDivElement
+              const stageRect = stage.getBoundingClientRect()
+              dragZoomStageHeight = stageRect.height
+              dragZoomStageTop = stageRect.top
+              stage.setPointerCapture(event.pointerId)
+              void beginRecord(event.pointerId, 'hold')
+            }),
+            on('pointermove', (event) => {
+              if (recordingMode !== 'hold') return
+              if (pointerId === null || pointerId !== event.pointerId) return
+              const zoom = camera.zoom
+              if (!zoom) return
+              if (zoom.max - zoom.min <= 0) return
+              // Dead zone: natural finger tremble while holding to record must
+              // not start zooming. Once crossed, re-anchor so zoom ramps from
+              // the current finger position without a jump.
+              if (!dragZoomMoved) {
+                if (Math.abs(event.clientY - dragZoomPressY) < DRAG_ZOOM_DEADZONE_PX) {
+                  return
+                }
+                dragZoomPressY = event.clientY
+              }
+              // Range-anchored mapping (see dragZoomValue's contract): dragging
+              // to the top of the stage reaches MAX zoom, to the bottom reaches
+              // MIN — except presses within ~20% of an edge, which keep a
+              // minimum ramp for control and cap partway at that edge.
+              const next = dragZoomValue({
+                anchorY: dragZoomPressY,
+                clientY: event.clientY,
+                stageTop: dragZoomStageTop,
+                stageHeight: dragZoomStageHeight || stageEl?.clientHeight || 1,
+                start: dragZoomStartValue,
+                min: zoom.min,
+                max: zoom.max,
+              })
+              dragZoomMoved = true
+              dragZoomLastValue = next
+              camera.setZoom(next)
+              showZoomHud(next)
+            }),
+            on('pointerup', (event) => {
+              if (keyboardTake) return
+              if (recordingMode !== 'hands-free') {
+                // Only the pointer that owns the hold may end the take and start
+                // the snap-back — a stray second finger lifting must not zoom
+                // out mid-recording.
+                const ownsHold = pointerId === null || pointerId === event.pointerId
+                void endRecord(event.pointerId)
+                if (ownsHold) restoreZoomAfterHold()
+              }
+            }),
+            on('pointercancel', (event) => {
+              if (keyboardTake) return
+              if (recordingMode !== 'hands-free') {
+                const ownsHold = pointerId === null || pointerId === event.pointerId
+                void endRecord(event.pointerId)
+                if (ownsHold) restoreZoomAfterHold()
+              }
+            }),
+            on('contextmenu', (event) => event.preventDefault()),
+          ]}
         >
-          Go
-        </button>
+          <video
+            className={`camera-video${camera.facing === 'user' ? ' mirror' : ''}`}
+            muted
+            playsInline
+            autoPlay
+            mix={ref((node, signal) => bindCameraVideo(node as HTMLVideoElement, signal))}
+          />
+
+          {recording ? (
+            <div className="record-overlay">
+              <div className="record-pill" aria-live="polite">
+                <span className="record-dot" />
+                <span className="record-pill-label">
+                  {recordingMode === 'hands-free' ? 'TAP TO STOP' : 'REC'}
+                </span>
+                <RecordTimer startedAt={recordStartedAt} className="record-elapsed" />
+              </div>
+            </div>
+          ) : null}
+
+          {screenRecording ? (
+            <div className="record-overlay">
+              <div className="record-pill" aria-live="polite">
+                <span className="record-dot" />
+                <span className="record-pill-label">SCREEN — TAP TO STOP</span>
+                <RecordTimer startedAt={screenRecordStartedAt} className="record-elapsed" />
+              </div>
+            </div>
+          ) : null}
+
+          {countdown !== null ? (
+            <div className="countdown-overlay" aria-live="assertive">
+              <span className="countdown-number">{countdown}</span>
+            </div>
+          ) : null}
+
+          {!recording && !screenRecording && countdown === null && camera.isReady ? (
+            <div className={`hold-hint${clips.length > 0 ? ' hold-hint-subtle' : ''}`}>
+              <strong>Hold anywhere</strong>
+              <span>release to stop</span>
+            </div>
+          ) : null}
+
+          <div
+            className="zoom-hud"
+            aria-hidden="true"
+            mix={ref((node, signal) => {
+              zoomHudEl = node as HTMLDivElement
+              signal.addEventListener('abort', () => {
+                zoomHudEl = null
+                window.clearTimeout(zoomHudTimer)
+              })
+            })}
+          />
+
+          {needsPermission ? (
+            <div className="permission-panel">
+              <div>
+                <h2>Camera access</h2>
+                <p>
+                  {camera.error ??
+                    camera.permission.message ??
+                    'Allow camera to preview. Recording needs the microphone too.'}
+                </p>
+                <button
+                  type="button"
+                  className="btn btn-primary"
+                  mix={on('click', () => void camera.start())}
+                >
+                  Try again
+                </button>
+              </div>
+            </div>
+          ) : null}
+        </div>
+
+        <div className="record-top">
+          <a
+            href="/"
+            className="btn-icon"
+            aria-label="Back to projects"
+            mix={on('click', cleanupOnUnmount)}
+          >
+            <IconBack />
+          </a>
+          <div className="record-meta">
+            <strong>{project.name}</strong>
+            <span className="record-total">{formatDuration(totalDurationMs)}</span>
+            {storage && severity !== 'ok' && !recording ? (
+              <a
+                href="/"
+                className={`storage-pill${severity === 'critical' ? ' is-critical' : ''}`}
+                aria-label="Device storage almost full — manage projects"
+              >
+                Storage {formatStoragePercent(storage.ratio)} full
+              </a>
+            ) : null}
+            {camera.micPermission === 'denied' && !recording ? (
+              <span
+                className="storage-pill is-critical"
+                role="status"
+                aria-label="Microphone blocked — recordings need sound"
+              >
+                Mic blocked — allow it in site settings
+              </span>
+            ) : null}
+            {micSilent && camera.micPermission !== 'denied' ? (
+              <span
+                className="storage-pill is-critical"
+                role="status"
+                aria-label="Microphone is not picking up sound"
+              >
+                Mic isn&rsquo;t picking up sound
+              </span>
+            ) : null}
+          </div>
+          <div className="record-top-actions">
+            {screenRecordingSupported ? (
+              <button
+                type="button"
+                className={`btn-icon${screenRecording ? ' is-active' : ''}`}
+                aria-label={screenRecording ? 'Stop screen recording' : 'Record your screen'}
+                aria-pressed={screenRecording}
+                disabled={recording || countdown !== null}
+                mix={on('click', () => {
+                  if (screenSession) void finishScreenRecord()
+                  else startScreenRecord()
+                })}
+              >
+                <IconScreen on={screenRecording} />
+              </button>
+            ) : null}
+            {camera.torchAvailable ? (
+              <button
+                type="button"
+                className={`btn-icon${camera.torchOn ? ' is-active' : ''}`}
+                aria-label="Toggle flash"
+                aria-pressed={camera.torchOn}
+                disabled={recording || countdown !== null}
+                mix={on('click', () => void camera.setTorch(!camera.torchOn))}
+              >
+                <IconTorch on={camera.torchOn} />
+              </button>
+            ) : null}
+            <button
+              type="button"
+              className="btn-icon"
+              aria-label="Flip camera"
+              disabled={!camera.canFlip || recording || countdown !== null}
+              mix={on('click', () => {
+                // The baseline belongs to the previous lens; the new camera
+                // starts from its own default zoom.
+                cancelAnimationFrame(zoomRestoreRaf)
+                zoomBaseline = null
+                dragZoomMoved = false
+                void camera.flip()
+              })}
+            >
+              <IconFlip />
+            </button>
+          </div>
+        </div>
+
+        {(camera.zoom && zoomLevels.length > 0) || showLensChip ? (
+          <div className="record-zoom" role="group" aria-label="Zoom and lens">
+            {showLensChip ? (
+              <button
+                type="button"
+                className="zoom-chip lens-chip"
+                aria-label={`Switch rear lens (${camera.rearLensIndex + 1} of ${camera.rearLensCount})`}
+                disabled={recording || countdown !== null || !camera.isReady}
+                mix={on('click', (event) => {
+                  event.stopPropagation()
+                  // Each lens has its own zoom range and default.
+                  cancelAnimationFrame(zoomRestoreRaf)
+                  zoomBaseline = null
+                  dragZoomMoved = false
+                  void camera
+                    .switchRearLens()
+                    .then(() => {
+                      const range = camera.getZoom()
+                      if (range) showZoomHud(range.value)
+                    })
+                    .catch(() => undefined)
+                })}
+              >
+                <IconLens size={14} />
+                {camera.rearLensIndex + 1}/{camera.rearLensCount}
+              </button>
+            ) : null}
+            {zoomLevels.map((level) => {
+              const isActive = activeZoomLevel !== null && Math.abs(activeZoomLevel - level) < 0.05
+              return (
+                <button
+                  key={level}
+                  type="button"
+                  className={`zoom-chip${isActive ? ' is-active' : ''}`}
+                  aria-pressed={isActive}
+                  disabled={countdown !== null}
+                  mix={on('click', (event) => {
+                    event.stopPropagation()
+                    cancelAnimationFrame(zoomRestoreRaf)
+                    zoomBaseline = level
+                    camera.setZoom(level)
+                    showZoomHud(level)
+                  })}
+                >
+                  {formatZoomLabel(level)}
+                </button>
+              )
+            })}
+          </div>
+        ) : null}
+
+        <div className="key-hints" aria-hidden="true">
+          Hold <kbd>Space</kbd> record · <kbd>F</kbd> flip · <kbd>T</kbd> timer ·{' '}
+          {screenRecordingSupported ? (
+            <>
+              <kbd>S</kbd> screen ·{' '}
+            </>
+          ) : null}
+          <kbd>E</kbd> editor · <kbd>P</kbd> play · <kbd>⌫</kbd> delete last
+        </div>
+
+        <div className="record-dock">
+          <div className="record-tools">
+            <button
+              type="button"
+              className="btn-icon"
+              aria-label="Open editor"
+              disabled={recording || screenRecording}
+              mix={on('click', () => {
+                camera.releaseMic()
+                onOpenEditor()
+              })}
+            >
+              <IconEditor />
+            </button>
+            <button
+              type="button"
+              className="btn-icon"
+              aria-label="Self-timer"
+              disabled={recording || screenRecording || countdown !== null}
+              mix={on('click', startSelfTimer)}
+            >
+              <IconTimer />
+            </button>
+            <button
+              type="button"
+              className={`btn-icon${locationTagging ? ' is-active' : ''}`}
+              aria-label="Toggle location tagging"
+              aria-pressed={locationTagging}
+              disabled={recording || countdown !== null}
+              mix={on('click', toggleLocationTagging)}
+            >
+              <IconLocation />
+            </button>
+            <button
+              type="button"
+              className="btn-icon"
+              aria-label="Play project preview"
+              disabled={recording || screenRecording || clips.length === 0}
+              mix={on('click', () => onPlay())}
+            >
+              <IconPlay />
+            </button>
+            <button
+              type="button"
+              className="btn-icon"
+              aria-label="Delete last clip"
+              disabled={recording || screenRecording || clips.length === 0}
+              mix={on('click', deleteLastClip)}
+            >
+              <IconDeleteLast />
+            </button>
+          </div>
+          <button
+            type="button"
+            className="go-button"
+            disabled={clips.length === 0 || recording || screenRecording}
+            mix={on('click', () => onOpenExport())}
+          >
+            Go
+          </button>
+        </div>
       </div>
-    </div>
-  )
+    )
+  }
 }

--- a/src/components/record-screen.tsx
+++ b/src/components/record-screen.tsx
@@ -555,10 +555,14 @@ export function RecordScreen(handle: Handle<RecordScreenProps>) {
         props.showToast("Location unavailable — check the site's location permission")
         return
       }
-      await setLocationTaggingEnabled(true)
-      locationTagging = true
-      void handle.update()
-      props.showToast('Location tagging on — new clips will be geotagged')
+      try {
+        await setLocationTaggingEnabled(true)
+        locationTagging = true
+        void handle.update()
+        props.showToast('Location tagging on — new clips will be geotagged')
+      } catch {
+        props.showToast('Could not save the setting — try again')
+      }
     })()
   }
 
@@ -916,7 +920,13 @@ export function RecordScreen(handle: Handle<RecordScreenProps>) {
             href="/"
             className="btn-icon"
             aria-label="Back to projects"
-            mix={on('click', cleanupOnUnmount)}
+            mix={on('click', (event) => {
+              // Modifier/middle clicks open a new tab and leave this page
+              // mounted — don't tear down the live camera session for them.
+              if (event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) return
+              if (event.button !== 0) return
+              cleanupOnUnmount()
+            })}
           >
             <IconBack />
           </a>

--- a/src/components/record-timer.tsx
+++ b/src/components/record-timer.tsx
@@ -1,4 +1,5 @@
-import { useCallback, useRef } from 'react'
+import type { Handle } from 'remix/ui'
+import { ref } from 'remix/ui'
 import { formatDuration } from '../lib/types'
 
 interface RecordTimerProps {
@@ -12,21 +13,21 @@ interface RecordTimerProps {
  * rest of the page never re-renders while recording — re-rendering the whole
  * screen 60×/s is what made the camera preview and encoder drop frames.
  */
-export function RecordTimer({ startedAt, className }: RecordTimerProps) {
-  const rafRef = useRef(0)
-
-  const bind = useCallback(
-    (el: HTMLSpanElement | null) => {
-      cancelAnimationFrame(rafRef.current)
-      if (!el) return
-      const tick = () => {
-        el.textContent = formatDuration(Math.max(0, performance.now() - startedAt))
-        rafRef.current = requestAnimationFrame(tick)
-      }
-      tick()
-    },
-    [startedAt],
+export function RecordTimer(handle: Handle<RecordTimerProps>) {
+  return () => (
+    <span
+      className={handle.props.className}
+      mix={ref((node, signal) => {
+        let raf = 0
+        const tick = () => {
+          node.textContent = formatDuration(
+            Math.max(0, performance.now() - handle.props.startedAt),
+          )
+          raf = requestAnimationFrame(tick)
+        }
+        tick()
+        signal.addEventListener('abort', () => cancelAnimationFrame(raf))
+      })}
+    />
   )
-
-  return <span ref={bind} className={className} />
 }

--- a/src/components/rename-sheet.tsx
+++ b/src/components/rename-sheet.tsx
@@ -27,7 +27,8 @@ export function RenameSheet(handle: Handle<RenameSheetProps>) {
       error = err instanceof Error ? err.message : 'Could not save'
     } finally {
       busy = false
-      void handle.update()
+      // onClose may have unmounted the sheet — nothing left to update.
+      if (!handle.signal.aborted) void handle.update()
     }
   }
 

--- a/src/components/rename-sheet.tsx
+++ b/src/components/rename-sheet.tsx
@@ -1,5 +1,6 @@
-import { useState } from 'react'
-import { useSheetModal } from '../hooks/use-sheet-modal'
+import type { Handle } from 'remix/ui'
+import { on, ref } from 'remix/ui'
+import { attachSheetModal } from '../lib/sheet-modal'
 
 interface RenameSheetProps {
   initialName: string
@@ -10,67 +11,87 @@ interface RenameSheetProps {
 }
 
 /** Remount with key={projectId} when renaming a different project. */
-export function RenameSheet({
-  initialName,
-  title = 'Rename project',
-  confirmLabel = 'Save',
-  onClose,
-  onSave,
-}: RenameSheetProps) {
-  const [name, setName] = useState(initialName)
-  const [busy, setBusy] = useState(false)
-  const [error, setError] = useState<string | null>(null)
-  const bindSheet = useSheetModal({ onDismiss: onClose, busy })
+export function RenameSheet(handle: Handle<RenameSheetProps>) {
+  let name = handle.props.initialName
+  let busy = false
+  let error: string | null = null
 
-  return (
-    <>
-      <div
-        className="sheet-backdrop"
-        onClick={() => {
-          if (!busy) onClose()
-        }}
-      />
-      <div className="sheet" role="dialog" aria-modal="true" aria-label={title} ref={bindSheet}>
-        <h3>{title}</h3>
-        <div className="field">
-          <label htmlFor="project-name">Name</label>
-          <input
-            id="project-name"
-            type="text"
-            value={name}
-            autoFocus
-            maxLength={48}
-            onChange={(e) => setName(e.target.value)}
-          />
+  const save = async () => {
+    busy = true
+    error = null
+    void handle.update()
+    try {
+      await handle.props.onSave(name.trim())
+      handle.props.onClose()
+    } catch (err) {
+      error = err instanceof Error ? err.message : 'Could not save'
+    } finally {
+      busy = false
+      void handle.update()
+    }
+  }
+
+  return () => {
+    const { title = 'Rename project', confirmLabel = 'Save', onClose } = handle.props
+
+    return (
+      <>
+        <div
+          className="sheet-backdrop"
+          mix={on('click', () => {
+            if (!busy) onClose()
+          })}
+        />
+        <div
+          className="sheet"
+          role="dialog"
+          aria-modal="true"
+          aria-label={title}
+          mix={ref((node, signal) =>
+            attachSheetModal(node as HTMLElement, signal, {
+              onDismiss: () => handle.props.onClose(),
+              busy: () => busy,
+            }),
+          )}
+        >
+          <h3>{title}</h3>
+          <div className="field">
+            <label htmlFor="project-name">Name</label>
+            <input
+              id="project-name"
+              type="text"
+              value={name}
+              maxLength={48}
+              mix={[
+                ref((node) => (node as HTMLInputElement).focus()),
+                on('input', (event) => {
+                  name = (event.currentTarget as HTMLInputElement).value
+                  void handle.update()
+                }),
+              ]}
+            />
+          </div>
+          {error ? <div className="error-banner">{error}</div> : null}
+          <div className="sheet-actions">
+            <button
+              type="button"
+              className="btn btn-ghost"
+              disabled={busy}
+              mix={on('click', () => onClose())}
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              className="btn btn-primary"
+              disabled={busy || !name.trim()}
+              mix={on('click', () => void save())}
+            >
+              {busy ? 'Saving…' : confirmLabel}
+            </button>
+          </div>
         </div>
-        {error ? <div className="error-banner">{error}</div> : null}
-        <div className="sheet-actions">
-          <button type="button" className="btn btn-ghost" onClick={onClose} disabled={busy}>
-            Cancel
-          </button>
-          <button
-            type="button"
-            className="btn btn-primary"
-            disabled={busy || !name.trim()}
-            onClick={() => {
-              void (async () => {
-                setBusy(true)
-                setError(null)
-                try {
-                  await onSave(name.trim())
-                  onClose()
-                } catch (err) {
-                  setError(err instanceof Error ? err.message : 'Could not save')
-                } finally {
-                  setBusy(false)
-                }
-              })()
-            }}
-          >
-            {busy ? 'Saving…' : confirmLabel}
-          </button>
-        </div>
-      </div>
-    </>
-  )
+      </>
+    )
+  }
 }

--- a/src/components/restore-sheet.tsx
+++ b/src/components/restore-sheet.tsx
@@ -1,5 +1,6 @@
-import { useState } from 'react'
-import { useSheetModal } from '../hooks/use-sheet-modal'
+import type { Handle } from 'remix/ui'
+import { on, ref } from 'remix/ui'
+import { attachSheetModal } from '../lib/sheet-modal'
 import { extractSessionId, verifyPurchaseSession } from '../lib/entitlement'
 
 interface RestoreSheetProps {
@@ -11,65 +12,91 @@ interface RestoreSheetProps {
  * Restore the "Remove Watermark" purchase on a new device: paste the link
  * from the Stripe receipt email (or the checkout session id) and re-verify.
  */
-export function RestoreSheet({ onRestored, onClose }: RestoreSheetProps) {
-  const [value, setValue] = useState('')
-  const [busy, setBusy] = useState(false)
-  const [error, setError] = useState<string | null>(null)
-  const bindSheet = useSheetModal({ onDismiss: onClose, busy })
+export function RestoreSheet(handle: Handle<RestoreSheetProps>) {
+  let value = ''
+  let busy = false
+  let error: string | null = null
 
-  return (
-    <>
-      <div
-        className="sheet-backdrop"
-        onClick={() => {
-          if (!busy) onClose()
-        }}
-      />
-      <div className="sheet" role="dialog" aria-modal="true" aria-label="Restore purchase" ref={bindSheet}>
-        <h3>Restore purchase</h3>
-        <p className="muted sheet-lede">
-          Paste the confirmation link from your Stripe receipt email (or the checkout session id
-          starting with “cs_”). We’ll verify it and remove the watermark on this device.
-        </p>
-        <div className="field">
-          <label htmlFor="restore-input">Receipt link or session id</label>
-          <input
-            id="restore-input"
-            type="text"
-            value={value}
-            autoFocus
-            placeholder="https://… or cs_live_…"
-            onChange={(e) => setValue(e.target.value)}
-          />
+  const restore = async () => {
+    const sessionId = extractSessionId(value)
+    if (!sessionId) return
+    busy = true
+    error = null
+    void handle.update()
+    const result = await verifyPurchaseSession(sessionId)
+    busy = false
+    if (result.unlocked) {
+      handle.props.onRestored()
+    } else {
+      error = result.error ?? 'Could not verify the purchase.'
+    }
+    void handle.update()
+  }
+
+  return () => {
+    const { onClose } = handle.props
+    return (
+      <>
+        <div
+          className="sheet-backdrop"
+          mix={on('click', () => {
+            if (!busy) onClose()
+          })}
+        />
+        <div
+          className="sheet"
+          role="dialog"
+          aria-modal="true"
+          aria-label="Restore purchase"
+          mix={ref((node, signal) =>
+            attachSheetModal(node as HTMLElement, signal, {
+              onDismiss: () => handle.props.onClose(),
+              busy: () => busy,
+            }),
+          )}
+        >
+          <h3>Restore purchase</h3>
+          <p className="muted sheet-lede">
+            Paste the confirmation link from your Stripe receipt email (or the checkout session id
+            starting with “cs_”). We’ll verify it and remove the watermark on this device.
+          </p>
+          <div className="field">
+            <label htmlFor="restore-input">Receipt link or session id</label>
+            <input
+              id="restore-input"
+              type="text"
+              value={value}
+              placeholder="https://… or cs_live_…"
+              mix={[
+                ref((node) => (node as HTMLInputElement).focus()),
+                on('input', (event) => {
+                  value = (event.currentTarget as HTMLInputElement).value
+                  void handle.update()
+                }),
+              ]}
+            />
+          </div>
+          {error ? <div className="error-banner">{error}</div> : null}
+          <div className="sheet-actions">
+            <button
+              type="button"
+              className="btn btn-ghost"
+              disabled={busy}
+              mix={on('click', () => onClose())}
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              className="btn btn-primary"
+              disabled={busy || !extractSessionId(value)}
+              mix={on('click', () => void restore())}
+            >
+              {busy ? 'Verifying…' : 'Restore'}
+            </button>
+          </div>
         </div>
-        {error ? <div className="error-banner">{error}</div> : null}
-        <div className="sheet-actions">
-          <button type="button" className="btn btn-ghost" onClick={onClose} disabled={busy}>
-            Cancel
-          </button>
-          <button
-            type="button"
-            className="btn btn-primary"
-            disabled={busy || !extractSessionId(value)}
-            onClick={() => {
-              const sessionId = extractSessionId(value)
-              if (!sessionId) return
-              setBusy(true)
-              setError(null)
-              void verifyPurchaseSession(sessionId).then((result) => {
-                setBusy(false)
-                if (result.unlocked) {
-                  onRestored()
-                } else {
-                  setError(result.error ?? 'Could not verify the purchase.')
-                }
-              })
-            }}
-          >
-            {busy ? 'Verifying…' : 'Restore'}
-          </button>
-        </div>
-      </div>
-    </>
-  )
+      </>
+    )
+  }
 }

--- a/src/components/restore-sheet.tsx
+++ b/src/components/restore-sheet.tsx
@@ -30,7 +30,8 @@ export function RestoreSheet(handle: Handle<RestoreSheetProps>) {
     } else {
       error = result.error ?? 'Could not verify the purchase.'
     }
-    void handle.update()
+    // onRestored may have unmounted the sheet — nothing left to update.
+    if (!handle.signal.aborted) void handle.update()
   }
 
   return () => {

--- a/src/components/timeline-thumb-image.tsx
+++ b/src/components/timeline-thumb-image.tsx
@@ -1,38 +1,28 @@
-import { useCallback, useRef, type ImgHTMLAttributes, type RefCallback } from 'react'
+import type { Handle, MixValue } from 'remix/ui'
+import { ref } from 'remix/ui'
+import { createBlobUrlBinder } from '../lib/blob-url'
 
-type TimelineThumbImageProps = Omit<ImgHTMLAttributes<HTMLImageElement>, 'src'> & {
+interface TimelineThumbImageProps {
   blob: Blob
+  className?: string
+  alt?: string
+  mix?: MixValue
 }
 
 /** Bind a Blob to an <img> via object URL (create/revoke on mount/blob change). */
-export function TimelineThumbImage({ blob, alt = '', ...props }: TimelineThumbImageProps) {
-  const stateRef = useRef<{ current: string | null; blob: Blob | null }>({
-    current: null,
-    blob: null,
-  })
+export function TimelineThumbImage(handle: Handle<TimelineThumbImageProps>) {
+  const binder = createBlobUrlBinder<HTMLImageElement>(() => handle.props.blob)
 
-  const setImgRef = useCallback<RefCallback<HTMLImageElement>>(
-    (element) => {
-      const state = stateRef.current
-      if (!element) {
-        if (state.current) URL.revokeObjectURL(state.current)
-        state.current = null
-        state.blob = null
-        return
-      }
-
-      if (state.blob !== blob || !state.current) {
-        if (state.current) URL.revokeObjectURL(state.current)
-        state.current = URL.createObjectURL(blob)
-        state.blob = blob
-      }
-
-      if (element.src !== state.current) {
-        element.src = state.current
-      }
-    },
-    [blob],
-  )
-
-  return <img {...props} alt={alt} ref={setImgRef} draggable={false} />
+  return () => {
+    const { blob: _blob, alt = '', mix, ...props } = handle.props
+    binder.sync()
+    return (
+      <img
+        {...props}
+        alt={alt}
+        draggable={false}
+        mix={[mix, ref((node, signal) => binder.attach(node as HTMLImageElement, signal))]}
+      />
+    )
+  }
 }

--- a/src/components/timeline.tsx
+++ b/src/components/timeline.tsx
@@ -198,8 +198,12 @@ export function Timeline(handle: Handle<TimelineProps>) {
     if (state.lifted) {
       const nextGap = gapFromX(event.clientX)
       state.gapIndex = nextGap
-      gapIndex = nextGap
-      void handle.update()
+      // Only an actual gap change re-renders the strip (pointer moves fire
+      // at sample rate; React's setState bail-out used to dedupe this).
+      if (gapIndex !== nextGap) {
+        gapIndex = nextGap
+        void handle.update()
+      }
       edgeAutoScroll(event.clientX)
       return
     }
@@ -307,6 +311,9 @@ export function Timeline(handle: Handle<TimelineProps>) {
                   ref((node, signal) => {
                     tileRefs.set(clip.id, node as HTMLButtonElement)
                     signal.addEventListener('abort', () => {
+                      // A replaced tile's late abort must not clobber the
+                      // entry its replacement just registered.
+                      if (tileRefs.get(clip.id) !== node) return
                       tileRefs.delete(clip.id)
                       // A tile removed mid-drag ends its drag session.
                       if (drag?.clipId === clip.id) clearDrag()

--- a/src/components/timeline.tsx
+++ b/src/components/timeline.tsx
@@ -1,4 +1,5 @@
-import { useCallback, useRef, useState, type PointerEvent as ReactPointerEvent } from 'react'
+import type { Handle } from 'remix/ui'
+import { on, ref } from 'remix/ui'
 import { reorderClips } from '../lib/storage'
 import {
   effectiveDurationMs,
@@ -36,31 +37,34 @@ export function tileWidthForClip(clip: ClipRecord): number {
   return Math.round(Math.min(MAX_TILE_WIDTH, Math.max(MIN_TILE_WIDTH, seconds * PX_PER_SECOND)))
 }
 
-export function Timeline({ projectId, clips, selectedClipId, onSelect, refresh }: TimelineProps) {
-  const [draggingId, setDraggingId] = useState<ClipId | null>(null)
-  const [gapIndex, setGapIndex] = useState<number | null>(null)
-  const trackRef = useRef<HTMLDivElement | null>(null)
-  const tileRefs = useRef(new Map<ClipId, HTMLButtonElement>())
-  const flingRafRef = useRef(0)
-  const dragRef = useRef<{
-    clipId: ClipId
-    startX: number
-    startY: number
-    startScrollLeft: number
-    fromIndex: number
-    pointerId: number
-    longPressTimer: ReturnType<typeof setTimeout> | null
-    lifted: boolean
-    /** Gesture turned into a drag-to-scroll (all pointer types). */
-    scrolling: boolean
-    gapIndex: number
-    /** Recent pointer samples for the release fling. */
-    samples: { t: number; x: number }[]
-  } | null>(null)
+interface DragState {
+  clipId: ClipId
+  startX: number
+  startY: number
+  startScrollLeft: number
+  fromIndex: number
+  pointerId: number
+  longPressTimer: ReturnType<typeof setTimeout> | null
+  lifted: boolean
+  /** Gesture turned into a drag-to-scroll (all pointer types). */
+  scrolling: boolean
+  gapIndex: number
+  /** Recent pointer samples for the release fling. */
+  samples: { t: number; x: number }[]
+}
+
+export function Timeline(handle: Handle<TimelineProps>) {
+  const { props } = handle
+  let draggingId: ClipId | null = null
+  let gapIndex: number | null = null
+  let trackEl: HTMLDivElement | null = null
+  const tileRefs = new Map<ClipId, HTMLButtonElement>()
+  let flingRaf = 0
+  let drag: DragState | null = null
 
   const selectClip = (id: ClipId) => {
-    onSelect(id)
-    const el = tileRefs.current.get(id)
+    props.onSelect(id)
+    const el = tileRefs.get(id)
     el?.scrollIntoView({ behavior: 'smooth', inline: 'nearest', block: 'nearest' })
   }
 
@@ -68,47 +72,35 @@ export function Timeline({ projectId, clips, selectedClipId, onSelect, refresh }
    * Open positioned at the selected clip (the most recent one by default) —
    * editing usually means checking or adjusting the last thing recorded, so
    * starting the strip at clip 1 constantly forced a scroll to the end.
-   * Runs once per mount; tile refs are already set (children bind first).
+   * Runs once per track mount; deferred a microtask so tile refs are set.
    */
-  const initialScrollDoneRef = useRef(false)
-  const selectedClipIdRef = useRef(selectedClipId)
-  selectedClipIdRef.current = selectedClipId
-  const bindTrack = useCallback((element: HTMLDivElement | null) => {
-    trackRef.current = element
-    if (!element) {
+  const bindTrack = (element: HTMLDivElement, signal: AbortSignal) => {
+    trackEl = element
+    signal.addEventListener('abort', () => {
       // The track detaches when the last clip is deleted (empty state) —
-      // re-arm so a later remount (undo) positions itself again.
-      initialScrollDoneRef.current = false
-      return
-    }
-    if (initialScrollDoneRef.current) return
-    initialScrollDoneRef.current = true
-    const selectedId = selectedClipIdRef.current
-    const target = selectedId ? tileRefs.current.get(selectedId) : null
-    if (!target) return
-    const delta =
-      target.getBoundingClientRect().right - element.getBoundingClientRect().right
-    // Align the selected clip toward the right edge (with a little padding)
-    // so the tail of the project is in view; clamp handles short strips.
-    element.scrollLeft = Math.max(0, delta + 12)
-  }, [])
-
-  if (clips.length === 0) {
-    return (
-      <div className="timeline" aria-label="Timeline empty">
-        <p className="timeline-empty muted">Hold the preview to add clips</p>
-      </div>
-    )
+      // a later remount (undo) positions itself again via a fresh bind.
+      if (trackEl === element) trackEl = null
+    })
+    queueMicrotask(() => {
+      if (signal.aborted) return
+      const selectedId = props.selectedClipId
+      const target = selectedId ? tileRefs.get(selectedId) : null
+      if (!target) return
+      const delta = target.getBoundingClientRect().right - element.getBoundingClientRect().right
+      // Align the selected clip toward the right edge (with a little padding)
+      // so the tail of the project is in view; clamp handles short strips.
+      element.scrollLeft = Math.max(0, delta + 12)
+    })
   }
 
   const stopFling = () => {
-    cancelAnimationFrame(flingRafRef.current)
-    flingRafRef.current = 0
+    cancelAnimationFrame(flingRaf)
+    flingRaf = 0
   }
 
   /** Continue a released swipe with decaying momentum. */
   const startFling = (samples: { t: number; x: number }[]) => {
-    const track = trackRef.current
+    const track = trackEl
     if (!track || samples.length < 2) return
     const last = samples[samples.length - 1]
     const first = samples[0]
@@ -126,25 +118,25 @@ export function Timeline({ projectId, clips, selectedClipId, onSelect, refresh }
       track.scrollLeft += velocity * elapsed
       velocity *= FLING_DECAY ** (elapsed / 16)
       if (Math.abs(velocity) >= FLING_MIN_VELOCITY) {
-        flingRafRef.current = requestAnimationFrame(tick)
+        flingRaf = requestAnimationFrame(tick)
       } else {
-        flingRafRef.current = 0
+        flingRaf = 0
       }
     }
-    flingRafRef.current = requestAnimationFrame(tick)
+    flingRaf = requestAnimationFrame(tick)
   }
 
   const clearDrag = () => {
-    const state = dragRef.current
-    if (state?.longPressTimer) clearTimeout(state.longPressTimer)
-    dragRef.current = null
-    setDraggingId(null)
-    setGapIndex(null)
+    if (drag?.longPressTimer) clearTimeout(drag.longPressTimer)
+    drag = null
+    draggingId = null
+    gapIndex = null
+    void handle.update()
   }
 
   /** Gap index in 0..clips.length (before tile i, or after the last tile). */
   const gapFromX = (clientX: number): number => {
-    const track = trackRef.current
+    const track = trackEl
     if (!track) return 0
     const tiles = Array.from(track.querySelectorAll<HTMLElement>('[data-clip-id]'))
     for (let i = 0; i < tiles.length; i++) {
@@ -155,32 +147,28 @@ export function Timeline({ projectId, clips, selectedClipId, onSelect, refresh }
   }
 
   const beginLift = (clipId: ClipId) => {
-    const state = dragRef.current
-    if (!state || state.clipId !== clipId || state.lifted || state.scrolling) return
-    state.lifted = true
-    state.gapIndex = state.fromIndex
-    setDraggingId(clipId)
-    setGapIndex(state.fromIndex)
+    if (!drag || drag.clipId !== clipId || drag.lifted || drag.scrolling) return
+    drag.lifted = true
+    drag.gapIndex = drag.fromIndex
+    draggingId = clipId
+    gapIndex = drag.fromIndex
+    void handle.update()
     navigator.vibrate?.(20)
   }
 
-  const onPointerDown = (
-    event: ReactPointerEvent<HTMLButtonElement>,
-    clip: ClipRecord,
-    index: number,
-  ) => {
+  const onPointerDown = (event: PointerEvent, clip: ClipRecord, index: number) => {
     if (event.button !== 0) return
     stopFling()
     // A previous session that never reached finishPointer (e.g. its tile
     // unmounted mid-drag) must not leak into this gesture.
-    if (dragRef.current) clearDrag()
-    event.currentTarget.setPointerCapture(event.pointerId)
+    if (drag) clearDrag()
+    ;(event.currentTarget as HTMLButtonElement).setPointerCapture(event.pointerId)
 
-    dragRef.current = {
+    drag = {
       clipId: clip.id,
       startX: event.clientX,
       startY: event.clientY,
-      startScrollLeft: trackRef.current?.scrollLeft ?? 0,
+      startScrollLeft: trackEl?.scrollLeft ?? 0,
       fromIndex: index,
       pointerId: event.pointerId,
       longPressTimer: setTimeout(() => beginLift(clip.id), LONG_PRESS_MS),
@@ -193,7 +181,7 @@ export function Timeline({ projectId, clips, selectedClipId, onSelect, refresh }
 
   /** Keep a lifted clip draggable to offscreen targets. */
   const edgeAutoScroll = (clientX: number) => {
-    const track = trackRef.current
+    const track = trackEl
     if (!track) return
     const rect = track.getBoundingClientRect()
     if (clientX < rect.left + EDGE_SCROLL_ZONE_PX) {
@@ -203,14 +191,15 @@ export function Timeline({ projectId, clips, selectedClipId, onSelect, refresh }
     }
   }
 
-  const onPointerMove = (event: ReactPointerEvent<HTMLButtonElement>) => {
-    const state = dragRef.current
+  const onPointerMove = (event: PointerEvent) => {
+    const state = drag
     if (!state || state.pointerId !== event.pointerId) return
 
     if (state.lifted) {
       const nextGap = gapFromX(event.clientX)
       state.gapIndex = nextGap
-      setGapIndex(nextGap)
+      gapIndex = nextGap
+      void handle.update()
       edgeAutoScroll(event.clientX)
       return
     }
@@ -229,18 +218,17 @@ export function Timeline({ projectId, clips, selectedClipId, onSelect, refresh }
     // Drive the scroll ourselves for every pointer type — relying on native
     // pan proved flaky on real Android devices, where the gesture could end
     // up neither scrolling nor cancelling.
-    const track = trackRef.current
-    if (track) track.scrollLeft = state.startScrollLeft - dx
+    if (trackEl) trackEl.scrollLeft = state.startScrollLeft - dx
     state.samples.push({ t: performance.now(), x: event.clientX })
     if (state.samples.length > 6) state.samples.shift()
   }
 
-  const finishPointer = (event: ReactPointerEvent<HTMLButtonElement>, cancelled: boolean) => {
-    const state = dragRef.current
+  const finishPointer = (event: PointerEvent, cancelled: boolean) => {
+    const state = drag
     if (!state || state.pointerId !== event.pointerId) return
 
     try {
-      event.currentTarget.releasePointerCapture(event.pointerId)
+      ;(event.currentTarget as HTMLButtonElement).releasePointerCapture(event.pointerId)
     } catch {
       /* already released */
     }
@@ -258,7 +246,7 @@ export function Timeline({ projectId, clips, selectedClipId, onSelect, refresh }
       return
     }
 
-    const nextIds = clips.map((c) => c.id)
+    const nextIds = props.clips.map((c) => c.id)
     const [removed] = nextIds.splice(fromIndex, 1)
     let insertAt = gap
     if (gap > fromIndex) insertAt = gap - 1
@@ -268,85 +256,94 @@ export function Timeline({ projectId, clips, selectedClipId, onSelect, refresh }
     }
     nextIds.splice(insertAt, 0, removed)
     selectClip(clipId)
-    void reorderClips(projectId, nextIds).then(refresh)
+    void reorderClips(props.projectId, nextIds).then(() => props.refresh())
   }
 
-  return (
-    <div
-      className={`timeline${draggingId !== null ? ' is-dragging' : ''}`}
-      role="listbox"
-      aria-label="Clip timeline"
-      ref={bindTrack}
-      onContextMenu={(event) => {
-        // Android long-press opens a context menu and cancels the pointer
-        // stream, which would kill the lift right as it begins.
-        event.preventDefault()
-      }}
-    >
-      {clips.map((clip, index) => {
-        const selected = clip.id === selectedClipId
-        const width = tileWidthForClip(clip)
-        const thumbs = clip.thumbs?.filter(Boolean) ?? []
-        const isDragging = draggingId === clip.id
-        const showDropBefore = draggingId !== null && gapIndex === index
+  return () => {
+    const { clips, selectedClipId } = props
 
-        return (
-          <div key={clip.id} className="timeline-slot">
-            {showDropBefore ? <div className="timeline-drop-indicator" aria-hidden /> : null}
-            <button
-              type="button"
-              className={`clip-thumb${selected ? ' selected' : ''}${isDragging ? ' lifting' : ''}`}
-              role="option"
-              aria-selected={selected}
-              aria-label={`Clip ${index + 1}, ${formatDuration(effectiveDurationMs(clip))}`}
-              data-clip-id={clip.id}
-              style={{ width }}
-              onPointerDown={(e) => onPointerDown(e, clip, index)}
-              onPointerMove={onPointerMove}
-              onPointerUp={(e) => finishPointer(e, false)}
-              onPointerCancel={(e) => finishPointer(e, true)}
-              onClick={(e) => {
-                e.preventDefault()
-              }}
-              ref={(el) => {
-                if (el) {
-                  tileRefs.current.set(clip.id, el)
-                } else {
-                  tileRefs.current.delete(clip.id)
-                  // Inline refs re-run on every render (null, then the new
-                  // element), so defer: only treat this as an unmount — and
-                  // end a drag session for a truly removed tile — if the
-                  // tile did not immediately re-register in the same commit.
-                  queueMicrotask(() => {
-                    if (!tileRefs.current.has(clip.id) && dragRef.current?.clipId === clip.id) {
-                      clearDrag()
-                    }
-                  })
-                }
-              }}
-            >
-              <div className="clip-filmstrip">
-                {thumbs.length > 0 ? (
-                  thumbs.map((thumb, thumbIndex) => (
-                    <TimelineThumbImage
-                      key={`${clip.id}-thumb-${thumbIndex}`}
-                      blob={thumb}
-                      className="clip-filmstrip-frame"
-                      alt=""
-                    />
-                  ))
-                ) : (
-                  <div className="clip-filmstrip-placeholder" aria-hidden />
-                )}
-              </div>
-              <span className="clip-dur">{formatDuration(effectiveDurationMs(clip))}</span>
-            </button>
-          </div>
-        )
-      })}
-      {draggingId !== null && gapIndex === clips.length ? (
-        <div className="timeline-drop-indicator timeline-drop-trailing" aria-hidden />
-      ) : null}
-    </div>
-  )
+    if (clips.length === 0) {
+      return (
+        <div key="timeline-empty" className="timeline" aria-label="Timeline empty">
+          <p className="timeline-empty muted">Hold the preview to add clips</p>
+        </div>
+      )
+    }
+
+    return (
+      <div
+        key="timeline-track"
+        className={`timeline${draggingId !== null ? ' is-dragging' : ''}`}
+        role="listbox"
+        aria-label="Clip timeline"
+        mix={[
+          ref((node, signal) => bindTrack(node as HTMLDivElement, signal)),
+          on('contextmenu', (event) => {
+            // Android long-press opens a context menu and cancels the pointer
+            // stream, which would kill the lift right as it begins.
+            event.preventDefault()
+          }),
+        ]}
+      >
+        {clips.map((clip, index) => {
+          const selected = clip.id === selectedClipId
+          const width = tileWidthForClip(clip)
+          const thumbs = clip.thumbs?.filter(Boolean) ?? []
+          const isDragging = draggingId === clip.id
+          const showDropBefore = draggingId !== null && gapIndex === index
+
+          return (
+            <div key={clip.id} className="timeline-slot">
+              {showDropBefore ? <div className="timeline-drop-indicator" aria-hidden /> : null}
+              <button
+                type="button"
+                className={`clip-thumb${selected ? ' selected' : ''}${isDragging ? ' lifting' : ''}`}
+                role="option"
+                aria-selected={selected}
+                aria-label={`Clip ${index + 1}, ${formatDuration(effectiveDurationMs(clip))}`}
+                data-clip-id={clip.id}
+                style={{ width: `${width}px` }}
+                mix={[
+                  ref((node, signal) => {
+                    tileRefs.set(clip.id, node as HTMLButtonElement)
+                    signal.addEventListener('abort', () => {
+                      tileRefs.delete(clip.id)
+                      // A tile removed mid-drag ends its drag session.
+                      if (drag?.clipId === clip.id) clearDrag()
+                    })
+                  }),
+                  on('pointerdown', (e) => onPointerDown(e, clip, index)),
+                  on('pointermove', (e) => onPointerMove(e)),
+                  on('pointerup', (e) => finishPointer(e, false)),
+                  on('pointercancel', (e) => finishPointer(e, true)),
+                  on('click', (e) => {
+                    e.preventDefault()
+                  }),
+                ]}
+              >
+                <div className="clip-filmstrip">
+                  {thumbs.length > 0 ? (
+                    thumbs.map((thumb, thumbIndex) => (
+                      <TimelineThumbImage
+                        key={`${clip.id}-thumb-${thumbIndex}`}
+                        blob={thumb}
+                        className="clip-filmstrip-frame"
+                        alt=""
+                      />
+                    ))
+                  ) : (
+                    <div className="clip-filmstrip-placeholder" aria-hidden />
+                  )}
+                </div>
+                <span className="clip-dur">{formatDuration(effectiveDurationMs(clip))}</span>
+              </button>
+            </div>
+          )
+        })}
+        {draggingId !== null && gapIndex === clips.length ? (
+          <div className="timeline-drop-indicator timeline-drop-trailing" aria-hidden />
+        ) : null}
+      </div>
+    )
+  }
 }

--- a/src/components/trim-strip.tsx
+++ b/src/components/trim-strip.tsx
@@ -1,4 +1,5 @@
-import { useRef, useState, type PointerEvent as ReactPointerEvent } from 'react'
+import type { Handle } from 'remix/ui'
+import { on } from 'remix/ui'
 import { formatDuration, type ClipRecord } from '../lib/types'
 import { TimelineThumbImage } from './timeline-thumb-image'
 
@@ -11,154 +12,165 @@ interface TrimStripProps {
   onCancel: () => void
 }
 
-export function TrimStrip({ clip, onSeek, onDone, onCancel }: TrimStripProps) {
-  const [startMs, setStartMs] = useState(clip.trimStartMs)
-  const [endMs, setEndMs] = useState(clip.trimEndMs)
-  const [saving, setSaving] = useState(false)
-  const [error, setError] = useState<string | null>(null)
-  const [activeHandle, setActiveHandle] = useState<'start' | 'end' | null>(null)
-  const rangeRef = useRef({ startMs: clip.trimStartMs, endMs: clip.trimEndMs })
+export function TrimStrip(handle: Handle<TrimStripProps>) {
+  const { props } = handle
+  let startMs = props.clip.trimStartMs
+  let endMs = props.clip.trimEndMs
+  let saving = false
+  let error: string | null = null
+  let activeHandle: 'start' | 'end' | null = null
 
-  const duration = Math.max(1, clip.durationMs)
-  const keptMs = Math.max(0, endMs - startMs)
-  const thumbs = clip.thumbs?.filter(Boolean) ?? []
-  const startPct = (startMs / duration) * 100
-  const endPct = (endMs / duration) * 100
+  const duration = () => Math.max(1, props.clip.durationMs)
 
   const msFromClientX = (clientX: number, strip: HTMLElement) => {
     const rect = strip.getBoundingClientRect()
     if (rect.width <= 0) return 0
     const ratio = Math.min(1, Math.max(0, (clientX - rect.left) / rect.width))
-    return Math.round(ratio * duration)
+    return Math.round(ratio * duration())
   }
 
-  const bindHandle = (which: 'start' | 'end') => (event: ReactPointerEvent<HTMLButtonElement>) => {
+  const startHandleDrag = (which: 'start' | 'end', event: PointerEvent) => {
     if (event.button !== 0) return
     event.preventDefault()
     event.stopPropagation()
-    const handle = event.currentTarget
-    const strip = handle.closest('.trim-strip-track') as HTMLElement | null
+    const dragHandle = event.currentTarget as HTMLButtonElement
+    const strip = dragHandle.closest('.trim-strip-track') as HTMLElement | null
     if (!strip) return
 
-    handle.setPointerCapture(event.pointerId)
-    setActiveHandle(which)
+    dragHandle.setPointerCapture(event.pointerId)
+    activeHandle = which
+    void handle.update()
 
     const onMove = (ev: PointerEvent) => {
       const next = msFromClientX(ev.clientX, strip)
-      const { startMs: curStart, endMs: curEnd } = rangeRef.current
       if (which === 'start') {
-        const clamped = Math.max(0, Math.min(next, curEnd - MIN_GAP_MS))
-        rangeRef.current = { startMs: clamped, endMs: curEnd }
-        setStartMs(clamped)
-        onSeek(clamped)
+        startMs = Math.max(0, Math.min(next, endMs - MIN_GAP_MS))
+        props.onSeek(startMs)
       } else {
-        const clamped = Math.min(duration, Math.max(next, curStart + MIN_GAP_MS))
-        rangeRef.current = { startMs: curStart, endMs: clamped }
-        setEndMs(clamped)
-        onSeek(clamped)
+        endMs = Math.min(duration(), Math.max(next, startMs + MIN_GAP_MS))
+        props.onSeek(endMs)
       }
+      void handle.update()
     }
 
     const onUp = (ev: PointerEvent) => {
       try {
-        handle.releasePointerCapture(ev.pointerId)
+        dragHandle.releasePointerCapture(ev.pointerId)
       } catch {
         /* already released */
       }
-      handle.removeEventListener('pointermove', onMove)
-      handle.removeEventListener('pointerup', onUp)
-      handle.removeEventListener('pointercancel', onUp)
-      setActiveHandle(null)
+      dragHandle.removeEventListener('pointermove', onMove)
+      dragHandle.removeEventListener('pointerup', onUp)
+      dragHandle.removeEventListener('pointercancel', onUp)
+      activeHandle = null
+      void handle.update()
     }
 
-    handle.addEventListener('pointermove', onMove)
-    handle.addEventListener('pointerup', onUp)
-    handle.addEventListener('pointercancel', onUp)
+    dragHandle.addEventListener('pointermove', onMove)
+    dragHandle.addEventListener('pointerup', onUp)
+    dragHandle.addEventListener('pointercancel', onUp)
 
-    onSeek(which === 'start' ? rangeRef.current.startMs : rangeRef.current.endMs)
+    props.onSeek(which === 'start' ? startMs : endMs)
   }
 
-  return (
-    <div className="trim-strip" role="group" aria-label="Trim clip">
-      <div className="trim-strip-meta">
-        <span className="trim-kept-label">{formatDuration(keptMs)} kept</span>
-        {error ? <span className="trim-error">{error}</span> : null}
-      </div>
+  const onDoneClick = () => {
+    void (async () => {
+      if (!(endMs > startMs)) {
+        error = 'End must be after start.'
+        void handle.update()
+        return
+      }
+      saving = true
+      error = null
+      void handle.update()
+      try {
+        await props.onDone(Math.round(startMs), Math.round(endMs))
+      } catch (err) {
+        error = err instanceof Error ? err.message : 'Could not save trim'
+        saving = false
+        void handle.update()
+      }
+    })()
+  }
 
-      <div className="trim-strip-track">
-        <div className="trim-strip-filmstrip" aria-hidden>
-          {thumbs.length > 0 ? (
-            thumbs.map((thumb, index) => (
-              <TimelineThumbImage
-                key={`${clip.id}-trim-thumb-${index}`}
-                blob={thumb}
-                className="trim-strip-frame"
-                alt=""
-              />
-            ))
-          ) : (
-            <div className="clip-filmstrip-placeholder" />
-          )}
+  return () => {
+    const clip = props.clip
+    const keptMs = Math.max(0, endMs - startMs)
+    const thumbs = clip.thumbs?.filter(Boolean) ?? []
+    const startPct = (startMs / duration()) * 100
+    const endPct = (endMs / duration()) * 100
+
+    return (
+      <div className="trim-strip" role="group" aria-label="Trim clip">
+        <div className="trim-strip-meta">
+          <span className="trim-kept-label">{formatDuration(keptMs)} kept</span>
+          {error ? <span className="trim-error">{error}</span> : null}
         </div>
 
-        <div className="trim-dim trim-dim-left" style={{ width: `${startPct}%` }} aria-hidden />
-        <div
-          className="trim-dim trim-dim-right"
-          style={{ width: `${100 - endPct}%` }}
-          aria-hidden
-        />
+        <div className="trim-strip-track">
+          <div className="trim-strip-filmstrip" aria-hidden>
+            {thumbs.length > 0 ? (
+              thumbs.map((thumb, index) => (
+                <TimelineThumbImage
+                  key={`${clip.id}-trim-thumb-${index}`}
+                  blob={thumb}
+                  className="trim-strip-frame"
+                  alt=""
+                />
+              ))
+            ) : (
+              <div className="clip-filmstrip-placeholder" />
+            )}
+          </div>
 
-        <div
-          className="trim-selection"
-          style={{ left: `${startPct}%`, width: `${Math.max(0, endPct - startPct)}%` }}
-          aria-hidden
-        />
+          <div className="trim-dim trim-dim-left" style={{ width: `${startPct}%` }} aria-hidden />
+          <div
+            className="trim-dim trim-dim-right"
+            style={{ width: `${100 - endPct}%` }}
+            aria-hidden
+          />
 
-        <button
-          type="button"
-          className={`trim-handle trim-handle-left${activeHandle === 'start' ? ' active' : ''}`}
-          style={{ left: `${startPct}%` }}
-          aria-label="Trim start"
-          onPointerDown={bindHandle('start')}
-        />
-        <button
-          type="button"
-          className={`trim-handle trim-handle-right${activeHandle === 'end' ? ' active' : ''}`}
-          style={{ left: `${endPct}%` }}
-          aria-label="Trim end"
-          onPointerDown={bindHandle('end')}
-        />
+          <div
+            className="trim-selection"
+            style={{ left: `${startPct}%`, width: `${Math.max(0, endPct - startPct)}%` }}
+            aria-hidden
+          />
+
+          <button
+            type="button"
+            className={`trim-handle trim-handle-left${activeHandle === 'start' ? ' active' : ''}`}
+            style={{ left: `${startPct}%` }}
+            aria-label="Trim start"
+            mix={on('pointerdown', (event) => startHandleDrag('start', event))}
+          />
+          <button
+            type="button"
+            className={`trim-handle trim-handle-right${activeHandle === 'end' ? ' active' : ''}`}
+            style={{ left: `${endPct}%` }}
+            aria-label="Trim end"
+            mix={on('pointerdown', (event) => startHandleDrag('end', event))}
+          />
+        </div>
+
+        <div className="trim-strip-actions">
+          <button
+            type="button"
+            className="btn btn-ghost"
+            disabled={saving}
+            mix={on('click', () => props.onCancel())}
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            className="btn btn-primary"
+            disabled={saving}
+            mix={on('click', onDoneClick)}
+          >
+            {saving ? 'Saving…' : 'Done'}
+          </button>
+        </div>
       </div>
-
-      <div className="trim-strip-actions">
-        <button type="button" className="btn btn-ghost" disabled={saving} onClick={onCancel}>
-          Cancel
-        </button>
-        <button
-          type="button"
-          className="btn btn-primary"
-          disabled={saving}
-          onClick={() => {
-            void (async () => {
-              const { startMs: s, endMs: e } = rangeRef.current
-              if (!(e > s)) {
-                setError('End must be after start.')
-                return
-              }
-              setSaving(true)
-              setError(null)
-              try {
-                await onDone(Math.round(s), Math.round(e))
-              } catch (err) {
-                setError(err instanceof Error ? err.message : 'Could not save trim')
-                setSaving(false)
-              }
-            })()
-          }}
-        >
-          {saving ? 'Saving…' : 'Done'}
-        </button>
-      </div>
-    </div>
-  )
+    )
+  }
 }

--- a/src/components/upsell-sheet.tsx
+++ b/src/components/upsell-sheet.tsx
@@ -1,4 +1,6 @@
-import { useSheetModal } from '../hooks/use-sheet-modal'
+import type { Handle } from 'remix/ui'
+import { on, ref } from 'remix/ui'
+import { attachSheetModal } from '../lib/sheet-modal'
 import { REMOVE_WATERMARK_LINK } from '../lib/entitlement'
 import { MAX_PROJECTS } from '../lib/types'
 
@@ -9,44 +11,53 @@ interface UpsellSheetProps {
 }
 
 /** The one-time Kody Video Plus purchase: watermark removal + more projects. */
-export function UpsellSheet({ onClose, onRestore }: UpsellSheetProps) {
-  const bindSheet = useSheetModal({ onDismiss: onClose })
-
-  return (
-    <>
-      <div className="sheet-backdrop" onClick={onClose} />
-      <div
-        className="sheet"
-        role="dialog"
-        aria-modal="true"
-        aria-label="Kody Video Plus"
-        ref={bindSheet}
-      >
-        <h3>Kody Video Plus</h3>
-        <p className="sheet-copy">
-          The free plan includes 1 project. Plus is a one-time $0.99 purchase that unlocks{' '}
-          {MAX_PROJECTS} project slots and removes the watermark from exports — forever, on this
-          device and any device you restore it on.
-        </p>
-        <div className="sheet-actions">
-          <button type="button" className="btn btn-ghost" onClick={onClose}>
-            Not now
-          </button>
+export function UpsellSheet(handle: Handle<UpsellSheetProps>) {
+  return () => {
+    const { onClose, onRestore } = handle.props
+    return (
+      <>
+        <div className="sheet-backdrop" mix={on('click', () => onClose())} />
+        <div
+          className="sheet"
+          role="dialog"
+          aria-modal="true"
+          aria-label="Kody Video Plus"
+          mix={ref((node, signal) =>
+            attachSheetModal(node as HTMLElement, signal, {
+              onDismiss: () => handle.props.onClose(),
+            }),
+          )}
+        >
+          <h3>Kody Video Plus</h3>
+          <p className="sheet-copy">
+            The free plan includes 1 project. Plus is a one-time $0.99 purchase that unlocks{' '}
+            {MAX_PROJECTS} project slots and removes the watermark from exports — forever, on this
+            device and any device you restore it on.
+          </p>
+          <div className="sheet-actions">
+            <button type="button" className="btn btn-ghost" mix={on('click', () => onClose())}>
+              Not now
+            </button>
+            <button
+              type="button"
+              className="btn btn-primary"
+              mix={on('click', () => {
+                window.open(REMOVE_WATERMARK_LINK, '_blank', 'noopener')
+                handle.props.onClose()
+              })}
+            >
+              Get Plus — $0.99
+            </button>
+          </div>
           <button
             type="button"
-            className="btn btn-primary"
-            onClick={() => {
-              window.open(REMOVE_WATERMARK_LINK, '_blank', 'noopener')
-              onClose()
-            }}
+            className="link-button sheet-footnote"
+            mix={on('click', () => onRestore())}
           >
-            Get Plus — $0.99
+            Already paid? Restore your purchase
           </button>
         </div>
-        <button type="button" className="link-button sheet-footnote" onClick={onRestore}>
-          Already paid? Restore your purchase
-        </button>
-      </div>
-    </>
-  )
+      </>
+    )
+  }
 }

--- a/src/lib/blob-url.ts
+++ b/src/lib/blob-url.ts
@@ -1,27 +1,40 @@
-/** Create an object URL and revoke it when the owning element unmounts or the blob changes. */
-export function bindBlobUrl(
-  element: HTMLMediaElement | null,
-  blob: Blob,
-  state: { current: string | null; blob: Blob | null },
-): void {
-  if (!element) {
-    if (state.current) {
-      URL.revokeObjectURL(state.current)
+/**
+ * Keep a media/img element's `src` bound to a Blob via object URL.
+ *
+ * Returns a small binder whose `attach` is designed for the `ref()` mixin
+ * (bind on insert, revoke on removal via the abort signal) and whose `sync`
+ * re-binds when the blob identity changes between renders.
+ */
+export function createBlobUrlBinder<E extends HTMLElement & { src: string }>(
+  getBlob: () => Blob,
+) {
+  let element: E | null = null
+  let url: string | null = null
+  let boundBlob: Blob | null = null
+
+  function sync(): void {
+    if (!element) return
+    const blob = getBlob()
+    if (boundBlob !== blob || !url) {
+      if (url) URL.revokeObjectURL(url)
+      url = URL.createObjectURL(blob)
+      boundBlob = blob
     }
-    state.current = null
-    state.blob = null
-    return
+    if (element.src !== url) {
+      element.src = url
+    }
   }
 
-  if (state.blob !== blob || !state.current) {
-    if (state.current) {
-      URL.revokeObjectURL(state.current)
-    }
-    state.current = URL.createObjectURL(blob)
-    state.blob = blob
+  function attach(node: E, signal: AbortSignal): void {
+    element = node
+    sync()
+    signal.addEventListener('abort', () => {
+      if (url) URL.revokeObjectURL(url)
+      element = null
+      url = null
+      boundBlob = null
+    })
   }
 
-  if (element.src !== state.current) {
-    element.src = state.current
-  }
+  return { attach, sync }
 }

--- a/src/lib/camera.ts
+++ b/src/lib/camera.ts
@@ -1,5 +1,4 @@
-import { useCallback, useRef, useState, type RefCallback } from 'react'
-import { engageRecordAudioSession, releaseRecordAudioSession } from '../lib/audio-session'
+import { engageRecordAudioSession, releaseRecordAudioSession } from './audio-session'
 import {
   canFlipCamera,
   isIosBrowser,
@@ -14,7 +13,7 @@ import {
   stopStream,
   type CameraPermissionState,
   type FacingMode,
-} from '../lib/media'
+} from './media'
 
 /**
  * iOS Safari is known to deliver muted (silent-but-live) audio tracks when
@@ -95,8 +94,22 @@ export interface CameraZoomRange {
   value: number
 }
 
-export interface UseCameraResult {
-  videoRef: RefCallback<HTMLVideoElement>
+interface ZoomCapability {
+  min?: number
+  max?: number
+  step?: number
+}
+
+interface ExtendedCapabilities extends MediaTrackCapabilities {
+  zoom?: ZoomCapability
+  torch?: boolean
+}
+
+interface ExtendedSettings extends MediaTrackSettings {
+  zoom?: number
+}
+
+export interface Camera {
   stream: MediaStream | null
   facing: FacingMode
   permission: CameraPermissionState
@@ -113,6 +126,8 @@ export interface UseCameraResult {
   rearLensCount: number
   /** Index of the active rear lens, when facing the environment. */
   rearLensIndex: number
+  /** Attach the preview element (from a `ref()` mixin); starts the camera. */
+  attachVideo: (element: HTMLVideoElement, signal: AbortSignal) => void
   /** Cycle to the next rear lens (no-op while facing the user). */
   switchRearLens: () => Promise<void>
   start: () => Promise<void>
@@ -122,168 +137,162 @@ export interface UseCameraResult {
   setTorch: (on: boolean) => Promise<void>
   enableMic: () => Promise<void>
   releaseMic: () => void
-  /** Latest live stream from the ref (safer than React state after awaits). */
   getStream: () => MediaStream | null
   /** The live preview element — for zero-cost frame capture at take end. */
   getVideoElement: () => HTMLVideoElement | null
-  /** Latest zoom range from the ref (safe to read right after awaits). */
   getZoom: () => CameraZoomRange | null
 }
 
-interface ZoomCapability {
-  min?: number
-  max?: number
-  step?: number
-}
-
-interface ExtendedCapabilities extends MediaTrackCapabilities {
-  zoom?: ZoomCapability
-  torch?: boolean
-}
-
-interface ExtendedSettings extends MediaTrackSettings {
-  zoom?: number
-}
-
 /**
- * Camera lifecycle is event/ref-driven (no useEffect):
- * - Video ref callback attaches/detaches the stream and starts capture when mounted.
+ * Camera lifecycle is event/ref-driven:
+ * - attachVideo (via a `ref()` mixin) attaches/detaches the stream and starts
+ *   capture when the preview mounts; its abort signal stops the camera.
  * - Preview is video-only so Android OS voice-to-text can keep the mic;
  *   enableMic/releaseMic attach a mic track only while recording.
  * - Except iOS: mic comes with the camera in one combined call and stays for
  *   the preview's lifetime (see HOLD_MIC_WITH_CAMERA).
+ *
+ * State lives as plain fields; `notify` asks the owning component to rerender.
  */
-export function useCamera(): UseCameraResult {
-  const streamRef = useRef<MediaStream | null>(null)
-  const videoElRef = useRef<HTMLVideoElement | null>(null)
-  const facingRef = useRef<FacingMode>('environment')
-  const startInFlightRef = useRef<Promise<void> | null>(null)
-  const micInFlightRef = useRef<Promise<void> | null>(null)
-
-  const [stream, setStream] = useState<MediaStream | null>(null)
-  const [facing, setFacing] = useState<FacingMode>('environment')
-  const [permission, setPermission] = useState<CameraPermissionState>({ status: 'unknown' })
-  const [canFlip, setCanFlip] = useState(false)
-  const [error, setError] = useState<string | null>(null)
-  const [isReady, setIsReady] = useState(false)
-  const [zoom, setZoomState] = useState<CameraZoomRange | null>(null)
-  const [torchAvailable, setTorchAvailable] = useState(false)
-  const [torchOn, setTorchOn] = useState(false)
-  const [micPermission, setMicPermission] = useState<'granted' | 'denied' | 'unknown'>('unknown')
-  const micPrimedRef = useRef(false)
-  const [rearLensCount, setRearLensCount] = useState(0)
-  const [rearLensIndex, setRearLensIndex] = useState(0)
-  const rearLensesRef = useRef<string[]>([])
-  const rearLensIndexRef = useRef(0)
-  const lensSwitchInFlightRef = useRef(false)
+export function createCamera(notify: () => void): Camera {
+  let videoEl: HTMLVideoElement | null = null
+  /** Facing intent — updated before the async open; `camera.facing` (which
+   * drives the preview's mirror transform) only flips once the new stream is
+   * in hand, so mirror and feed swap together. */
+  let facingIntent: FacingMode = 'environment'
+  let startInFlight: Promise<void> | null = null
+  let micInFlight: Promise<void> | null = null
+  let micPrimed = false
+  let rearLenses: string[] = []
+  let lensSwitchInFlight = false
   /** Bumped by stop(): async opens started before a stop must not adopt. */
-  const cameraEpochRef = useRef(0)
+  let cameraEpoch = 0
+  let zoomNotifyTimer = 0
 
-  const zoomRangeRef = useRef<CameraZoomRange | null>(null)
-  const zoomSyncTimerRef = useRef(0)
+  const camera: Camera = {
+    stream: null,
+    facing: 'environment',
+    permission: { status: 'unknown' },
+    canFlip: false,
+    error: null,
+    isReady: false,
+    zoom: null,
+    torchAvailable: false,
+    torchOn: false,
+    micPermission: 'unknown',
+    rearLensCount: 0,
+    rearLensIndex: 0,
+    attachVideo,
+    switchRearLens,
+    start,
+    flip,
+    stop,
+    setZoom,
+    setTorch,
+    enableMic,
+    releaseMic,
+    getStream: () => camera.stream,
+    getVideoElement: () => videoEl,
+    getZoom: () => camera.zoom,
+  }
 
-  const applyZoomState = useCallback((next: CameraZoomRange | null) => {
-    window.clearTimeout(zoomSyncTimerRef.current)
-    zoomSyncTimerRef.current = 0
-    zoomRangeRef.current = next
-    setZoomState(next)
-  }, [])
+  function setZoomRange(next: CameraZoomRange | null): void {
+    window.clearTimeout(zoomNotifyTimer)
+    zoomNotifyTimer = 0
+    camera.zoom = next
+  }
 
-  const attachToVideo = useCallback((next: MediaStream) => {
-    const video = videoElRef.current
-    if (!video) return
-    video.srcObject = next
-    void video.play().catch(() => undefined)
-  }, [])
+  function attachToVideo(next: MediaStream): void {
+    if (!videoEl) return
+    videoEl.srcObject = next
+    void videoEl.play().catch(() => undefined)
+  }
 
-  const readTrackCapabilities = useCallback(
-    (next: MediaStream) => {
-      const track = next.getVideoTracks()[0]
-      if (!track || typeof track.getCapabilities !== 'function') {
-        applyZoomState(null)
-        setTorchAvailable(false)
-        setTorchOn(false)
-        return
+  function readTrackCapabilities(next: MediaStream): void {
+    const track = next.getVideoTracks()[0]
+    if (!track || typeof track.getCapabilities !== 'function') {
+      setZoomRange(null)
+      camera.torchAvailable = false
+      camera.torchOn = false
+      return
+    }
+    try {
+      const caps = track.getCapabilities() as ExtendedCapabilities
+      if (caps.zoom && typeof caps.zoom.min === 'number' && typeof caps.zoom.max === 'number') {
+        const settings = track.getSettings() as ExtendedSettings
+        setZoomRange({
+          min: caps.zoom.min,
+          max: caps.zoom.max,
+          step: caps.zoom.step && caps.zoom.step > 0 ? caps.zoom.step : 0.1,
+          value: typeof settings.zoom === 'number' ? settings.zoom : caps.zoom.min,
+        })
+      } else {
+        setZoomRange(null)
       }
-      try {
-        const caps = track.getCapabilities() as ExtendedCapabilities
-        if (caps.zoom && typeof caps.zoom.min === 'number' && typeof caps.zoom.max === 'number') {
-          const settings = track.getSettings() as ExtendedSettings
-          applyZoomState({
-            min: caps.zoom.min,
-            max: caps.zoom.max,
-            step: caps.zoom.step && caps.zoom.step > 0 ? caps.zoom.step : 0.1,
-            value: typeof settings.zoom === 'number' ? settings.zoom : caps.zoom.min,
-          })
-        } else {
-          applyZoomState(null)
-        }
-        setTorchAvailable(caps.torch === true)
-        setTorchOn(false)
-      } catch {
-        applyZoomState(null)
-        setTorchAvailable(false)
-        setTorchOn(false)
-      }
-    },
-    [applyZoomState],
-  )
+      camera.torchAvailable = caps.torch === true
+      camera.torchOn = false
+    } catch {
+      setZoomRange(null)
+      camera.torchAvailable = false
+      camera.torchOn = false
+    }
+  }
 
-  const replaceStream = useCallback(
-    (next: MediaStream) => {
-      const hadMic = (streamRef.current?.getAudioTracks().length ?? 0) > 0
-      stopStream(streamRef.current)
-      streamRef.current = next
-      setStream(next)
-      attachToVideo(next)
-      readTrackCapabilities(next)
-      // iOS: every (re)open is a combined request, so the adopted stream's
-      // audio presence is the freshest mic-permission signal — including
-      // after flips and lens switches. A missing track is NOT proof of a
-      // denial though (the combined open also falls back on transient
-      // failures) — only the Permissions API may claim "blocked".
-      if (HOLD_MIC_WITH_CAMERA) {
-        if (next.getAudioTracks().length > 0) {
-          setMicPermission('granted')
-          // External mics (DJI transmitters, AirPods, wired headsets): iOS
-          // only routes capture to them after this post-grant audio-session
-          // kick — see audio-session.ts. Must run AFTER getUserMedia
-          // resolved.
-          engageRecordAudioSession()
-        } else {
-          // A combined reopen can fall back to video-only (mic mid-flip
-          // failure) — a sticky play-and-record session with no mic held
-          // would degrade playback until the camera fully stops.
-          if (hadMic) releaseRecordAudioSession()
-          void queryMicrophonePermission().then(setMicPermission)
-        }
+  function replaceStream(next: MediaStream): void {
+    const hadMic = (camera.stream?.getAudioTracks().length ?? 0) > 0
+    stopStream(camera.stream)
+    camera.stream = next
+    attachToVideo(next)
+    readTrackCapabilities(next)
+    // iOS: every (re)open is a combined request, so the adopted stream's
+    // audio presence is the freshest mic-permission signal — including
+    // after flips and lens switches. A missing track is NOT proof of a
+    // denial though (the combined open also falls back on transient
+    // failures) — only the Permissions API may claim "blocked".
+    if (HOLD_MIC_WITH_CAMERA) {
+      if (next.getAudioTracks().length > 0) {
+        camera.micPermission = 'granted'
+        // External mics (DJI transmitters, AirPods, wired headsets): iOS
+        // only routes capture to them after this post-grant audio-session
+        // kick — see audio-session.ts. Must run AFTER getUserMedia resolved.
+        engageRecordAudioSession()
+      } else {
+        // A combined reopen can fall back to video-only (mic mid-flip
+        // failure) — a sticky play-and-record session with no mic held
+        // would degrade playback until the camera fully stops.
+        if (hadMic) releaseRecordAudioSession()
+        void queryMicrophonePermission().then((state) => {
+          camera.micPermission = state
+          notify()
+        })
       }
-      setIsReady(true)
-    },
-    [attachToVideo, readTrackCapabilities],
-  )
+    }
+    camera.isReady = true
+    notify()
+  }
 
   /** Discover rear lenses and locate the active one (post-permission only).
    * Not on iOS: the OS handles lens switching through the virtual composite
    * camera's zoom range, and offering six raw devices (physical lenses plus
    * composites) as a cycling chip is confusing noise there. */
-  const syncRearLenses = useCallback(async (active: MediaStream) => {
-    if (facingRef.current !== 'environment' || isIosBrowser()) {
-      rearLensesRef.current = []
-      setRearLensCount(0)
-      setRearLensIndex(0)
+  async function syncRearLenses(active: MediaStream): Promise<void> {
+    if (facingIntent !== 'environment' || isIosBrowser()) {
+      rearLenses = []
+      camera.rearLensCount = 0
+      camera.rearLensIndex = 0
+      notify()
       return
     }
     const lenses = await listRearCameras()
     // A flip/stop/switch may have replaced the stream while enumerating —
     // stale results must not clobber the newer call's state.
-    if (streamRef.current !== active || facingRef.current !== 'environment') return
-    rearLensesRef.current = lenses
-    setRearLensCount(lenses.length)
+    if (camera.stream !== active || facingIntent !== 'environment') return
+    rearLenses = lenses
+    camera.rearLensCount = lenses.length
     const activeId = active.getVideoTracks()[0]?.getSettings().deviceId ?? ''
     const index = lenses.indexOf(activeId)
-    rearLensIndexRef.current = index >= 0 ? index : 0
-    setRearLensIndex(index >= 0 ? index : 0)
+    camera.rearLensIndex = index >= 0 ? index : 0
+    notify()
 
     // Seamless multi-lens discovery: a rear lens whose zoom range reaches
     // below 1× is Android's logical multi-camera — the HAL hands off
@@ -294,7 +303,7 @@ export function useCamera(): UseCameraResult {
     // land in this path incidentally too (getUserMedia fallbacks), and the
     // user's explicit pick must survive those. The chip's own switch
     // handler re-locks the logical lens when the user returns to it.
-    const zoomRange = zoomRangeRef.current
+    const zoomRange = camera.zoom
     if (zoomRange && zoomRange.min < 1 && activeId && index >= 0) {
       const remembered = rememberedRearLens()
       const rememberedValid = remembered !== null && lenses.includes(remembered.id)
@@ -302,41 +311,43 @@ export function useCamera(): UseCameraResult {
         rememberRearLens({ id: activeId, index })
       }
     }
-  }, [])
+  }
 
-  const start = useCallback(async () => {
-    if (startInFlightRef.current) {
-      await startInFlightRef.current
+  async function start(): Promise<void> {
+    if (startInFlight) {
+      await startInFlight
       return
     }
 
     const run = (async () => {
-      setError(null)
+      camera.error = null
       const perm = await queryCameraPermission()
-      setPermission(perm)
+      camera.permission = perm
+      notify()
       if (perm.status === 'unsupported') {
-        setError(perm.message ?? 'Camera unsupported')
+        camera.error = perm.message ?? 'Camera unsupported'
+        notify()
         return
       }
 
       try {
         const rememberedLens =
-          facingRef.current === 'environment' ? await resolveRearLens() : undefined
-        let next = await openCombinedOrVideoStream(facingRef.current, rememberedLens)
-        setPermission({ status: 'granted' })
+          facingIntent === 'environment' ? await resolveRearLens() : undefined
+        let next = await openCombinedOrVideoStream(facingIntent, rememberedLens)
+        camera.permission = { status: 'granted' }
         // iOS first run: device labels are empty before the permission grant,
         // so the preferred multi-lens camera can't be resolved until now.
         // Re-resolve and reopen once so 0.5× works from the very first
         // session, not just after a restart.
-        if (isIosBrowser() && !rememberedLens && facingRef.current === 'environment') {
+        if (isIosBrowser() && !rememberedLens && facingIntent === 'environment') {
           const preferred = await preferredIosRearCameraId()
           const activeId = next.getVideoTracks()[0]?.getSettings().deviceId
           if (preferred && preferred !== activeId) {
-            const epoch = cameraEpochRef.current
+            const epoch = cameraEpoch
             // iOS camera access is exclusive — release before reopening.
             stopStream(next)
-            const reopened = await openCombinedOrVideoStream(facingRef.current, preferred)
-            if (cameraEpochRef.current !== epoch) {
+            const reopened = await openCombinedOrVideoStream(facingIntent, preferred)
+            if (cameraEpoch !== epoch) {
               stopStream(reopened)
               return
             }
@@ -344,7 +355,8 @@ export function useCamera(): UseCameraResult {
           }
         }
         replaceStream(next)
-        setCanFlip(await canFlipCamera())
+        camera.canFlip = await canFlipCamera()
+        notify()
         void syncRearLenses(next)
         // Mic permission priming (see primeMicrophonePermission): asking
         // mid-hold is silently denied by some browsers (Brave/Android never
@@ -353,81 +365,81 @@ export function useCamera(): UseCameraResult {
         // interrupted by backgrounding) so the next camera start retries.
         // Not on iOS: the mic came with the combined camera request, and a
         // separate audio-only call is the muted-track pattern to avoid.
-        if (!micPrimedRef.current && !HOLD_MIC_WITH_CAMERA) {
-          micPrimedRef.current = true
+        if (!micPrimed && !HOLD_MIC_WITH_CAMERA) {
+          micPrimed = true
           void primeMicrophonePermission().then((state) => {
-            setMicPermission(state)
-            if (state === 'unknown') micPrimedRef.current = false
+            camera.micPermission = state
+            if (state === 'unknown') micPrimed = false
+            notify()
           })
         }
       } catch (err) {
         const message = permissionMessage(err)
-        setPermission({ status: 'denied', message })
-        setError(message)
-        setIsReady(false)
+        camera.permission = { status: 'denied', message }
+        camera.error = message
+        camera.isReady = false
+        notify()
       }
     })()
 
-    startInFlightRef.current = run
+    startInFlight = run
     try {
       await run
     } finally {
-      startInFlightRef.current = null
+      startInFlight = null
     }
-  }, [replaceStream])
+  }
 
-  const flip = useCallback(async () => {
-    const previousFacing = facingRef.current
+  async function flip(): Promise<void> {
+    const previousFacing = facingIntent
     const nextFacing: FacingMode = previousFacing === 'environment' ? 'user' : 'environment'
-    facingRef.current = nextFacing
-    setError(null)
+    facingIntent = nextFacing
+    camera.error = null
     try {
-      const rememberedLens =
-        nextFacing === 'environment' ? await resolveRearLens() : undefined
+      const rememberedLens = nextFacing === 'environment' ? await resolveRearLens() : undefined
       const next = await openCombinedOrVideoStream(nextFacing, rememberedLens)
-      // The facing STATE (which drives the preview's mirror transform)
+      // The rendered facing (which drives the preview's mirror transform)
       // changes only once the new stream is in hand: setting it up front
       // mirrored the still-showing old feed for the whole camera warm-up.
-      // Both updates land in one React commit, so mirror and feed swap
-      // together.
-      setFacing(nextFacing)
+      camera.facing = nextFacing
       replaceStream(next)
       void syncRearLenses(next)
     } catch (err) {
-      facingRef.current = previousFacing
-      setFacing(previousFacing)
-      setError(permissionMessage(err))
+      facingIntent = previousFacing
+      camera.facing = previousFacing
+      camera.error = permissionMessage(err)
+      notify()
     }
-  }, [replaceStream, syncRearLenses])
+  }
 
-  const switchRearLens = useCallback(async () => {
-    const lenses = rearLensesRef.current
-    if (facingRef.current !== 'environment' || lenses.length < 2) return
+  async function switchRearLens(): Promise<void> {
+    const lenses = rearLenses
+    if (facingIntent !== 'environment' || lenses.length < 2) return
     // No live stream means the camera is stopped or restarting — switching
     // now would open a camera behind that lifecycle's back.
-    if (!streamRef.current) return
-    if (lensSwitchInFlightRef.current) return
-    lensSwitchInFlightRef.current = true
+    if (!camera.stream) return
+    if (lensSwitchInFlight) return
+    lensSwitchInFlight = true
     try {
-      const current = streamRef.current
+      const current = camera.stream
       const activeId = current?.getVideoTracks()[0]?.getSettings().deviceId ?? ''
       const foundIndex = lenses.indexOf(activeId)
       // When the open stream and the enumeration disagree (id rotation,
       // fallback opens), advance from the lens the UI shows instead of
       // silently jumping back to the first lens.
-      const activeIndex = foundIndex >= 0 ? foundIndex : rearLensIndexRef.current
+      const activeIndex = foundIndex >= 0 ? foundIndex : camera.rearLensIndex
       const nextId = lenses[(activeIndex + 1) % lenses.length]!
       // Android camera HALs are often exclusive across rear lenses: release
       // the current camera before opening the next one.
       stopStream(current)
-      streamRef.current = null
-      setStream(null)
-      setIsReady(false)
+      camera.stream = null
+      camera.isReady = false
+      notify()
       // A flip or a full stop (e.g. tab hidden) may land while a lens open
       // is in flight — never adopt a stream into a stopped or flipped camera.
-      const epoch = cameraEpochRef.current
+      const epoch = cameraEpoch
       const adopt = (opened: MediaStream): boolean => {
-        if (facingRef.current !== 'environment' || cameraEpochRef.current !== epoch) {
+        if (facingIntent !== 'environment' || cameraEpoch !== epoch) {
           stopStream(opened)
           return false
         }
@@ -452,56 +464,58 @@ export function useCamera(): UseCameraResult {
           const restored = await openCombinedOrVideoStream('environment', activeId || undefined)
           adopt(restored)
         } catch {
-          setError(permissionMessage(err))
+          camera.error = permissionMessage(err)
+          notify()
         }
       }
     } finally {
-      lensSwitchInFlightRef.current = false
+      lensSwitchInFlight = false
     }
-  }, [replaceStream, syncRearLenses])
+  }
 
-  const setZoom = useCallback((value: number) => {
-    const track = streamRef.current?.getVideoTracks()[0]
-    const range = zoomRangeRef.current
+  function setZoom(value: number): void {
+    const track = camera.stream?.getVideoTracks()[0]
+    const range = camera.zoom
     if (!track || !range) return
     const clamped = Math.min(range.max, Math.max(range.min, value))
-    zoomRangeRef.current = { ...range, value: clamped }
+    camera.zoom = { ...range, value: clamped }
     void track
       .applyConstraints({ advanced: [{ zoom: clamped } as MediaTrackConstraintSet] })
       .catch(() => undefined)
-    // Constraints apply immediately; React state syncs on a trailing timer so
-    // drag-to-zoom during a recording doesn't re-render the page per move.
-    if (!zoomSyncTimerRef.current) {
-      zoomSyncTimerRef.current = window.setTimeout(() => {
-        zoomSyncTimerRef.current = 0
-        if (zoomRangeRef.current) setZoomState(zoomRangeRef.current)
+    // Constraints apply immediately; the owning component syncs on a trailing
+    // timer so drag-to-zoom during a recording doesn't rerender per move.
+    if (!zoomNotifyTimer) {
+      zoomNotifyTimer = window.setTimeout(() => {
+        zoomNotifyTimer = 0
+        notify()
       }, 150)
     }
-  }, [])
+  }
 
-  const setTorch = useCallback(async (on: boolean) => {
-    const track = streamRef.current?.getVideoTracks()[0]
+  async function setTorch(on: boolean): Promise<void> {
+    const track = camera.stream?.getVideoTracks()[0]
     if (!track) return
     try {
       await track.applyConstraints({ advanced: [{ torch: on } as MediaTrackConstraintSet] })
-      setTorchOn(on)
+      camera.torchOn = on
     } catch {
-      setTorchOn(false)
+      camera.torchOn = false
     }
-  }, [])
+    notify()
+  }
 
-  const releaseMic = useCallback(() => {
+  function releaseMic(): void {
     // iOS: the mic lives and dies with the camera stream (single-call
     // pattern) — stopping it per-take would force the separate audio-only
     // getUserMedia that produces muted tracks on the next take.
     if (HOLD_MIC_WITH_CAMERA) return
-    stopAudioTracks(streamRef.current)
-  }, [])
+    stopAudioTracks(camera.stream)
+  }
 
-  const enableMic = useCallback(async () => {
-    if (micInFlightRef.current) {
-      await micInFlightRef.current
-      if (!streamRef.current?.getAudioTracks().some((track) => track.readyState === 'live')) {
+  async function enableMic(): Promise<void> {
+    if (micInFlight) {
+      await micInFlight
+      if (!camera.stream?.getAudioTracks().some((track) => track.readyState === 'live')) {
         throw new Error('Microphone unavailable')
       }
       return
@@ -515,14 +529,14 @@ export function useCamera(): UseCameraResult {
      * exists to avoid.
      */
     const reopenCombinedStream = async (): Promise<void> => {
-      const current = streamRef.current
+      const current = camera.stream
       if (!current) throw new Error('Camera not ready')
-      const epoch = cameraEpochRef.current
+      const epoch = cameraEpoch
       const deviceId = current.getVideoTracks()[0]?.getSettings().deviceId
-      const next = await openCameraStream(facingRef.current, { audio: true, deviceId })
+      const next = await openCameraStream(facingIntent, { audio: true, deviceId })
       // The camera may have been stopped or swapped while the permission
       // prompt was open — never adopt into that lifecycle's back.
-      if (cameraEpochRef.current !== epoch || streamRef.current !== current) {
+      if (cameraEpoch !== epoch || camera.stream !== current) {
         stopStream(next)
         throw new Error('Camera changed while enabling microphone')
       }
@@ -530,7 +544,7 @@ export function useCamera(): UseCameraResult {
     }
 
     const attachToCurrentStream = async (attempt = 0): Promise<void> => {
-      const current = streamRef.current
+      const current = camera.stream
       if (!current) {
         throw new Error('Camera not ready')
       }
@@ -541,7 +555,7 @@ export function useCamera(): UseCameraResult {
       }
 
       const audioTrack = await openMicrophoneTrack()
-      const latest = streamRef.current
+      const latest = camera.stream
       if (!latest) {
         audioTrack.stop()
         throw new Error('Camera not ready')
@@ -561,88 +575,57 @@ export function useCamera(): UseCameraResult {
     const run = (async () => {
       try {
         await attachToCurrentStream()
-        if (!streamRef.current?.getAudioTracks().some((track) => track.readyState === 'live')) {
+        if (!camera.stream?.getAudioTracks().some((track) => track.readyState === 'live')) {
           throw new Error('Microphone unavailable')
         }
         // The user may have fixed a denied permission in site settings.
-        setMicPermission('granted')
+        camera.micPermission = 'granted'
+        notify()
       } catch (err) {
         throw new Error(permissionMessage(err))
       }
     })()
 
-    micInFlightRef.current = run
+    micInFlight = run
     try {
       await run
     } finally {
-      micInFlightRef.current = null
+      micInFlight = null
     }
-  }, [replaceStream])
+  }
 
-  const stop = useCallback(() => {
-    cameraEpochRef.current += 1
-    const hadMic = (streamRef.current?.getAudioTracks().length ?? 0) > 0
-    stopStream(streamRef.current)
-    streamRef.current = null
-    setStream(null)
-    setIsReady(false)
-    applyZoomState(null)
-    setTorchAvailable(false)
-    setTorchOn(false)
-    if (videoElRef.current) {
-      videoElRef.current.srcObject = null
+  function stop(): void {
+    cameraEpoch += 1
+    const hadMic = (camera.stream?.getAudioTracks().length ?? 0) > 0
+    stopStream(camera.stream)
+    camera.stream = null
+    camera.isReady = false
+    setZoomRange(null)
+    camera.torchAvailable = false
+    camera.torchOn = false
+    if (videoEl) {
+      videoEl.srcObject = null
     }
     // The play-and-record session is sticky after capture ends and degrades
     // playback output — restore hi-fi routing (no-op off iOS).
     if (hadMic) releaseRecordAudioSession()
-  }, [applyZoomState])
-
-  const videoRef = useCallback<RefCallback<HTMLVideoElement>>(
-    (element) => {
-      videoElRef.current = element
-      if (!element) {
-        stop()
-        return
-      }
-      if (streamRef.current) {
-        attachToVideo(streamRef.current)
-        return
-      }
-      void start()
-    },
-    [attachToVideo, start, stop],
-  )
-
-  const getStream = useCallback(() => streamRef.current, [])
-  const getVideoElement = useCallback(() => videoElRef.current, [])
-  const getZoom = useCallback(() => zoomRangeRef.current, [])
-
-  return {
-    videoRef,
-    stream,
-    facing,
-    permission,
-    canFlip,
-    error,
-    isReady,
-    zoom,
-    torchAvailable,
-    torchOn,
-    micPermission,
-    rearLensCount,
-    rearLensIndex,
-    switchRearLens,
-    start,
-    flip,
-    stop,
-    setZoom,
-    setTorch,
-    enableMic,
-    releaseMic,
-    getStream,
-    getVideoElement,
-    getZoom,
+    notify()
   }
+
+  function attachVideo(element: HTMLVideoElement, signal: AbortSignal): void {
+    videoEl = element
+    signal.addEventListener('abort', () => {
+      videoEl = null
+      stop()
+    })
+    if (camera.stream) {
+      attachToVideo(camera.stream)
+      return
+    }
+    void start()
+  }
+
+  return camera
 }
 
 function permissionMessage(err: unknown): string {

--- a/src/lib/camera.ts
+++ b/src/lib/camera.ts
@@ -321,7 +321,12 @@ export function createCamera(notify: () => void): Camera {
 
     const run = (async () => {
       camera.error = null
+      // A stop() while any await below is in flight must win: a stream
+      // adopted after stop() would keep the camera (and OS privacy
+      // indicator) live behind an unmounted preview.
+      const epoch = cameraEpoch
       const perm = await queryCameraPermission()
+      if (cameraEpoch !== epoch) return
       camera.permission = perm
       notify()
       if (perm.status === 'unsupported') {
@@ -334,6 +339,10 @@ export function createCamera(notify: () => void): Camera {
         const rememberedLens =
           facingIntent === 'environment' ? await resolveRearLens() : undefined
         let next = await openCombinedOrVideoStream(facingIntent, rememberedLens)
+        if (cameraEpoch !== epoch) {
+          stopStream(next)
+          return
+        }
         camera.permission = { status: 'granted' }
         // iOS first run: device labels are empty before the permission grant,
         // so the preferred multi-lens camera can't be resolved until now.
@@ -395,9 +404,15 @@ export function createCamera(notify: () => void): Camera {
     const nextFacing: FacingMode = previousFacing === 'environment' ? 'user' : 'environment'
     facingIntent = nextFacing
     camera.error = null
+    const epoch = cameraEpoch
     try {
       const rememberedLens = nextFacing === 'environment' ? await resolveRearLens() : undefined
       const next = await openCombinedOrVideoStream(nextFacing, rememberedLens)
+      // A stop() while the open was in flight wins (see start()).
+      if (cameraEpoch !== epoch) {
+        stopStream(next)
+        return
+      }
       // The rendered facing (which drives the preview's mirror transform)
       // changes only once the new stream is in hand: setting it up front
       // mirrored the still-showing old feed for the whole camera warm-up.

--- a/src/lib/error-reporting.ts
+++ b/src/lib/error-reporting.ts
@@ -1,5 +1,4 @@
-import * as Sentry from '@sentry/react'
-import type { ErrorInfo } from 'react'
+import * as Sentry from '@sentry/browser'
 import { COMMIT_SHA } from './build-info'
 
 /** Publishable client key for the kody-video Sentry project (not a secret). */
@@ -193,25 +192,13 @@ export function reportError(
 }
 
 /**
- * React 19 routes uncaught render errors through createRoot options instead
- * of window.onerror — without these, UI crashes would never reach Sentry.
- *
- * Classification subtlety: `reactErrorHandler(callback)` marks the event
- * handled, `reactErrorHandler()` marks it unhandled. Uncaught root errors
- * must stay *unhandled*, so their console logging wraps the capture instead
- * of being passed as the callback.
+ * Remix component errors surface on the virtual root's `error` event instead
+ * of window.onerror — without this, UI crashes would never reach Sentry.
+ * The mechanism: main.tsx wires `root.addEventListener('error', …)` to this.
  */
-const captureUncaughtReactError = Sentry.reactErrorHandler()
-
-export const reactRootErrorHandlers = {
-  onUncaughtError: (error: unknown, errorInfo: ErrorInfo) => {
-    console.error('Uncaught React error', error, errorInfo.componentStack)
-    captureUncaughtReactError(error, errorInfo)
-  },
-  onCaughtError: Sentry.reactErrorHandler((error, errorInfo) => {
-    console.error('Caught React error', error, errorInfo.componentStack)
-  }),
-  onRecoverableError: Sentry.reactErrorHandler((error, errorInfo) => {
-    console.warn('Recoverable React error', error, errorInfo.componentStack)
-  }),
+export function reportComponentError(error: unknown): void {
+  console.error('Uncaught component error', error)
+  Sentry.captureException(error, {
+    mechanism: { type: 'remix.componentError', handled: false },
+  })
 }

--- a/src/lib/sheet-modal.ts
+++ b/src/lib/sheet-modal.ts
@@ -1,9 +1,7 @@
-import { useCallback, useLayoutEffect, useRef, type RefCallback } from 'react'
-
 interface SheetModalOptions {
   onDismiss: () => void
-  /** Blocks Esc dismissal while an action is in flight. */
-  busy?: boolean
+  /** Blocks Esc dismissal while an action is in flight (read per keydown). */
+  busy?: () => boolean
 }
 
 /** Mounted sheets, in stacking order — only the topmost owns the keyboard
@@ -13,20 +11,19 @@ const sheetStack: HTMLElement[] = []
 /**
  * Modal behavior for bottom sheets: Escape dismisses (unless busy), Tab is
  * trapped inside the sheet, initial focus lands on `[data-sheet-focus]` (or
- * the first focusable), and focus returns to the opener on close. Attach the
- * returned ref to the sheet's dialog element and add `aria-modal="true"`.
+ * the first focusable), and focus returns to the opener on close. Attach via
+ * the `ref()` mixin on the sheet's dialog element and add `aria-modal="true"`.
  */
-export function useSheetModal({ onDismiss, busy }: SheetModalOptions): RefCallback<HTMLElement> {
-  const optionsRef = useRef({ onDismiss, busy })
-  useLayoutEffect(() => {
-    optionsRef.current = { onDismiss, busy }
-  })
-  const elementRef = useRef<HTMLElement | null>(null)
-  const previousFocusRef = useRef<HTMLElement | null>(null)
+export function attachSheetModal(
+  element: HTMLElement,
+  signal: AbortSignal,
+  options: SheetModalOptions,
+): void {
+  sheetStack.push(element)
+  const previousFocus =
+    document.activeElement instanceof HTMLElement ? document.activeElement : null
 
-  const onKeyDown = useCallback((event: KeyboardEvent) => {
-    const element = elementRef.current
-    if (!element) return
+  const onKeyDown = (event: KeyboardEvent) => {
     // Stacked sheets: only the topmost handles keys (the lower sheet's
     // listener must neither trap Tab nor dismiss on the same Escape).
     if (sheetStack[sheetStack.length - 1] !== element) return
@@ -34,7 +31,7 @@ export function useSheetModal({ onDismiss, busy }: SheetModalOptions): RefCallba
       // Capture-phase stop: the sheet's Escape must never also trigger
       // screen-level shortcuts (e.g. the editor's back-to-camera).
       event.stopPropagation()
-      if (!optionsRef.current.busy) optionsRef.current.onDismiss()
+      if (!options.busy?.()) options.onDismiss()
       return
     }
     if (event.key !== 'Tab') return
@@ -65,31 +62,18 @@ export function useSheetModal({ onDismiss, busy }: SheetModalOptions): RefCallba
       event.preventDefault()
       first.focus()
     }
-  }, [])
+  }
 
-  return useCallback(
-    (element: HTMLElement | null) => {
-      if (element) {
-        elementRef.current = element
-        sheetStack.push(element)
-        previousFocusRef.current =
-          document.activeElement instanceof HTMLElement ? document.activeElement : null
-        window.addEventListener('keydown', onKeyDown, true)
-        const initial =
-          element.querySelector<HTMLElement>('[data-sheet-focus]') ??
-          element.querySelector<HTMLElement>(
-            'button:not([disabled]), [href], input, select, textarea',
-          )
-        initial?.focus()
-      } else {
-        const index = elementRef.current ? sheetStack.indexOf(elementRef.current) : -1
-        if (index >= 0) sheetStack.splice(index, 1)
-        elementRef.current = null
-        window.removeEventListener('keydown', onKeyDown, true)
-        previousFocusRef.current?.focus()
-        previousFocusRef.current = null
-      }
-    },
-    [onKeyDown],
-  )
+  window.addEventListener('keydown', onKeyDown, { capture: true })
+  const initial =
+    element.querySelector<HTMLElement>('[data-sheet-focus]') ??
+    element.querySelector<HTMLElement>('button:not([disabled]), [href], input, select, textarea')
+  initial?.focus()
+
+  signal.addEventListener('abort', () => {
+    const index = sheetStack.indexOf(element)
+    if (index >= 0) sheetStack.splice(index, 1)
+    window.removeEventListener('keydown', onKeyDown, { capture: true })
+    previousFocus?.focus()
+  })
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,7 +1,6 @@
-import { StrictMode } from 'react'
-import { createRoot } from 'react-dom/client'
+import { createRoot } from 'remix/ui'
 import { App } from './app'
-import { initErrorReporting, reactRootErrorHandlers } from './lib/error-reporting'
+import { initErrorReporting, reportComponentError } from './lib/error-reporting'
 import { sweepExportCache } from './lib/export/export-cache'
 import './lib/install-prompt'
 import './styles/global.css'
@@ -14,8 +13,8 @@ initErrorReporting()
 // longer referenced. No export can be running at boot, so this is safe.
 void sweepExportCache().catch(() => undefined)
 
-createRoot(document.getElementById('root')!, reactRootErrorHandlers).render(
-  <StrictMode>
-    <App />
-  </StrictMode>,
-)
+const root = createRoot(document.getElementById('root')!)
+root.addEventListener('error', (event) => {
+  reportComponentError(event.error)
+})
+root.render(<App />)

--- a/src/pages/about-page.tsx
+++ b/src/pages/about-page.tsx
@@ -1,5 +1,5 @@
-import { useState } from 'react'
-import { Link, useLoaderData, useRevalidator } from 'react-router-dom'
+import type { Handle } from 'remix/ui'
+import { on } from 'remix/ui'
 import { IconBack } from '../components/icons'
 import { BrandMark } from '../components/brand-mark'
 import { checkForUpdates } from '../lib/app-update'
@@ -27,12 +27,12 @@ function reportProblemUrl(): string {
   return `https://github.com/kentcdodds/kody-video/issues/new?${params}`
 }
 
-export interface AboutLoaderData {
+interface AboutData {
   storage: StorageSpace | null
   exportCacheBytes: number
 }
 
-export async function aboutLoader(): Promise<AboutLoaderData> {
+async function loadAboutData(): Promise<AboutData> {
   const [storage, exportCacheBytes] = await Promise.all([
     estimateStorageSpace(),
     estimateExportCacheBytes(),
@@ -51,100 +51,108 @@ const UPDATE_STATUS_LABEL: Record<Exclude<UpdateStatus, 'idle'>, string> = {
 }
 
 /** Credits, inspiration, and the open-source pointer. */
-export function AboutPage() {
-  const { storage, exportCacheBytes } = useLoaderData() as AboutLoaderData
-  const revalidator = useRevalidator()
-  const [updateStatus, setUpdateStatus] = useState<UpdateStatus>('idle')
-  const [cacheStatus, setCacheStatus] = useState<string | null>(null)
-  const [clearingCache, setClearingCache] = useState(false)
+export function AboutPage(handle: Handle) {
+  let data: AboutData = { storage: null, exportCacheBytes: 0 }
+  let updateStatus: UpdateStatus = 'idle'
+  let cacheStatus: string | null = null
+  let clearingCache = false
+  let cameraReport: string | null = null
+  let inspectingCameras = false
 
-  const [cameraReport, setCameraReport] = useState<string | null>(null)
-  const [inspectingCameras, setInspectingCameras] = useState(false)
+  const refresh = async () => {
+    data = await loadAboutData()
+    if (handle.signal.aborted) return
+    void handle.update()
+  }
+  void refresh()
 
   /**
    * On-device camera diagnostic: what the browser exposes varies wildly by
    * phone and Chrome build (labels, facingMode capability, zoom ranges),
    * and remote bug reports about lenses are unresolvable without it.
    */
-  const onInspectCameras = () => {
+  const onInspectCameras = async () => {
     if (inspectingCameras) return
-    setInspectingCameras(true)
-    void (async () => {
-      let probe: MediaStream | null = null
-      try {
-        probe = await navigator.mediaDevices.getUserMedia({ video: true })
-        const track = probe.getVideoTracks()[0]
-        const caps = track?.getCapabilities?.() as
-          | (MediaTrackCapabilities & { zoom?: { min?: number; max?: number } })
-          | undefined
-        const lines: string[] = [`Active camera: ${track?.label || '(no label)'}`]
-        if (caps?.zoom && typeof caps.zoom.min === 'number') {
-          lines.push(`Active zoom range: ${caps.zoom.min}–${caps.zoom.max}×`)
-        } else {
-          lines.push('Active zoom range: not exposed')
-        }
-        const rear = await listRearCameras()
-        lines.push(`Detected rear lenses: ${rear.length}`)
-        const devices = await navigator.mediaDevices.enumerateDevices()
-        for (const device of devices) {
-          if (device.kind !== 'videoinput') continue
-          const facing = (
-            device as MediaDeviceInfo & { getCapabilities?: () => MediaTrackCapabilities }
-          ).getCapabilities?.()?.facingMode
-          const facingLabel =
-            Array.isArray(facing) && facing.length > 0 ? ` [${facing.join(', ')}]` : ''
-          const rearMark = rear.includes(device.deviceId) ? ' — rear' : ''
-          lines.push(`• ${device.label || '(no label)'}${facingLabel}${rearMark}`)
-        }
-        setCameraReport(lines.join('\n'))
-      } catch (err) {
-        setCameraReport(
-          err instanceof Error ? `Could not inspect: ${err.message}` : 'Could not inspect cameras.',
-        )
-      } finally {
-        probe?.getTracks().forEach((track) => {
-          track.stop()
-        })
-        setInspectingCameras(false)
+    inspectingCameras = true
+    void handle.update()
+    let probe: MediaStream | null = null
+    try {
+      probe = await navigator.mediaDevices.getUserMedia({ video: true })
+      const track = probe.getVideoTracks()[0]
+      const caps = track?.getCapabilities?.() as
+        | (MediaTrackCapabilities & { zoom?: { min?: number; max?: number } })
+        | undefined
+      const lines: string[] = [`Active camera: ${track?.label || '(no label)'}`]
+      if (caps?.zoom && typeof caps.zoom.min === 'number') {
+        lines.push(`Active zoom range: ${caps.zoom.min}–${caps.zoom.max}×`)
+      } else {
+        lines.push('Active zoom range: not exposed')
       }
-    })()
+      const rear = await listRearCameras()
+      lines.push(`Detected rear lenses: ${rear.length}`)
+      const devices = await navigator.mediaDevices.enumerateDevices()
+      for (const device of devices) {
+        if (device.kind !== 'videoinput') continue
+        const facing = (
+          device as MediaDeviceInfo & { getCapabilities?: () => MediaTrackCapabilities }
+        ).getCapabilities?.()?.facingMode
+        const facingLabel =
+          Array.isArray(facing) && facing.length > 0 ? ` [${facing.join(', ')}]` : ''
+        const rearMark = rear.includes(device.deviceId) ? ' — rear' : ''
+        lines.push(`• ${device.label || '(no label)'}${facingLabel}${rearMark}`)
+      }
+      cameraReport = lines.join('\n')
+    } catch (err) {
+      cameraReport =
+        err instanceof Error ? `Could not inspect: ${err.message}` : 'Could not inspect cameras.'
+    } finally {
+      probe?.getTracks().forEach((track) => {
+        track.stop()
+      })
+      inspectingCameras = false
+      void handle.update()
+    }
   }
 
   const onClearExportCache = () => {
     if (clearingCache) return
-    setClearingCache(true)
+    clearingCache = true
+    void handle.update()
     void clearExportCache()
       .then((freedBytes) => {
-        setCacheStatus(`Freed ${formatBytes(freedBytes)}.`)
-        void revalidator.revalidate()
+        cacheStatus = `Freed ${formatBytes(freedBytes)}.`
+        void refresh()
       })
       .catch((err) => {
         reportError(err, 'clear-export-cache')
-        setCacheStatus(
-          err instanceof Error ? err.message : 'Could not clear cached exports — try again.',
-        )
+        cacheStatus =
+          err instanceof Error ? err.message : 'Could not clear cached exports — try again.'
       })
-      .finally(() => setClearingCache(false))
+      .finally(() => {
+        clearingCache = false
+        void handle.update()
+      })
   }
 
   const onCheckForUpdates = () => {
     if (updateStatus === 'checking' || updateStatus === 'updating') return
-    setUpdateStatus('checking')
+    updateStatus = 'checking'
+    void handle.update()
     void checkForUpdates()
       .then((result) => {
         switch (result) {
           case 'updated':
             // checkForUpdates already applied it; the page is about to reload.
-            setUpdateStatus('updating')
+            updateStatus = 'updating'
             return
           case 'current':
-            setUpdateStatus('current')
+            updateStatus = 'current'
             return
           case 'downloading':
-            setUpdateStatus('downloading')
+            updateStatus = 'downloading'
             return
           case 'unavailable':
-            setUpdateStatus('unavailable')
+            updateStatus = 'unavailable'
             return
           default: {
             const exhaustive: never = result
@@ -152,187 +160,193 @@ export function AboutPage() {
           }
         }
       })
-      .catch(() => setUpdateStatus('unavailable'))
+      .catch(() => {
+        updateStatus = 'unavailable'
+      })
+      .finally(() => void handle.update())
   }
 
-  return (
-    <div className="screen about-screen">
-      <div className="about-top">
-        <Link to="/" className="btn-icon" aria-label="Back to projects">
-          <IconBack />
-        </Link>
-        <strong>About</strong>
-        <span className="about-top-spacer" aria-hidden="true" />
-      </div>
-
-      <div className="about-body">
-        <div className="about-hero" aria-hidden="true">
-          <BrandMark size={96} className="brand-hero-art" variant="icon" />
+  return () => {
+    const { storage, exportCacheBytes } = data
+    return (
+      <div className="screen about-screen">
+        <div className="about-top">
+          <a href="/" className="btn-icon" aria-label="Back to projects">
+            <IconBack />
+          </a>
+          <strong>About</strong>
+          <span className="about-top-spacer" aria-hidden="true" />
         </div>
-        <h1>
-          Kody <span>Video</span>
-        </h1>
 
-        <section className="about-section">
-          <h2>Free &amp; open source</h2>
-          <p>
-            Kody Video is open source — the whole app, including the export engine, lives at{' '}
-            <a
-              href="https://github.com/kentcdodds/kody-video"
-              target="_blank"
-              rel="noreferrer noopener"
-            >
-              github.com/kentcdodds/kody-video
-            </a>
-            . Issues, ideas, and pull requests are welcome.
-          </p>
-        </section>
+        <div className="about-body">
+          <div className="about-hero" aria-hidden="true">
+            <BrandMark size={96} className="brand-hero-art" variant="icon" />
+          </div>
+          <h1>
+            Kody <span>Video</span>
+          </h1>
 
-        <section className="about-section">
-          <h2>Inspired by OK Video</h2>
-          <p>
-            This app exists because of{' '}
-            <a href="https://okvideo.app" target="_blank" rel="noreferrer noopener">
-              OK Video
-            </a>{' '}
-            by Pim Coumans — a wonderful hold-to-record clips camera for iPhone and a heavy source
-            of inspiration for Kody Video&rsquo;s whole interaction model. If you&rsquo;re on iOS,
-            go get the real thing. Kody Video is an independent project and is not affiliated with
-            OK Video.
-          </p>
-        </section>
+          <section className="about-section">
+            <h2>Free &amp; open source</h2>
+            <p>
+              Kody Video is open source — the whole app, including the export engine, lives at{' '}
+              <a
+                href="https://github.com/kentcdodds/kody-video"
+                target="_blank"
+                rel="noreferrer noopener"
+              >
+                github.com/kentcdodds/kody-video
+              </a>
+              . Issues, ideas, and pull requests are welcome.
+            </p>
+          </section>
 
-        <section className="about-section">
-          <h2>Kody the koala</h2>
-          <p>
-            The mascot comes from the KCD community —{' '}
-            <a href="https://kentcdodds.com/kody" target="_blank" rel="noreferrer noopener">
-              kentcdodds.com/kody
-            </a>
-            .
-          </p>
-        </section>
+          <section className="about-section">
+            <h2>Inspired by OK Video</h2>
+            <p>
+              This app exists because of{' '}
+              <a href="https://okvideo.app" target="_blank" rel="noreferrer noopener">
+                OK Video
+              </a>{' '}
+              by Pim Coumans — a wonderful hold-to-record clips camera for iPhone and a heavy source
+              of inspiration for Kody Video&rsquo;s whole interaction model. If you&rsquo;re on iOS,
+              go get the real thing. Kody Video is an independent project and is not affiliated with
+              OK Video.
+            </p>
+          </section>
 
-        <section className="about-section">
-          <h2>Private by design</h2>
-          <p>
-            No accounts, no uploads, no cross-site tracking. Clips live in this browser&rsquo;s
-            storage until you export and share them yourself. The app&rsquo;s only own network
-            traffic: Stripe checkout and its purchase verification if you buy the watermark
-            removal, anonymous crash reports (error and stack trace only — never your media) when
-            something breaks, and cookieless page-view counts via Fathom Analytics.
-          </p>
-        </section>
+          <section className="about-section">
+            <h2>Kody the koala</h2>
+            <p>
+              The mascot comes from the KCD community —{' '}
+              <a href="https://kentcdodds.com/kody" target="_blank" rel="noreferrer noopener">
+                kentcdodds.com/kody
+              </a>
+              .
+            </p>
+          </section>
 
-        <section className="about-section">
-          <h2>Made for phones</h2>
-          <p>
-            Kody Video is designed as a mobile camera app — install it on your phone for the real
-            experience. It works on desktop too, with keyboard support: hold <kbd>Space</kbd> to
-            record, <kbd>F</kbd> flips the camera, <kbd>T</kbd> starts the self-timer,{' '}
-            <kbd>E</kbd> opens the editor, <kbd>P</kbd> plays your cut, and <kbd>Delete</kbd>{' '}
-            removes the last clip. In the editor the arrow keys select clips,{' '}
-            <kbd>Alt</kbd>+arrows reorder, <kbd>T</kbd> trims, <kbd>D</kbd> duplicates,{' '}
-            <kbd>Delete</kbd> deletes, and <kbd>Esc</kbd> goes back. During playback the arrows
-            skip clips, <kbd>Space</kbd> pauses, and <kbd>Esc</kbd> closes.
-          </p>
-        </section>
+          <section className="about-section">
+            <h2>Private by design</h2>
+            <p>
+              No accounts, no uploads, no cross-site tracking. Clips live in this browser&rsquo;s
+              storage until you export and share them yourself. The app&rsquo;s only own network
+              traffic: Stripe checkout and its purchase verification if you buy the watermark
+              removal, anonymous crash reports (error and stack trace only — never your media) when
+              something breaks, and cookieless page-view counts via Fathom Analytics.
+            </p>
+          </section>
 
-        <section className="about-section">
-          <h2>Storage</h2>
-          <p>
-            {storage
-              ? `This app uses ${formatBytes(storage.usedBytes)} of the ${formatBytes(storage.quotaBytes)} the browser allows. `
-              : ''}
-            Your recordings are the big consumer — delete old projects from the home screen
-            (⋯ → Delete) to free the most space. The app also keeps your latest export cached so
-            tapping Go on an unchanged project is instant.
-          </p>
-          <p>
-            Cached export files: <strong>{formatBytes(exportCacheBytes)}</strong>
-            {exportCacheBytes > 0 ? (
-              <>
-                {' · '}
-                <button
-                  type="button"
-                  className="link-button"
-                  onClick={onClearExportCache}
-                  disabled={clearingCache}
-                >
-                  Clear
-                </button>
-              </>
+          <section className="about-section">
+            <h2>Made for phones</h2>
+            <p>
+              Kody Video is designed as a mobile camera app — install it on your phone for the real
+              experience. It works on desktop too, with keyboard support: hold <kbd>Space</kbd> to
+              record, <kbd>F</kbd> flips the camera, <kbd>T</kbd> starts the self-timer,{' '}
+              <kbd>E</kbd> opens the editor, <kbd>P</kbd> plays your cut, and <kbd>Delete</kbd>{' '}
+              removes the last clip. In the editor the arrow keys select clips,{' '}
+              <kbd>Alt</kbd>+arrows reorder, <kbd>T</kbd> trims, <kbd>D</kbd> duplicates,{' '}
+              <kbd>Delete</kbd> deletes, and <kbd>Esc</kbd> goes back. During playback the arrows
+              skip clips, <kbd>Space</kbd> pauses, and <kbd>Esc</kbd> closes.
+            </p>
+          </section>
+
+          <section className="about-section">
+            <h2>Storage</h2>
+            <p>
+              {storage
+                ? `This app uses ${formatBytes(storage.usedBytes)} of the ${formatBytes(storage.quotaBytes)} the browser allows. `
+                : ''}
+              Your recordings are the big consumer — delete old projects from the home screen
+              (⋯ → Delete) to free the most space. The app also keeps your latest export cached so
+              tapping Go on an unchanged project is instant.
+            </p>
+            <p>
+              Cached export files: <strong>{formatBytes(exportCacheBytes)}</strong>
+              {exportCacheBytes > 0 ? (
+                <>
+                  {' · '}
+                  <button
+                    type="button"
+                    className="link-button"
+                    disabled={clearingCache}
+                    mix={on('click', onClearExportCache)}
+                  >
+                    Clear
+                  </button>
+                </>
+              ) : null}
+            </p>
+            {cacheStatus ? (
+              <p role="status" aria-live="polite">
+                {cacheStatus}
+              </p>
             ) : null}
-          </p>
-          {cacheStatus ? (
-            <p role="status" aria-live="polite">
-              {cacheStatus}
+          </section>
+
+          <section className="about-section">
+            <h2>Cameras</h2>
+            <p>
+              Wondering why a lens or zoom level isn&rsquo;t available? Browsers expose cameras
+              very differently across phones —{' '}
+              <button
+                type="button"
+                className="link-button"
+                disabled={inspectingCameras}
+                mix={on('click', () => void onInspectCameras())}
+              >
+                {inspectingCameras ? 'Inspecting…' : 'Inspect cameras'}
+              </button>{' '}
+              shows exactly what this browser reports (nothing is sent anywhere — attach it to a
+              bug report if something looks wrong).
             </p>
-          ) : null}
-        </section>
+            {cameraReport ? <pre className="camera-report">{cameraReport}</pre> : null}
+          </section>
 
-        <section className="about-section">
-          <h2>Cameras</h2>
-          <p>
-            Wondering why a lens or zoom level isn&rsquo;t available? Browsers expose cameras
-            very differently across phones —{' '}
-            <button
-              type="button"
-              className="link-button"
-              onClick={onInspectCameras}
-              disabled={inspectingCameras}
-            >
-              {inspectingCameras ? 'Inspecting…' : 'Inspect cameras'}
-            </button>{' '}
-            shows exactly what this browser reports (nothing is sent anywhere — attach it to a
-            bug report if something looks wrong).
-          </p>
-          {cameraReport ? <pre className="camera-report">{cameraReport}</pre> : null}
-        </section>
-
-        <section className="about-section">
-          <h2>Support</h2>
-          <p>
-            Hit a bug? Please{' '}
-            <a href={reportProblemUrl()} target="_blank" rel="noreferrer noopener">
-              open an issue on GitHub
-            </a>{' '}
-            — the link pre-fills your device details so you only have to describe what went wrong.
-            Prefer email (or need help with a purchase)? Write to{' '}
-            <a href="mailto:team@kody.video">team@kody.video</a>.
-          </p>
-        </section>
-
-        <section className="about-section">
-          <h2>Version</h2>
-          <p>
-            <code>{shortVersion()}</code> · built {buildDateLabel()}
-            {' · '}
-            <button
-              type="button"
-              className="link-button"
-              onClick={onCheckForUpdates}
-              disabled={updateStatus === 'checking' || updateStatus === 'updating'}
-            >
-              Check for updates
-            </button>
-          </p>
-          {updateStatus !== 'idle' ? (
-            <p role="status" aria-live="polite">
-              {UPDATE_STATUS_LABEL[updateStatus]}
+          <section className="about-section">
+            <h2>Support</h2>
+            <p>
+              Hit a bug? Please{' '}
+              <a href={reportProblemUrl()} target="_blank" rel="noreferrer noopener">
+                open an issue on GitHub
+              </a>{' '}
+              — the link pre-fills your device details so you only have to describe what went wrong.
+              Prefer email (or need help with a purchase)? Write to{' '}
+              <a href="mailto:team@kody.video">team@kody.video</a>.
             </p>
-          ) : null}
-        </section>
+          </section>
 
-        <section className="about-section">
-          <h2>Legal</h2>
-          <p>
-            <Link to="/privacy">Privacy</Link>
-            {' · '}
-            <Link to="/terms">Terms</Link>
-          </p>
-        </section>
+          <section className="about-section">
+            <h2>Version</h2>
+            <p>
+              <code>{shortVersion()}</code> · built {buildDateLabel()}
+              {' · '}
+              <button
+                type="button"
+                className="link-button"
+                disabled={updateStatus === 'checking' || updateStatus === 'updating'}
+                mix={on('click', onCheckForUpdates)}
+              >
+                Check for updates
+              </button>
+            </p>
+            {updateStatus !== 'idle' ? (
+              <p role="status" aria-live="polite">
+                {UPDATE_STATUS_LABEL[updateStatus]}
+              </p>
+            ) : null}
+          </section>
+
+          <section className="about-section">
+            <h2>Legal</h2>
+            <p>
+              <a href="/privacy">Privacy</a>
+              {' · '}
+              <a href="/terms">Terms</a>
+            </p>
+          </section>
+        </div>
       </div>
-    </div>
-  )
+    )
+  }
 }

--- a/src/pages/home-page.tsx
+++ b/src/pages/home-page.tsx
@@ -1,5 +1,5 @@
-import { startTransition, useRef, useState, useSyncExternalStore } from 'react'
-import { Link, useLoaderData, useNavigate, useRevalidator } from 'react-router-dom'
+import type { Handle } from 'remix/ui'
+import { on } from 'remix/ui'
 import { BlobImage } from '../components/blob-image'
 import { BrandMark } from '../components/brand-mark'
 import { ConfirmSheet } from '../components/confirm-sheet'
@@ -22,6 +22,7 @@ import { clearExportCache } from '../lib/export/export-cache'
 import { reportError } from '../lib/error-reporting'
 import { canPromptInstall, promptInstall, subscribeInstallPrompt } from '../lib/install-prompt'
 import { dismissIosInstallHint, shouldShowIosInstallHint } from '../lib/install-hint'
+import { navigate } from '../router'
 import {
   formatBytes,
   formatStoragePercent,
@@ -44,37 +45,33 @@ function isLegacyOrigin(): boolean {
   return location.hostname === 'kody-video.pages.dev'
 }
 
-export async function homeLoader(): Promise<HomeLoaderData> {
-  return loadHomePage()
-}
-
-export function HomePage() {
-  const { projects, storage, exportCacheBytes, plus } = useLoaderData() as HomeLoaderData
-  const revalidator = useRevalidator()
-  const navigate = useNavigate()
-  const [error, setError] = useState<string | null>(null)
-  const [menuProject, setMenuProject] = useState<ProjectSummary | null>(null)
-  const [renaming, setRenaming] = useState<ProjectSummary | null>(null)
-  const [deleting, setDeleting] = useState<ProjectSummary | null>(null)
-  const [busy, setBusy] = useState(false)
-  const [notice, setNotice] = useState<string | null>(null)
-  const [importProgress, setImportProgress] = useState<string | null>(null)
-  const [showInstallHint, setShowInstallHint] = useState(shouldShowIosInstallHint)
-  const [upselling, setUpselling] = useState(false)
-  const [restoring, setRestoring] = useState(false)
+export function HomePage(handle: Handle) {
+  let data: HomeLoaderData | null = null
+  let error: string | null = null
+  let menuProject: ProjectSummary | null = null
+  let renaming: ProjectSummary | null = null
+  let deleting: ProjectSummary | null = null
+  let busy = false
+  let notice: string | null = null
+  let importProgress: string | null = null
+  let showInstallHint = shouldShowIosInstallHint()
+  let upselling = false
+  let restoring = false
   // Prefetched when the options sheet opens so the Save-backup tap keeps its
   // user activation (Web Share needs it; an IndexedDB read can outlive it).
-  const prefetchedClipsRef = useRef<{ projectId: string; clips: Promise<ClipRecord[]> } | null>(
-    null,
-  )
+  let prefetchedClips: { projectId: string; clips: Promise<ClipRecord[]> } | null = null
 
   const refresh = () => {
-    startTransition(() => {
-      void revalidator.revalidate()
+    void loadHomePage().then((loaded) => {
+      if (handle.signal.aborted) return
+      data = loaded
+      void handle.update()
     })
   }
+  refresh()
 
-  const installable = useSyncExternalStore(subscribeInstallPrompt, canPromptInstall)
+  const unsubscribeInstall = subscribeInstallPrompt(() => void handle.update())
+  handle.signal.addEventListener('abort', unsubscribeInstall)
 
   // Nothing is persisted until the first clip is recorded — backing out of
   // an untouched new project leaves no empty project behind.
@@ -85,32 +82,33 @@ export function HomePage() {
   // Cached export files (the recoverable last export + scratch) can hold
   // gigabytes — when storage runs hot, the fix must be one tap away.
   const onClearExportCache = () => {
-    setBusy(true)
-    setError(null)
-    setNotice(null)
+    busy = true
+    error = null
+    notice = null
+    void handle.update()
     void clearExportCache()
       .then((freedBytes) => {
-        setNotice(`Cleared cached export files — freed ${formatBytes(freedBytes)}.`)
+        notice = `Cleared cached export files — freed ${formatBytes(freedBytes)}.`
         refresh()
       })
       .catch((err) => {
         reportError(err, 'clear-export-cache')
-        setError(
-          err instanceof Error ? err.message : 'Could not clear cached exports — try again.',
-        )
+        error = err instanceof Error ? err.message : 'Could not clear cached exports — try again.'
       })
       .finally(() => {
-        setBusy(false)
+        busy = false
+        void handle.update()
       })
   }
 
   const backupProject = (project: ProjectSummary) => {
     void (async () => {
-      setBusy(true)
-      setError(null)
-      setNotice(null)
+      busy = true
+      error = null
+      notice = null
+      void handle.update()
       try {
-        const prefetched = prefetchedClipsRef.current
+        const prefetched = prefetchedClips
         const clips =
           prefetched && prefetched.projectId === project.id
             ? await prefetched.clips
@@ -123,36 +121,36 @@ export function HomePage() {
         // route big backups straight to a download instead.
         if (backup.size > SHARE_BACKUP_LIMIT_BYTES) {
           await downloadBlob(backup, filename)
-          setNotice(
+          notice =
             `Backup (${sizeLabel}) saved to your downloads — too large for the share sheet. ` +
-              'Open kody.video and tap Import to restore it.',
-          )
+            'Open kody.video and tap Import to restore it.'
         } else {
           const outcome = await shareOrDownload(backup, filename)
           if (outcome !== 'cancelled') {
-            setNotice(
-              `Backup (${sizeLabel}) saved. Open kody.video (or any Kody Video) and tap Import to restore it.`,
-            )
+            notice = `Backup (${sizeLabel}) saved. Open kody.video (or any Kody Video) and tap Import to restore it.`
           }
         }
       } catch (err) {
-        setError(err instanceof Error ? err.message : 'Could not create the backup')
+        error = err instanceof Error ? err.message : 'Could not create the backup'
       } finally {
-        setBusy(false)
+        busy = false
+        void handle.update()
       }
     })()
   }
 
   const importBackup = (file: File) => {
     void (async () => {
-      setBusy(true)
-      setError(null)
-      setNotice(null)
-      setImportProgress('Reading backup…')
+      busy = true
+      error = null
+      notice = null
+      importProgress = 'Reading backup…'
+      void handle.update()
       try {
         const parsed = await parseProjectBackup(file)
         const project = await importProjectBackup(parsed, (done, total) => {
-          setImportProgress(`Importing clip ${Math.min(done + 1, total)} of ${total}…`)
+          importProgress = `Importing clip ${Math.min(done + 1, total)} of ${total}…`
+          void handle.update()
         })
         requestPersistentStorage()
         // Land directly in the imported project — unambiguous success, and
@@ -161,305 +159,350 @@ export function HomePage() {
       } catch (err) {
         // Wrong/damaged file picked = expected user input, not a crash.
         if (!(err instanceof BackupFormatError)) reportError(err, 'import')
-        setError(err instanceof Error ? err.message : 'Could not import that file')
+        error = err instanceof Error ? err.message : 'Could not import that file'
       } finally {
-        setImportProgress(null)
-        setBusy(false)
+        importProgress = null
+        busy = false
+        void handle.update()
       }
     })()
   }
 
-  const slots = Array.from({ length: MAX_PROJECTS }, (_, index) => projects[index] ?? null)
-  const projectLimit = plus ? MAX_PROJECTS : FREE_PROJECTS
-  const atCap = projects.length >= projectLimit
-  const severity = storage ? storageSeverity(storage.ratio) : 'ok'
-  const oldestProject = projects[0] ?? null
+  return () => {
+    if (!data) return null
+    const { projects, storage, exportCacheBytes, plus } = data
+    const installable = canPromptInstall()
 
-  return (
-    <div className="screen home-screen">
-      <div className="home-hero">
-        <div className="home-hero-art" aria-hidden="true">
-          <BrandMark size={96} className="brand-hero-art" variant="camera" />
+    const slots = Array.from({ length: MAX_PROJECTS }, (_, index) => projects[index] ?? null)
+    const projectLimit = plus ? MAX_PROJECTS : FREE_PROJECTS
+    const atCap = projects.length >= projectLimit
+    const severity = storage ? storageSeverity(storage.ratio) : 'ok'
+    const oldestProject = projects[0] ?? null
+
+    return (
+      <div className="screen home-screen">
+        <div className="home-hero">
+          <div className="home-hero-art" aria-hidden="true">
+            <BrandMark size={96} className="brand-hero-art" variant="camera" />
+          </div>
+          <h1 className="brand">
+            Kody <span>Video</span>
+          </h1>
+          <p className="lede">Hold to record. Tap Go to share.</p>
         </div>
-        <h1 className="brand">
-          Kody <span>Video</span>
-        </h1>
-        <p className="lede">Hold to record. Tap Go to share.</p>
-      </div>
 
-      {isLegacyOrigin() ? (
-        <div className="home-migrate">
-          <strong>Kody Video has moved to <a href="https://kody.video">kody.video</a>.</strong>{' '}
-          Projects live in this browser per-site, so use ⋯ → Save backup here, then Import them
-          over there. This address keeps working but won&rsquo;t get updates.
-        </div>
-      ) : null}
+        {isLegacyOrigin() ? (
+          <div className="home-migrate">
+            <strong>Kody Video has moved to <a href="https://kody.video">kody.video</a>.</strong>{' '}
+            Projects live in this browser per-site, so use ⋯ → Save backup here, then Import them
+            over there. This address keeps working but won&rsquo;t get updates.
+          </div>
+        ) : null}
 
-      {error ? <div className="error-banner">{error}</div> : null}
-      {notice ? <p className="home-notice">{notice}</p> : null}
-      {importProgress ? (
-        <p className="home-notice" role="status" aria-live="polite">
-          {importProgress} Keep this tab open.
-        </p>
-      ) : null}
+        {error ? <div className="error-banner">{error}</div> : null}
+        {notice ? <p className="home-notice">{notice}</p> : null}
+        {importProgress ? (
+          <p className="home-notice" role="status" aria-live="polite">
+            {importProgress} Keep this tab open.
+          </p>
+        ) : null}
 
-      {storage && severity !== 'ok' ? (
-        <div
-          className={`storage-banner${severity === 'critical' ? ' is-critical' : ''}`}
-          role="alert"
-        >
-          <strong>
-            Device storage {formatStoragePercent(storage.ratio)} full
-            {severity === 'critical' ? ' — recordings may start failing' : ''}
-          </strong>
-          <span>
-            {formatBytes(storage.usedBytes)} of {formatBytes(storage.quotaBytes)} used.
-            {oldestProject
-              ? ` Free space fast: delete an old project (⋯ on “${oldestProject.name}”, then Delete).`
-              : ' Free space by clearing other site data or files on this device.'}
-          </span>
-          {exportCacheBytes > 0 ? (
-            <button
-              type="button"
-              className="btn btn-secondary storage-banner-action"
-              disabled={busy}
-              onClick={onClearExportCache}
-            >
-              Clear cached exports ({formatBytes(exportCacheBytes)})
-            </button>
-          ) : null}
-        </div>
-      ) : null}
-
-      {showInstallHint ? (
-        <div className="home-install-hint">
-          <span className="install-hint-icon" aria-hidden="true">
-            <IconShareIos size={18} />
-          </span>
-          <span>
-            Install Kody Video: tap <strong>Share</strong>, then{' '}
-            <strong>Add to Home Screen</strong> — full screen, and your clips are safer from
-            Safari&rsquo;s storage cleanup.
-          </span>
-          <button
-            type="button"
-            className="install-hint-dismiss"
-            aria-label="Dismiss install tip"
-            onClick={() => {
-              dismissIosInstallHint()
-              setShowInstallHint(false)
-            }}
+        {storage && severity !== 'ok' ? (
+          <div
+            className={`storage-banner${severity === 'critical' ? ' is-critical' : ''}`}
+            role="alert"
           >
-            <IconClose size={16} />
-          </button>
-        </div>
-      ) : null}
-
-      <section className="project-slots" aria-label="Kody Video projects">
-        {slots.map((project, index) =>
-          project ? (
-            <article
-              key={project.id}
-              className={project.posterThumb ? 'project-slot filled has-poster' : 'project-slot filled'}
-            >
-              {project.posterThumb ? (
-                <BlobImage
-                  blob={project.posterThumb}
-                  className="slot-poster"
-                  alt=""
-                  aria-hidden="true"
-                  draggable={false}
-                />
-              ) : null}
-              <div className="slot-fade" aria-hidden="true" />
-              <Link className="slot-open" to={`/project/${project.id}`}>
-                <span className="slot-number">Slot {index + 1}</span>
-                <strong>{project.name}</strong>
-                <small>
-                  {project.clipCount} clip{project.clipCount === 1 ? '' : 's'} ·{' '}
-                  {formatDuration(project.durationMs)}
-                </small>
-              </Link>
+            <strong>
+              Device storage {formatStoragePercent(storage.ratio)} full
+              {severity === 'critical' ? ' — recordings may start failing' : ''}
+            </strong>
+            <span>
+              {formatBytes(storage.usedBytes)} of {formatBytes(storage.quotaBytes)} used.
+              {oldestProject
+                ? ` Free space fast: delete an old project (⋯ on “${oldestProject.name}”, then Delete).`
+                : ' Free space by clearing other site data or files on this device.'}
+            </span>
+            {exportCacheBytes > 0 ? (
               <button
                 type="button"
-                className="slot-options"
-                aria-label={`Options for ${project.name}`}
-                onClick={() => {
-                  prefetchedClipsRef.current = {
-                    projectId: project.id,
-                    clips: getClipsForProject(project.id),
-                  }
-                  setMenuProject(project)
-                }}
+                className="btn btn-secondary storage-banner-action"
+                disabled={busy}
+                mix={on('click', onClearExportCache)}
               >
-                <IconMore />
+                Clear cached exports ({formatBytes(exportCacheBytes)})
               </button>
-            </article>
-          ) : index < projectLimit ? (
+            ) : null}
+          </div>
+        ) : null}
+
+        {showInstallHint ? (
+          <div className="home-install-hint">
+            <span className="install-hint-icon" aria-hidden="true">
+              <IconShareIos size={18} />
+            </span>
+            <span>
+              Install Kody Video: tap <strong>Share</strong>, then{' '}
+              <strong>Add to Home Screen</strong> — full screen, and your clips are safer from
+              Safari&rsquo;s storage cleanup.
+            </span>
             <button
-              key={`empty-${index}`}
               type="button"
-              className="project-slot empty"
-              disabled={busy}
-              onClick={openNewProject}
+              className="install-hint-dismiss"
+              aria-label="Dismiss install tip"
+              mix={on('click', () => {
+                dismissIosInstallHint()
+                showInstallHint = false
+                void handle.update()
+              })}
             >
-              <span className="slot-plus" aria-hidden="true">
-                <IconPlus size={26} />
-              </span>
-              <strong>New project</strong>
-              <small>{`Slot ${index + 1}`}</small>
+              <IconClose size={16} />
+            </button>
+          </div>
+        ) : null}
+
+        <section className="project-slots" aria-label="Kody Video projects">
+          {slots.map((project, index) =>
+            project ? (
+              <article
+                key={project.id}
+                className={
+                  project.posterThumb ? 'project-slot filled has-poster' : 'project-slot filled'
+                }
+              >
+                {project.posterThumb ? (
+                  <BlobImage
+                    blob={project.posterThumb}
+                    className="slot-poster"
+                    alt=""
+                    aria-hidden="true"
+                    draggable={false}
+                  />
+                ) : null}
+                <div className="slot-fade" aria-hidden="true" />
+                <a className="slot-open" href={`/project/${project.id}`}>
+                  <span className="slot-number">Slot {index + 1}</span>
+                  <strong>{project.name}</strong>
+                  <small>
+                    {project.clipCount} clip{project.clipCount === 1 ? '' : 's'} ·{' '}
+                    {formatDuration(project.durationMs)}
+                  </small>
+                </a>
+                <button
+                  type="button"
+                  className="slot-options"
+                  aria-label={`Options for ${project.name}`}
+                  mix={on('click', () => {
+                    prefetchedClips = {
+                      projectId: project.id,
+                      clips: getClipsForProject(project.id),
+                    }
+                    menuProject = project
+                    void handle.update()
+                  })}
+                >
+                  <IconMore />
+                </button>
+              </article>
+            ) : index < projectLimit ? (
+              <button
+                key={`empty-${index}`}
+                type="button"
+                className="project-slot empty"
+                disabled={busy}
+                mix={on('click', openNewProject)}
+              >
+                <span className="slot-plus" aria-hidden="true">
+                  <IconPlus size={26} />
+                </span>
+                <strong>New project</strong>
+                <small>{`Slot ${index + 1}`}</small>
+              </button>
+            ) : (
+              <button
+                key={`locked-${index}`}
+                type="button"
+                className="project-slot empty locked"
+                mix={on('click', () => {
+                  upselling = true
+                  void handle.update()
+                })}
+              >
+                <span className="slot-plus" aria-hidden="true">
+                  <IconLock size={22} />
+                </span>
+                <strong>Plus slot</strong>
+                <small>Unlock with Kody Video Plus</small>
+              </button>
+            ),
+          )}
+        </section>
+
+        <p className="home-privacy">
+          Clips stay on this phone until you share.
+          {storage
+            ? ` ${formatBytes(storage.usedBytes)} of ${formatBytes(storage.quotaBytes)} used.`
+            : ''}{' '}
+          <a href="/about">About</a>
+          {installable ? (
+            <>
+              {' · '}
+              <button
+                type="button"
+                className="link-button"
+                mix={on('click', () => {
+                  void promptInstall()
+                })}
+              >
+                Install app
+              </button>
+            </>
+          ) : null}
+        </p>
+
+        <div className="home-footer">
+          {atCap && !plus ? (
+            <button
+              type="button"
+              className="btn btn-primary"
+              mix={on('click', () => {
+                upselling = true
+                void handle.update()
+              })}
+            >
+              Get more projects
             </button>
           ) : (
             <button
-              key={`locked-${index}`}
               type="button"
-              className="project-slot empty locked"
-              onClick={() => setUpselling(true)}
+              className="btn btn-primary"
+              disabled={busy || atCap}
+              mix={on('click', openNewProject)}
             >
-              <span className="slot-plus" aria-hidden="true">
-                <IconLock size={22} />
-              </span>
-              <strong>Plus slot</strong>
-              <small>Unlock with Kody Video Plus</small>
+              {atCap ? `Limit ${MAX_PROJECTS}` : 'New project'}
             </button>
-          ),
-        )}
-      </section>
-
-      <p className="home-privacy">
-        Clips stay on this phone until you share.
-        {storage ? ` ${formatBytes(storage.usedBytes)} of ${formatBytes(storage.quotaBytes)} used.` : ''}{' '}
-        <Link to="/about">About</Link>
-        {installable ? (
-          <>
-            {' · '}
-            <button
-              type="button"
-              className="link-button"
-              onClick={() => {
-                void promptInstall()
-              }}
-            >
-              Install app
-            </button>
-          </>
-        ) : null}
-      </p>
-
-      <div className="home-footer">
-        {atCap && !plus ? (
-          <button type="button" className="btn btn-primary" onClick={() => setUpselling(true)}>
-            Get more projects
-          </button>
-        ) : (
-          <button
-            type="button"
-            className="btn btn-primary"
-            disabled={busy || atCap}
-            onClick={openNewProject}
+          )}
+          <label
+            className={`btn btn-ghost home-import${busy ? ' is-disabled' : ''}`}
+            mix={on('click', (event) => {
+              if (!atCap) return
+              event.preventDefault()
+              if (!plus) {
+                upselling = true
+                void handle.update()
+                return
+              }
+              error = `Project limit reached (${MAX_PROJECTS}). Delete a project before importing.`
+              void handle.update()
+            })}
           >
-            {atCap ? `Limit ${MAX_PROJECTS}` : 'New project'}
-          </button>
-        )}
-        <label
-          className={`btn btn-ghost home-import${busy ? ' is-disabled' : ''}`}
-          onClick={(event) => {
-            if (!atCap) return
-            event.preventDefault()
-            if (!plus) {
-              setUpselling(true)
-              return
-            }
-            setError(
-              `Project limit reached (${MAX_PROJECTS}). Delete a project before importing.`,
-            )
-          }}
-        >
-          Import
-          <input
-            type="file"
-            accept=".kodyvideo,application/octet-stream"
-            className="visually-hidden"
-            disabled={busy}
-            onChange={(event) => {
-              const file = event.target.files?.[0]
-              event.target.value = ''
-              if (file) importBackup(file)
+            Import
+            <input
+              type="file"
+              accept=".kodyvideo,application/octet-stream"
+              className="visually-hidden"
+              disabled={busy}
+              mix={on('change', (event) => {
+                const input = event.currentTarget as HTMLInputElement
+                const file = input.files?.[0]
+                input.value = ''
+                if (file) importBackup(file)
+              })}
+            />
+          </label>
+        </div>
+
+        {menuProject ? (
+          <HomeOptionsSheet
+            projectName={menuProject.name}
+            onClose={() => {
+              menuProject = null
+              void handle.update()
+            }}
+            onOpen={() => {
+              const id = menuProject!.id
+              menuProject = null
+              void handle.update()
+              navigate(`/project/${id}`)
+            }}
+            onRename={() => {
+              renaming = menuProject
+              menuProject = null
+              void handle.update()
+            }}
+            onBackup={() => {
+              const project = menuProject!
+              menuProject = null
+              void handle.update()
+              backupProject(project)
+            }}
+            onDelete={() => {
+              deleting = menuProject
+              menuProject = null
+              void handle.update()
             }}
           />
-        </label>
+        ) : null}
+
+        {renaming ? (
+          <RenameSheet
+            key={renaming.id}
+            initialName={renaming.name}
+            onClose={() => {
+              renaming = null
+              void handle.update()
+            }}
+            onSave={async (name) => {
+              await renameProject(renaming!.id, name)
+              refresh()
+            }}
+          />
+        ) : null}
+
+        {deleting ? (
+          <ConfirmSheet
+            title="Delete project?"
+            message={`Delete “${deleting.name}” and all its clips? This can’t be undone.`}
+            confirmLabel="Delete"
+            onClose={() => {
+              deleting = null
+              void handle.update()
+            }}
+            onConfirm={async () => {
+              await deleteProject(deleting!.id)
+              refresh()
+            }}
+          />
+        ) : null}
+
+        {upselling ? (
+          <UpsellSheet
+            onClose={() => {
+              upselling = false
+              void handle.update()
+            }}
+            onRestore={() => {
+              upselling = false
+              restoring = true
+              void handle.update()
+            }}
+          />
+        ) : null}
+
+        {restoring ? (
+          <RestoreSheet
+            onClose={() => {
+              restoring = false
+              void handle.update()
+            }}
+            onRestored={() => {
+              restoring = false
+              notice = 'Kody Video Plus restored — all project slots are unlocked.'
+              void handle.update()
+              refresh()
+            }}
+          />
+        ) : null}
       </div>
-
-      {menuProject ? (
-        <HomeOptionsSheet
-          projectName={menuProject.name}
-          onClose={() => setMenuProject(null)}
-          onOpen={() => {
-            const id = menuProject.id
-            setMenuProject(null)
-            navigate(`/project/${id}`)
-          }}
-          onRename={() => {
-            setRenaming(menuProject)
-            setMenuProject(null)
-          }}
-          onBackup={() => {
-            const project = menuProject
-            setMenuProject(null)
-            backupProject(project)
-          }}
-          onDelete={() => {
-            setDeleting(menuProject)
-            setMenuProject(null)
-          }}
-        />
-      ) : null}
-
-      {renaming ? (
-        <RenameSheet
-          key={renaming.id}
-          initialName={renaming.name}
-          onClose={() => setRenaming(null)}
-          onSave={async (name) => {
-            await renameProject(renaming.id, name)
-            refresh()
-          }}
-        />
-      ) : null}
-
-      {deleting ? (
-        <ConfirmSheet
-          title="Delete project?"
-          message={`Delete “${deleting.name}” and all its clips? This can’t be undone.`}
-          confirmLabel="Delete"
-          onClose={() => setDeleting(null)}
-          onConfirm={async () => {
-            await deleteProject(deleting.id)
-            refresh()
-          }}
-        />
-      ) : null}
-
-      {upselling ? (
-        <UpsellSheet
-          onClose={() => setUpselling(false)}
-          onRestore={() => {
-            setUpselling(false)
-            setRestoring(true)
-          }}
-        />
-      ) : null}
-
-      {restoring ? (
-        <RestoreSheet
-          onClose={() => setRestoring(false)}
-          onRestored={() => {
-            setRestoring(false)
-            setNotice('Kody Video Plus restored — all project slots are unlocked.')
-            refresh()
-          }}
-        />
-      ) : null}
-    </div>
-  )
+    )
+  }
 }

--- a/src/pages/home-page.tsx
+++ b/src/pages/home-page.tsx
@@ -45,8 +45,15 @@ function isLegacyOrigin(): boolean {
   return location.hostname === 'kody-video.pages.dev'
 }
 
+/**
+ * Last loaded home data, kept across mounts: navigating back to home renders
+ * the slots immediately (like React Router's blocking loader used to) while
+ * a fresh load revalidates underneath.
+ */
+let lastHomeData: HomeLoaderData | null = null
+
 export function HomePage(handle: Handle) {
-  let data: HomeLoaderData | null = null
+  let data: HomeLoaderData | null = lastHomeData
   let error: string | null = null
   let menuProject: ProjectSummary | null = null
   let renaming: ProjectSummary | null = null
@@ -62,11 +69,19 @@ export function HomePage(handle: Handle) {
   let prefetchedClips: { projectId: string; clips: Promise<ClipRecord[]> } | null = null
 
   const refresh = () => {
-    void loadHomePage().then((loaded) => {
-      if (handle.signal.aborted) return
-      data = loaded
-      void handle.update()
-    })
+    void loadHomePage()
+      .then((loaded) => {
+        lastHomeData = loaded
+        if (handle.signal.aborted) return
+        data = loaded
+        void handle.update()
+      })
+      .catch((err) => {
+        if (handle.signal.aborted) return
+        reportError(err, 'load-home')
+        error = err instanceof Error ? err.message : 'Could not load your projects.'
+        void handle.update()
+      })
   }
   refresh()
 
@@ -169,7 +184,14 @@ export function HomePage(handle: Handle) {
   }
 
   return () => {
-    if (!data) return null
+    if (!data) {
+      // Load failure must not leave a silent blank screen.
+      return error ? (
+        <div className="screen home-screen">
+          <div className="error-banner">{error}</div>
+        </div>
+      ) : null
+    }
     const { projects, storage, exportCacheBytes, plus } = data
     const installable = canPromptInstall()
 

--- a/src/pages/home-page.tsx
+++ b/src/pages/home-page.tsx
@@ -68,16 +68,21 @@ export function HomePage(handle: Handle) {
   // user activation (Web Share needs it; an IndexedDB read can outlive it).
   let prefetchedClips: { projectId: string; clips: Promise<ClipRecord[]> } | null = null
 
+  /** Monotonic request id: an older in-flight load (e.g. the mount load
+   * resolving after a delete's refresh) must never overwrite newer state. */
+  let refreshVersion = 0
   const refresh = () => {
+    const version = ++refreshVersion
     void loadHomePage()
       .then((loaded) => {
+        if (handle.signal.aborted || version !== refreshVersion) return
         lastHomeData = loaded
-        if (handle.signal.aborted) return
         data = loaded
+        error = null
         void handle.update()
       })
       .catch((err) => {
-        if (handle.signal.aborted) return
+        if (handle.signal.aborted || version !== refreshVersion) return
         reportError(err, 'load-home')
         error = err instanceof Error ? err.message : 'Could not load your projects.'
         void handle.update()

--- a/src/pages/privacy-page.tsx
+++ b/src/pages/privacy-page.tsx
@@ -1,14 +1,13 @@
-import { Link } from 'react-router-dom'
 import { IconBack } from '../components/icons'
 
 /** Plain-language privacy policy for on-device Kody Video. */
 export function PrivacyPage() {
-  return (
+  return () => (
     <div className="screen about-screen">
       <div className="about-top">
-        <Link to="/" className="btn-icon" aria-label="Back to projects">
+        <a href="/" className="btn-icon" aria-label="Back to projects">
           <IconBack />
-        </Link>
+        </a>
         <strong>Privacy</strong>
         <span className="about-top-spacer" aria-hidden="true" />
       </div>
@@ -113,8 +112,7 @@ export function PrivacyPage() {
 
         <section className="about-section legal-nav">
           <p>
-            See also the <Link to="/terms">Terms</Link> and{' '}
-            <Link to="/about">About</Link> pages.
+            See also the <a href="/terms">Terms</a> and <a href="/about">About</a> pages.
           </p>
         </section>
       </div>

--- a/src/pages/project-page.tsx
+++ b/src/pages/project-page.tsx
@@ -101,15 +101,32 @@ export function ProjectPage(handle: Handle<ProjectPageProps>) {
 
   const load = (projectId: string) => {
     loadedForId = projectId
-    void loadProjectPage(projectId).then((loaded) => {
-      if (handle.signal.aborted || loadedForId !== projectId) return
-      data = loaded
-      if (!onboardingInitialized) {
-        onboardingInitialized = true
-        onboardingOpen = !loaded.onboardingDismissed
-      }
-      void handle.update()
-    })
+    void loadProjectPage(projectId)
+      .then((loaded) => {
+        if (handle.signal.aborted || loadedForId !== projectId) return
+        data = loaded
+        if (!onboardingInitialized) {
+          onboardingInitialized = true
+          onboardingOpen = !loaded.onboardingDismissed
+        }
+        void handle.update()
+      })
+      .catch((err) => {
+        if (handle.signal.aborted || loadedForId !== projectId) return
+        reportError(err, 'load-project')
+        // Reuse the page's error rendering path (banner + back-home link).
+        data = {
+          project: null,
+          clips: [],
+          canUndo: false,
+          onboardingDismissed: true,
+          watermarkRemoved: false,
+          storage: null,
+          locationTaggingEnabled: false,
+          error: err instanceof Error ? err.message : 'Could not load this project.',
+        }
+        void handle.update()
+      })
   }
   load(props.projectId)
 

--- a/src/pages/project-page.tsx
+++ b/src/pages/project-page.tsx
@@ -134,8 +134,17 @@ export function ProjectPage(handle: Handle<ProjectPageProps>) {
   }
   load(props.projectId)
 
+  /** The URL is the authority on which project this page shows. Right after
+   * lazy creation, `navigate(replace)` has already rewritten the path while
+   * `props.projectId` only catches up on the router's next render — a
+   * mutation's immediate refresh must follow the URL, never a stale id. */
+  const currentProjectId = () => {
+    const match = window.location.pathname.match(/^\/project\/([^/]+)/)
+    return match?.[1] ?? props.projectId
+  }
+
   const refresh = () => {
-    if (loadedForId) load(loadedForId)
+    load(currentProjectId())
   }
 
   const showToast = (message: string, action?: ToastAction) => {
@@ -152,12 +161,17 @@ export function ProjectPage(handle: Handle<ProjectPageProps>) {
   // first clip finishes recording. The promise is memoized so overlapping
   // takes (or a camera take racing a screen take) create exactly one.
   let ensureProjectPromise: Promise<ProjectId> | null = null
+  /** Set once the lazy project persists: data loaded for 'new' may keep
+   * rendering under the created id (same logical project — the camera must
+   * not unmount mid-flow while the reload is in flight). */
+  let createdProjectId: ProjectId | null = null
   const ensureProjectId = (): Promise<ProjectId> => {
     const project = data?.project
     if (project && project.id !== NEW_PROJECT_ID) return Promise.resolve(project.id)
     ensureProjectPromise ??= (async () => {
       try {
         const created = await createProject()
+        createdProjectId = created.id
         // Their recordings should survive storage pressure.
         requestPersistentStorage()
         navigate(`/project/${created.id}`, { replace: true })
@@ -375,6 +389,17 @@ export function ProjectPage(handle: Handle<ProjectPageProps>) {
         </div>
       )
     }
+
+    // The rendered data must belong to the current route: browser history
+    // between two projects changes the param in place, and the previous
+    // project's clips must not stay visible (or actionable) while the new
+    // load is in flight. The lazy-create transition ('new' → the freshly
+    // created id) is the same logical project and keeps rendering, so the
+    // camera never unmounts mid-flow.
+    const isLazyCreateAlias =
+      project.id === NEW_PROJECT_ID &&
+      (props.projectId === NEW_PROJECT_ID || props.projectId === createdProjectId)
+    if (project.id !== props.projectId && !isLazyCreateAlias) return null
 
     const exporting = exportState?.status === 'exporting'
     const overlayOpen = playing || exportState !== null || onboardingOpen

--- a/src/pages/project-page.tsx
+++ b/src/pages/project-page.tsx
@@ -1,29 +1,18 @@
-import { startTransition, useCallback, useRef, useState } from 'react'
-import {
-  Link,
-  Navigate,
-  useLoaderData,
-  useNavigate,
-  useRevalidator,
-  type LoaderFunctionArgs,
-} from 'react-router-dom'
+import type { Handle } from 'remix/ui'
+import { on } from 'remix/ui'
 import { EditorScreen } from '../components/editor-screen'
 import { ExportOverlay } from '../components/export-overlay'
 import { ExportSheet, type ExportStatus } from '../components/export-sheet'
 import { OnboardingOverlay } from '../components/onboarding-overlay'
 import { PlaybackOverlay } from '../components/playback-overlay'
 import { RecordScreen, type ToastAction } from '../components/record-screen'
-import { useCamera } from '../hooks/use-camera'
+import { createCamera } from '../lib/camera'
 import { RestoreSheet } from '../components/restore-sheet'
 import { REMOVE_WATERMARK_LINK } from '../lib/entitlement'
 import { buildClipsZip } from '../lib/clips-zip'
 import { clearExportMarker, markExportStarted, reportError } from '../lib/error-reporting'
 import { exportProject, type ExportResult } from '../lib/export'
-import {
-  exportSignature,
-  loadMatchingExport,
-  persistLastExport,
-} from '../lib/export/last-export'
+import { exportSignature, loadMatchingExport, persistLastExport } from '../lib/export/last-export'
 import { MediaElementFailureError } from '../lib/export/media-error'
 import { wait } from '../lib/export/shared'
 import {
@@ -36,6 +25,7 @@ import {
 import { loadProjectPage, type ProjectLoaderData } from '../lib/project-actions'
 import { createProject, setOnboardingDismissed } from '../lib/storage'
 import { requestPersistentStorage } from '../lib/storage-space'
+import { navigate } from '../router'
 import { NEW_PROJECT_ID, type ProjectId } from '../lib/types'
 
 /** Resolve after the next animation frame (or a short timeout when rAF is busy). */
@@ -68,72 +58,83 @@ interface ExportUiState {
   watermarked: boolean
 }
 
-export async function projectLoader({ params }: LoaderFunctionArgs): Promise<ProjectLoaderData> {
-  const projectId = params.projectId
-  if (!projectId) {
-    return {
-      project: null,
-      clips: [],
-      canUndo: false,
-      onboardingDismissed: true,
-      watermarkRemoved: false,
-      storage: null,
-      locationTaggingEnabled: false,
-      error: 'Project not found',
-    }
-  }
-  return loadProjectPage(projectId)
+interface ProjectPageProps {
+  projectId: string
 }
 
-export function ProjectPage() {
-  const data = useLoaderData() as ProjectLoaderData
-  const revalidator = useRevalidator()
-  const camera = useCamera()
+export function ProjectPage(handle: Handle<ProjectPageProps>) {
+  const { props } = handle
+  const camera = createCamera(() => void handle.update())
 
-  const toastTimerRef = useRef(0)
-  const exportRunRef = useRef(0)
-  const previewCanvasRef = useRef<HTMLCanvasElement | null>(null)
+  let data: ProjectLoaderData | null = null
+  /** The projectId the current `data` was loaded for — reloads when the URL
+   * param changes in place (e.g. /project/new → /project/<id> after the
+   * first clip persists the lazy project; the page instance survives so the
+   * camera never restarts). */
+  let loadedForId: string | null = null
 
-  const bindPreviewCanvas = useCallback((element: HTMLCanvasElement | null) => {
-    previewCanvasRef.current = element
-  }, [])
+  let toastTimer = 0
+  let exportRun = 0
+  let previewCanvas: HTMLCanvasElement | null = null
+  const bindPreviewCanvas = (element: HTMLCanvasElement | null) => {
+    previewCanvas = element
+  }
 
-  const [mode, setMode] = useState<ProjectMode>('record')
-  const [onboardingOpen, setOnboardingOpen] = useState(() => !data.onboardingDismissed)
-  const [playing, setPlaying] = useState(false)
-  const [toast, setToast] = useState<ToastState | null>(null)
-  const [exportState, setExportState] = useState<ExportUiState | null>(null)
-  const [restoring, setRestoring] = useState(false)
+  let mode: ProjectMode = 'record'
+  let onboardingOpen = false
+  let onboardingInitialized = false
+  let playing = false
+  let toast: ToastState | null = null
+  let exportState: ExportUiState | null = null
+  let restoring = false
   /** In-flight share/save COUNT (concurrent actions must not clear each
    * other's busy state) — the export sheet must not dismiss while > 0. */
-  const [exportActionCount, setExportActionCount] = useState(0)
-  const beginExportAction = () => setExportActionCount((count) => count + 1)
-  const endExportAction = () => setExportActionCount((count) => Math.max(0, count - 1))
+  let exportActionCount = 0
+  const beginExportAction = () => {
+    exportActionCount += 1
+    void handle.update()
+  }
+  const endExportAction = () => {
+    exportActionCount = Math.max(0, exportActionCount - 1)
+    void handle.update()
+  }
 
-  const refresh = useCallback(() => {
-    startTransition(() => {
-      void revalidator.revalidate()
+  const load = (projectId: string) => {
+    loadedForId = projectId
+    void loadProjectPage(projectId).then((loaded) => {
+      if (handle.signal.aborted || loadedForId !== projectId) return
+      data = loaded
+      if (!onboardingInitialized) {
+        onboardingInitialized = true
+        onboardingOpen = !loaded.onboardingDismissed
+      }
+      void handle.update()
     })
-  }, [revalidator])
+  }
+  load(props.projectId)
 
-  const showToast = useCallback((message: string, action?: ToastAction) => {
-    window.clearTimeout(toastTimerRef.current)
-    setToast({ message, ...action })
-    toastTimerRef.current = window.setTimeout(() => setToast(null), 2600)
-  }, [])
+  const refresh = () => {
+    if (loadedForId) load(loadedForId)
+  }
 
-  const clips = data.clips
-  const stopCamera = camera.stop
-  const navigate = useNavigate()
-  const project = data.project
+  const showToast = (message: string, action?: ToastAction) => {
+    window.clearTimeout(toastTimer)
+    toast = { message, ...action }
+    void handle.update()
+    toastTimer = window.setTimeout(() => {
+      toast = null
+      void handle.update()
+    }, 2600)
+  }
 
   // Lazy creation: a "/project/new" project is persisted only when the
   // first clip finishes recording. The promise is memoized so overlapping
   // takes (or a camera take racing a screen take) create exactly one.
-  const ensureProjectRef = useRef<Promise<ProjectId> | null>(null)
-  const ensureProjectId = useCallback((): Promise<ProjectId> => {
+  let ensureProjectPromise: Promise<ProjectId> | null = null
+  const ensureProjectId = (): Promise<ProjectId> => {
+    const project = data?.project
     if (project && project.id !== NEW_PROJECT_ID) return Promise.resolve(project.id)
-    ensureProjectRef.current ??= (async () => {
+    ensureProjectPromise ??= (async () => {
       try {
         const created = await createProject()
         // Their recordings should survive storage pressure.
@@ -142,17 +143,25 @@ export function ProjectPage() {
         return created.id
       } catch (err) {
         // A failed creation must not poison later attempts.
-        ensureProjectRef.current = null
+        ensureProjectPromise = null
         throw err
       }
     })()
-    return ensureProjectRef.current
-  }, [navigate, project])
+    return ensureProjectPromise
+  }
 
-  const startExport = useCallback((options?: { force?: boolean }) => {
+  const setExportState = (next: ExportUiState | null) => {
+    exportState = next
+    void handle.update()
+  }
+
+  const startExport = (options?: { force?: boolean }) => {
+    if (!data) return
+    const clips = data.clips
+    const project = data.project
     if (clips.length === 0) return
-    const runId = exportRunRef.current + 1
-    exportRunRef.current = runId
+    const runId = exportRun + 1
+    exportRun = runId
 
     // Unlock an AudioContext from this tap: the realtime engine needs it for
     // audio mixing, including when WebCodecs fails mid-export and we fall
@@ -173,7 +182,7 @@ export function ProjectPage() {
     // unmount. On iOS the combined mic+camera session can hold decoder
     // slots past the first paints, and WebKit reports that race as
     // MEDIA_ERR_SRC_NOT_SUPPORTED for an otherwise playable clip.
-    stopCamera()
+    camera.stop()
     setExportState({
       status: 'exporting',
       progress: 0,
@@ -184,19 +193,19 @@ export function ProjectPage() {
     })
     // Long exports must survive the screen dimming: without a wake lock the
     // OS suspends the tab mid-export and the user returns to a restart.
-    const wakeLockRef: { current: WakeLockSentinel | null; released: boolean } = {
+    const wakeLockState: { current: WakeLockSentinel | null; released: boolean } = {
       current: null,
       released: false,
     }
     void navigator.wakeLock
       ?.request('screen')
       .then((sentinel) => {
-        if (wakeLockRef.released) {
+        if (wakeLockState.released) {
           // The export finished before the request resolved — never leak.
           void sentinel.release().catch(() => undefined)
           return
         }
-        wakeLockRef.current = sentinel
+        wakeLockState.current = sentinel
       })
       .catch(() => undefined)
 
@@ -207,7 +216,7 @@ export function ProjectPage() {
         // bypasses this (force) and always renders fresh.
         if (!options?.force && project) {
           const recovered = await loadMatchingExport(project.id, signature).catch(() => null)
-          if (exportRunRef.current !== runId) return
+          if (exportRun !== runId) return
           if (recovered) {
             setExportState({
               status: 'ready',
@@ -232,7 +241,7 @@ export function ProjectPage() {
         // two frames alone was enough on Android but not after the combined
         // mic+camera capture path.
         if (isIosBrowser()) await wait(400)
-        if (exportRunRef.current !== runId) return
+        if (exportRun !== runId) return
 
         // If the page dies mid-export (tab crash / OOM — no JS error fires),
         // this marker survives the reload and reports the death at next boot.
@@ -240,14 +249,13 @@ export function ProjectPage() {
         const result = await exportProject(clips, {
           audioContext,
           watermark: watermarked,
-          getPreviewCanvas: () => previewCanvasRef.current,
+          getPreviewCanvas: () => previewCanvas,
           onProgress: (ratio) => {
-            if (exportRunRef.current !== runId) return
-            setExportState((current) =>
-              current && current.status === 'exporting'
-                ? { ...current, progress: ratio }
-                : current,
-            )
+            if (exportRun !== runId) return
+            if (exportState && exportState.status === 'exporting') {
+              exportState = { ...exportState, progress: ratio }
+              void handle.update()
+            }
           },
         })
         // Persist for recovery/instant reuse — in the background, the sheet
@@ -260,7 +268,7 @@ export function ProjectPage() {
             watermarked,
           }).catch(() => undefined)
         }
-        if (exportRunRef.current !== runId) return
+        if (exportRun !== runId) return
         setExportState({
           status: 'ready',
           progress: 1,
@@ -285,7 +293,7 @@ export function ProjectPage() {
               ? (err as { exportDetail?: Record<string, unknown> }).exportDetail
               : undefined,
         })
-        if (exportRunRef.current !== runId) return
+        if (exportRun !== runId) return
         setExportState({
           status: 'error',
           progress: 0,
@@ -297,9 +305,9 @@ export function ProjectPage() {
       } finally {
         // The export ended in this session (success or error) — it did not die.
         clearExportMarker()
-        wakeLockRef.released = true
-        void wakeLockRef.current?.release().catch(() => undefined)
-        wakeLockRef.current = null
+        wakeLockState.released = true
+        void wakeLockState.current?.release().catch(() => undefined)
+        wakeLockState.current = null
         // The realtime engine closes the context it used; when WebCodecs
         // handled the export, release the unused tap-unlocked context.
         if (audioContext && audioContext.state !== 'closed') {
@@ -307,190 +315,234 @@ export function ProjectPage() {
         }
       }
     })()
-  }, [clips, data.watermarkRemoved, project, stopCamera])
+  }
 
-  const closeExport = useCallback(() => {
-    exportRunRef.current += 1
+  const closeExport = () => {
+    exportRun += 1
     setExportState(null)
-  }, [])
+  }
 
-  const setExportNotice = useCallback((notice: string) => {
-    setExportState((current) => (current ? { ...current, notice } : current))
-  }, [])
-
-  if (!project || data.error) {
-    if (data.error === 'Project not found') {
-      return <Navigate to="/" replace />
+  const setExportNotice = (notice: string) => {
+    if (exportState) {
+      exportState = { ...exportState, notice }
+      void handle.update()
     }
-    return (
-      <div className="screen">
-        <div className="error-banner">{data.error ?? 'Project missing'}</div>
-        <div style={{ marginTop: 16 }}>
-          <Link className="btn btn-secondary" to="/">
-            Back home
-          </Link>
+  }
+
+  return () => {
+    // The URL param changed in place (lazy create, or another project link).
+    if (props.projectId !== loadedForId) {
+      load(props.projectId)
+    }
+    if (!data) return null
+    const project = data.project
+    const clips = data.clips
+
+    if (!project || data.error) {
+      if (data.error === 'Project not found') {
+        handle.queueTask(() => navigate('/', { replace: true }))
+        return null
+      }
+      return (
+        <div className="screen">
+          <div className="error-banner">{data.error ?? 'Project missing'}</div>
+          <div style={{ marginTop: '16px' }}>
+            <a className="btn btn-secondary" href="/">
+              Back home
+            </a>
+          </div>
         </div>
+      )
+    }
+
+    const exporting = exportState?.status === 'exporting'
+    const overlayOpen = playing || exportState !== null || onboardingOpen
+    const exportFilename = exportState?.result
+      ? projectFilename(project.name, exportState.result.fileExtension)
+      : null
+
+    return (
+      <div className="screen project-screen">
+        {/* While exporting, the screens unmount entirely: the camera is
+            released (no dead preview burning battery behind the overlay) and
+            the full-screen progress takes over. */}
+        {exporting ? null : mode === 'record' ? (
+          <RecordScreen
+            project={project}
+            ensureProjectId={ensureProjectId}
+            clips={clips}
+            camera={camera}
+            storage={data.storage}
+            locationTaggingEnabled={data.locationTaggingEnabled}
+            interactionLocked={overlayOpen}
+            onOpenEditor={() => {
+              mode = 'editor'
+              void handle.update()
+            }}
+            onOpenExport={() => startExport()}
+            onPlay={() => {
+              playing = true
+              void handle.update()
+            }}
+            showToast={showToast}
+            refresh={refresh}
+          />
+        ) : (
+          <EditorScreen
+            project={project}
+            clips={clips}
+            canUndo={data.canUndo}
+            interactionLocked={overlayOpen}
+            onOpenCamera={() => {
+              mode = 'record'
+              void handle.update()
+            }}
+            onOpenExport={() => startExport()}
+            onPlay={() => {
+              playing = true
+              void handle.update()
+            }}
+            showToast={showToast}
+            refresh={refresh}
+          />
+        )}
+
+        {playing ? (
+          <PlaybackOverlay
+            clips={clips}
+            onClose={() => {
+              playing = false
+              void handle.update()
+            }}
+          />
+        ) : null}
+
+        {exporting ? (
+          <ExportOverlay
+            projectName={project.name}
+            progress={exportState?.progress ?? 0}
+            bindPreviewCanvas={bindPreviewCanvas}
+          />
+        ) : null}
+
+        {exportState && exportState.status !== 'exporting' ? (
+          <ExportSheet
+            status={exportState.status}
+            error={exportState.error}
+            notice={exportState.notice}
+            watermarked={exportState.watermarked}
+            purchased={data.watermarkRemoved}
+            busy={exportActionCount > 0}
+            onRemoveWatermark={() => {
+              window.open(REMOVE_WATERMARK_LINK, '_blank', 'noopener')
+            }}
+            onRestorePurchase={() => {
+              restoring = true
+              void handle.update()
+            }}
+            canShare={
+              !!exportState.result &&
+              !!exportFilename &&
+              canShareFile(exportState.result.blob, exportFilename)
+            }
+            fileExtension={exportState.result?.fileExtension ?? null}
+            fileSizeBytes={exportState.result?.blob.size ?? null}
+            onShare={() => {
+              const result = exportState?.result
+              if (!result || !exportFilename) return
+              beginExportAction()
+              void shareFile(result.blob, exportFilename)
+                .then((outcome) => {
+                  // A cancel (AbortError → 'cancelled') is a routine user action,
+                  // not something worth announcing — only confirm real shares.
+                  if (outcome === 'shared') setExportNotice('Shared!')
+                })
+                .catch(() => {
+                  setExportNotice('Sharing failed — try Save instead.')
+                })
+                .finally(endExportAction)
+            }}
+            onSave={() => {
+              const result = exportState?.result
+              if (!result || !exportFilename) return
+              beginExportAction()
+              void downloadBlob(result.blob, exportFilename)
+                .then(() => {
+                  setExportNotice('Saved — check your downloads.')
+                })
+                .catch(() => {
+                  setExportNotice('Saving failed — try again.')
+                })
+                .finally(endExportAction)
+            }}
+            onSaveClips={() => {
+              beginExportAction()
+              setExportNotice(
+                `Zipping ${clips.length} clip${clips.length === 1 ? '' : 's'}… keep this open.`,
+              )
+              void buildClipsZip(clips)
+                .then((zip) => downloadBlob(zip, projectFilename(`${project.name} clips`, 'zip')))
+                .then(() => {
+                  setExportNotice('Clips zipped — check your downloads.')
+                })
+                .catch(() => {
+                  setExportNotice('Zipping failed — try again.')
+                })
+                .finally(endExportAction)
+            }}
+            onRetry={() => startExport({ force: true })}
+            onReExport={() => startExport({ force: true })}
+            onClose={closeExport}
+          />
+        ) : null}
+
+        {restoring ? (
+          <RestoreSheet
+            onClose={() => {
+              restoring = false
+              void handle.update()
+            }}
+            onRestored={() => {
+              restoring = false
+              void handle.update()
+              showToast('Purchase restored — new exports are watermark-free')
+              refresh()
+            }}
+          />
+        ) : null}
+
+        {onboardingOpen ? (
+          <OnboardingOverlay
+            onDismiss={() => {
+              void (async () => {
+                await setOnboardingDismissed(true)
+                onboardingOpen = false
+                void handle.update()
+              })()
+            }}
+          />
+        ) : null}
+
+        {toast ? (
+          <div className="toast">
+            <span>{toast.message}</span>
+            {toast.actionLabel && toast.onAction ? (
+              <button
+                type="button"
+                mix={on('click', () => {
+                  window.clearTimeout(toastTimer)
+                  const action = toast?.onAction
+                  toast = null
+                  void handle.update()
+                  action?.()
+                })}
+              >
+                {toast.actionLabel}
+              </button>
+            ) : null}
+          </div>
+        ) : null}
       </div>
     )
   }
-
-  const exporting = exportState?.status === 'exporting'
-  const overlayOpen = playing || exportState !== null || onboardingOpen
-  const exportFilename = exportState?.result
-    ? projectFilename(project.name, exportState.result.fileExtension)
-    : null
-
-  return (
-    <div className="screen project-screen">
-      {/* While exporting, the screens unmount entirely: the camera is
-          released (no dead preview burning battery behind the overlay) and
-          the full-screen progress takes over. */}
-      {exporting ? null : mode === 'record' ? (
-        <RecordScreen
-          project={project}
-          ensureProjectId={ensureProjectId}
-          clips={clips}
-          camera={camera}
-          storage={data.storage}
-          locationTaggingEnabled={data.locationTaggingEnabled}
-          interactionLocked={overlayOpen}
-          onOpenEditor={() => setMode('editor')}
-          onOpenExport={startExport}
-          onPlay={() => setPlaying(true)}
-          showToast={showToast}
-          refresh={refresh}
-        />
-      ) : (
-        <EditorScreen
-          project={project}
-          clips={clips}
-          canUndo={data.canUndo}
-          interactionLocked={overlayOpen}
-          onOpenCamera={() => setMode('record')}
-          onOpenExport={startExport}
-          onPlay={() => setPlaying(true)}
-          showToast={showToast}
-          refresh={refresh}
-        />
-      )}
-
-      {playing ? <PlaybackOverlay clips={clips} onClose={() => setPlaying(false)} /> : null}
-
-      {exporting ? (
-        <ExportOverlay
-          projectName={project.name}
-          progress={exportState?.progress ?? 0}
-          bindPreviewCanvas={bindPreviewCanvas}
-        />
-      ) : null}
-
-      {exportState && exportState.status !== 'exporting' ? (
-        <ExportSheet
-          status={exportState.status}
-          error={exportState.error}
-          notice={exportState.notice}
-          watermarked={exportState.watermarked}
-          purchased={data.watermarkRemoved}
-          busy={exportActionCount > 0}
-          onRemoveWatermark={() => {
-            window.open(REMOVE_WATERMARK_LINK, '_blank', 'noopener')
-          }}
-          onRestorePurchase={() => setRestoring(true)}
-          canShare={
-            !!exportState.result &&
-            !!exportFilename &&
-            canShareFile(exportState.result.blob, exportFilename)
-          }
-          fileExtension={exportState.result?.fileExtension ?? null}
-          fileSizeBytes={exportState.result?.blob.size ?? null}
-          onShare={() => {
-            const result = exportState.result
-            if (!result || !exportFilename) return
-            beginExportAction()
-            void shareFile(result.blob, exportFilename)
-              .then((outcome) => {
-                // A cancel (AbortError → 'cancelled') is a routine user action,
-                // not something worth announcing — only confirm real shares.
-                if (outcome === 'shared') setExportNotice('Shared!')
-              })
-              .catch(() => {
-                setExportNotice('Sharing failed — try Save instead.')
-              })
-              .finally(endExportAction)
-          }}
-          onSave={() => {
-            const result = exportState.result
-            if (!result || !exportFilename) return
-            beginExportAction()
-            void downloadBlob(result.blob, exportFilename)
-              .then(() => {
-                setExportNotice('Saved — check your downloads.')
-              })
-              .catch(() => {
-                setExportNotice('Saving failed — try again.')
-              })
-              .finally(endExportAction)
-          }}
-          onSaveClips={() => {
-            beginExportAction()
-            setExportNotice(
-              `Zipping ${clips.length} clip${clips.length === 1 ? '' : 's'}… keep this open.`,
-            )
-            void buildClipsZip(clips)
-              .then((zip) => downloadBlob(zip, projectFilename(`${project.name} clips`, 'zip')))
-              .then(() => {
-                setExportNotice('Clips zipped — check your downloads.')
-              })
-              .catch(() => {
-                setExportNotice('Zipping failed — try again.')
-              })
-              .finally(endExportAction)
-          }}
-          onRetry={() => startExport({ force: true })}
-          onReExport={() => startExport({ force: true })}
-          onClose={closeExport}
-        />
-      ) : null}
-
-      {restoring ? (
-        <RestoreSheet
-          onClose={() => setRestoring(false)}
-          onRestored={() => {
-            setRestoring(false)
-            showToast('Purchase restored — new exports are watermark-free')
-            refresh()
-          }}
-        />
-      ) : null}
-
-      {onboardingOpen ? (
-        <OnboardingOverlay
-          onDismiss={() => {
-            void (async () => {
-              await setOnboardingDismissed(true)
-              setOnboardingOpen(false)
-            })()
-          }}
-        />
-      ) : null}
-
-      {toast ? (
-        <div className="toast">
-          <span>{toast.message}</span>
-          {toast.actionLabel && toast.onAction ? (
-            <button
-              type="button"
-              onClick={() => {
-                window.clearTimeout(toastTimerRef.current)
-                setToast(null)
-                toast.onAction?.()
-              }}
-            >
-              {toast.actionLabel}
-            </button>
-          ) : null}
-        </div>
-      ) : null}
-    </div>
-  )
 }

--- a/src/pages/project-page.tsx
+++ b/src/pages/project-page.tsx
@@ -99,11 +99,15 @@ export function ProjectPage(handle: Handle<ProjectPageProps>) {
     void handle.update()
   }
 
+  /** Monotonic request id: an older in-flight load for the same project
+   * (mount racing a post-mutation refresh) must never overwrite newer data. */
+  let loadVersion = 0
   const load = (projectId: string) => {
     loadedForId = projectId
+    const version = ++loadVersion
     void loadProjectPage(projectId)
       .then((loaded) => {
-        if (handle.signal.aborted || loadedForId !== projectId) return
+        if (handle.signal.aborted || version !== loadVersion) return
         data = loaded
         if (!onboardingInitialized) {
           onboardingInitialized = true
@@ -112,7 +116,7 @@ export function ProjectPage(handle: Handle<ProjectPageProps>) {
         void handle.update()
       })
       .catch((err) => {
-        if (handle.signal.aborted || loadedForId !== projectId) return
+        if (handle.signal.aborted || version !== loadVersion) return
         reportError(err, 'load-project')
         // Reuse the page's error rendering path (banner + back-home link).
         data = {

--- a/src/pages/terms-page.tsx
+++ b/src/pages/terms-page.tsx
@@ -1,14 +1,13 @@
-import { Link } from 'react-router-dom'
 import { IconBack } from '../components/icons'
 
 /** Plain-language terms of use for on-device Kody Video. */
 export function TermsPage() {
-  return (
+  return () => (
     <div className="screen about-screen">
       <div className="about-top">
-        <Link to="/" className="btn-icon" aria-label="Back to projects">
+        <a href="/" className="btn-icon" aria-label="Back to projects">
           <IconBack />
-        </Link>
+        </a>
         <strong>Terms</strong>
         <span className="about-top-spacer" aria-hidden="true" />
       </div>
@@ -76,8 +75,7 @@ export function TermsPage() {
 
         <section className="about-section legal-nav">
           <p>
-            See also the <Link to="/privacy">Privacy</Link> and{' '}
-            <Link to="/about">About</Link> pages.
+            See also the <a href="/privacy">Privacy</a> and <a href="/about">About</a> pages.
           </p>
         </section>
       </div>

--- a/src/pages/unlocked-page.tsx
+++ b/src/pages/unlocked-page.tsx
@@ -1,28 +1,39 @@
-import { Link, useLoaderData, type LoaderFunctionArgs } from 'react-router-dom'
+import type { Handle } from 'remix/ui'
 import { BrandMark } from '../components/brand-mark'
 import { verifyPurchaseSession, type VerifyResult } from '../lib/entitlement'
 
 /**
  * Stripe's Payment Link redirects here after checkout with
- * ?session_id={CHECKOUT_SESSION_ID}; the loader verifies it server-side and
- * persists the entitlement before the page renders.
+ * ?session_id={CHECKOUT_SESSION_ID}; setup verifies it server-side and
+ * persists the entitlement before rendering the result.
  */
-export async function unlockedLoader({ request }: LoaderFunctionArgs): Promise<VerifyResult> {
-  const sessionId = new URL(request.url).searchParams.get('session_id')
+async function verifyFromLocation(): Promise<VerifyResult> {
+  const sessionId = new URL(window.location.href).searchParams.get('session_id')
   if (!sessionId) {
     return { unlocked: false, error: 'Missing checkout session. Use the link from your receipt.' }
   }
   return verifyPurchaseSession(sessionId)
 }
 
-export function UnlockedPage() {
-  const result = useLoaderData() as VerifyResult
+export function UnlockedPage(handle: Handle) {
+  let result: VerifyResult | null = null
 
-  return (
+  void verifyFromLocation().then((verified) => {
+    if (handle.signal.aborted) return
+    result = verified
+    void handle.update()
+  })
+
+  return () => (
     <div className="screen unlocked-screen">
       <div className="unlocked-card">
         <BrandMark size={110} className="export-celebrate-art" variant="share" />
-        {result.unlocked ? (
+        {result === null ? (
+          <>
+            <p className="eyebrow">Checking your purchase…</p>
+            <h1>One moment</h1>
+          </>
+        ) : result.unlocked ? (
           <>
             <p className="eyebrow">Purchase verified</p>
             <h1>Kody Video Plus unlocked! 🎉</h1>
@@ -42,9 +53,11 @@ export function UnlockedPage() {
             </p>
           </>
         )}
-        <Link className="btn btn-primary" to="/">
-          {result.unlocked ? 'Start creating' : 'Back to Kody Video'}
-        </Link>
+        {result === null ? null : (
+          <a className="btn btn-primary" href="/">
+            {result.unlocked ? 'Start creating' : 'Back to Kody Video'}
+          </a>
+        )}
       </div>
     </div>
   )

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -1,42 +1,95 @@
-import { Navigate, createBrowserRouter } from 'react-router-dom'
-import { AboutPage, aboutLoader } from './pages/about-page'
-import { HomePage, homeLoader } from './pages/home-page'
-import { PrivacyPage } from './pages/privacy-page'
-import { ProjectPage, projectLoader } from './pages/project-page'
-import { TermsPage } from './pages/terms-page'
-import { UnlockedPage, unlockedLoader } from './pages/unlocked-page'
+import { createMultiMatcher } from 'remix/route-pattern/match'
+import type { Handle, RemixNode } from 'remix/ui'
 
-export const router = createBrowserRouter([
-  {
-    path: '/',
-    element: <HomePage />,
-    loader: homeLoader,
-  },
-  {
-    path: '/project/:projectId',
-    element: <ProjectPage />,
-    loader: projectLoader,
-  },
-  {
-    path: '/unlocked',
-    element: <UnlockedPage />,
-    loader: unlockedLoader,
-  },
-  {
-    path: '/about',
-    element: <AboutPage />,
-    loader: aboutLoader,
-  },
-  {
-    path: '/privacy',
-    element: <PrivacyPage />,
-  },
-  {
-    path: '/terms',
-    element: <TermsPage />,
-  },
-  {
-    path: '*',
-    element: <Navigate to="/" replace />,
-  },
-])
+/**
+ * Minimal client-side router for a pure SPA.
+ *
+ * The app's data lives in IndexedDB, so there is nothing to preload from a
+ * server on navigation — pages own their data loading. All this router does
+ * is keep `location.pathname` in sync with which page component renders:
+ * pushState/replaceState + popstate + same-origin link interception.
+ */
+
+export type RouteParams = Record<string, string>
+
+const routerEvents = new EventTarget()
+let interceptInstalled = false
+
+function notify() {
+  routerEvents.dispatchEvent(new Event('navigate'))
+}
+
+export function navigate(to: string, options: { replace?: boolean } = {}): void {
+  const destination = new URL(to, window.location.href)
+  if (destination.origin !== window.location.origin) {
+    window.location.assign(destination.toString())
+    return
+  }
+  const nextPath = `${destination.pathname}${destination.search}${destination.hash}`
+  const currentPath = `${window.location.pathname}${window.location.search}${window.location.hash}`
+  if (nextPath === currentPath) return
+  if (options.replace) {
+    window.history.replaceState({}, '', nextPath)
+  } else {
+    window.history.pushState({}, '', nextPath)
+  }
+  window.scrollTo(0, 0)
+  notify()
+}
+
+function shouldInterceptClick(event: MouseEvent, anchor: HTMLAnchorElement): boolean {
+  if (event.defaultPrevented) return false
+  if (event.button !== 0) return false
+  if (event.metaKey || event.altKey || event.ctrlKey || event.shiftKey) return false
+  if (anchor.target && anchor.target !== '_self') return false
+  if (anchor.hasAttribute('download')) return false
+  const href = anchor.getAttribute('href')
+  if (!href || href.startsWith('#')) return false
+  const destination = new URL(anchor.href, window.location.href)
+  return destination.origin === window.location.origin
+}
+
+function installIntercepts() {
+  if (interceptInstalled) return
+  interceptInstalled = true
+  document.addEventListener('click', (event) => {
+    const anchor = (event.target as Element | null)?.closest('a')
+    if (!anchor || !shouldInterceptClick(event, anchor)) return
+    event.preventDefault()
+    const destination = new URL(anchor.href, window.location.href)
+    navigate(`${destination.pathname}${destination.search}${destination.hash}`)
+  })
+  window.addEventListener('popstate', notify)
+}
+
+export function onNavigate(handle: Pick<Handle, 'signal'>, listener: () => void): void {
+  installIntercepts()
+  routerEvents.addEventListener('navigate', listener, { signal: handle.signal })
+}
+
+type RouterProps = {
+  routes: Record<string, (params: RouteParams) => RemixNode>
+}
+
+export function Router(handle: Handle<RouterProps>) {
+  const matcher = createMultiMatcher<(params: RouteParams) => RemixNode>()
+  for (const [pattern, page] of Object.entries(handle.props.routes)) {
+    matcher.add(pattern, page)
+  }
+
+  onNavigate(handle, () => void handle.update())
+
+  return () => {
+    const match = matcher.match(new URL(window.location.href))
+    if (!match) {
+      // Unknown paths bounce home, like the old `*` route.
+      handle.queueTask(() => navigate('/', { replace: true }))
+      return null
+    }
+    const params: RouteParams = {}
+    for (const [name, value] of Object.entries(match.params)) {
+      if (typeof value === 'string') params[name] = value
+    }
+    return match.data(params)
+  }
+}

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -12,6 +12,7 @@
     "moduleDetection": "force",
     "noEmit": true,
     "jsx": "react-jsx",
+    "jsxImportSource": "remix/ui",
     "strict": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,5 +1,4 @@
 import { defineConfig } from 'vite'
-import react from '@vitejs/plugin-react'
 import { VitePWA } from 'vite-plugin-pwa'
 import { sentryVitePlugin } from '@sentry/vite-plugin'
 
@@ -17,8 +16,11 @@ export default defineConfig({
     // Generated for Sentry upload, never referenced from the served bundles.
     sourcemap: sentryUpload ? 'hidden' : false,
   },
+  esbuild: {
+    jsx: 'automatic',
+    jsxImportSource: 'remix/ui',
+  },
   plugins: [
-    react(),
     ...(sentryUpload
       ? [
           sentryVitePlugin({

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,6 +3,8 @@ import { defineConfig } from 'vitest/config'
 export default defineConfig({
   test: {
     environment: 'node',
+    // Unit tests only — tests/e2e belongs to Playwright.
+    include: ['src/**/*.test.ts', 'functions/**/*.test.ts'],
     setupFiles: ['./src/test/setup.ts'],
   },
 })


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What this is

The whole UI layer re-implemented on **Remix 3** (`remix@3.0.0-beta.5`, pinned — the current `next` dist-tag), replacing React 19 + React Router 7. It's a pure client-side app (no SSR): `remix/ui` components rendered with `createRoot`, JSX compiled with `jsxImportSource: 'remix/ui'`. Vite, vite-plugin-pwa, the Cloudflare Pages Function, and all of `src/lib` (storage, recorder, export engines, thumbs, …) stay as they were — that code never depended on React.

**Live preview: https://remix.kody.video** (proxied CNAME → the `cursor-remix3-rewrite-b52b` branch alias on the existing Pages project, so every push here redeploys it). Production kody.video is untouched.

## Verification

- **All 45 Playwright e2e tests pass without modifying a single test** — recording, lazy project creation, editor/trim/reorder, playback, export + share, purchase/upsell flows, storage management, install hints, iOS audio session, and the full desktop keyboard suite. The suite drives the real DOM, so this is a meaningful behavioral-parity check, not a unit-level one.
- All 88 unit tests pass (13 files — three more files than were even collectible on `main`, where vitest silently failed to load some; vitest is now scoped to unit tests so `npm test` exits 0).
- `tsc -b` clean, production build + service worker generate normally.
- A live smoke probe against the deployed preview (`scripts/probe-deployed-remix.mjs`) records with the fake camera, verifies the clip lands on the filmstrip, runs playback, and confirms `/api/verify-purchase` reaches Stripe from the preview environment.

## How the port maps

| React implementation | Remix 3 implementation |
|---|---|
| `useState` + re-render on set | plain setup-scope variables + explicit `handle.update()` |
| `useRef` for mutable non-render state | just… variables (no distinction needed) |
| ref callbacks for mount/unmount lifecycle | `ref()` mixin (runs once on insert, `AbortSignal` on removal) |
| `onClick` etc. props | `on()` mixins (real DOM events; handlers re-bound with latest closure each render) |
| `useSyncExternalStore` for install prompt | subscribe in setup, read in render |
| Route loaders + `useRevalidator` + `startTransition` | pages load in setup and expose `refresh()` |
| `createBrowserRouter` (React Router 7) | ~100-line router on `remix/route-pattern` (`src/router.tsx`) |
| `useCamera` hook (14 refs + 12 state cells) | `createCamera(notify)` controller with plain fields (`src/lib/camera.ts`) |
| `useSheetModal` hook | `attachSheetModal(el, signal, opts)` (`src/lib/sheet-modal.ts`) |
| `@sentry/react` + React 19 root error options | `@sentry/browser` + the virtual root's `error` event |
| `virtual:pwa-register/react` | `virtual:pwa-register` |

## My take on the hypothesis ("the subtle bugs will disappear because Remix is simpler")

**Partially confirmed, with an important asterisk.**

Where the hypothesis is right: an entire *class* of React failure modes is structurally impossible now. The React codebase had accumulated visible scar tissue defending against them:

- **Stale-closure ref mirrors are gone.** The React record screen kept `lockedRef`, `keyActionsRef`, `visibilityActionRef`, `locationTaggingRef`, `selectedClipIdRef` — refs whose only job was to smuggle the latest committed state past stale event-listener closures, re-synced via `useLayoutEffect` after every commit. In Remix, closures read live setup-scope variables, so that whole layer (and every bug hiding in it) evaporates. The record screen lost ~15 refs while keeping identical behavior.
- **No dependency arrays.** `useCallback`/`useMemo`/effect dep lists were the app's biggest latent-bug surface (a wrong dep = a stale camera handler). There are zero now.
- **No StrictMode double-mount defenses needed.** The camera's epoch counter survives (it guards real races, not React artifacts), but setup runs exactly once, predictably.
- **Performance hacks became unnecessary defaults.** The React app carefully deferred zoom state to a 150ms trailing timer and wrote the REC timer via `textContent` from rAF *because any setState re-rendered the page during capture*. With explicit `handle.update()`, nothing re-renders unless asked — the same discipline is now just how the framework works rather than something the code fights for.

Where the asterisk lives: **the update explicitness cuts both ways.** React guarantees render-after-state-change; Remix makes you say it. During the port the most error-prone edit was remembering `void handle.update()` after every mutation — a forgotten one is exactly the kind of subtle bug the hypothesis wants to eliminate, just relocated from "stale closure" to "stale screen". Similarly, `ref()` runs once per element insert (not per render like React ref callbacks), so anything reacting to *prop changes* on a live element — the blob→URL binding, the playback overlay's segment source — needs an explicit sync-in-render step that React's re-run-the-ref model gave for free. The blob components and the playback overlay carry that logic now.

Net: fewer places where bugs *can* hide, in exchange for a small number of new places where discipline is required. For an app like this one — imperative media APIs, pointer gestures, hardware lifecycles — the trade is clearly favorable: the Remix component model (setup scope + real DOM events + abort signals) is a much more honest match for what the code actually does than hooks were. The `AbortSignal`-everywhere convention (component lifetime, element removal, event re-entry) composes beautifully with `MediaRecorder`, `getUserMedia`, and fetch.

Worth noting honestly: the React implementation was already written in an unusually Remix-shaped style (ref-callback lifecycles, almost no `useEffect`), which is *why* the port preserved behavior so cleanly — and also why the diff reads as "the same design with the scaffolding removed". A hook-heavy codebase would have been a much bloodier rewrite, and would probably have shed more real bugs in the process.

Beta-5 rough edges encountered (minor): `Props<'img'>` is an accessibility-variant union that breaks under `Omit`, and `on()`'s target inference falls back to `Element` for non-inline handler references (pointer events then don't typecheck) — both worked around with explicit prop types and inline arrows.

## Notes

- Bundle: 841 kB minified / 236 kB gzip vs ~1 MB with React — `remix/ui` is lighter than react-dom + react-router combined, despite mediabunny dominating either way.
- `docs`-visible domains: the deployed preview shares production's IndexedDB *origin isolation* rules — remix.kody.video has its own storage, so projects there don't touch kody.video data.
- If the experiment is rejected, delete the `remix.kody.video` CNAME and the Pages custom domain; nothing else changed outside this branch.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-464aedb4-ac9c-4b24-8162-8e80ff39b52b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-464aedb4-ac9c-4b24-8162-8e80ff39b52b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Improved camera, recording, playback, trimming, export, project management, and modal interactions.
  * Updated navigation, loading states, service updates, and media previews for a smoother experience.
  * Purchase verification now displays a clear checking state before unlocked content appears.

* **Documentation**
  * Updated architecture documentation and client-side data-flow guidance.

* **Tests**
  * Added an automated deployed-preview smoke test covering recording, playback, project creation, and purchase verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->