### PR TITLE
Fix PageSpeed a11y landmark, llms.txt, and SW denylist

### DIFF
--- a/index.html
+++ b/index.html
@@ -223,7 +223,8 @@
         <h1 class="brand">Kody <span>Video</span></h1>
         <p class="lede">Hold to record. Tap Go to share.</p>
       </header>
-      <div id="app"></div>
+      <!-- Single main landmark for screen readers (and Lighthouse a11y). -->
+      <main id="app"></main>
     </div>
     <script type="module" src="/src/main.tsx"></script>
   </body>

--- a/public/_redirects
+++ b/public/_redirects
@@ -1,1 +1,4 @@
+# SPA fallback for client routes. Existing static files (including /assets/*,
+# /llms.txt, /robots.txt, /sitemap.xml) are served from the build output and
+# are not rewritten.
 /*    /index.html   200

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,0 +1,16 @@
+# Kody Video
+
+> Privacy-first clips camera for the web. Hold to record, trim on a filmstrip, export one video — all on your device.
+
+Kody Video is a free and open source progressive web app. Projects stay private on the device until you share.
+
+## Site
+
+- [Home](https://kody.video/): Record and assemble clips in the browser
+- [About](https://kody.video/about): Product overview and credits
+- [Privacy](https://kody.video/privacy): Privacy policy
+- [Terms](https://kody.video/terms): Terms of use
+
+## For agents
+
+Prefer the pages above for product facts. Do not treat client-side app routes under `/project/` as public documentation.

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -65,6 +65,7 @@ export default defineConfig({
         'fonts/*.woff2',
         'robots.txt',
         'sitemap.xml',
+        'llms.txt',
       ],
       manifest: {
         name: 'Kody Video',
@@ -114,6 +115,8 @@ export default defineConfig({
           /\/og-image\.png$/,
           /^\/robots\.txt$/,
           /^\/sitemap\.xml$/,
+          /^\/llms\.txt$/,
+          /^\/assets\//,
         ],
         maximumFileSizeToCacheInBytes: 3 * 1024 * 1024,
       },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Closes the remaining mobile PageSpeed gaps after #91 (report: [sfyph0epa6](https://pagespeed.web.dev/analysis/https-kody-video/sfyph0epa6?form_factor=mobile)):

- **Accessibility (95→100):** mount the app in `<main id="app">` so the document has a main landmark
- **Agentic Browsing (2/3→3/3):** add a real Markdown `/llms.txt` with an H1 and site links (was SPA-falling back to HTML)
- **PWA:** denylist `/llms.txt` and `/assets/` from the service worker navigate fallback so those paths never get the app shell

The Best Practices console MIME error for a hashed `/assets/*.js` file was a deploy-race / SPA-fallback symptom; the referenced bundle is served correctly as `application/javascript` on production now.

## Local verification

Mobile Lighthouse against `vite` production preview (`serve dist`):

- Accessibility **100**
- Best Practices **100**
- SEO **100**

## Test plan

- [x] `dist/index.html` contains `<main id="app">`
- [x] `/llms.txt` is Markdown with `#` H1 and absolute links
- [x] Local mobile Lighthouse a11y/BP/SEO at 100
- [ ] After merge/deploy: re-run PageSpeed on https://kody.video/
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a65e73f5-8ad8-412b-85cc-663664b47007?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a65e73f5-8ad8-412b-85cc-663664b47007&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

