### PR TITLE
Ship public sourcemaps and shrink the Sentry boot chunk

### DIFF
--- a/docs/contribute/environment.md
+++ b/docs/contribute/environment.md
@@ -26,7 +26,9 @@ postinstall scripts (`esbuild`, `@sentry/cli`). This is safe to ignore:
 
 - `esbuild` works via its `@esbuild/linux-x64` optional dependency.
 - `@sentry/cli` is only needed for source-map upload at build time, which is
-  skipped unless `SENTRY_AUTH_TOKEN` is set.
+  skipped unless `SENTRY_AUTH_TOKEN` is set. Production builds always emit
+  public `*.map` files in `dist/` (open source); when the token is present,
+  those same maps are also uploaded to Sentry and left in the deploy.
 
 `npm run build`, `npm run dev`, and the test suites all work without approving
 those scripts.

--- a/src/lib/error-reporting.ts
+++ b/src/lib/error-reporting.ts
@@ -46,6 +46,8 @@ type SentryLike = {
 
 /** Set after the dynamic `@sentry/browser` import resolves on reporting hosts. */
 let sentry: SentryLike | null = null
+/** In-flight SDK load + init so early captures share one import. */
+let sentryLoad: Promise<SentryLike> | null = null
 
 /** True for intentional monitoring self-test events (narrow signature only). */
 export function isMonitoringSelfTestEvent(event: FilterableSentryEvent): boolean {
@@ -99,13 +101,13 @@ export function clearExportMarker(): void {
   }
 }
 
-function reportExportSessionDeath(): void {
+function reportExportSessionDeath(client: SentryLike): void {
   try {
     const raw = sessionStorage.getItem(EXPORT_MARKER_KEY)
     if (!raw) return
     sessionStorage.removeItem(EXPORT_MARKER_KEY)
     const info = JSON.parse(raw) as Record<string, unknown>
-    sentry?.captureMessage('Export session died (page reloaded mid-export, likely OOM/crash)', {
+    client.captureMessage('Export session died (page reloaded mid-export, likely OOM/crash)', {
       level: 'error',
       tags: { step: 'export-crash' },
       extra: info,
@@ -158,12 +160,19 @@ export function coarsePlatformTags(): Record<string, string> {
   return { 'app.os': os, 'app.browser': browser, 'app.installed': String(installed) }
 }
 
-export function initErrorReporting(): void {
-  if (!REPORTING_HOSTNAMES.has(location.hostname)) return
-  // Defer the Sentry SDK so it is not in the critical home-shell parse.
-  void import('@sentry/browser').then((Sentry) => {
-    sentry = Sentry
-    Sentry.init({
+/**
+ * Load only the crash-reporting surface from `@sentry/browser`.
+ * Assigning the whole module namespace kept Session Replay / rrweb in the
+ * chunk (Legacy JS Array.from override + ~500KB), even though we never
+ * enable replay.
+ */
+function loadSentry(): Promise<SentryLike> {
+  if (sentry) return Promise.resolve(sentry)
+  if (sentryLoad) return sentryLoad
+
+  sentryLoad = import('@sentry/browser').then(({ init, captureException, captureMessage }) => {
+    const client: SentryLike = { init, captureException, captureMessage }
+    client.init({
       dsn: SENTRY_DSN,
       release: COMMIT_SHA,
       environment: location.hostname === 'kody.video' ? 'production' : 'legacy-pages-dev',
@@ -176,7 +185,7 @@ export function initErrorReporting(): void {
       tracesSampleRate: 0,
       maxBreadcrumbs: 0,
       beforeBreadcrumb: () => null,
-      beforeSend(event) {
+      beforeSend(event: FilterableSentryEvent & Record<string, unknown>) {
         // Never attach user context (Sentry would otherwise infer an IP-based
         // user) or request metadata (URL/headers).
         delete event.user
@@ -186,8 +195,31 @@ export function initErrorReporting(): void {
         return event
       },
     })
-    reportExportSessionDeath()
+    sentry = client
+    reportExportSessionDeath(client)
+    return client
   })
+
+  return sentryLoad
+}
+
+/**
+ * Schedule Sentry after the home shell is interactive. PSI / Lighthouse still
+ * see a hostname-gated import eventually; idle defer keeps it off the LCP
+ * critical request chain.
+ */
+export function initErrorReporting(): void {
+  if (!REPORTING_HOSTNAMES.has(location.hostname)) return
+
+  const start = () => {
+    void loadSentry().catch(() => undefined)
+  }
+
+  if (typeof window.requestIdleCallback === 'function') {
+    window.requestIdleCallback(start, { timeout: 4000 })
+    return
+  }
+  window.setTimeout(start, 2500)
 }
 
 /**
@@ -204,10 +236,12 @@ export function reportError(
     sentry.captureException(error, { tags: { step }, ...(extra ? { extra } : {}) })
     return
   }
-  // SDK still loading — queue via dynamic import so early failures are not lost.
-  void import('@sentry/browser').then((Sentry) => {
-    Sentry.captureException(error, { tags: { step }, ...(extra ? { extra } : {}) })
-  })
+  // SDK still loading / idle-deferred — queue via the shared loader.
+  void loadSentry()
+    .then((client) => {
+      client.captureException(error, { tags: { step }, ...(extra ? { extra } : {}) })
+    })
+    .catch(() => undefined)
 }
 
 /**
@@ -223,9 +257,11 @@ export function reportComponentError(error: unknown): void {
     })
     return
   }
-  void import('@sentry/browser').then((Sentry) => {
-    Sentry.captureException(error, {
-      mechanism: { type: 'remix.componentError', handled: false },
+  void loadSentry()
+    .then((client) => {
+      client.captureException(error, {
+        mechanism: { type: 'remix.componentError', handled: false },
+      })
     })
-  })
+    .catch(() => undefined)
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -13,8 +13,11 @@ export default defineConfig({
     __BUILD_DATE__: JSON.stringify(new Date().toISOString()),
   },
   build: {
-    // Generated for Sentry upload, never referenced from the served bundles.
-    sourcemap: sentryUpload ? 'hidden' : false,
+    // Open-source app: ship public source maps for DevTools / PSI, and still
+    // upload the same maps to Sentry when the CI token is present.
+    sourcemap: true,
+    // Modern baselines only — matches Vite 7 defaults; keeps transforms lean.
+    target: ['chrome107', 'edge107', 'firefox104', 'safari16'],
   },
   esbuild: {
     jsx: 'automatic',
@@ -27,7 +30,8 @@ export default defineConfig({
             org: 'kent-c-dodds-tech-llc',
             project: 'kody-video',
             release: { name: commitSha },
-            sourcemaps: { filesToDeleteAfterUpload: 'dist/**/*.map' },
+            // Keep *.map in the Pages deploy so browsers can fetch them.
+            sourcemaps: { filesToDeleteAfterUpload: [] },
           }),
         ]
       : []),
@@ -105,7 +109,8 @@ export default defineConfig({
         globPatterns: ['**/*.{js,css,html,ico,png,svg,webp,woff2}'],
         // Not part of the app shell: the social card is for link scrapers
         // and the icon master is only the source for generated icons.
-        globIgnores: ['**/og-image.png', '**/art/kody-video-icon.png'],
+        // Source maps are served on demand for debugging — do not precache.
+        globIgnores: ['**/og-image.png', '**/art/kody-video-icon.png', '**/*.map'],
         navigateFallback: '/index.html',
         // Never SPA-fallback these: opening the social card in a tab with an
         // active service worker was "redirecting" to the app, and the API
@@ -117,6 +122,7 @@ export default defineConfig({
           /^\/sitemap\.xml$/,
           /^\/llms\.txt$/,
           /^\/assets\//,
+          /\.map$/,
         ],
         maximumFileSizeToCacheInBytes: 3 * 1024 * 1024,
       },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-up to the PageSpeed diagnostics on [wzqhg9b58c](https://pagespeed.web.dev/analysis/https-kody-video/wzqhg9b58c?form_factor=desktop) / mobile:

- **Public sourcemaps:** always emit `sourcemap: true`, stop deleting maps after Sentry upload, and keep `*.map` out of the service-worker precache (still served on demand under `/assets/`).
- **Legacy JS / unused JS:** assigning the whole `@sentry/browser` namespace pulled Session Replay / rrweb into the dynamic chunk (~531KB) and tripped Lighthouse’s `Array.from` legacy audit. Only `init` / `captureException` / `captureMessage` are imported now, and init is idle-deferred off the LCP critical path. Reporting chunk is ~90KB; Legacy JS audit passes locally.
- **Build target:** explicit modern baselines (`chrome107` / `edge107` / `firefox104` / `safari16`).

Desktop still uses the intentional phone chrome (≥720px) — that matches this mobile camera PWA and is unchanged.

Cloudflare Insights `beacon.min.js` cache TTL remains zone-injected third-party; not app-owned.

## Local verification

Mobile Lighthouse against `vite preview`:

| Category | Score |
|---|---|
| Performance | **100** |
| Accessibility | **100** |
| Best Practices | **100** |
| SEO | **100** |

- `legacy-javascript`: pass
- `unused-javascript`: ~28 KiB remaining (Remix runtime on the home shell), down from ~161 KiB
- Preview: `*.map` served as `application/json` with `sourceMappingURL` footers

## Test plan

- [x] `npm run build` emits `dist/assets/*.map` and `//# sourceMappingURL=`
- [x] No `Unable to override Array.from` / replay in `dist/assets`
- [x] SW precache has no `.map` entries
- [x] `error-reporting` unit tests pass
- [x] Preview deploy serves `.js.map` as JSON
- [ ] After production deploy: confirm maps on `kody.video` and re-run PSI
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a65e73f5-8ad8-412b-85cc-663664b47007?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a65e73f5-8ad8-412b-85cc-663664b47007&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

