### PR TITLE
Add clips from device/gallery to the timeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ For a phone on the same network, use your machine’s LAN URL over HTTPS, or tun
 - Hold-to-record anywhere on the preview; drag up/down while holding to zoom
 - Self-timer for hands-free takes (tap to stop)
 - Recording feedback (REC pill + elapsed) with a page that does **not** re-render per frame — capture stays smooth
-- Editor: filmstrip timeline (thumbnails, width ∝ duration), drag to reorder, duplicate, delete w/ undo, **in-timeline trim with drag handles**
+- Editor: filmstrip timeline (thumbnails, width ∝ duration), drag to reorder, duplicate, delete w/ undo, **in-timeline trim with drag handles**, **add clips from your device/gallery**
 - Project preview playback: tap edges to skip clips, tap middle to stop
 - Up to **6** stable project slots (create / open / rename / delete, poster art from your clips)
 - Big Go CTA: on-device export to **one video file**, then Share (system sheet) or Save

--- a/manual-test-checklist.md
+++ b/manual-test-checklist.md
@@ -27,7 +27,8 @@ npm test           # unit tests
 - **Editor**: opens at the most recent clip; tap selects; tiles show
   filmstrip thumbnails; duplicate inserts the copy right after the selection;
   delete offers Undo; trim strip opens, dragging the end handle + Done
-  persists `trimEndMs` and updates the tile duration
+  persists `trimEndMs` and updates the tile duration; **Add** imports a
+  video from the device onto the timeline
 - **Playback**: whole cut with segmented progress; edge taps skip
   next/previous; middle tap stops; auto-closes at the end of the cut
 - **Go / export**: full export to a ready sheet with format + size; Save

--- a/src/components/editor-screen.tsx
+++ b/src/components/editor-screen.tsx
@@ -66,8 +66,7 @@ export function EditorScreen(handle: Handle<EditorScreenProps>) {
     fileInputRef.current?.click()
   }
 
-  const importFromDevice = (fileList: FileList | null) => {
-    const files = fileList ? [...fileList] : []
+  const importFromDevice = (files: File[]) => {
     if (files.length === 0 || importing) return
     importing = true
     void handle.update()
@@ -284,7 +283,8 @@ export function EditorScreen(handle: Handle<EditorScreenProps>) {
             }),
             on('change', (event) => {
               const input = event.currentTarget as HTMLInputElement
-              const files = input.files
+              // Copy before clearing: FileList is live and empties with value=''.
+              const files = input.files ? [...input.files] : []
               input.value = ''
               importFromDevice(files)
             }),

--- a/src/components/editor-screen.tsx
+++ b/src/components/editor-screen.tsx
@@ -72,16 +72,20 @@ export function EditorScreen(handle: Handle<EditorScreenProps>) {
     void handle.update()
     void (async () => {
       try {
-        const projectId = await props.ensureProjectId()
-        const result = await importDeviceClips(projectId, files, (done, total) => {
-          if (total > 1) {
-            props.showToast(`Adding clip ${Math.min(done + 1, total)} of ${total}…`)
-          }
+        // ensureProjectId runs only after the first file probes successfully
+        // — a bad pick on /project/new must not create an empty project.
+        const result = await importDeviceClips(files, {
+          ensureProjectId: props.ensureProjectId,
+          onProgress: (done, total) => {
+            if (total > 1) {
+              props.showToast(`Adding clip ${Math.min(done + 1, total)} of ${total}…`)
+            }
+          },
         })
         const last = result.added.at(-1)
         if (last) selectedClipId = last.id
         trimming = false
-        props.refresh()
+        if (result.added.length > 0) props.refresh()
         if (result.added.length === 0 && result.failed.length > 0) {
           props.showToast(result.failed[0]?.reason || 'Could not add that clip')
         } else if (result.failed.length > 0) {
@@ -143,7 +147,7 @@ export function EditorScreen(handle: Handle<EditorScreenProps>) {
 
   // Desktop keyboard support. Closures read live state — no re-binding.
   const onWindowKeyDown = (event: KeyboardEvent) => {
-    if (props.interactionLocked) return
+    if (props.interactionLocked || importing) return
     // Escape stays global; everything else yields to focused controls.
     if (event.code !== 'Escape' && isInteractiveTarget(event)) return
     const clips = props.clips
@@ -295,7 +299,11 @@ export function EditorScreen(handle: Handle<EditorScreenProps>) {
             type="button"
             className="btn-icon"
             aria-label="Back to camera"
-            mix={on('click', () => onOpenCamera())}
+            disabled={importing}
+            mix={on('click', () => {
+              if (importing) return
+              onOpenCamera()
+            })}
           >
             <IconBack />
           </button>
@@ -309,7 +317,7 @@ export function EditorScreen(handle: Handle<EditorScreenProps>) {
             type="button"
             className="btn-icon"
             aria-label="Play project preview"
-            disabled={clips.length === 0}
+            disabled={clips.length === 0 || importing}
             mix={on('click', () => onPlay())}
           >
             <IconPlay />

--- a/src/components/editor-screen.tsx
+++ b/src/components/editor-screen.tsx
@@ -2,7 +2,9 @@ import type { Handle, RemixNode } from 'remix/ui'
 import { on, ref } from 'remix/ui'
 import '../styles/editor.css'
 import {
+  DEVICE_CLIP_ACCEPT,
   duplicateSelectedClip,
+  importDeviceClips,
   moveSelectedClip,
   removeClip,
   trimClip,
@@ -14,6 +16,7 @@ import {
   type ClipId,
   type ClipRecord,
   type Project,
+  type ProjectId,
 } from '../lib/types'
 import { EditorClipPreview, type EditorClipPreviewHandle } from './editor-clip-preview'
 import {
@@ -22,6 +25,7 @@ import {
   IconChevronRight,
   IconDuplicate,
   IconPlay,
+  IconPlus,
   IconTrash,
   IconTrim,
   IconUndo,
@@ -30,10 +34,14 @@ import { Timeline } from './timeline'
 import { TrimStrip } from './trim-strip'
 import type { ToastAction } from './record-screen'
 import { isInteractiveTarget } from '../lib/keyboard'
+import { reportError } from '../lib/error-reporting'
 import { THUMB_COUNT, refineClipFilmstrip } from '../lib/thumbs'
 
 interface EditorScreenProps {
   project: Project
+  /** Resolves the persisted project id, creating the project when the first
+   * clip is added from a lazy "/project/new" shell. */
+  ensureProjectId: () => Promise<ProjectId>
   clips: ClipRecord[]
   canUndo: boolean
   /** True while a full-screen overlay owns input (playback, export, …). */
@@ -49,7 +57,52 @@ export function EditorScreen(handle: Handle<EditorScreenProps>) {
   const { props } = handle
   let selectedClipId: ClipId | null = props.clips.at(-1)?.id ?? null
   let trimming = false
+  let importing = false
+  const fileInputRef: { current: HTMLInputElement | null } = { current: null }
   const previewApi: { current: EditorClipPreviewHandle | null } = { current: null }
+
+  const openDevicePicker = () => {
+    if (importing || props.interactionLocked) return
+    fileInputRef.current?.click()
+  }
+
+  const importFromDevice = (fileList: FileList | null) => {
+    const files = fileList ? [...fileList] : []
+    if (files.length === 0 || importing) return
+    importing = true
+    void handle.update()
+    void (async () => {
+      try {
+        const projectId = await props.ensureProjectId()
+        const result = await importDeviceClips(projectId, files, (done, total) => {
+          if (total > 1) {
+            props.showToast(`Adding clip ${Math.min(done + 1, total)} of ${total}…`)
+          }
+        })
+        const last = result.added.at(-1)
+        if (last) selectedClipId = last.id
+        trimming = false
+        props.refresh()
+        if (result.added.length === 0 && result.failed.length > 0) {
+          props.showToast(result.failed[0]?.reason || 'Could not add that clip')
+        } else if (result.failed.length > 0) {
+          props.showToast(
+            `Added ${result.added.length} · ${result.failed.length} skipped`,
+          )
+        } else if (result.added.length === 1) {
+          props.showToast('Clip added')
+        } else if (result.added.length > 1) {
+          props.showToast(`Added ${result.added.length} clips`)
+        }
+      } catch (err) {
+        reportError(err, 'import-device-clips')
+        props.showToast(err instanceof Error ? err.message : 'Could not add clips')
+      } finally {
+        importing = false
+        void handle.update()
+      }
+    })()
+  }
 
   // Derive a valid selection from the loaded clips (no state syncing).
   const resolveSelectedId = (): ClipId | null =>
@@ -207,7 +260,7 @@ export function EditorScreen(handle: Handle<EditorScreenProps>) {
 
     return (
       <div
-        className={`editor-screen${trimming ? ' is-trimming' : ''}`}
+        className={`editor-screen${trimming ? ' is-trimming' : ''}${importing ? ' is-importing' : ''}`}
         mix={ref((_node, signal) => {
           window.addEventListener('keydown', onWindowKeyDown)
           signal.addEventListener('abort', () => {
@@ -215,6 +268,28 @@ export function EditorScreen(handle: Handle<EditorScreenProps>) {
           })
         })}
       >
+        <input
+          type="file"
+          accept={DEVICE_CLIP_ACCEPT}
+          multiple
+          className="visually-hidden"
+          tabindex={-1}
+          aria-hidden="true"
+          mix={[
+            ref((node, signal) => {
+              fileInputRef.current = node as HTMLInputElement
+              signal.addEventListener('abort', () => {
+                if (fileInputRef.current === node) fileInputRef.current = null
+              })
+            }),
+            on('change', (event) => {
+              const input = event.currentTarget as HTMLInputElement
+              const files = input.files
+              input.value = ''
+              importFromDevice(files)
+            }),
+          ]}
+        />
         <div className="editor-top">
           <button
             type="button"
@@ -289,6 +364,8 @@ export function EditorScreen(handle: Handle<EditorScreenProps>) {
                 trimming = false
                 void handle.update()
               }}
+              onAddFromDevice={openDevicePicker}
+              addingFromDevice={importing}
               refresh={props.refresh}
             />
           )}
@@ -298,7 +375,7 @@ export function EditorScreen(handle: Handle<EditorScreenProps>) {
               <ActionButton
                 label="Delete"
                 ariaLabel="Delete clip"
-                disabled={!selected}
+                disabled={!selected || importing}
                 tone="danger"
                 onClick={handleDelete}
                 icon={<IconTrash />}
@@ -306,7 +383,7 @@ export function EditorScreen(handle: Handle<EditorScreenProps>) {
               <ActionButton
                 label="Duplicate"
                 ariaLabel="Duplicate clip"
-                disabled={!selected}
+                disabled={!selected || importing}
                 onClick={() => {
                   if (!resolvedSelectedId) return
                   void duplicateSelectedClip(resolvedSelectedId).then((copy) => {
@@ -318,7 +395,7 @@ export function EditorScreen(handle: Handle<EditorScreenProps>) {
               />
               <ActionButton
                 label="Trim"
-                disabled={!selected}
+                disabled={!selected || importing}
                 prominent
                 onClick={() => {
                   previewApi.current?.pause()
@@ -329,7 +406,7 @@ export function EditorScreen(handle: Handle<EditorScreenProps>) {
               <ActionButton
                 label="Left"
                 ariaLabel="Move clip left"
-                disabled={!selected || selectedIndex <= 0}
+                disabled={!selected || selectedIndex <= 0 || importing}
                 onClick={() => {
                   if (!resolvedSelectedId) return
                   void moveSelectedClip(project.id, resolvedSelectedId, 'left').then(() =>
@@ -341,7 +418,7 @@ export function EditorScreen(handle: Handle<EditorScreenProps>) {
               <ActionButton
                 label="Right"
                 ariaLabel="Move clip right"
-                disabled={!selected || selectedIndex >= clips.length - 1}
+                disabled={!selected || selectedIndex >= clips.length - 1 || importing}
                 onClick={() => {
                   if (!resolvedSelectedId) return
                   void moveSelectedClip(project.id, resolvedSelectedId, 'right').then(() =>
@@ -354,26 +431,38 @@ export function EditorScreen(handle: Handle<EditorScreenProps>) {
           ) : null}
 
           <div className="editor-toolbar">
-            <button
-              type="button"
-              className="btn btn-ghost"
-              disabled={!canUndo}
-              mix={on('click', () => {
-                void (async () => {
-                  const restored = await undoLastDelete(project.id)
-                  if (restored) setSelectedClipId(restored.id)
-                  props.refresh()
-                  props.showToast('Clip restored')
-                })()
-              })}
-            >
-              <IconUndo size={18} />
-              Undo delete
-            </button>
+            <div className="editor-toolbar-start">
+              <button
+                type="button"
+                className="btn btn-ghost"
+                disabled={importing}
+                aria-label="Add clips from device"
+                mix={on('click', () => openDevicePicker())}
+              >
+                <IconPlus size={18} />
+                Add
+              </button>
+              <button
+                type="button"
+                className="btn btn-ghost"
+                disabled={!canUndo || importing}
+                mix={on('click', () => {
+                  void (async () => {
+                    const restored = await undoLastDelete(project.id)
+                    if (restored) setSelectedClipId(restored.id)
+                    props.refresh()
+                    props.showToast('Clip restored')
+                  })()
+                })}
+              >
+                <IconUndo size={18} />
+                Undo delete
+              </button>
+            </div>
             <button
               type="button"
               className="go-button compact"
-              disabled={clips.length === 0}
+              disabled={clips.length === 0 || importing}
               mix={on('click', () => onOpenExport())}
             >
               Go

--- a/src/components/timeline.tsx
+++ b/src/components/timeline.tsx
@@ -161,6 +161,12 @@ export function Timeline(handle: Handle<TimelineProps>) {
 
   const onPointerDown = (event: PointerEvent, clip: ClipRecord, index: number) => {
     if (event.button !== 0) return
+    // During device import, clips land in IndexedDB before props.clips
+    // refreshes — a reorder against the stale id list throws. Select only.
+    if (props.addingFromDevice) {
+      selectClip(clip.id)
+      return
+    }
     stopFling()
     // A previous session that never reached finishPointer (e.g. its tile
     // unmounted mid-drag) must not leak into this gesture.
@@ -258,6 +264,10 @@ export function Timeline(handle: Handle<TimelineProps>) {
     let insertAt = gap
     if (gap > fromIndex) insertAt = gap - 1
     if (insertAt === fromIndex) {
+      selectClip(clipId)
+      return
+    }
+    if (props.addingFromDevice) {
       selectClip(clipId)
       return
     }

--- a/src/components/timeline.tsx
+++ b/src/components/timeline.tsx
@@ -29,6 +29,9 @@ interface TimelineProps {
   clips: ClipRecord[]
   selectedClipId: ClipId | null
   onSelect: (id: ClipId) => void
+  /** Open the device file picker to append gallery videos. */
+  onAddFromDevice?: () => void
+  addingFromDevice?: boolean
   refresh: () => void
 }
 
@@ -264,12 +267,28 @@ export function Timeline(handle: Handle<TimelineProps>) {
   }
 
   return () => {
-    const { clips, selectedClipId } = props
+    const { clips, selectedClipId, onAddFromDevice, addingFromDevice } = props
 
     if (clips.length === 0) {
       return (
         <div key="timeline-empty" className="timeline" aria-label="Timeline empty">
-          <p className="timeline-empty muted">Hold the preview to add clips</p>
+          {onAddFromDevice ? (
+            <button
+              type="button"
+              className="timeline-empty-add"
+              disabled={addingFromDevice}
+              mix={on('click', () => onAddFromDevice())}
+            >
+              <span className="timeline-empty-add-title">
+                {addingFromDevice ? 'Adding…' : 'Add clips from your device'}
+              </span>
+              <span className="timeline-empty-add-sub muted">
+                Or go back and hold the preview to record
+              </span>
+            </button>
+          ) : (
+            <p className="timeline-empty muted">Hold the preview to add clips</p>
+          )}
         </div>
       )
     }
@@ -349,6 +368,21 @@ export function Timeline(handle: Handle<TimelineProps>) {
         })}
         {draggingId !== null && gapIndex === clips.length ? (
           <div className="timeline-drop-indicator timeline-drop-trailing" aria-hidden />
+        ) : null}
+        {onAddFromDevice && draggingId === null ? (
+          <div className="timeline-slot">
+            <button
+              type="button"
+              className="timeline-add-tile"
+              aria-label="Add clips from device"
+              disabled={addingFromDevice}
+              mix={on('click', () => onAddFromDevice())}
+            >
+              <span className="timeline-add-plus" aria-hidden>
+                +
+              </span>
+            </button>
+          </div>
         ) : null}
       </div>
     )

--- a/src/lib/import-device-clips.test.ts
+++ b/src/lib/import-device-clips.test.ts
@@ -1,0 +1,67 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import {
+  importDeviceClips,
+  isLikelyVideoFile,
+  mimeTypeForDeviceFile,
+  probeDeviceClip,
+} from './import-device-clips'
+import { __resetDbForTests, createProject, getClipsForProject } from './storage'
+
+describe('mimeTypeForDeviceFile', () => {
+  it('prefers an explicit video MIME type', () => {
+    expect(mimeTypeForDeviceFile({ name: 'clip.mov', type: 'video/mp4' })).toBe('video/mp4')
+  })
+
+  it('infers from common extensions when type is empty', () => {
+    expect(mimeTypeForDeviceFile({ name: 'Take 01.MP4', type: '' })).toBe('video/mp4')
+    expect(mimeTypeForDeviceFile({ name: 'clip.m4v', type: '' })).toBe('video/mp4')
+    expect(mimeTypeForDeviceFile({ name: 'clip.webm', type: '' })).toBe('video/webm')
+    expect(mimeTypeForDeviceFile({ name: 'clip.mov', type: '' })).toBe('video/quicktime')
+    expect(mimeTypeForDeviceFile({ name: 'clip.mkv', type: '' })).toBe('video/x-matroska')
+  })
+
+  it('falls back to mp4 for extension-less gallery picks', () => {
+    expect(mimeTypeForDeviceFile({ name: 'content', type: '' })).toBe('video/mp4')
+  })
+})
+
+describe('isLikelyVideoFile', () => {
+  it('accepts video/* and known extensions', () => {
+    expect(isLikelyVideoFile({ name: 'a.bin', type: 'video/webm' })).toBe(true)
+    expect(isLikelyVideoFile({ name: 'a.mp4', type: '' })).toBe(true)
+    expect(isLikelyVideoFile({ name: 'a.MOV', type: 'application/octet-stream' })).toBe(true)
+  })
+
+  it('rejects obvious non-video types', () => {
+    expect(isLikelyVideoFile({ name: 'photo.jpg', type: 'image/jpeg' })).toBe(false)
+    expect(isLikelyVideoFile({ name: 'notes.txt', type: 'text/plain' })).toBe(false)
+  })
+})
+
+describe('probeDeviceClip / importDeviceClips', () => {
+  beforeEach(async () => {
+    await __resetDbForTests()
+  })
+
+  it('rejects empty and non-video picks before probing', async () => {
+    await expect(probeDeviceClip(new File([], 'empty.mp4', { type: 'video/mp4' }))).rejects.toThrow(
+      /empty/i,
+    )
+    await expect(
+      probeDeviceClip(new File(['not-video'], 'photo.jpg', { type: 'image/jpeg' })),
+    ).rejects.toThrow(/video/i)
+  })
+
+  it('collects per-file failures without aborting the batch', async () => {
+    const project = await createProject('Import batch')
+    const result = await importDeviceClips(project.id, [
+      new File([], 'empty.mp4', { type: 'video/mp4' }),
+      new File(['x'], 'notes.txt', { type: 'text/plain' }),
+    ])
+    expect(result.added).toHaveLength(0)
+    expect(result.failed).toHaveLength(2)
+    expect(result.failed[0]?.name).toBe('empty.mp4')
+    expect(result.failed[1]?.name).toBe('notes.txt')
+    expect(await getClipsForProject(project.id)).toHaveLength(0)
+  })
+})

--- a/src/lib/import-device-clips.test.ts
+++ b/src/lib/import-device-clips.test.ts
@@ -26,10 +26,13 @@ describe('mimeTypeForDeviceFile', () => {
 })
 
 describe('isLikelyVideoFile', () => {
-  it('accepts video/* and known extensions', () => {
+  it('accepts video/* and ambiguous gallery picks', () => {
     expect(isLikelyVideoFile({ name: 'a.bin', type: 'video/webm' })).toBe(true)
     expect(isLikelyVideoFile({ name: 'a.mp4', type: '' })).toBe(true)
     expect(isLikelyVideoFile({ name: 'a.MOV', type: 'application/octet-stream' })).toBe(true)
+    // Android content URIs often lack both a useful type and an extension.
+    expect(isLikelyVideoFile({ name: 'content', type: '' })).toBe(true)
+    expect(isLikelyVideoFile({ name: 'content', type: 'application/octet-stream' })).toBe(true)
   })
 
   it('rejects obvious non-video types', () => {

--- a/src/lib/import-device-clips.test.ts
+++ b/src/lib/import-device-clips.test.ts
@@ -54,14 +54,24 @@ describe('probeDeviceClip / importDeviceClips', () => {
 
   it('collects per-file failures without aborting the batch', async () => {
     const project = await createProject('Import batch')
-    const result = await importDeviceClips(project.id, [
-      new File([], 'empty.mp4', { type: 'video/mp4' }),
-      new File(['x'], 'notes.txt', { type: 'text/plain' }),
-    ])
+    let ensureCalls = 0
+    const result = await importDeviceClips(
+      [
+        new File([], 'empty.mp4', { type: 'video/mp4' }),
+        new File(['x'], 'notes.txt', { type: 'text/plain' }),
+      ],
+      {
+        ensureProjectId: async () => {
+          ensureCalls += 1
+          return project.id
+        },
+      },
+    )
     expect(result.added).toHaveLength(0)
     expect(result.failed).toHaveLength(2)
     expect(result.failed[0]?.name).toBe('empty.mp4')
     expect(result.failed[1]?.name).toBe('notes.txt')
+    expect(ensureCalls).toBe(0)
     expect(await getClipsForProject(project.id)).toHaveLength(0)
   })
 })

--- a/src/lib/import-device-clips.ts
+++ b/src/lib/import-device-clips.ts
@@ -1,0 +1,191 @@
+import { addClip, clearUndo } from './storage'
+import type { ClipRecord, ProjectId } from './types'
+
+/** Accept string for `<input type="file">` — common phone/desktop video types. */
+export const DEVICE_CLIP_ACCEPT =
+  'video/*,video/mp4,video/webm,video/quicktime,video/x-matroska,.mp4,.m4v,.webm,.mov,.mkv'
+
+export interface DeviceClipProbe {
+  blob: Blob
+  mimeType: string
+  durationMs: number
+  width?: number
+  height?: number
+  createdAt: number
+}
+
+export interface DeviceClipImportFailure {
+  name: string
+  reason: string
+}
+
+export interface DeviceClipImportResult {
+  added: ClipRecord[]
+  failed: DeviceClipImportFailure[]
+}
+
+/**
+ * Infer a playable MIME type for a picked gallery/file. Empty `File.type` is
+ * common on Android content URIs and desktop picks that only carry an
+ * extension — Safari rejects `application/octet-stream` object URLs later.
+ */
+export function mimeTypeForDeviceFile(file: Pick<File, 'name' | 'type'>): string {
+  const typed = (file.type || '').trim().toLowerCase()
+  if (typed.startsWith('video/')) return typed
+  const name = file.name.toLowerCase()
+  if (name.endsWith('.webm')) return 'video/webm'
+  if (name.endsWith('.mov')) return 'video/quicktime'
+  if (name.endsWith('.mkv')) return 'video/x-matroska'
+  if (name.endsWith('.m4v') || name.endsWith('.mp4')) return 'video/mp4'
+  // Last resort: assume MP4 (most phone library exports). Empty type alone is
+  // not enough to reject — the probe decides playability.
+  return typed || 'video/mp4'
+}
+
+export function isLikelyVideoFile(file: Pick<File, 'name' | 'type'>): boolean {
+  const typed = (file.type || '').trim().toLowerCase()
+  if (typed.startsWith('video/')) return true
+  if (typed && !typed.startsWith('application/octet-stream')) return false
+  return /\.(mp4|m4v|webm|mov|mkv)$/i.test(file.name)
+}
+
+/**
+ * Materialize bytes and resolve duration/dimensions. File-backed blobs from
+ * the picker must be copied before IndexedDB persistence — Chromium stores
+ * references to the underlying file (esp. Android content URIs), which go
+ * stale after the picker closes.
+ */
+export async function probeDeviceClip(
+  file: File,
+  timeoutMs = 15_000,
+): Promise<DeviceClipProbe> {
+  if (file.size <= 0) {
+    throw new Error('That file is empty')
+  }
+  if (!isLikelyVideoFile(file)) {
+    throw new Error('Pick a video file')
+  }
+
+  const mimeType = mimeTypeForDeviceFile(file)
+  const bytes = await file.arrayBuffer()
+  const blob = new Blob([bytes], { type: mimeType })
+  const createdAt =
+    Number.isFinite(file.lastModified) && file.lastModified > 0
+      ? file.lastModified
+      : Date.now()
+
+  // Prefer container demux (no hardware decoder). Falls back to a media
+  // element when mediabunny cannot parse the file.
+  try {
+    const { ALL_FORMATS, BlobSource, Input } = await import('mediabunny')
+    const input = new Input({ source: new BlobSource(blob), formats: ALL_FORMATS })
+    const seconds = await Promise.race([
+      input.computeDuration(),
+      new Promise<number>((_, reject) => {
+        window.setTimeout(() => reject(new Error('Demux duration timed out')), timeoutMs)
+      }),
+    ])
+    if (!Number.isFinite(seconds) || seconds <= 0) {
+      throw new Error('Could not read video duration')
+    }
+    const track = await input.getPrimaryVideoTrack().catch(() => null)
+    const width =
+      track && track.displayWidth > 0
+        ? track.displayWidth
+        : track && track.codedWidth > 0
+          ? track.codedWidth
+          : undefined
+    const height =
+      track && track.displayHeight > 0
+        ? track.displayHeight
+        : track && track.codedHeight > 0
+          ? track.codedHeight
+          : undefined
+    if (!width || !height) {
+      throw new Error('No video track')
+    }
+    return {
+      blob,
+      mimeType,
+      durationMs: Math.round(seconds * 1000),
+      width,
+      height,
+      createdAt,
+    }
+  } catch {
+    const { loadClipVideo } = await import('./export/shared')
+    const loaded = await loadClipVideo(blob, timeoutMs, mimeType)
+    try {
+      if (loaded.mediaDurationMs <= 0) {
+        throw new Error('Could not read video duration')
+      }
+      const width = loaded.video.videoWidth
+      const height = loaded.video.videoHeight
+      if (width <= 0 || height <= 0) {
+        throw new Error('No video track')
+      }
+      return {
+        blob,
+        mimeType,
+        durationMs: loaded.mediaDurationMs,
+        width,
+        height,
+        createdAt,
+      }
+    } finally {
+      loaded.release()
+    }
+  }
+}
+
+/** Append one device file as a timeline clip. */
+export async function importDeviceClip(
+  projectId: ProjectId,
+  file: File,
+): Promise<ClipRecord> {
+  const probed = await probeDeviceClip(file)
+  return addClip({
+    projectId,
+    blob: probed.blob,
+    mimeType: probed.mimeType,
+    durationMs: probed.durationMs,
+    width: probed.width,
+    height: probed.height,
+    createdAt: probed.createdAt,
+  })
+}
+
+/**
+ * Append one or more device videos to a project. Failures on individual
+ * files are collected so a bad pick in a multi-select does not block the
+ * rest. Clears the delete-undo stack after any successful add (same as a
+ * fresh recording).
+ */
+export async function importDeviceClips(
+  projectId: ProjectId,
+  files: Iterable<File>,
+  onProgress?: (done: number, total: number) => void,
+): Promise<DeviceClipImportResult> {
+  const list = [...files]
+  const added: ClipRecord[] = []
+  const failed: DeviceClipImportFailure[] = []
+  onProgress?.(0, list.length)
+
+  for (let i = 0; i < list.length; i += 1) {
+    const file = list[i]!
+    try {
+      added.push(await importDeviceClip(projectId, file))
+    } catch (error) {
+      failed.push({
+        name: file.name || 'clip',
+        reason: error instanceof Error ? error.message : 'Could not import',
+      })
+    }
+    onProgress?.(i + 1, list.length)
+  }
+
+  if (added.length > 0) {
+    await clearUndo(projectId)
+  }
+  return { added, failed }
+}

--- a/src/lib/import-device-clips.ts
+++ b/src/lib/import-device-clips.ts
@@ -49,11 +49,49 @@ export function isLikelyVideoFile(file: Pick<File, 'name' | 'type'>): boolean {
   return /\.(mp4|m4v|webm|mov|mkv)$/i.test(file.name)
 }
 
+async function demuxClipMeta(
+  blob: Blob,
+  timeoutMs: number,
+): Promise<{ durationMs: number; width: number; height: number }> {
+  const { ALL_FORMATS, BlobSource, Input } = await import('mediabunny')
+  const input = new Input({ source: new BlobSource(blob), formats: ALL_FORMATS })
+  const seconds = await Promise.race([
+    input.computeDuration(),
+    new Promise<number>((_, reject) => {
+      window.setTimeout(() => reject(new Error('Demux duration timed out')), timeoutMs)
+    }),
+  ])
+  if (!Number.isFinite(seconds) || seconds <= 0) {
+    throw new Error('Could not read video duration')
+  }
+  const track = await input.getPrimaryVideoTrack().catch(() => null)
+  const width =
+    track && track.displayWidth > 0
+      ? track.displayWidth
+      : track && track.codedWidth > 0
+        ? track.codedWidth
+        : 0
+  const height =
+    track && track.displayHeight > 0
+      ? track.displayHeight
+      : track && track.codedHeight > 0
+        ? track.codedHeight
+        : 0
+  if (width <= 0 || height <= 0) {
+    throw new Error('No video track')
+  }
+  return { durationMs: Math.round(seconds * 1000), width, height }
+}
+
 /**
  * Materialize bytes and resolve duration/dimensions. File-backed blobs from
  * the picker must be copied before IndexedDB persistence — Chromium stores
  * references to the underlying file (esp. Android content URIs), which go
  * stale after the picker closes.
+ *
+ * Demux is preferred for metadata, but the browser must still be able to
+ * decode the clip (unsupported codecs would otherwise persist and fail in
+ * preview/export).
  */
 export async function probeDeviceClip(
   file: File,
@@ -74,67 +112,42 @@ export async function probeDeviceClip(
       ? file.lastModified
       : Date.now()
 
-  // Prefer container demux (no hardware decoder). Falls back to a media
-  // element when mediabunny cannot parse the file.
+  let demuxMeta: { durationMs: number; width: number; height: number } | null = null
   try {
-    const { ALL_FORMATS, BlobSource, Input } = await import('mediabunny')
-    const input = new Input({ source: new BlobSource(blob), formats: ALL_FORMATS })
-    const seconds = await Promise.race([
-      input.computeDuration(),
-      new Promise<number>((_, reject) => {
-        window.setTimeout(() => reject(new Error('Demux duration timed out')), timeoutMs)
-      }),
-    ])
-    if (!Number.isFinite(seconds) || seconds <= 0) {
+    demuxMeta = await demuxClipMeta(blob, timeoutMs)
+  } catch {
+    demuxMeta = null
+  }
+
+  // Prove the browser can decode before we persist — demux alone accepts
+  // containers whose video codec this device cannot play.
+  const { loadClipVideo } = await import('./export/shared')
+  const loaded = await loadClipVideo(blob, timeoutMs, mimeType)
+  try {
+    const durationMs =
+      demuxMeta?.durationMs && demuxMeta.durationMs > 0
+        ? demuxMeta.durationMs
+        : loaded.mediaDurationMs
+    const width =
+      demuxMeta?.width && demuxMeta.width > 0 ? demuxMeta.width : loaded.video.videoWidth
+    const height =
+      demuxMeta?.height && demuxMeta.height > 0 ? demuxMeta.height : loaded.video.videoHeight
+    if (durationMs <= 0) {
       throw new Error('Could not read video duration')
     }
-    const track = await input.getPrimaryVideoTrack().catch(() => null)
-    const width =
-      track && track.displayWidth > 0
-        ? track.displayWidth
-        : track && track.codedWidth > 0
-          ? track.codedWidth
-          : undefined
-    const height =
-      track && track.displayHeight > 0
-        ? track.displayHeight
-        : track && track.codedHeight > 0
-          ? track.codedHeight
-          : undefined
-    if (!width || !height) {
+    if (width <= 0 || height <= 0) {
       throw new Error('No video track')
     }
     return {
       blob,
       mimeType,
-      durationMs: Math.round(seconds * 1000),
+      durationMs,
       width,
       height,
       createdAt,
     }
-  } catch {
-    const { loadClipVideo } = await import('./export/shared')
-    const loaded = await loadClipVideo(blob, timeoutMs, mimeType)
-    try {
-      if (loaded.mediaDurationMs <= 0) {
-        throw new Error('Could not read video duration')
-      }
-      const width = loaded.video.videoWidth
-      const height = loaded.video.videoHeight
-      if (width <= 0 || height <= 0) {
-        throw new Error('No video track')
-      }
-      return {
-        blob,
-        mimeType,
-        durationMs: loaded.mediaDurationMs,
-        width,
-        height,
-        createdAt,
-      }
-    } finally {
-      loaded.release()
-    }
+  } finally {
+    loaded.release()
   }
 }
 
@@ -155,6 +168,13 @@ export async function importDeviceClip(
   })
 }
 
+export interface ImportDeviceClipsOptions {
+  /** Lazily create/resolve the project only after the first file probes OK —
+   * so a failed pick on `/project/new` does not burn a free project slot. */
+  ensureProjectId: () => Promise<ProjectId>
+  onProgress?: (done: number, total: number) => void
+}
+
 /**
  * Append one or more device videos to a project. Failures on individual
  * files are collected so a bad pick in a multi-select does not block the
@@ -162,29 +182,41 @@ export async function importDeviceClip(
  * fresh recording).
  */
 export async function importDeviceClips(
-  projectId: ProjectId,
   files: Iterable<File>,
-  onProgress?: (done: number, total: number) => void,
+  options: ImportDeviceClipsOptions,
 ): Promise<DeviceClipImportResult> {
   const list = [...files]
   const added: ClipRecord[] = []
   const failed: DeviceClipImportFailure[] = []
-  onProgress?.(0, list.length)
+  let projectId: ProjectId | null = null
+  options.onProgress?.(0, list.length)
 
   for (let i = 0; i < list.length; i += 1) {
     const file = list[i]!
     try {
-      added.push(await importDeviceClip(projectId, file))
+      const probed = await probeDeviceClip(file)
+      projectId ??= await options.ensureProjectId()
+      added.push(
+        await addClip({
+          projectId,
+          blob: probed.blob,
+          mimeType: probed.mimeType,
+          durationMs: probed.durationMs,
+          width: probed.width,
+          height: probed.height,
+          createdAt: probed.createdAt,
+        }),
+      )
     } catch (error) {
       failed.push({
         name: file.name || 'clip',
         reason: error instanceof Error ? error.message : 'Could not import',
       })
     }
-    onProgress?.(i + 1, list.length)
+    options.onProgress?.(i + 1, list.length)
   }
 
-  if (added.length > 0) {
+  if (added.length > 0 && projectId) {
     await clearUndo(projectId)
   }
   return { added, failed }

--- a/src/lib/import-device-clips.ts
+++ b/src/lib/import-device-clips.ts
@@ -45,8 +45,11 @@ export function mimeTypeForDeviceFile(file: Pick<File, 'name' | 'type'>): string
 export function isLikelyVideoFile(file: Pick<File, 'name' | 'type'>): boolean {
   const typed = (file.type || '').trim().toLowerCase()
   if (typed.startsWith('video/')) return true
+  // Reject clear non-video MIME types. Empty type / octet-stream is common for
+  // Android content-URI picks (often extension-less names like "content") —
+  // let probeDeviceClip decide playability for those.
   if (typed && !typed.startsWith('application/octet-stream')) return false
-  return /\.(mp4|m4v|webm|mov|mkv)$/i.test(file.name)
+  return true
 }
 
 async function demuxClipMeta(

--- a/src/lib/project-actions.ts
+++ b/src/lib/project-actions.ts
@@ -240,3 +240,9 @@ export async function trimClip(
 ): Promise<void> {
   await updateClipTrim(clipId, trimStartMs, trimEndMs)
 }
+
+export {
+  DEVICE_CLIP_ACCEPT,
+  importDeviceClips,
+  type DeviceClipImportResult,
+} from './import-device-clips'

--- a/src/pages/project-page.tsx
+++ b/src/pages/project-page.tsx
@@ -436,6 +436,7 @@ export function ProjectPage(handle: Handle<ProjectPageProps>) {
         ) : (
           <EditorScreen
             project={project}
+            ensureProjectId={ensureProjectId}
             clips={clips}
             canUndo={data.canUndo}
             interactionLocked={overlayOpen}

--- a/src/styles/editor.css
+++ b/src/styles/editor.css
@@ -144,6 +144,59 @@
   font-size: 0.9rem;
 }
 
+.timeline-empty-add {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 4px;
+  width: 100%;
+  margin: 8px 4px;
+  padding: 14px 16px;
+  border-radius: 16px;
+  text-align: left;
+  color: var(--ink);
+  background: color-mix(in srgb, var(--accent) 12%, transparent);
+  border: 1px dashed color-mix(in srgb, var(--accent) 45%, transparent);
+}
+
+.timeline-empty-add:disabled {
+  opacity: 0.6;
+  cursor: wait;
+}
+
+.timeline-empty-add-title {
+  font-size: 0.95rem;
+  font-weight: 700;
+}
+
+.timeline-empty-add-sub {
+  font-size: 0.78rem;
+  line-height: 1.3;
+}
+
+.timeline-add-tile {
+  display: grid;
+  place-items: center;
+  width: 56px;
+  height: var(--editor-tile-h);
+  border-radius: 10px;
+  background: color-mix(in srgb, var(--ink) 6%, transparent);
+  border: 1px dashed color-mix(in srgb, var(--ink) 28%, transparent);
+  color: var(--ink-muted);
+  flex: 0 0 auto;
+}
+
+.timeline-add-tile:disabled {
+  opacity: 0.5;
+  cursor: wait;
+}
+
+.timeline-add-plus {
+  font-size: 1.6rem;
+  font-weight: 500;
+  line-height: 1;
+}
+
 .timeline-slot {
   display: flex;
   align-items: center;
@@ -461,6 +514,13 @@
   justify-content: space-between;
 }
 
+.editor-toolbar-start {
+  display: flex;
+  gap: 4px;
+  align-items: center;
+  min-width: 0;
+}
+
 .editor-toolbar .btn {
-  flex: 1;
+  flex: 0 1 auto;
 }

--- a/tests/e2e/editor-playback.spec.ts
+++ b/tests/e2e/editor-playback.spec.ts
@@ -90,6 +90,59 @@ test.describe('editor', () => {
     await page.getByRole('button', { name: 'Back to camera' }).click()
     await expect(page.locator('.record-stage')).toBeVisible()
   })
+
+  test('Add imports a device video onto the timeline', async ({ page }) => {
+    await openEditorWithClips(page, 1)
+    const tiles = page.locator('.clip-thumb[data-clip-id]')
+    await expect(tiles).toHaveCount(1)
+
+    const clipPath = await page.evaluate(async () => {
+      const { makeTestClipBlob } = await import('/src/lib/testing/make-test-clip.ts')
+      const blob = await makeTestClipBlob(1200)
+      const buffer = await blob.arrayBuffer()
+      const bytes = Array.from(new Uint8Array(buffer))
+      return { bytes, type: blob.type || 'video/webm' }
+    })
+    const file = {
+      name: 'from-device.webm',
+      mimeType: clipPath.type,
+      buffer: Buffer.from(clipPath.bytes),
+    }
+
+    await page.locator('.editor-screen input[type="file"]').setInputFiles(file)
+    await expect(tiles).toHaveCount(2, { timeout: 20_000 })
+    await expect(page.locator('.toast')).toContainText(/clip added/i)
+    // The imported clip is selected (most recently added).
+    await expect(tiles.last()).toHaveClass(/selected/)
+
+    const stored = await page.evaluate(async () => {
+      const storage = await import('/src/lib/storage.ts')
+      const projects = await storage.listProjects()
+      const clips = await storage.getClipMetasForProject(projects[0]!.id)
+      return clips.map((clip: { durationMs: number; mimeType: string; width?: number; height?: number }) => ({
+        durationMs: clip.durationMs,
+        mimeType: clip.mimeType,
+        width: clip.width ?? null,
+        height: clip.height ?? null,
+      }))
+    })
+    expect(stored).toHaveLength(2)
+    const imported = stored[1]!
+    expect(imported.durationMs).toBeGreaterThan(500)
+    expect(imported.mimeType).toMatch(/video\//)
+    expect(imported.width).toBeGreaterThan(0)
+    expect(imported.height).toBeGreaterThan(0)
+  })
+
+  test('empty timeline offers Add clips from your device', async ({ page }) => {
+    await openSeededProject(page, { clips: 0 })
+    // openSeededProject with 0 clips still creates a project; open editor.
+    await page.getByRole('button', { name: 'Open editor' }).click()
+    await expect(page.locator('.editor-screen')).toBeVisible()
+    await expect(
+      page.getByRole('button', { name: 'Add clips from your device' }),
+    ).toBeVisible()
+  })
 })
 
 test.describe('preview playback', () => {

--- a/tests/e2e/editor-playback.spec.ts
+++ b/tests/e2e/editor-playback.spec.ts
@@ -109,7 +109,12 @@ test.describe('editor', () => {
       buffer: Buffer.from(clipPath.bytes),
     }
 
-    await page.locator('.editor-screen input[type="file"]').setInputFiles(file)
+    // Drive the toolbar Add control through the real file chooser so a
+    // disconnected hidden input cannot fake a green test.
+    const chooserPromise = page.waitForEvent('filechooser')
+    await page.getByRole('button', { name: 'Add clips from device' }).first().click()
+    const chooser = await chooserPromise
+    await chooser.setFiles(file)
     await expect(tiles).toHaveCount(2, { timeout: 20_000 })
     await expect(page.locator('.toast')).toContainText(/clip added/i)
     // The imported clip is selected (most recently added).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

You can now import videos from your phone or computer onto a project’s filmstrip timeline — not only clips recorded in-app.

### How to use it

In the editor:

- **Empty timeline** — “Add clips from your device”
- **Trailing `+` tile** on the filmstrip
- **Add** in the bottom toolbar

The system file picker accepts common video types (`mp4`, `mov`, `webm`, `mkv`, …) and multi-select.

### Implementation notes

- New `importDeviceClips` helper materializes file bytes before IndexedDB writes (same Android content-URI pitfall as project backup import), probes duration/dimensions via mediabunny, **then verifies the browser can decode** before `addClip`.
- Lazy `/project/new`: project is created only after the first file probes successfully (failed picks don’t burn a free slot).
- Editor actions (including keyboard / camera / play) are locked while an import is in flight.
- Per-file failures in a multi-select are skipped with a toast; successful adds clear the delete-undo stack like a new recording.

### Tests

- Unit: MIME inference + empty/non-video rejection + batch failure collection (no project creation on total failure)
- E2E: toolbar **Add** drives the real file chooser; empty-state CTA visible

### Review follow-up

Addressed CodeRabbit majors: import lock, lazy project creation, decode verification, filechooser e2e. Skipped the duplicate-`return` finding (false positive on current code).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-447a4e8e-e977-44a6-a243-88f3d84180d4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-447a4e8e-e977-44a6-a243-88f3d84180d4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Import video clips from your device or gallery directly into the editor timeline.
  * Add clips from empty or populated timelines with clear loading and progress feedback.
  * Imported clips are automatically selected and validated for duration and dimensions.
  * Undo and export are temporarily disabled while clips are importing.

* **Documentation**
  * Updated editor documentation and testing guidance to cover device clip imports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->