### PR TITLE
Show the trimmed frame in the preview while dragging trim handles

### DIFF
--- a/src/components/editor-clip-preview.tsx
+++ b/src/components/editor-clip-preview.tsx
@@ -35,11 +35,29 @@ export function EditorClipPreview(handle: Handle<EditorClipPreviewProps>) {
   /** An explicit seek before loadeddata must not be snapped back to the trim
    * start when the metadata arrives. */
   let explicitSeek = false
+  /** Latest scrub target (seconds) deferred while a seek is in flight.
+   * Assigning currentTime mid-seek cancels the pending seek, so a fast trim
+   * drag would paint no frames until the pointer rests; instead the newest
+   * target waits for `seeked` and is applied then. */
+  let pendingSeekSec: number | null = null
 
   const setPlaying = (next: boolean) => {
     if (playing === next) return
     playing = next
     void handle.update()
+  }
+
+  const applySeek = (video: HTMLVideoElement, sec: number) => {
+    if (video.seeking) {
+      pendingSeekSec = sec
+      return
+    }
+    pendingSeekSec = null
+    if (Math.abs(video.currentTime - sec) > 0.02) {
+      video.currentTime = sec
+    } else {
+      nudgeFrame(video)
+    }
   }
 
   // Bound to the element's mount/unmount (not the first media event) so the
@@ -48,6 +66,7 @@ export function EditorClipPreview(handle: Handle<EditorClipPreviewProps>) {
   const bindVideo = (video: HTMLVideoElement, signal: AbortSignal) => {
     media = video
     explicitSeek = false
+    pendingSeekSec = null
     const apiRef = props.apiRef
     if (!apiRef) return
     apiRef.current = {
@@ -57,12 +76,7 @@ export function EditorClipPreview(handle: Handle<EditorClipPreviewProps>) {
         explicitSeek = true
         el.pause()
         setPlaying(false)
-        const sec = Math.max(0, Math.min(timeMs, props.clip.durationMs)) / 1000
-        if (Math.abs(el.currentTime - sec) > 0.02) {
-          el.currentTime = sec
-        } else {
-          nudgeFrame(el)
-        }
+        applySeek(el, Math.max(0, Math.min(timeMs, props.clip.durationMs)) / 1000)
       },
       pause: () => {
         const el = media
@@ -97,6 +111,8 @@ export function EditorClipPreview(handle: Handle<EditorClipPreviewProps>) {
     if (atEnd || beforeStart) {
       video.currentTime = startSec
     }
+    // A stale scrub target must not yank playback once it starts.
+    pendingSeekSec = null
 
     void video
       .play()
@@ -132,6 +148,14 @@ export function EditorClipPreview(handle: Handle<EditorClipPreviewProps>) {
             }),
             on('seeked', (event) => {
               const video = event.currentTarget as HTMLVideoElement
+              if (pendingSeekSec !== null) {
+                const sec = pendingSeekSec
+                pendingSeekSec = null
+                if (Math.abs(video.currentTime - sec) > 0.02) {
+                  video.currentTime = sec
+                  return
+                }
+              }
               if (video.paused) nudgeFrame(video)
             }),
             on('timeupdate', (event) => {

--- a/src/components/editor-screen.tsx
+++ b/src/components/editor-screen.tsx
@@ -122,6 +122,16 @@ export function EditorScreen(handle: Handle<EditorScreenProps>) {
     void handle.update()
   }
 
+  const openTrim = (clip: ClipRecord) => {
+    previewApi.current?.pause()
+    trimming = true
+    // Seek after the commit: entering trim can remount the preview (the trim
+    // override changes its remount key), and the seek must land on the new
+    // element so the stage opens on the trim-start frame.
+    handle.queueTask(() => previewApi.current?.seekToMs(clip.trimStartMs))
+    void handle.update()
+  }
+
   const handleDelete = () => {
     const id = resolveSelectedId()
     if (!id) return
@@ -197,8 +207,7 @@ export function EditorScreen(handle: Handle<EditorScreenProps>) {
       }
       case 'KeyT': {
         if (!selected) return
-        previewApi.current?.pause()
-        setTrimming(true)
+        openTrim(selected)
         return
       }
       case 'KeyD': {
@@ -406,8 +415,7 @@ export function EditorScreen(handle: Handle<EditorScreenProps>) {
                 disabled={!selected || importing}
                 prominent
                 onClick={() => {
-                  previewApi.current?.pause()
-                  setTrimming(true)
+                  if (selected) openTrim(selected)
                 }}
                 icon={<IconTrim />}
               />

--- a/tests/e2e/editor-playback.spec.ts
+++ b/tests/e2e/editor-playback.spec.ts
@@ -85,6 +85,56 @@ test.describe('editor', () => {
     expect(durAfter).not.toBe(durBefore)
   })
 
+  test('trim preview scrubs to the frame at the dragged handle', async ({ page }) => {
+    const clipMs = 4000
+    await openEditorWithClips(page, 1, clipMs)
+    const preview = page.locator('.editor-clip-preview')
+    const previewTime = () => preview.evaluate((el) => (el as HTMLVideoElement).currentTime)
+
+    await page.getByRole('button', { name: 'Trim' }).click()
+    const strip = page.locator('.trim-strip')
+    await expect(strip).toBeVisible()
+
+    const track = await strip.locator('.trim-strip-track').boundingBox()
+    if (!track) throw new Error('trim geometry unavailable')
+    // Handles are centered on their time position (translateX(-50%)), so an
+    // x fraction of the track maps straight to a fraction of the duration.
+    const xAt = (fraction: number) => track.x + track.width * fraction
+    const secondsNear = async (fraction: number) => {
+      const target = (clipMs / 1000) * fraction
+      await expect.poll(previewTime).toBeGreaterThan(target - 0.25)
+      expect(await previewTime()).toBeLessThan(target + 0.25)
+    }
+
+    // Drag the end handle to the middle; the preview must scrub with it.
+    const endBox = await strip.locator('.trim-handle-right').boundingBox()
+    if (!endBox) throw new Error('trim geometry unavailable')
+    const y = endBox.y + endBox.height / 2
+    await page.mouse.move(endBox.x + endBox.width / 2, y)
+    await page.mouse.down()
+    await page.mouse.move(xAt(0.5), y, { steps: 8 })
+    await secondsNear(0.5)
+    await page.mouse.up()
+
+    // Same for the start handle.
+    const startBox = await strip.locator('.trim-handle-left').boundingBox()
+    if (!startBox) throw new Error('trim geometry unavailable')
+    await page.mouse.move(startBox.x + startBox.width / 2, y)
+    await page.mouse.down()
+    await page.mouse.move(xAt(0.25), y, { steps: 8 })
+    await secondsNear(0.25)
+    await page.mouse.up()
+
+    await strip.getByRole('button', { name: 'Done' }).click()
+    await expect(strip).toBeHidden()
+
+    // Re-opening trim starts the preview on the saved trim-start frame, not
+    // frame zero.
+    await page.getByRole('button', { name: 'Trim' }).click()
+    await expect(strip).toBeVisible()
+    await secondsNear(0.25)
+  })
+
   test('back returns to the camera', async ({ page }) => {
     await openEditorWithClips(page, 1)
     await page.getByRole('button', { name: 'Back to camera' }).click()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

While trimming a clip, the stage preview should show the frame at the trim handle so you can see exactly where the cut lands. Two things got in the way:

- Every trim-handle drag move assigned `video.currentTime` directly. Assigning `currentTime` while a seek is still in flight cancels that seek, so on devices where a seek takes longer than the interval between pointer moves, no frame painted until the finger stopped moving.
- Entering trim mode never positioned the preview: the stage stayed on whatever frame it was last paused on, and re-opening trim on an already-trimmed clip remounted the preview on frame zero (a frame outside the kept range).

## Changes

- `src/components/editor-clip-preview.tsx`: scrub seeks now coalesce. While a seek is in flight, the newest target is remembered and applied on `seeked`, so a frame paints after every completed seek during a drag instead of only after the pointer rests. A stale scrub target is dropped when playback starts.
- `src/components/editor-screen.tsx`: entering trim mode (Trim button or `T`) seeks the preview to the clip's trim start after the commit, so the stage opens on the trim-start frame even when the trim override remounts the preview.
- `tests/e2e/editor-playback.spec.ts`: new spec asserts the preview `currentTime` tracks the end and start handles mid-drag, and that re-opening trim lands on the saved trim start rather than frame zero.

## Testing

- `npm run lint`, `npm test` — pass.
- `npm run test:e2e` — the new trim-scrub spec and all editor/keyboard specs pass. Four failures in `export`, `install-hint`, and `storage` specs also fail identically on unmodified `main` in this VM (pre-existing environment failures, unrelated to this change).
- Manual demo (fake-media Chrome, seeded clip whose frames show their frame number): dragging the end handle counts the preview frame down (52 → 45 → 38 → 31 → 24), dragging the start handle counts it up (7 → 14), and re-opening Trim after Done immediately shows the saved trim-start frame (14) instead of frame 0.

<a href="https://cursor.com/agents/bc-edce7037-58da-49e8-b6d1-79dc34420a8a/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftrim_preview_frame_tracking_demo.mp4"><img src="https://cursor.com/artifacts/c/art-6018a6e0-7cf7-4525-96aa-c2a95107a19c" alt="trim_preview_frame_tracking_demo.mp4" /></a>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-edce7037-58da-49e8-b6d1-79dc34420a8a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-edce7037-58da-49e8-b6d1-79dc34420a8a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

