### PR TITLE
Background music: playlist with per-clip volumes and fades (Plus)

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,13 +33,19 @@ For a phone on the same network, use your machine’s LAN URL over HTTPS, or tun
 - Self-timer for hands-free takes (tap to stop)
 - Recording feedback (REC pill + elapsed) with a page that does **not** re-render per frame — capture stays smooth
 - Editor: filmstrip timeline (thumbnails, width ∝ duration), drag to reorder, duplicate, delete w/ undo, **in-timeline trim with drag handles**, **add clips from your device/gallery**
+- **Background music** (Plus): add one audio track that plays under the whole
+  film at a background-friendly default volume; tap any clip to set the music
+  volume just for that clip (duck it under speech, swell it for b-roll) and
+  volume changes glide across clip boundaries — in the preview and in the
+  exported file (track loops when shorter than the film)
 - Project preview playback: tap edges to skip clips, tap middle to stop
 - Up to **6** stable project slots (create / open / rename / delete, poster art from your clips)
 - Big Go CTA: on-device export to **one video file**, then Share (system sheet) or Save
 - Fallback: save clips as separate files
 - Project **backup/import**: one `.kodyvideo` file per project (clips, trims,
-  location data) — a safety net, and the way to move a project between
-  devices or origins (e.g. kody-video.pages.dev → kody.video)
+  location data, background music + volumes) — a safety net, and the way to
+  move a project between devices or origins (e.g. kody-video.pages.dev →
+  kody.video)
 - Installable PWA (manifest + Workbox service worker for the app shell)
 - **No accounts, no uploads, no analytics**
 
@@ -118,6 +124,7 @@ before this feature simply lack the data and degrade gracefully.
 | clips    | Clip metadata, `Blob` media, filmstrip thumbnails     |
 | undo     | Last deleted clip per project (for Undo)              |
 | meta     | Settings (`maxProjects`, last opened id, onboarding)  |
+| audio    | Background-music track per project (blob + volumes)   |
 
 Database name: `kody-video`. Blobs never leave the device unless the user explicitly shares/downloads.
 
@@ -177,8 +184,9 @@ API is missing.
 
 The free plan includes one project, and exports carry a small Kody Video mark
 in the corner. Kody Video Plus — a one-time $0.99 Stripe Payment Link —
-removes the watermark and unlocks six project slots: the export sheet (or a
-locked home slot) links to checkout, Stripe redirects back to
+removes the watermark, unlocks six project slots, and unlocks background
+music: the export sheet (or a locked home slot, or the locked "Add music"
+button in the editor) links to checkout, Stripe redirects back to
 `/unlocked?session_id=…`, and a single Cloudflare Pages Function
 (`functions/api/verify-purchase.ts`) verifies the session server-side before
 the entitlement is stored in IndexedDB. 100%-off promotion codes (friends /

--- a/README.md
+++ b/README.md
@@ -33,11 +33,14 @@ For a phone on the same network, use your machine’s LAN URL over HTTPS, or tun
 - Self-timer for hands-free takes (tap to stop)
 - Recording feedback (REC pill + elapsed) with a page that does **not** re-render per frame — capture stays smooth
 - Editor: filmstrip timeline (thumbnails, width ∝ duration), drag to reorder, duplicate, delete w/ undo, **in-timeline trim with drag handles**, **add clips from your device/gallery**
-- **Background music** (Plus): add one audio track that plays under the whole
-  film at a background-friendly default volume; tap any clip to set the music
-  volume just for that clip (duck it under speech, swell it for b-roll) and
-  volume changes glide across clip boundaries — in the preview and in the
-  exported file (track loops when shorter than the film)
+- **Background music** (Plus): build a playlist of audio tracks that play one
+  after the other under the film at a background-friendly default volume
+  (nothing loops — a hint suggests adding another track when the music ends
+  before the film does); tap any clip to set the music volume just for that
+  clip (duck it under speech, swell it for b-roll), volume changes glide
+  across clip boundaries, and the music fades in/out at the start and end of
+  the film (both toggleable, on by default) — in the preview and in the
+  exported file
 - Project preview playback: tap edges to skip clips, tap middle to stop
 - Up to **6** stable project slots (create / open / rename / delete, poster art from your clips)
 - Big Go CTA: on-device export to **one video file**, then Share (system sheet) or Save
@@ -124,7 +127,7 @@ before this feature simply lack the data and degrade gracefully.
 | clips    | Clip metadata, `Blob` media, filmstrip thumbnails     |
 | undo     | Last deleted clip per project (for Undo)              |
 | meta     | Settings (`maxProjects`, last opened id, onboarding)  |
-| audio    | Background-music track per project (blob + volumes)   |
+| audio    | Background-music playlist per project (blobs, volumes, fades) |
 
 Database name: `kody-video`. Blobs never leave the device unless the user explicitly shares/downloads.
 

--- a/src/components/audio-strip.tsx
+++ b/src/components/audio-strip.tsx
@@ -4,19 +4,20 @@ import { AUDIO_FILE_ACCEPT, AudioImportError } from '../lib/audio-import'
 import { reportError } from '../lib/error-reporting'
 import {
   addProjectAudioFromFile,
-  removeProjectAudioTrack,
+  removeAudioTrack,
   setClipAudioVolume,
-  setProjectAudioDefaultVolume,
+  setProjectAudioSettings,
 } from '../lib/project-actions'
 import {
   clipAudioVolume,
   formatDuration,
+  projectAudioTotalDurationMs,
   type ClipId,
   type ClipRecord,
   type ProjectAudioRecord,
   type ProjectId,
 } from '../lib/types'
-import { IconClose, IconLock, IconMusic } from './icons'
+import { IconClose, IconLock, IconMusic, IconPlus } from './icons'
 
 interface AudioStripProps {
   /** Resolves the persisted project id (creates it from a lazy "new" shell). */
@@ -25,6 +26,8 @@ interface AudioStripProps {
   selectedClip: ClipRecord | null
   /** Index of the selected clip in the timeline (for the row label). */
   selectedIndex: number
+  /** Total film length — drives the "music ends early" hint. */
+  projectDurationMs: number
   disabled: boolean
   /** Background music is a Kody Video Plus perk. */
   plus: boolean
@@ -35,18 +38,21 @@ interface AudioStripProps {
 }
 
 /**
- * Background-music panel under the timeline: pick a track, set its default
- * volume, and dial the music volume for the selected clip. Volume writes
- * persist on slider release; the label tracks the thumb live.
+ * Background-music panel under the timeline: build a playlist of tracks
+ * (played one after the other until the film ends), toggle the fade in/out,
+ * set the default volume, and dial the music volume for the selected clip.
+ * Volume writes persist on slider release; the label tracks the thumb live.
  */
 export function AudioStrip(handle: Handle<AudioStripProps>) {
   const { props } = handle
   let busy = false
   const fileInputRef: { current: HTMLInputElement | null } = { current: null }
-  /** Slider positions mid-drag / awaiting the post-write refresh — they keep
-   * the thumb steady until props catch up with what was persisted. */
+  /** Slider/toggle values mid-edit / awaiting the post-write refresh — they
+   * keep the controls steady until props catch up with what was persisted. */
   let pendingDefault: number | null = null
   let pendingClip: { clipId: ClipId; volume: number } | null = null
+  let pendingFadeIn: boolean | null = null
+  let pendingFadeOut: boolean | null = null
 
   const setBusy = (next: boolean) => {
     busy = next
@@ -58,8 +64,12 @@ export function AudioStrip(handle: Handle<AudioStripProps>) {
     setBusy(true)
     void (async () => {
       try {
-        await addProjectAudioFromFile(file, props.ensureProjectId)
-        props.showToast('Music added — it plays under every clip')
+        const record = await addProjectAudioFromFile(file, props.ensureProjectId)
+        props.showToast(
+          record.tracks.length === 1
+            ? 'Music added — it plays under every clip'
+            : `Track ${record.tracks.length} added — it plays after the previous one`,
+        )
         props.refresh()
       } catch (err) {
         if (!(err instanceof AudioImportError)) reportError(err, 'add-project-audio')
@@ -70,16 +80,14 @@ export function AudioStrip(handle: Handle<AudioStripProps>) {
     })()
   }
 
-  const removeTrack = () => {
+  const removeTrack = (trackId: string) => {
     const audio = props.audio
     if (!audio || busy) return
     setBusy(true)
     void (async () => {
       try {
-        await removeProjectAudioTrack(audio.projectId)
-        pendingDefault = null
-        pendingClip = null
-        props.showToast('Music removed')
+        await removeAudioTrack(audio.projectId, trackId)
+        props.showToast(audio.tracks.length === 1 ? 'Music removed' : 'Track removed')
         props.refresh()
       } finally {
         setBusy(false)
@@ -87,11 +95,24 @@ export function AudioStrip(handle: Handle<AudioStripProps>) {
     })()
   }
 
+  const setFade = (which: 'fadeIn' | 'fadeOut', enabled: boolean) => {
+    const audio = props.audio
+    if (!audio) return
+    if (which === 'fadeIn') pendingFadeIn = enabled
+    else pendingFadeOut = enabled
+    void handle.update()
+    void setProjectAudioSettings(audio.projectId, { [which]: enabled }).then(() =>
+      props.refresh(),
+    )
+  }
+
   const commitDefaultVolume = (volume: number) => {
     const audio = props.audio
     if (!audio) return
     pendingDefault = volume
-    void setProjectAudioDefaultVolume(audio.projectId, volume).then(() => props.refresh())
+    void setProjectAudioSettings(audio.projectId, { defaultVolume: volume }).then(() =>
+      props.refresh(),
+    )
   }
 
   const commitClipVolume = (clipId: ClipId, volume: number) => {
@@ -171,10 +192,12 @@ export function AudioStrip(handle: Handle<AudioStripProps>) {
       )
     }
 
-    // Drop the held slider positions once a refresh delivered them back.
+    // Drop the held control values once a refresh delivered them back.
     if (pendingDefault !== null && Math.abs(audio.defaultVolume - pendingDefault) < 0.005) {
       pendingDefault = null
     }
+    if (pendingFadeIn !== null && audio.fadeIn === pendingFadeIn) pendingFadeIn = null
+    if (pendingFadeOut !== null && audio.fadeOut === pendingFadeOut) pendingFadeOut = null
     if (
       pendingClip !== null &&
       (selectedClip?.id !== pendingClip.clipId ||
@@ -194,33 +217,78 @@ export function AudioStrip(handle: Handle<AudioStripProps>) {
         : clipAudioVolume(selectedClip, audio.defaultVolume)
       : defaultVolume
 
+    const musicMs = projectAudioTotalDurationMs(audio)
+    const musicEndsEarly = props.projectDurationMs > 0 && musicMs < props.projectDurationMs
+
     return (
       <div key="audio-strip" className="audio-strip has-track">
         {fileInput}
-        <div className="audio-track-row">
-          <span className="audio-track-icon" aria-hidden="true">
-            <IconMusic size={16} />
-          </span>
+        {audio.tracks.map((track, trackIndex) => (
+          <div key={track.id} className="audio-track-row">
+            <span className="audio-track-icon" aria-hidden="true">
+              <IconMusic size={16} />
+            </span>
+            <span
+              className="audio-track-name"
+              title={audio.tracks.length > 1 ? `Track ${trackIndex + 1}: ${track.name}` : track.name}
+            >
+              {track.name}
+            </span>
+            <span className="audio-track-duration muted">{formatDuration(track.durationMs)}</span>
+            <button
+              type="button"
+              className="btn-icon audio-remove"
+              disabled={disabled || busy}
+              aria-label={`Remove music track ${trackIndex + 1} (${track.name})`}
+              mix={on('click', () => removeTrack(track.id))}
+            >
+              <IconClose size={16} />
+            </button>
+          </div>
+        ))}
+
+        <div className="audio-playlist-row">
           <button
             type="button"
-            className="audio-track-name"
+            className="audio-add-track"
             disabled={disabled || busy}
-            aria-label={`Replace background music (currently ${audio.name})`}
-            title="Replace music"
+            aria-label="Add another music track"
             mix={on('click', () => fileInputRef.current?.click())}
           >
-            {audio.name}
+            <IconPlus size={14} />
+            Add track
           </button>
-          <span className="audio-track-duration muted">{formatDuration(audio.durationMs)}</span>
-          <button
-            type="button"
-            className="btn-icon audio-remove"
-            disabled={disabled || busy}
-            aria-label="Remove background music"
-            mix={on('click', () => removeTrack())}
-          >
-            <IconClose size={16} />
-          </button>
+          {musicEndsEarly ? (
+            <span className="audio-coverage-hint muted">
+              Music ends at {formatDuration(musicMs)} of {formatDuration(props.projectDurationMs)}
+            </span>
+          ) : null}
+          <span className="audio-fades" role="group" aria-label="Music fades">
+            <label className="audio-fade-toggle">
+              <input
+                type="checkbox"
+                checked={pendingFadeIn ?? audio.fadeIn}
+                disabled={disabled || busy}
+                aria-label="Fade the music in at the start"
+                mix={on('change', (event) => {
+                  setFade('fadeIn', (event.currentTarget as HTMLInputElement).checked)
+                })}
+              />
+              Fade in
+            </label>
+            <label className="audio-fade-toggle">
+              <input
+                type="checkbox"
+                checked={pendingFadeOut ?? audio.fadeOut}
+                disabled={disabled || busy}
+                aria-label="Fade the music out at the end"
+                mix={on('change', (event) => {
+                  setFade('fadeOut', (event.currentTarget as HTMLInputElement).checked)
+                })}
+              />
+              Fade out
+            </label>
+          </span>
         </div>
 
         {selectedClip ? (

--- a/src/components/audio-strip.tsx
+++ b/src/components/audio-strip.tsx
@@ -80,6 +80,23 @@ export function AudioStrip(handle: Handle<AudioStripProps>) {
     })()
   }
 
+  /** Run a persistence write; on failure surface it, drop the held control
+   * values (so the UI snaps back to the stored state), and still refresh. */
+  const persist = (write: Promise<unknown>) => {
+    void write
+      .then(() => props.refresh())
+      .catch((err) => {
+        reportError(err, 'project-audio')
+        pendingDefault = null
+        pendingClip = null
+        pendingFadeIn = null
+        pendingFadeOut = null
+        props.showToast('Could not save that change — try again')
+        props.refresh()
+        void handle.update()
+      })
+  }
+
   const removeTrack = (trackId: string) => {
     const audio = props.audio
     if (!audio || busy) return
@@ -89,6 +106,9 @@ export function AudioStrip(handle: Handle<AudioStripProps>) {
         await removeAudioTrack(audio.projectId, trackId)
         props.showToast(audio.tracks.length === 1 ? 'Music removed' : 'Track removed')
         props.refresh()
+      } catch (err) {
+        reportError(err, 'project-audio')
+        props.showToast('Could not remove that track — try again')
       } finally {
         setBusy(false)
       }
@@ -101,28 +121,24 @@ export function AudioStrip(handle: Handle<AudioStripProps>) {
     if (which === 'fadeIn') pendingFadeIn = enabled
     else pendingFadeOut = enabled
     void handle.update()
-    void setProjectAudioSettings(audio.projectId, { [which]: enabled }).then(() =>
-      props.refresh(),
-    )
+    persist(setProjectAudioSettings(audio.projectId, { [which]: enabled }))
   }
 
   const commitDefaultVolume = (volume: number) => {
     const audio = props.audio
     if (!audio) return
     pendingDefault = volume
-    void setProjectAudioSettings(audio.projectId, { defaultVolume: volume }).then(() =>
-      props.refresh(),
-    )
+    persist(setProjectAudioSettings(audio.projectId, { defaultVolume: volume }))
   }
 
   const commitClipVolume = (clipId: ClipId, volume: number) => {
     pendingClip = { clipId, volume }
-    void setClipAudioVolume(clipId, volume).then(() => props.refresh())
+    persist(setClipAudioVolume(clipId, volume))
   }
 
   const resetClipVolume = (clipId: ClipId) => {
     pendingClip = null
-    void setClipAudioVolume(clipId, null).then(() => props.refresh())
+    persist(setClipAudioVolume(clipId, null))
     void handle.update()
   }
 
@@ -211,10 +227,11 @@ export function AudioStrip(handle: Handle<AudioStripProps>) {
     const clipOverridden = selectedClip
       ? pendingClip?.clipId === selectedClip.id || selectedClip.audioVolume !== undefined
       : false
+    // Follows the pending default too, so both rows agree mid-drag.
     const clipVolume = selectedClip
       ? pendingClip?.clipId === selectedClip.id
         ? pendingClip.volume
-        : clipAudioVolume(selectedClip, audio.defaultVolume)
+        : clipAudioVolume(selectedClip, defaultVolume)
       : defaultVolume
 
     const musicMs = projectAudioTotalDurationMs(audio)

--- a/src/components/audio-strip.tsx
+++ b/src/components/audio-strip.tsx
@@ -1,0 +1,291 @@
+import type { Handle } from 'remix/ui'
+import { on, ref } from 'remix/ui'
+import { AUDIO_FILE_ACCEPT, AudioImportError } from '../lib/audio-import'
+import { reportError } from '../lib/error-reporting'
+import {
+  addProjectAudioFromFile,
+  removeProjectAudioTrack,
+  setClipAudioVolume,
+  setProjectAudioDefaultVolume,
+} from '../lib/project-actions'
+import {
+  clipAudioVolume,
+  formatDuration,
+  type ClipId,
+  type ClipRecord,
+  type ProjectAudioRecord,
+  type ProjectId,
+} from '../lib/types'
+import { IconClose, IconLock, IconMusic } from './icons'
+
+interface AudioStripProps {
+  /** Resolves the persisted project id (creates it from a lazy "new" shell). */
+  ensureProjectId: () => Promise<ProjectId>
+  audio: ProjectAudioRecord | null
+  selectedClip: ClipRecord | null
+  /** Index of the selected clip in the timeline (for the row label). */
+  selectedIndex: number
+  disabled: boolean
+  /** Background music is a Kody Video Plus perk. */
+  plus: boolean
+  /** Open the Plus upsell sheet (owned by the page, like restore). */
+  onUpsell: () => void
+  showToast: (message: string) => void
+  refresh: () => void
+}
+
+/**
+ * Background-music panel under the timeline: pick a track, set its default
+ * volume, and dial the music volume for the selected clip. Volume writes
+ * persist on slider release; the label tracks the thumb live.
+ */
+export function AudioStrip(handle: Handle<AudioStripProps>) {
+  const { props } = handle
+  let busy = false
+  const fileInputRef: { current: HTMLInputElement | null } = { current: null }
+  /** Slider positions mid-drag / awaiting the post-write refresh — they keep
+   * the thumb steady until props catch up with what was persisted. */
+  let pendingDefault: number | null = null
+  let pendingClip: { clipId: ClipId; volume: number } | null = null
+
+  const setBusy = (next: boolean) => {
+    busy = next
+    void handle.update()
+  }
+
+  const addFromFile = (file: File | undefined) => {
+    if (!file || busy) return
+    setBusy(true)
+    void (async () => {
+      try {
+        await addProjectAudioFromFile(file, props.ensureProjectId)
+        props.showToast('Music added — it plays under every clip')
+        props.refresh()
+      } catch (err) {
+        if (!(err instanceof AudioImportError)) reportError(err, 'add-project-audio')
+        props.showToast(err instanceof Error ? err.message : 'Could not add that audio file')
+      } finally {
+        setBusy(false)
+      }
+    })()
+  }
+
+  const removeTrack = () => {
+    const audio = props.audio
+    if (!audio || busy) return
+    setBusy(true)
+    void (async () => {
+      try {
+        await removeProjectAudioTrack(audio.projectId)
+        pendingDefault = null
+        pendingClip = null
+        props.showToast('Music removed')
+        props.refresh()
+      } finally {
+        setBusy(false)
+      }
+    })()
+  }
+
+  const commitDefaultVolume = (volume: number) => {
+    const audio = props.audio
+    if (!audio) return
+    pendingDefault = volume
+    void setProjectAudioDefaultVolume(audio.projectId, volume).then(() => props.refresh())
+  }
+
+  const commitClipVolume = (clipId: ClipId, volume: number) => {
+    pendingClip = { clipId, volume }
+    void setClipAudioVolume(clipId, volume).then(() => props.refresh())
+  }
+
+  const resetClipVolume = (clipId: ClipId) => {
+    pendingClip = null
+    void setClipAudioVolume(clipId, null).then(() => props.refresh())
+    void handle.update()
+  }
+
+  return () => {
+    const { audio, selectedClip, selectedIndex, disabled } = props
+
+    const fileInput = (
+      <input
+        type="file"
+        accept={AUDIO_FILE_ACCEPT}
+        className="visually-hidden"
+        tabindex={-1}
+        aria-hidden="true"
+        mix={[
+          ref((node, signal) => {
+            fileInputRef.current = node as HTMLInputElement
+            signal.addEventListener('abort', () => {
+              if (fileInputRef.current === node) fileInputRef.current = null
+            })
+          }),
+          on('change', (event) => {
+            const input = event.currentTarget as HTMLInputElement
+            const file = input.files?.[0]
+            input.value = ''
+            addFromFile(file)
+          }),
+        ]}
+      />
+    )
+
+    if (!audio) {
+      // Free plan: the button stays visible (discoverable) but opens the
+      // Plus upsell instead of the file picker.
+      if (!props.plus) {
+        return (
+          <div key="audio-strip-locked" className="audio-strip">
+            <button
+              type="button"
+              className="btn btn-ghost audio-add audio-add-locked"
+              disabled={disabled}
+              aria-label="Add background music (Kody Video Plus)"
+              mix={on('click', () => props.onUpsell())}
+            >
+              <IconMusic size={18} />
+              Add music
+              <span className="audio-plus-lock" aria-hidden="true">
+                <IconLock size={13} />
+              </span>
+            </button>
+          </div>
+        )
+      }
+      return (
+        <div key="audio-strip-empty" className="audio-strip">
+          {fileInput}
+          <button
+            type="button"
+            className="btn btn-ghost audio-add"
+            disabled={disabled || busy}
+            aria-label="Add background music"
+            mix={on('click', () => fileInputRef.current?.click())}
+          >
+            <IconMusic size={18} />
+            {busy ? 'Adding music…' : 'Add music'}
+          </button>
+        </div>
+      )
+    }
+
+    // Drop the held slider positions once a refresh delivered them back.
+    if (pendingDefault !== null && Math.abs(audio.defaultVolume - pendingDefault) < 0.005) {
+      pendingDefault = null
+    }
+    if (
+      pendingClip !== null &&
+      (selectedClip?.id !== pendingClip.clipId ||
+        (selectedClip.audioVolume !== undefined &&
+          Math.abs(selectedClip.audioVolume - pendingClip.volume) < 0.005))
+    ) {
+      pendingClip = null
+    }
+
+    const defaultVolume = pendingDefault ?? audio.defaultVolume
+    const clipOverridden = selectedClip
+      ? pendingClip?.clipId === selectedClip.id || selectedClip.audioVolume !== undefined
+      : false
+    const clipVolume = selectedClip
+      ? pendingClip?.clipId === selectedClip.id
+        ? pendingClip.volume
+        : clipAudioVolume(selectedClip, audio.defaultVolume)
+      : defaultVolume
+
+    return (
+      <div key="audio-strip" className="audio-strip has-track">
+        {fileInput}
+        <div className="audio-track-row">
+          <span className="audio-track-icon" aria-hidden="true">
+            <IconMusic size={16} />
+          </span>
+          <button
+            type="button"
+            className="audio-track-name"
+            disabled={disabled || busy}
+            aria-label={`Replace background music (currently ${audio.name})`}
+            title="Replace music"
+            mix={on('click', () => fileInputRef.current?.click())}
+          >
+            {audio.name}
+          </button>
+          <span className="audio-track-duration muted">{formatDuration(audio.durationMs)}</span>
+          <button
+            type="button"
+            className="btn-icon audio-remove"
+            disabled={disabled || busy}
+            aria-label="Remove background music"
+            mix={on('click', () => removeTrack())}
+          >
+            <IconClose size={16} />
+          </button>
+        </div>
+
+        {selectedClip ? (
+          <div className="audio-volume-row">
+            <span className="audio-volume-label">
+              Clip {selectedIndex + 1}
+              {clipOverridden ? '' : ' · default'}
+            </span>
+            <input
+              type="range"
+              min={0}
+              max={100}
+              step={5}
+              value={Math.round(clipVolume * 100)}
+              disabled={disabled || busy}
+              aria-label={`Music volume during clip ${selectedIndex + 1}`}
+              mix={[
+                on('input', (event) => {
+                  const volume = Number((event.currentTarget as HTMLInputElement).value) / 100
+                  pendingClip = { clipId: selectedClip.id, volume }
+                  void handle.update()
+                }),
+                on('change', (event) => {
+                  const volume = Number((event.currentTarget as HTMLInputElement).value) / 100
+                  commitClipVolume(selectedClip.id, volume)
+                }),
+              ]}
+            />
+            <span className="audio-volume-value">{Math.round(clipVolume * 100)}%</span>
+            <button
+              type="button"
+              className="audio-volume-reset"
+              disabled={disabled || busy || !clipOverridden}
+              aria-label="Reset this clip to the default music volume"
+              mix={on('click', () => resetClipVolume(selectedClip.id))}
+            >
+              Reset
+            </button>
+          </div>
+        ) : null}
+
+        <div className="audio-volume-row">
+          <span className="audio-volume-label">All clips</span>
+          <input
+            type="range"
+            min={0}
+            max={100}
+            step={5}
+            value={Math.round(defaultVolume * 100)}
+            disabled={disabled || busy}
+            aria-label="Default music volume"
+            mix={[
+              on('input', (event) => {
+                pendingDefault = Number((event.currentTarget as HTMLInputElement).value) / 100
+                void handle.update()
+              }),
+              on('change', (event) => {
+                const volume = Number((event.currentTarget as HTMLInputElement).value) / 100
+                commitDefaultVolume(volume)
+              }),
+            ]}
+          />
+          <span className="audio-volume-value">{Math.round(defaultVolume * 100)}%</span>
+        </div>
+      </div>
+    )
+  }
+}

--- a/src/components/editor-screen.tsx
+++ b/src/components/editor-screen.tsx
@@ -393,6 +393,7 @@ export function EditorScreen(handle: Handle<EditorScreenProps>) {
               audio={props.audio}
               selectedClip={selected}
               selectedIndex={selectedIndex}
+              projectDurationMs={totalDurationMs}
               disabled={importing}
               plus={props.plus}
               onUpsell={props.onUpsell}

--- a/src/components/editor-screen.tsx
+++ b/src/components/editor-screen.tsx
@@ -16,8 +16,10 @@ import {
   type ClipId,
   type ClipRecord,
   type Project,
+  type ProjectAudioRecord,
   type ProjectId,
 } from '../lib/types'
+import { AudioStrip } from './audio-strip'
 import { EditorClipPreview, type EditorClipPreviewHandle } from './editor-clip-preview'
 import {
   IconBack,
@@ -43,6 +45,12 @@ interface EditorScreenProps {
    * clip is added from a lazy "/project/new" shell. */
   ensureProjectId: () => Promise<ProjectId>
   clips: ClipRecord[]
+  /** Background-music track for the project (null when none is set). */
+  audio: ProjectAudioRecord | null
+  /** Kody Video Plus unlocked (background music is a Plus perk). */
+  plus: boolean
+  /** Open the Plus upsell sheet. */
+  onUpsell: () => void
   canUndo: boolean
   /** True while a full-screen overlay owns input (playback, export, …). */
   interactionLocked: boolean
@@ -374,9 +382,24 @@ export function EditorScreen(handle: Handle<EditorScreenProps>) {
               }}
               onAddFromDevice={openDevicePicker}
               addingFromDevice={importing}
+              showAudioBadges={props.audio !== null}
               refresh={props.refresh}
             />
           )}
+
+          {!trimming ? (
+            <AudioStrip
+              ensureProjectId={props.ensureProjectId}
+              audio={props.audio}
+              selectedClip={selected}
+              selectedIndex={selectedIndex}
+              disabled={importing}
+              plus={props.plus}
+              onUpsell={props.onUpsell}
+              showToast={props.showToast}
+              refresh={props.refresh}
+            />
+          ) : null}
 
           {!trimming ? (
             <div className="editor-actions" role="toolbar" aria-label="Clip actions">

--- a/src/components/icons.tsx
+++ b/src/components/icons.tsx
@@ -203,6 +203,16 @@ export function IconShareIos(handle: Handle<IconProps>) {
   )
 }
 
+export function IconMusic(handle: Handle<IconProps>) {
+  return () => (
+    <svg {...baseProps(handle.props.size ?? 22)}>
+      <path d="M9 18V5l12-2v13" />
+      <circle cx="6" cy="18" r="3" />
+      <circle cx="18" cy="16" r="3" />
+    </svg>
+  )
+}
+
 export function IconClose(handle: Handle<IconProps>) {
   return () => (
     <svg {...baseProps(handle.props.size ?? 22)}>

--- a/src/components/playback-overlay.tsx
+++ b/src/components/playback-overlay.tsx
@@ -1,14 +1,19 @@
 import type { Handle } from 'remix/ui'
 import { on, ref } from 'remix/ui'
 import { planExport } from '../lib/export'
-import type { ClipRecord } from '../lib/types'
+import { clipAudioVolume, type ClipRecord, type ProjectAudioRecord } from '../lib/types'
 import { IconPlay } from './icons'
 import { isInteractiveTarget } from '../lib/keyboard'
 
 interface PlaybackOverlayProps {
   clips: ClipRecord[]
+  /** Background-music track played under the clips (null when none). */
+  audio: ProjectAudioRecord | null
   onClose: () => void
 }
+
+/** Smoothing time constant for music volume moves (~settles in 3×). */
+const MUSIC_VOLUME_TAU_MS = 200
 
 /**
  * Sequential project preview, OK Video style: one persistent video element
@@ -41,6 +46,13 @@ export function PlaybackOverlay(handle: Handle<PlaybackOverlayProps>) {
    * events from the previous clip that fire before the new source is ready. */
   let loadedIndex = -1
 
+  // Background music: one looping audio element under the whole preview.
+  // Its volume glides toward the current clip's music volume every frame,
+  // so transitions between clips ramp instead of jumping — same behavior
+  // the export renders, heard live.
+  let audioEl: HTMLAudioElement | null = null
+  let audioUrl: string | null = null
+
   const currentSegment = () => resolveSegments()[index] ?? null
   const startSec = () => {
     const segment = currentSegment()
@@ -53,6 +65,76 @@ export function PlaybackOverlay(handle: Handle<PlaybackOverlayProps>) {
   const segmentMs = () => {
     const segment = currentSegment()
     return segment ? segment.endMs - segment.startMs : 0
+  }
+
+  const segmentMusicVolume = () => {
+    const segment = currentSegment()
+    const track = props.audio
+    if (!segment || !track) return 0
+    return clipAudioVolume(segment.clip, track.defaultVolume)
+  }
+
+  /** Playhead position on the output timeline, in ms. */
+  const timelinePositionMs = () => {
+    const segment = currentSegment()
+    if (!segment) return 0
+    const elapsedSec = videoEl ? Math.max(0, videoEl.currentTime - segment.startMs / 1000) : 0
+    return segment.offsetMs + elapsedSec * 1000
+  }
+
+  /** Keep the looping track under the playhead. Small drift is left alone —
+   * a re-seek every segment would audibly hiccup continuous playback. */
+  const syncMusicPosition = () => {
+    const audio = audioEl
+    const track = props.audio
+    if (!audio || !track || track.durationMs <= 0) return
+    const expectedSec = (timelinePositionMs() % track.durationMs) / 1000
+    if (Math.abs(audio.currentTime - expectedSec) > 0.35) {
+      audio.currentTime = expectedSec
+    }
+  }
+
+  const playMusic = () => {
+    const audio = audioEl
+    if (!audio) return
+    syncMusicPosition()
+    void audio.play().catch(() => undefined)
+  }
+
+  const pauseMusic = () => {
+    audioEl?.pause()
+  }
+
+  const bindAudio = (el: HTMLAudioElement, signal: AbortSignal) => {
+    const track = props.audio
+    if (!track) return
+    audioEl = el
+    el.loop = true
+    el.volume = 0
+    audioUrl = URL.createObjectURL(track.blob)
+    el.src = audioUrl
+
+    // Per-frame volume glide toward the current clip's target.
+    let last = performance.now()
+    let raf = 0
+    const tick = (now: number) => {
+      const dt = Math.min(100, now - last)
+      last = now
+      const target = segmentMusicVolume()
+      const alpha = 1 - Math.exp(-dt / MUSIC_VOLUME_TAU_MS)
+      const next = el.volume + (target - el.volume) * alpha
+      el.volume = Math.abs(next - target) < 0.005 ? target : next
+      raf = requestAnimationFrame(tick)
+    }
+    raf = requestAnimationFrame(tick)
+
+    signal.addEventListener('abort', () => {
+      cancelAnimationFrame(raf)
+      el.pause()
+      if (audioEl === el) audioEl = null
+      if (audioUrl) URL.revokeObjectURL(audioUrl)
+      audioUrl = null
+    })
   }
 
   /** Bind the current segment's blob to the persistent video element.
@@ -80,10 +162,13 @@ export function PlaybackOverlay(handle: Handle<PlaybackOverlayProps>) {
       const video = videoEl
       if (video) {
         video.currentTime = startSec()
-        void video.play().catch(() => {
-          needsTap = true
-          void handle.update()
-        })
+        void video
+          .play()
+          .then(() => playMusic())
+          .catch(() => {
+            needsTap = true
+            void handle.update()
+          })
       }
       void handle.update()
       return
@@ -110,6 +195,7 @@ export function PlaybackOverlay(handle: Handle<PlaybackOverlayProps>) {
       .play()
       .then(() => {
         needsTap = false
+        playMusic()
         void handle.update()
       })
       .catch(() => {
@@ -146,6 +232,7 @@ export function PlaybackOverlay(handle: Handle<PlaybackOverlayProps>) {
             .play()
             .then(() => {
               needsTap = false
+              playMusic()
               void handle.update()
             })
             .catch(() => {
@@ -154,6 +241,7 @@ export function PlaybackOverlay(handle: Handle<PlaybackOverlayProps>) {
             })
         } else {
           video.pause()
+          pauseMusic()
         }
         return
       }
@@ -241,6 +329,14 @@ export function PlaybackOverlay(handle: Handle<PlaybackOverlayProps>) {
           ))}
         </div>
 
+        {props.audio ? (
+          <audio
+            preload="auto"
+            aria-hidden="true"
+            mix={ref((node, signal) => bindAudio(node as HTMLAudioElement, signal))}
+          />
+        ) : null}
+
         <video
           className="playback-video"
           playsInline
@@ -291,6 +387,7 @@ export function PlaybackOverlay(handle: Handle<PlaybackOverlayProps>) {
                   .play()
                   .then(() => {
                     needsTap = false
+                    playMusic()
                     void handle.update()
                   })
                   .catch(() => undefined)

--- a/src/components/playback-overlay.tsx
+++ b/src/components/playback-overlay.tsx
@@ -261,6 +261,9 @@ export function PlaybackOverlay(handle: Handle<PlaybackOverlayProps>) {
     }
     segmentProgress = 0
     index = index + 1
+    // Positionally a no-op (segments abut on the timeline), but keeps the
+    // playlist hand-off logic on one path with manual skips.
+    syncMusicPosition()
     void handle.update()
   }
 

--- a/src/components/playback-overlay.tsx
+++ b/src/components/playback-overlay.tsx
@@ -246,6 +246,9 @@ export function PlaybackOverlay(handle: Handle<PlaybackOverlayProps>) {
       return
     }
     index = Math.max(0, Math.min(resolveSegments().length - 1, nextIndex))
+    // Jump the music to the new position now — waiting for the next clip's
+    // metadata would leave the old position playing through the load gap.
+    syncMusicPosition()
     void handle.update()
   }
 

--- a/src/components/playback-overlay.tsx
+++ b/src/components/playback-overlay.tsx
@@ -1,6 +1,7 @@
 import type { Handle } from 'remix/ui'
 import { on, ref } from 'remix/ui'
 import { planExport } from '../lib/export'
+import { FADE_OUT_MS } from '../lib/export/background-audio'
 import { clipAudioVolume, type ClipRecord, type ProjectAudioRecord } from '../lib/types'
 import { IconPlay } from './icons'
 import { isInteractiveTarget } from '../lib/keyboard'
@@ -75,7 +76,19 @@ export function PlaybackOverlay(handle: Handle<PlaybackOverlayProps>) {
     const segment = currentSegment()
     const track = props.audio
     if (!segment || !track) return 0
-    return clipAudioVolume(segment.clip, track.defaultVolume)
+    return clipAudioVolume(segment.clip, track.defaultVolume) * fadeOutScale()
+  }
+
+  /** Mirror the export's end-of-film fade-out in the live preview: inside
+   * the final FADE_OUT_MS the music target scales down toward silence. */
+  const fadeOutScale = () => {
+    if (!props.audio?.fadeOut) return 1
+    const segs = resolveSegments()
+    const last = segs[segs.length - 1]
+    if (!last) return 1
+    const totalMs = last.offsetMs + (last.endMs - last.startMs)
+    const remainingMs = totalMs - timelinePositionMs()
+    return Math.max(0, Math.min(1, remainingMs / FADE_OUT_MS))
   }
 
   /** Playhead position on the output timeline, in ms. */

--- a/src/components/playback-overlay.tsx
+++ b/src/components/playback-overlay.tsx
@@ -46,12 +46,16 @@ export function PlaybackOverlay(handle: Handle<PlaybackOverlayProps>) {
    * events from the previous clip that fire before the new source is ready. */
   let loadedIndex = -1
 
-  // Background music: one looping audio element under the whole preview.
-  // Its volume glides toward the current clip's music volume every frame,
-  // so transitions between clips ramp instead of jumping — same behavior
+  // Background music: one audio element under the whole preview, playing
+  // the playlist's tracks one after the other (nothing loops — when the
+  // playlist runs out the rest of the preview is music-free). Its volume
+  // glides toward the current clip's music volume every frame, so
+  // transitions between clips ramp instead of jumping — the same behavior
   // the export renders, heard live.
   let audioEl: HTMLAudioElement | null = null
-  let audioUrl: string | null = null
+  /** Lazily created object URL per playlist track (revoked on unmount). */
+  const trackUrls = new Map<number, string>()
+  let musicTrackIndex = -1
 
   const currentSegment = () => resolveSegments()[index] ?? null
   const startSec = () => {
@@ -82,23 +86,53 @@ export function PlaybackOverlay(handle: Handle<PlaybackOverlayProps>) {
     return segment.offsetMs + elapsedSec * 1000
   }
 
-  /** Keep the looping track under the playhead. Small drift is left alone —
-   * a re-seek every segment would audibly hiccup continuous playback. */
-  const syncMusicPosition = () => {
-    const audio = audioEl
-    const track = props.audio
-    if (!audio || !track || track.durationMs <= 0) return
-    const expectedSec = (timelinePositionMs() % track.durationMs) / 1000
-    if (Math.abs(audio.currentTime - expectedSec) > 0.35) {
-      audio.currentTime = expectedSec
+  /** Playlist track and in-track offset covering an output position, or
+   * null when the playlist has already run out there. */
+  const trackAtMs = (positionMs: number): { index: number; offsetMs: number } | null => {
+    const tracks = props.audio?.tracks ?? []
+    let cursor = 0
+    for (let i = 0; i < tracks.length; i += 1) {
+      if (positionMs < cursor + tracks[i].durationMs) {
+        return { index: i, offsetMs: positionMs - cursor }
+      }
+      cursor += tracks[i].durationMs
     }
+    return null
+  }
+
+  const urlForTrack = (trackIndex: number): string => {
+    let url = trackUrls.get(trackIndex)
+    if (!url) {
+      url = URL.createObjectURL(props.audio!.tracks[trackIndex].blob)
+      trackUrls.set(trackIndex, url)
+    }
+    return url
+  }
+
+  /** Put the right playlist track under the playhead. Small drift within a
+   * track is left alone — a re-seek every segment would audibly hiccup
+   * continuous playback. Returns false when there is no music to play. */
+  const syncMusicPosition = (): boolean => {
+    const audio = audioEl
+    if (!audio || !props.audio) return false
+    const target = trackAtMs(timelinePositionMs())
+    if (!target) {
+      audio.pause()
+      return false
+    }
+    if (musicTrackIndex !== target.index) {
+      musicTrackIndex = target.index
+      audio.src = urlForTrack(target.index)
+      audio.currentTime = target.offsetMs / 1000
+    } else if (Math.abs(audio.currentTime - target.offsetMs / 1000) > 0.35) {
+      audio.currentTime = target.offsetMs / 1000
+    }
+    return true
   }
 
   const playMusic = () => {
-    const audio = audioEl
-    if (!audio) return
-    syncMusicPosition()
-    void audio.play().catch(() => undefined)
+    if (!syncMusicPosition()) return
+    void audioEl?.play().catch(() => undefined)
   }
 
   const pauseMusic = () => {
@@ -109,10 +143,9 @@ export function PlaybackOverlay(handle: Handle<PlaybackOverlayProps>) {
     const track = props.audio
     if (!track) return
     audioEl = el
-    el.loop = true
-    el.volume = 0
-    audioUrl = URL.createObjectURL(track.blob)
-    el.src = audioUrl
+    // No fade-in means the music opens at full clip volume; otherwise the
+    // per-frame glide below fades it in from silence.
+    el.volume = track.fadeIn ? 0 : segmentMusicVolume()
 
     // Per-frame volume glide toward the current clip's target.
     let last = performance.now()
@@ -132,8 +165,9 @@ export function PlaybackOverlay(handle: Handle<PlaybackOverlayProps>) {
       cancelAnimationFrame(raf)
       el.pause()
       if (audioEl === el) audioEl = null
-      if (audioUrl) URL.revokeObjectURL(audioUrl)
-      audioUrl = null
+      for (const url of trackUrls.values()) URL.revokeObjectURL(url)
+      trackUrls.clear()
+      musicTrackIndex = -1
     })
   }
 
@@ -333,7 +367,13 @@ export function PlaybackOverlay(handle: Handle<PlaybackOverlayProps>) {
           <audio
             preload="auto"
             aria-hidden="true"
-            mix={ref((node, signal) => bindAudio(node as HTMLAudioElement, signal))}
+            mix={[
+              ref((node, signal) => bindAudio(node as HTMLAudioElement, signal)),
+              // A track running out mid-preview hands off to the next one.
+              on('ended', () => {
+                if (videoEl && !videoEl.paused) playMusic()
+              }),
+            ]}
           />
         ) : null}
 

--- a/src/components/playback-overlay.tsx
+++ b/src/components/playback-overlay.tsx
@@ -128,19 +128,44 @@ export function PlaybackOverlay(handle: Handle<PlaybackOverlayProps>) {
   const syncMusicPosition = (): boolean => {
     const audio = audioEl
     if (!audio || !props.audio) return false
-    const target = trackAtMs(timelinePositionMs())
+    const positionMs = timelinePositionMs()
+    const target = trackAtMs(positionMs)
     if (!target) {
       audio.pause()
       return false
     }
     if (musicTrackIndex !== target.index) {
-      musicTrackIndex = target.index
-      audio.src = urlForTrack(target.index)
-      audio.currentTime = target.offsetMs / 1000
+      // Metadata durations can run slightly past the decoded length, so a
+      // just-ended track briefly still "covers" the playhead — moving back
+      // to it would restart it. Only genuine backward skips switch back.
+      const boundaryMs = props.audio.tracks
+        .slice(0, target.index + 1)
+        .reduce((sum, track) => sum + track.durationMs, 0)
+      const nearHandOff = target.index < musicTrackIndex && boundaryMs - positionMs < 1500
+      if (!nearHandOff) {
+        musicTrackIndex = target.index
+        audio.src = urlForTrack(target.index)
+        audio.currentTime = target.offsetMs / 1000
+      }
     } else if (Math.abs(audio.currentTime - target.offsetMs / 1000) > 0.35) {
       audio.currentTime = target.offsetMs / 1000
     }
     return true
+  }
+
+  /** A track finished — hand off to the next one (never replay the ended
+   * track: metadata duration may outlast the decoded audio, so a
+   * position-based sync could still map into it). */
+  const advanceMusicTrack = () => {
+    const tracks = props.audio?.tracks ?? []
+    const audio = audioEl
+    if (!audio) return
+    const next = musicTrackIndex + 1
+    if (next >= tracks.length) return // Playlist over — the rest is music-free.
+    musicTrackIndex = next
+    audio.src = urlForTrack(next)
+    audio.currentTime = 0
+    if (videoEl && !videoEl.paused) void audio.play().catch(() => undefined)
   }
 
   const playMusic = () => {
@@ -383,9 +408,7 @@ export function PlaybackOverlay(handle: Handle<PlaybackOverlayProps>) {
             mix={[
               ref((node, signal) => bindAudio(node as HTMLAudioElement, signal)),
               // A track running out mid-preview hands off to the next one.
-              on('ended', () => {
-                if (videoEl && !videoEl.paused) playMusic()
-              }),
+              on('ended', () => advanceMusicTrack()),
             ]}
           />
         ) : null}

--- a/src/components/timeline.tsx
+++ b/src/components/timeline.tsx
@@ -32,6 +32,8 @@ interface TimelineProps {
   /** Open the device file picker to append gallery videos. */
   onAddFromDevice?: () => void
   addingFromDevice?: boolean
+  /** Show per-clip music-volume badges (project has a background track). */
+  showAudioBadges?: boolean
   refresh: () => void
 }
 
@@ -372,6 +374,11 @@ export function Timeline(handle: Handle<TimelineProps>) {
                   )}
                 </div>
                 <span className="clip-dur">{formatDuration(effectiveDurationMs(clip))}</span>
+                {props.showAudioBadges && clip.audioVolume !== undefined ? (
+                  <span className="clip-audio-badge" aria-hidden="true">
+                    ♪ {Math.round(clip.audioVolume * 100)}%
+                  </span>
+                ) : null}
               </button>
             </div>
           )

--- a/src/components/timeline.tsx
+++ b/src/components/timeline.tsx
@@ -335,7 +335,11 @@ export function Timeline(handle: Handle<TimelineProps>) {
                 className={`clip-thumb${selected ? ' selected' : ''}${isDragging ? ' lifting' : ''}`}
                 role="option"
                 aria-selected={selected}
-                aria-label={`Clip ${index + 1}, ${formatDuration(effectiveDurationMs(clip))}`}
+                aria-label={`Clip ${index + 1}, ${formatDuration(effectiveDurationMs(clip))}${
+                  props.showAudioBadges && clip.audioVolume !== undefined
+                    ? `, music ${Math.round(clip.audioVolume * 100)}%`
+                    : ''
+                }`}
                 data-clip-id={clip.id}
                 style={{ width: `${width}px` }}
                 mix={[

--- a/src/components/upsell-sheet.tsx
+++ b/src/components/upsell-sheet.tsx
@@ -31,8 +31,8 @@ export function UpsellSheet(handle: Handle<UpsellSheetProps>) {
           <h3>Kody Video Plus</h3>
           <p className="sheet-copy">
             The free plan includes 1 project. Plus is a one-time $0.99 purchase that unlocks{' '}
-            {MAX_PROJECTS} project slots and removes the watermark from exports — forever, on this
-            device and any device you restore it on.
+            {MAX_PROJECTS} project slots, background music for your films, and removes the
+            watermark from exports — forever, on this device and any device you restore it on.
           </p>
           <div className="sheet-actions">
             <button type="button" className="btn btn-ghost" mix={on('click', () => onClose())}>

--- a/src/lib/audio-import.ts
+++ b/src/lib/audio-import.ts
@@ -1,0 +1,87 @@
+/** Accept string for the background-music file picker. */
+export const AUDIO_FILE_ACCEPT = 'audio/*'
+
+/** Songs, not albums: a soft cap that keeps IndexedDB quotas comfortable. */
+const MAX_AUDIO_BYTES = 80 * 1024 * 1024
+
+export interface ProbedAudioFile {
+  blob: Blob
+  mimeType: string
+  durationMs: number
+  name: string
+}
+
+/**
+ * A picked file that can't be used as a background track (wrong type,
+ * undecodable, too large). Expected user input — surfaced as guidance.
+ */
+export class AudioImportError extends Error {
+  override readonly name = 'AudioImportError'
+}
+
+/**
+ * Validate a picked audio file and measure its real duration by loading it
+ * into an off-DOM audio element — the same engine that will play it back,
+ * so "it probed" means "it will play".
+ */
+export async function probeAudioFile(file: File): Promise<ProbedAudioFile> {
+  if (file.size === 0) {
+    throw new AudioImportError('That file is empty')
+  }
+  if (file.size > MAX_AUDIO_BYTES) {
+    throw new AudioImportError('That audio file is too large — pick one under 80 MB')
+  }
+  const mimeType = file.type || 'audio/mpeg'
+  const durationMs = await probeAudioDuration(file, mimeType)
+  if (durationMs < 500) {
+    throw new AudioImportError('That audio file is too short to use as background music')
+  }
+  return {
+    blob: file,
+    mimeType,
+    durationMs,
+    name: file.name || 'Audio track',
+  }
+}
+
+function probeAudioDuration(blob: Blob, mimeType: string, timeoutMs = 8000): Promise<number> {
+  const typed = blob.type ? blob : new Blob([blob], { type: mimeType })
+  const url = URL.createObjectURL(typed)
+  const audio = new Audio()
+  audio.preload = 'metadata'
+
+  return new Promise<number>((resolve, reject) => {
+    const timer = window.setTimeout(() => {
+      fail(new AudioImportError('Could not read that audio file'))
+    }, timeoutMs)
+    const cleanup = () => {
+      window.clearTimeout(timer)
+      audio.onloadedmetadata = null
+      audio.ondurationchange = null
+      audio.onerror = null
+      audio.removeAttribute('src')
+      audio.load()
+      URL.revokeObjectURL(url)
+    }
+    const fail = (error: Error) => {
+      cleanup()
+      reject(error)
+    }
+    const tryResolve = () => {
+      const seconds = audio.duration
+      if (Number.isFinite(seconds) && seconds > 0) {
+        cleanup()
+        resolve(Math.round(seconds * 1000))
+      }
+    }
+    audio.onloadedmetadata = tryResolve
+    // Some encoders (VBR MP3s, streamed captures) only report a finite
+    // duration on a later durationchange.
+    audio.ondurationchange = tryResolve
+    audio.onerror = () => {
+      fail(new AudioImportError('That file could not be played — try an MP3, M4A, or WAV'))
+    }
+    audio.src = url
+    audio.load()
+  })
+}

--- a/src/lib/export/background-audio.test.ts
+++ b/src/lib/export/background-audio.test.ts
@@ -4,31 +4,24 @@ import {
   FADE_IN_MS,
   FADE_OUT_MS,
   VOLUME_RAMP_MS,
+  boundaryRampHalfMs,
   createBackgroundMixer,
   gainAtMs,
-  planBackgroundGain,
+  planSegmentGain,
+  segmentVolume,
+  type GainPoint,
   type SequentialBackgroundSource,
 } from './background-audio'
 
-function segment(offsetMs: number, durationMs: number, audioVolume?: number) {
-  return {
-    offsetMs,
-    startMs: 0,
-    endMs: durationMs,
-    clip: { audioVolume },
-  }
-}
-
 const bothFades = { fadeIn: true, fadeOut: true }
 
-describe('planBackgroundGain', () => {
-  it('returns an empty envelope for empty plans', () => {
-    expect(planBackgroundGain([], 0.25, 0, bothFades)).toEqual([])
-    expect(planBackgroundGain([segment(0, 1000)], 0.25, 0, bothFades)).toEqual([])
+describe('planSegmentGain', () => {
+  it('returns an empty envelope for degenerate durations', () => {
+    expect(planSegmentGain({ volume: 0.5, durationMs: 0, fades: bothFades })).toEqual([])
   })
 
-  it('fades in from silence and out to silence when enabled', () => {
-    const points = planBackgroundGain([segment(0, 8000)], 0.25, 8000, bothFades)
+  it('fades a single-segment film in from silence and out to silence', () => {
+    const points = planSegmentGain({ volume: 0.25, durationMs: 8000, fades: bothFades })
     expect(gainAtMs(points, 0)).toBe(0)
     expect(gainAtMs(points, FADE_IN_MS / 2)).toBeCloseTo(0.125)
     expect(gainAtMs(points, FADE_IN_MS)).toBeCloseTo(0.25)
@@ -38,94 +31,114 @@ describe('planBackgroundGain', () => {
   })
 
   it('keeps only inaudible click-kill edges when fades are disabled', () => {
-    const points = planBackgroundGain([segment(0, 8000)], 0.25, 8000, {
-      fadeIn: false,
-      fadeOut: false,
+    const points = planSegmentGain({
+      volume: 0.25,
+      durationMs: 8000,
+      fades: { fadeIn: false, fadeOut: false },
     })
     expect(gainAtMs(points, EDGE_RAMP_MS)).toBeCloseTo(0.25)
-    expect(gainAtMs(points, 8000 - EDGE_RAMP_MS)).toBeCloseTo(0.25)
-    expect(gainAtMs(points, 8000)).toBe(0)
-    // Well before what a real fade would cover, the gain is already full.
     expect(gainAtMs(points, 100)).toBeCloseTo(0.25)
     expect(gainAtMs(points, 7900)).toBeCloseTo(0.25)
+    expect(gainAtMs(points, 8000)).toBe(0)
   })
 
-  it('honors the toggles independently', () => {
-    const inOnly = planBackgroundGain([segment(0, 8000)], 0.5, 8000, {
-      fadeIn: true,
-      fadeOut: false,
+  it('honors the fade toggles independently', () => {
+    const inOnly = planSegmentGain({
+      volume: 0.5,
+      durationMs: 8000,
+      fades: { fadeIn: true, fadeOut: false },
     })
     expect(gainAtMs(inOnly, FADE_IN_MS / 2)).toBeCloseTo(0.25)
     expect(gainAtMs(inOnly, 7900)).toBeCloseTo(0.5)
 
-    const outOnly = planBackgroundGain([segment(0, 8000)], 0.5, 8000, {
-      fadeIn: false,
-      fadeOut: true,
+    const outOnly = planSegmentGain({
+      volume: 0.5,
+      durationMs: 8000,
+      fades: { fadeIn: false, fadeOut: true },
     })
     expect(gainAtMs(outOnly, 100)).toBeCloseTo(0.5)
     expect(gainAtMs(outOnly, 8000 - FADE_OUT_MS / 2)).toBeCloseTo(0.25)
   })
 
   it('ramps across a boundary between different clip volumes', () => {
-    const points = planBackgroundGain(
-      [segment(0, 4000, 0.8), segment(4000, 4000, 0.2)],
-      0.25,
-      8000,
-      bothFades,
-    )
     const half = VOLUME_RAMP_MS / 2
-    expect(gainAtMs(points, 4000 - half)).toBeCloseTo(0.8)
-    expect(gainAtMs(points, 4000)).toBeCloseTo(0.5)
-    expect(gainAtMs(points, 4000 + half)).toBeCloseTo(0.2)
-    expect(gainAtMs(points, 2000)).toBeCloseTo(0.8)
-    expect(gainAtMs(points, 6000)).toBeCloseTo(0.2)
+    // Two 4s clips at 0.8 → 0.2: the outgoing tail meets the incoming head
+    // at the midpoint (0.5) exactly at the boundary.
+    const outgoing = planSegmentGain({
+      volume: 0.8,
+      durationMs: 4000,
+      exit: { toVolume: 0.2, halfMs: boundaryRampHalfMs(4000, 4000) },
+      fades: bothFades,
+    })
+    expect(gainAtMs(outgoing, 2000)).toBeCloseTo(0.8)
+    expect(gainAtMs(outgoing, 4000 - half)).toBeCloseTo(0.8)
+    expect(gainAtMs(outgoing, 4000)).toBeCloseTo(0.5)
+
+    const incoming = planSegmentGain({
+      volume: 0.2,
+      durationMs: 4000,
+      entry: { fromVolume: 0.8, halfMs: boundaryRampHalfMs(4000, 4000) },
+      fades: bothFades,
+    })
+    expect(gainAtMs(incoming, 0)).toBeCloseTo(0.5)
+    expect(gainAtMs(incoming, half)).toBeCloseTo(0.2)
+    expect(gainAtMs(incoming, 2000)).toBeCloseTo(0.2)
   })
 
   it('holds one flat gain across same-volume boundaries (no dip)', () => {
-    const points = planBackgroundGain(
-      [segment(0, 3000, 0.5), segment(3000, 3000, 0.5)],
-      0.25,
-      6000,
-      bothFades,
-    )
-    expect(gainAtMs(points, 2900)).toBeCloseTo(0.5)
-    expect(gainAtMs(points, 3000)).toBeCloseTo(0.5)
-    expect(gainAtMs(points, 3100)).toBeCloseTo(0.5)
+    const half = boundaryRampHalfMs(3000, 3000)
+    const outgoing = planSegmentGain({
+      volume: 0.5,
+      durationMs: 3000,
+      exit: { toVolume: 0.5, halfMs: half },
+      fades: bothFades,
+    })
+    const incoming = planSegmentGain({
+      volume: 0.5,
+      durationMs: 3000,
+      entry: { fromVolume: 0.5, halfMs: half },
+      fades: bothFades,
+    })
+    expect(gainAtMs(outgoing, 2900)).toBeCloseTo(0.5)
+    expect(gainAtMs(outgoing, 3000)).toBeCloseTo(0.5)
+    expect(gainAtMs(incoming, 0)).toBeCloseTo(0.5)
+    expect(gainAtMs(incoming, 100)).toBeCloseTo(0.5)
   })
 
-  it('falls back to the default volume for clips without an override', () => {
-    const points = planBackgroundGain(
-      [segment(0, 4000), segment(4000, 4000, 0)],
-      0.3,
-      8000,
-      bothFades,
-    )
-    expect(gainAtMs(points, 2000)).toBeCloseTo(0.3)
-    expect(gainAtMs(points, 6000)).toBe(0)
-  })
-
-  it('keeps time monotonic when clips are shorter than the ramps', () => {
-    const points = planBackgroundGain(
-      [segment(0, 120, 1), segment(120, 100, 0), segment(220, 130, 0.9)],
-      0.25,
-      350,
-      bothFades,
-    )
+  it('keeps time monotonic and gains in range on tiny segments', () => {
+    const points = planSegmentGain({
+      volume: 1,
+      durationMs: 120,
+      entry: { fromVolume: 0, halfMs: boundaryRampHalfMs(100, 120) },
+      exit: { toVolume: 0.9, halfMs: boundaryRampHalfMs(120, 130) },
+      fades: bothFades,
+    })
     for (let i = 1; i < points.length; i += 1) {
       expect(points[i].tMs).toBeGreaterThanOrEqual(points[i - 1].tMs)
     }
-    for (let t = 0; t <= 350; t += 10) {
+    for (let t = 0; t <= 120; t += 5) {
       const gain = gainAtMs(points, t)
       expect(gain).toBeGreaterThanOrEqual(0)
       expect(gain).toBeLessThanOrEqual(1)
     }
   })
+
+  it('clamps the boundary ramp to the shorter neighbor', () => {
+    expect(boundaryRampHalfMs(4000, 4000)).toBe(VOLUME_RAMP_MS / 2)
+    expect(boundaryRampHalfMs(400, 4000)).toBe(200)
+    expect(boundaryRampHalfMs(4000, 100)).toBe(50)
+  })
+
+  it('reads the clip override through segmentVolume', () => {
+    expect(segmentVolume({ clip: { audioVolume: 0.7 } } as never, 0.25)).toBe(0.7)
+    expect(segmentVolume({ clip: {} } as never, 0.25)).toBe(0.25)
+  })
 })
 
 describe('createBackgroundMixer', () => {
-  const flatEnvelope = [
-    { tMs: 0, volume: 0.5 },
-    { tMs: 1_000_000, volume: 0.5 },
+  const flatEnvelope = (volume: number): GainPoint[] => [
+    { tMs: 0, volume },
+    { tMs: 1_000_000, volume },
   ]
 
   function sourceOf(tracks: Array<Float32Array[] | null>): SequentialBackgroundSource {
@@ -139,10 +152,9 @@ describe('createBackgroundMixer', () => {
     const slice = [new Float32Array([0.1, 0.1, 0.1, 0.1])]
     const mixer = createBackgroundMixer(
       sourceOf([[new Float32Array([0.4, 0.4, 0.4, 0.4])]]),
-      flatEnvelope,
       48000,
     )
-    await mixer.mixInto(slice, 0)
+    await mixer.mixInto(slice, 0, flatEnvelope(0.5))
     for (const sample of slice[0]) {
       expect(sample).toBeCloseTo(0.1 + 0.4 * 0.5)
     }
@@ -152,14 +164,10 @@ describe('createBackgroundMixer', () => {
     // Track A: two frames of 0.2; track B: two frames of 0.6; film: 6 frames.
     const mixer = createBackgroundMixer(
       sourceOf([[new Float32Array([0.2, 0.2])], [new Float32Array([0.6, 0.6])]]),
-      [
-        { tMs: 0, volume: 1 },
-        { tMs: 1_000_000, volume: 1 },
-      ],
       48000,
     )
     const slice = [new Float32Array(6)]
-    await mixer.mixInto(slice, 0)
+    await mixer.mixInto(slice, 0, flatEnvelope(1))
     expect(Array.from(slice[0]).map((v) => Number(v.toFixed(2)))).toEqual([
       0.2, 0.2, 0.6, 0.6, 0, 0,
     ])
@@ -168,43 +176,49 @@ describe('createBackgroundMixer', () => {
   it('mixes across slice boundaries in output order', async () => {
     const mixer = createBackgroundMixer(
       sourceOf([[new Float32Array([0.2, 0.2, 0.2])], [new Float32Array([0.6, 0.6, 0.6])]]),
-      [
-        { tMs: 0, volume: 1 },
-        { tMs: 1_000_000, volume: 1 },
-      ],
       48000,
     )
     const first = [new Float32Array(2)]
     const second = [new Float32Array(4)]
-    await mixer.mixInto(first, 0)
-    await mixer.mixInto(second, 2)
+    await mixer.mixInto(first, 0, flatEnvelope(1))
+    await mixer.mixInto(second, 2, flatEnvelope(1))
     expect(Array.from(first[0]).map((v) => Number(v.toFixed(2)))).toEqual([0.2, 0.2])
     // Second slice spans the A→B hand-off (frame 3) and B's end (frame 6).
     expect(Array.from(second[0]).map((v) => Number(v.toFixed(2)))).toEqual([0.2, 0.6, 0.6, 0.6])
   })
 
+  it('applies each slice its own local envelope', async () => {
+    // One 4-frame track mixed as two slices with different gains — the
+    // envelope is local to each slice (its time 0 = the slice start).
+    const mixer = createBackgroundMixer(
+      sourceOf([[new Float32Array([0.4, 0.4, 0.4, 0.4])]]),
+      1000, // 1 frame = 1ms for readable positions
+    )
+    const first = [new Float32Array(2)]
+    const second = [new Float32Array(2)]
+    await mixer.mixInto(first, 0, flatEnvelope(1))
+    await mixer.mixInto(second, 2, [
+      { tMs: 0, volume: 0.5 },
+      { tMs: 2, volume: 0.5 },
+    ])
+    expect(first[0][0]).toBeCloseTo(0.4)
+    expect(second[0][0]).toBeCloseTo(0.2)
+  })
+
   it('skips undecodable tracks and continues with the next', async () => {
     const mixer = createBackgroundMixer(
       sourceOf([null, [new Float32Array([0.4, 0.4])]]),
-      flatEnvelope,
       48000,
     )
     const slice = [new Float32Array(3)]
-    await mixer.mixInto(slice, 0)
+    await mixer.mixInto(slice, 0, flatEnvelope(0.5))
     expect(Array.from(slice[0]).map((v) => Number(v.toFixed(2)))).toEqual([0.2, 0.2, 0])
   })
 
   it('spreads a mono track across stereo slices and clamps the sum', async () => {
     const slice = [new Float32Array([0.9]), new Float32Array([-0.9])]
-    const mixer = createBackgroundMixer(
-      sourceOf([[new Float32Array([1])]]),
-      [
-        { tMs: 0, volume: 1 },
-        { tMs: 1000, volume: 1 },
-      ],
-      48000,
-    )
-    await mixer.mixInto(slice, 0)
+    const mixer = createBackgroundMixer(sourceOf([[new Float32Array([1])]]), 48000)
+    await mixer.mixInto(slice, 0, flatEnvelope(1))
     expect(slice[0][0]).toBe(1)
     expect(slice[1][0]).toBeCloseTo(0.1)
   })
@@ -212,38 +226,9 @@ describe('createBackgroundMixer', () => {
   it('leaves slices untouched when the gain is zero', async () => {
     const slice = [new Float32Array([0.3, 0.3])]
     const before = Array.from(slice[0])
-    const mixer = createBackgroundMixer(
-      sourceOf([[new Float32Array([0.5, 0.5])]]),
-      [
-        { tMs: 0, volume: 0 },
-        { tMs: 1000, volume: 0 },
-      ],
-      48000,
-    )
-    await mixer.mixInto(slice, 0)
+    const mixer = createBackgroundMixer(sourceOf([[new Float32Array([0.5, 0.5])]]), 48000)
+    await mixer.mixInto(slice, 0, flatEnvelope(0))
     expect(Array.from(slice[0])).toEqual(before)
-  })
-
-  it('anchors gain lookups at the provided planned offset', async () => {
-    // Envelope: silent until 1000ms, then full volume.
-    const points = [
-      { tMs: 0, volume: 0 },
-      { tMs: 999, volume: 0 },
-      { tMs: 1000, volume: 1 },
-      { tMs: 2000, volume: 1 },
-    ]
-    const mixer = createBackgroundMixer(
-      sourceOf([[new Float32Array(10).fill(0.5)]]),
-      points,
-      1000, // 1 frame = 1ms for readable positions
-    )
-    // The slice physically sits at frame 0, but its planned position is
-    // 1000ms — the gain must come from the planned timeline (1), not the
-    // frame-derived one (0).
-    const slice = [new Float32Array(2)]
-    await mixer.mixInto(slice, 0, 1000)
-    expect(slice[0][0]).toBeCloseTo(0.5)
-    expect(slice[0][1]).toBeCloseTo(0.5)
   })
 
   it('decodes each track at most once (lazy, in order)', async () => {
@@ -256,13 +241,12 @@ describe('createBackgroundMixer', () => {
           return Promise.resolve([new Float32Array(2).fill(0.1)])
         },
       },
-      flatEnvelope,
       48000,
     )
     // The film only reaches into track 2's range (frames 0..5).
-    await mixer.mixInto([new Float32Array(3)], 0)
+    await mixer.mixInto([new Float32Array(3)], 0, flatEnvelope(0.5))
     expect(decoded).toEqual([0, 1])
-    await mixer.mixInto([new Float32Array(3)], 3)
+    await mixer.mixInto([new Float32Array(3)], 3, flatEnvelope(0.5))
     expect(decoded).toEqual([0, 1, 2])
   })
 })

--- a/src/lib/export/background-audio.test.ts
+++ b/src/lib/export/background-audio.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it } from 'vitest'
+import {
+  FADE_IN_MS,
+  FADE_OUT_MS,
+  VOLUME_RAMP_MS,
+  gainAtMs,
+  mixBackgroundIntoChannels,
+  planBackgroundGain,
+} from './background-audio'
+
+function segment(offsetMs: number, durationMs: number, audioVolume?: number) {
+  return {
+    offsetMs,
+    startMs: 0,
+    endMs: durationMs,
+    clip: { audioVolume },
+  }
+}
+
+describe('planBackgroundGain', () => {
+  it('returns an empty envelope for empty plans', () => {
+    expect(planBackgroundGain([], 0.25, 0)).toEqual([])
+    expect(planBackgroundGain([segment(0, 1000)], 0.25, 0)).toEqual([])
+  })
+
+  it('fades in from silence and out to silence', () => {
+    const points = planBackgroundGain([segment(0, 5000)], 0.25, 5000)
+    expect(gainAtMs(points, 0)).toBe(0)
+    expect(gainAtMs(points, FADE_IN_MS)).toBeCloseTo(0.25)
+    expect(gainAtMs(points, 2500)).toBeCloseTo(0.25)
+    expect(gainAtMs(points, 5000 - FADE_OUT_MS)).toBeCloseTo(0.25)
+    expect(gainAtMs(points, 5000)).toBe(0)
+  })
+
+  it('ramps across a boundary between different clip volumes', () => {
+    const points = planBackgroundGain(
+      [segment(0, 4000, 0.8), segment(4000, 4000, 0.2)],
+      0.25,
+      8000,
+    )
+    const half = VOLUME_RAMP_MS / 2
+    expect(gainAtMs(points, 4000 - half)).toBeCloseTo(0.8)
+    expect(gainAtMs(points, 4000)).toBeCloseTo(0.5)
+    expect(gainAtMs(points, 4000 + half)).toBeCloseTo(0.2)
+    // Steady state well away from the boundary.
+    expect(gainAtMs(points, 2000)).toBeCloseTo(0.8)
+    expect(gainAtMs(points, 6000)).toBeCloseTo(0.2)
+  })
+
+  it('holds one flat gain across same-volume boundaries (no dip)', () => {
+    const points = planBackgroundGain(
+      [segment(0, 3000, 0.5), segment(3000, 3000, 0.5)],
+      0.25,
+      6000,
+    )
+    expect(gainAtMs(points, 2900)).toBeCloseTo(0.5)
+    expect(gainAtMs(points, 3000)).toBeCloseTo(0.5)
+    expect(gainAtMs(points, 3100)).toBeCloseTo(0.5)
+  })
+
+  it('falls back to the default volume for clips without an override', () => {
+    const points = planBackgroundGain(
+      [segment(0, 4000), segment(4000, 4000, 0)],
+      0.3,
+      8000,
+    )
+    expect(gainAtMs(points, 2000)).toBeCloseTo(0.3)
+    expect(gainAtMs(points, 6000)).toBe(0)
+  })
+
+  it('keeps time monotonic when clips are shorter than the ramps', () => {
+    const points = planBackgroundGain(
+      [segment(0, 120, 1), segment(120, 100, 0), segment(220, 130, 0.9)],
+      0.25,
+      350,
+    )
+    for (let i = 1; i < points.length; i += 1) {
+      expect(points[i].tMs).toBeGreaterThanOrEqual(points[i - 1].tMs)
+    }
+    // Every gain the envelope produces stays within the volume range.
+    for (let t = 0; t <= 350; t += 10) {
+      const gain = gainAtMs(points, t)
+      expect(gain).toBeGreaterThanOrEqual(0)
+      expect(gain).toBeLessThanOrEqual(1)
+    }
+  })
+})
+
+describe('mixBackgroundIntoChannels', () => {
+  const flatEnvelope = [
+    { tMs: 0, volume: 0.5 },
+    { tMs: 1_000_000, volume: 0.5 },
+  ]
+
+  it('adds the background at the envelope gain', () => {
+    const slice = [new Float32Array([0.1, 0.1, 0.1, 0.1])]
+    const background = [new Float32Array([0.4, 0.4, 0.4, 0.4])]
+    mixBackgroundIntoChannels({
+      channels: slice,
+      background,
+      sampleRate: 48000,
+      sliceStartFrame: 0,
+      points: flatEnvelope,
+    })
+    for (const sample of slice[0]) {
+      expect(sample).toBeCloseTo(0.1 + 0.4 * 0.5)
+    }
+  })
+
+  it('loops the background when the film is longer than the track', () => {
+    const slice = [new Float32Array(6)]
+    const background = [new Float32Array([0.2, 0.4])]
+    mixBackgroundIntoChannels({
+      channels: slice,
+      background,
+      sampleRate: 48000,
+      sliceStartFrame: 5,
+      points: flatEnvelope,
+    })
+    // Frames 5..10 alternate through the 2-sample track: odd → 0.4, even → 0.2.
+    expect(Array.from(slice[0]).map((v) => Number(v.toFixed(2)))).toEqual([
+      0.2, 0.1, 0.2, 0.1, 0.2, 0.1,
+    ])
+  })
+
+  it('spreads a mono background across stereo slices and clamps the sum', () => {
+    const slice = [new Float32Array([0.9]), new Float32Array([-0.9])]
+    const background = [new Float32Array([1])]
+    mixBackgroundIntoChannels({
+      channels: slice,
+      background,
+      sampleRate: 48000,
+      sliceStartFrame: 0,
+      points: [
+        { tMs: 0, volume: 1 },
+        { tMs: 1000, volume: 1 },
+      ],
+    })
+    expect(slice[0][0]).toBe(1)
+    expect(slice[1][0]).toBeCloseTo(0.1)
+  })
+
+  it('leaves the slice untouched when the gain is zero', () => {
+    const slice = [new Float32Array([0.3, 0.3])]
+    const before = Array.from(slice[0])
+    mixBackgroundIntoChannels({
+      channels: slice,
+      background: [new Float32Array([0.5, 0.5])],
+      sampleRate: 48000,
+      sliceStartFrame: 0,
+      points: [
+        { tMs: 0, volume: 0 },
+        { tMs: 1000, volume: 0 },
+      ],
+    })
+    expect(Array.from(slice[0])).toEqual(before)
+  })
+})

--- a/src/lib/export/background-audio.test.ts
+++ b/src/lib/export/background-audio.test.ts
@@ -224,6 +224,28 @@ describe('createBackgroundMixer', () => {
     expect(Array.from(slice[0])).toEqual(before)
   })
 
+  it('anchors gain lookups at the provided planned offset', async () => {
+    // Envelope: silent until 1000ms, then full volume.
+    const points = [
+      { tMs: 0, volume: 0 },
+      { tMs: 999, volume: 0 },
+      { tMs: 1000, volume: 1 },
+      { tMs: 2000, volume: 1 },
+    ]
+    const mixer = createBackgroundMixer(
+      sourceOf([[new Float32Array(10).fill(0.5)]]),
+      points,
+      1000, // 1 frame = 1ms for readable positions
+    )
+    // The slice physically sits at frame 0, but its planned position is
+    // 1000ms — the gain must come from the planned timeline (1), not the
+    // frame-derived one (0).
+    const slice = [new Float32Array(2)]
+    await mixer.mixInto(slice, 0, 1000)
+    expect(slice[0][0]).toBeCloseTo(0.5)
+    expect(slice[0][1]).toBeCloseTo(0.5)
+  })
+
   it('decodes each track at most once (lazy, in order)', async () => {
     const decoded: number[] = []
     const mixer = createBackgroundMixer(

--- a/src/lib/export/background-audio.test.ts
+++ b/src/lib/export/background-audio.test.ts
@@ -1,11 +1,13 @@
 import { describe, expect, it } from 'vitest'
 import {
+  EDGE_RAMP_MS,
   FADE_IN_MS,
   FADE_OUT_MS,
   VOLUME_RAMP_MS,
+  createBackgroundMixer,
   gainAtMs,
-  mixBackgroundIntoChannels,
   planBackgroundGain,
+  type SequentialBackgroundSource,
 } from './background-audio'
 
 function segment(offsetMs: number, durationMs: number, audioVolume?: number) {
@@ -17,19 +19,51 @@ function segment(offsetMs: number, durationMs: number, audioVolume?: number) {
   }
 }
 
+const bothFades = { fadeIn: true, fadeOut: true }
+
 describe('planBackgroundGain', () => {
   it('returns an empty envelope for empty plans', () => {
-    expect(planBackgroundGain([], 0.25, 0)).toEqual([])
-    expect(planBackgroundGain([segment(0, 1000)], 0.25, 0)).toEqual([])
+    expect(planBackgroundGain([], 0.25, 0, bothFades)).toEqual([])
+    expect(planBackgroundGain([segment(0, 1000)], 0.25, 0, bothFades)).toEqual([])
   })
 
-  it('fades in from silence and out to silence', () => {
-    const points = planBackgroundGain([segment(0, 5000)], 0.25, 5000)
+  it('fades in from silence and out to silence when enabled', () => {
+    const points = planBackgroundGain([segment(0, 8000)], 0.25, 8000, bothFades)
     expect(gainAtMs(points, 0)).toBe(0)
+    expect(gainAtMs(points, FADE_IN_MS / 2)).toBeCloseTo(0.125)
     expect(gainAtMs(points, FADE_IN_MS)).toBeCloseTo(0.25)
-    expect(gainAtMs(points, 2500)).toBeCloseTo(0.25)
-    expect(gainAtMs(points, 5000 - FADE_OUT_MS)).toBeCloseTo(0.25)
-    expect(gainAtMs(points, 5000)).toBe(0)
+    expect(gainAtMs(points, 4000)).toBeCloseTo(0.25)
+    expect(gainAtMs(points, 8000 - FADE_OUT_MS)).toBeCloseTo(0.25)
+    expect(gainAtMs(points, 8000)).toBe(0)
+  })
+
+  it('keeps only inaudible click-kill edges when fades are disabled', () => {
+    const points = planBackgroundGain([segment(0, 8000)], 0.25, 8000, {
+      fadeIn: false,
+      fadeOut: false,
+    })
+    expect(gainAtMs(points, EDGE_RAMP_MS)).toBeCloseTo(0.25)
+    expect(gainAtMs(points, 8000 - EDGE_RAMP_MS)).toBeCloseTo(0.25)
+    expect(gainAtMs(points, 8000)).toBe(0)
+    // Well before what a real fade would cover, the gain is already full.
+    expect(gainAtMs(points, 100)).toBeCloseTo(0.25)
+    expect(gainAtMs(points, 7900)).toBeCloseTo(0.25)
+  })
+
+  it('honors the toggles independently', () => {
+    const inOnly = planBackgroundGain([segment(0, 8000)], 0.5, 8000, {
+      fadeIn: true,
+      fadeOut: false,
+    })
+    expect(gainAtMs(inOnly, FADE_IN_MS / 2)).toBeCloseTo(0.25)
+    expect(gainAtMs(inOnly, 7900)).toBeCloseTo(0.5)
+
+    const outOnly = planBackgroundGain([segment(0, 8000)], 0.5, 8000, {
+      fadeIn: false,
+      fadeOut: true,
+    })
+    expect(gainAtMs(outOnly, 100)).toBeCloseTo(0.5)
+    expect(gainAtMs(outOnly, 8000 - FADE_OUT_MS / 2)).toBeCloseTo(0.25)
   })
 
   it('ramps across a boundary between different clip volumes', () => {
@@ -37,12 +71,12 @@ describe('planBackgroundGain', () => {
       [segment(0, 4000, 0.8), segment(4000, 4000, 0.2)],
       0.25,
       8000,
+      bothFades,
     )
     const half = VOLUME_RAMP_MS / 2
     expect(gainAtMs(points, 4000 - half)).toBeCloseTo(0.8)
     expect(gainAtMs(points, 4000)).toBeCloseTo(0.5)
     expect(gainAtMs(points, 4000 + half)).toBeCloseTo(0.2)
-    // Steady state well away from the boundary.
     expect(gainAtMs(points, 2000)).toBeCloseTo(0.8)
     expect(gainAtMs(points, 6000)).toBeCloseTo(0.2)
   })
@@ -52,6 +86,7 @@ describe('planBackgroundGain', () => {
       [segment(0, 3000, 0.5), segment(3000, 3000, 0.5)],
       0.25,
       6000,
+      bothFades,
     )
     expect(gainAtMs(points, 2900)).toBeCloseTo(0.5)
     expect(gainAtMs(points, 3000)).toBeCloseTo(0.5)
@@ -63,6 +98,7 @@ describe('planBackgroundGain', () => {
       [segment(0, 4000), segment(4000, 4000, 0)],
       0.3,
       8000,
+      bothFades,
     )
     expect(gainAtMs(points, 2000)).toBeCloseTo(0.3)
     expect(gainAtMs(points, 6000)).toBe(0)
@@ -73,11 +109,11 @@ describe('planBackgroundGain', () => {
       [segment(0, 120, 1), segment(120, 100, 0), segment(220, 130, 0.9)],
       0.25,
       350,
+      bothFades,
     )
     for (let i = 1; i < points.length; i += 1) {
       expect(points[i].tMs).toBeGreaterThanOrEqual(points[i - 1].tMs)
     }
-    // Every gain the envelope produces stays within the volume range.
     for (let t = 0; t <= 350; t += 10) {
       const gain = gainAtMs(points, t)
       expect(gain).toBeGreaterThanOrEqual(0)
@@ -86,73 +122,125 @@ describe('planBackgroundGain', () => {
   })
 })
 
-describe('mixBackgroundIntoChannels', () => {
+describe('createBackgroundMixer', () => {
   const flatEnvelope = [
     { tMs: 0, volume: 0.5 },
     { tMs: 1_000_000, volume: 0.5 },
   ]
 
-  it('adds the background at the envelope gain', () => {
+  function sourceOf(tracks: Array<Float32Array[] | null>): SequentialBackgroundSource {
+    return {
+      trackCount: tracks.length,
+      getTrack: (index) => Promise.resolve(tracks[index] ?? null),
+    }
+  }
+
+  it('adds a track at the envelope gain', async () => {
     const slice = [new Float32Array([0.1, 0.1, 0.1, 0.1])]
-    const background = [new Float32Array([0.4, 0.4, 0.4, 0.4])]
-    mixBackgroundIntoChannels({
-      channels: slice,
-      background,
-      sampleRate: 48000,
-      sliceStartFrame: 0,
-      points: flatEnvelope,
-    })
+    const mixer = createBackgroundMixer(
+      sourceOf([[new Float32Array([0.4, 0.4, 0.4, 0.4])]]),
+      flatEnvelope,
+      48000,
+    )
+    await mixer.mixInto(slice, 0)
     for (const sample of slice[0]) {
       expect(sample).toBeCloseTo(0.1 + 0.4 * 0.5)
     }
   })
 
-  it('loops the background when the film is longer than the track', () => {
+  it('plays tracks one after the other and goes silent when they run out', async () => {
+    // Track A: two frames of 0.2; track B: two frames of 0.6; film: 6 frames.
+    const mixer = createBackgroundMixer(
+      sourceOf([[new Float32Array([0.2, 0.2])], [new Float32Array([0.6, 0.6])]]),
+      [
+        { tMs: 0, volume: 1 },
+        { tMs: 1_000_000, volume: 1 },
+      ],
+      48000,
+    )
     const slice = [new Float32Array(6)]
-    const background = [new Float32Array([0.2, 0.4])]
-    mixBackgroundIntoChannels({
-      channels: slice,
-      background,
-      sampleRate: 48000,
-      sliceStartFrame: 5,
-      points: flatEnvelope,
-    })
-    // Frames 5..10 alternate through the 2-sample track: odd → 0.4, even → 0.2.
+    await mixer.mixInto(slice, 0)
     expect(Array.from(slice[0]).map((v) => Number(v.toFixed(2)))).toEqual([
-      0.2, 0.1, 0.2, 0.1, 0.2, 0.1,
+      0.2, 0.2, 0.6, 0.6, 0, 0,
     ])
   })
 
-  it('spreads a mono background across stereo slices and clamps the sum', () => {
+  it('mixes across slice boundaries in output order', async () => {
+    const mixer = createBackgroundMixer(
+      sourceOf([[new Float32Array([0.2, 0.2, 0.2])], [new Float32Array([0.6, 0.6, 0.6])]]),
+      [
+        { tMs: 0, volume: 1 },
+        { tMs: 1_000_000, volume: 1 },
+      ],
+      48000,
+    )
+    const first = [new Float32Array(2)]
+    const second = [new Float32Array(4)]
+    await mixer.mixInto(first, 0)
+    await mixer.mixInto(second, 2)
+    expect(Array.from(first[0]).map((v) => Number(v.toFixed(2)))).toEqual([0.2, 0.2])
+    // Second slice spans the A→B hand-off (frame 3) and B's end (frame 6).
+    expect(Array.from(second[0]).map((v) => Number(v.toFixed(2)))).toEqual([0.2, 0.6, 0.6, 0.6])
+  })
+
+  it('skips undecodable tracks and continues with the next', async () => {
+    const mixer = createBackgroundMixer(
+      sourceOf([null, [new Float32Array([0.4, 0.4])]]),
+      flatEnvelope,
+      48000,
+    )
+    const slice = [new Float32Array(3)]
+    await mixer.mixInto(slice, 0)
+    expect(Array.from(slice[0]).map((v) => Number(v.toFixed(2)))).toEqual([0.2, 0.2, 0])
+  })
+
+  it('spreads a mono track across stereo slices and clamps the sum', async () => {
     const slice = [new Float32Array([0.9]), new Float32Array([-0.9])]
-    const background = [new Float32Array([1])]
-    mixBackgroundIntoChannels({
-      channels: slice,
-      background,
-      sampleRate: 48000,
-      sliceStartFrame: 0,
-      points: [
+    const mixer = createBackgroundMixer(
+      sourceOf([[new Float32Array([1])]]),
+      [
         { tMs: 0, volume: 1 },
         { tMs: 1000, volume: 1 },
       ],
-    })
+      48000,
+    )
+    await mixer.mixInto(slice, 0)
     expect(slice[0][0]).toBe(1)
     expect(slice[1][0]).toBeCloseTo(0.1)
   })
 
-  it('leaves the slice untouched when the gain is zero', () => {
+  it('leaves slices untouched when the gain is zero', async () => {
     const slice = [new Float32Array([0.3, 0.3])]
     const before = Array.from(slice[0])
-    mixBackgroundIntoChannels({
-      channels: slice,
-      background: [new Float32Array([0.5, 0.5])],
-      sampleRate: 48000,
-      sliceStartFrame: 0,
-      points: [
+    const mixer = createBackgroundMixer(
+      sourceOf([[new Float32Array([0.5, 0.5])]]),
+      [
         { tMs: 0, volume: 0 },
         { tMs: 1000, volume: 0 },
       ],
-    })
+      48000,
+    )
+    await mixer.mixInto(slice, 0)
     expect(Array.from(slice[0])).toEqual(before)
+  })
+
+  it('decodes each track at most once (lazy, in order)', async () => {
+    const decoded: number[] = []
+    const mixer = createBackgroundMixer(
+      {
+        trackCount: 3,
+        getTrack: (index) => {
+          decoded.push(index)
+          return Promise.resolve([new Float32Array(2).fill(0.1)])
+        },
+      },
+      flatEnvelope,
+      48000,
+    )
+    // The film only reaches into track 2's range (frames 0..5).
+    await mixer.mixInto([new Float32Array(3)], 0)
+    expect(decoded).toEqual([0, 1])
+    await mixer.mixInto([new Float32Array(3)], 3)
+    expect(decoded).toEqual([0, 1, 2])
   })
 })

--- a/src/lib/export/background-audio.ts
+++ b/src/lib/export/background-audio.ts
@@ -1,0 +1,144 @@
+import { clipAudioVolume } from '../types'
+import type { PlannedSegment } from './plan'
+
+/**
+ * Background-music gain planning shared by both export engines and unit
+ * tests: turns the per-clip volumes into one piecewise-linear gain envelope
+ * over the output timeline, so volume changes glide across clip boundaries
+ * instead of jumping.
+ */
+
+/** Length of the glide between two clips with different music volumes. */
+export const VOLUME_RAMP_MS = 600
+/** Music eases in at the start of the film rather than slamming on. */
+export const FADE_IN_MS = 300
+/** …and eases out at the end rather than cutting mid-note. */
+export const FADE_OUT_MS = 600
+
+export interface BackgroundAudioTrack {
+  blob: Blob
+  defaultVolume: number
+}
+
+export interface GainPoint {
+  tMs: number
+  volume: number
+}
+
+type GainSegment = Pick<PlannedSegment, 'offsetMs'> & {
+  clip: Pick<PlannedSegment['clip'], 'audioVolume'>
+  startMs: number
+  endMs: number
+}
+
+/**
+ * Piecewise-linear gain envelope for the whole output timeline. Boundary
+ * ramps are centered on each clip transition and clamped to the shorter
+ * neighbor, so even sub-second clips keep a monotonic envelope.
+ */
+export function planBackgroundGain(
+  segments: GainSegment[],
+  defaultVolume: number,
+  totalMs: number,
+): GainPoint[] {
+  if (segments.length === 0 || totalMs <= 0) return []
+  const volumes = segments.map((segment) => clipAudioVolume(segment.clip, defaultVolume))
+  const durations = segments.map((segment) => segment.endMs - segment.startMs)
+
+  const points: GainPoint[] = [
+    { tMs: 0, volume: 0 },
+    { tMs: Math.min(FADE_IN_MS, durations[0] / 2), volume: volumes[0] },
+  ]
+  for (let i = 1; i < segments.length; i += 1) {
+    if (volumes[i] === volumes[i - 1]) continue
+    const boundary = segments[i].offsetMs
+    const half = Math.min(VOLUME_RAMP_MS / 2, durations[i - 1] / 2, durations[i] / 2)
+    points.push({ tMs: boundary - half, volume: volumes[i - 1] })
+    points.push({ tMs: boundary + half, volume: volumes[i] })
+  }
+  const fadeOut = Math.min(FADE_OUT_MS, durations[durations.length - 1] / 2)
+  points.push({ tMs: totalMs - fadeOut, volume: volumes[volumes.length - 1] })
+  points.push({ tMs: totalMs, volume: 0 })
+
+  // Overlapping ramps (very short clips) collapse into steps instead of
+  // travelling back in time.
+  for (let i = 1; i < points.length; i += 1) {
+    points[i].tMs = Math.max(points[i].tMs, points[i - 1].tMs)
+  }
+  return points
+}
+
+/** Envelope gain at an output-timeline position (linear between points). */
+export function gainAtMs(points: GainPoint[], tMs: number): number {
+  if (points.length === 0) return 0
+  if (tMs <= points[0].tMs) return points[0].volume
+  for (let i = 1; i < points.length; i += 1) {
+    if (tMs <= points[i].tMs) {
+      const prev = points[i - 1]
+      const next = points[i]
+      const span = next.tMs - prev.tMs
+      if (span <= 0) return next.volume
+      return prev.volume + ((next.volume - prev.volume) * (tMs - prev.tMs)) / span
+    }
+  }
+  return points[points.length - 1].volume
+}
+
+export interface MixBackgroundArgs {
+  /** Slice channel data, mutated in place. All channels equal length. */
+  channels: Float32Array[]
+  /** Decoded background track at the same sample rate (any channel count). */
+  background: Float32Array[]
+  sampleRate: number
+  /** Output-timeline frame index of the slice's first sample. */
+  sliceStartFrame: number
+  points: GainPoint[]
+}
+
+/**
+ * Add the background track into a segment's audio slice, sample-accurately:
+ * gain follows the envelope, the track loops when shorter than the film,
+ * and the sum hard-clamps to [-1, 1].
+ */
+export function mixBackgroundIntoChannels({
+  channels,
+  background,
+  sampleRate,
+  sliceStartFrame,
+  points,
+}: MixBackgroundArgs): void {
+  const backgroundLength = background[0]?.length ?? 0
+  if (backgroundLength === 0 || channels.length === 0 || points.length === 0) return
+  const sliceLength = channels[0].length
+  const sources = channels.map(
+    (_, ch) => background[Math.min(ch, background.length - 1)],
+  )
+
+  // Walking cursor into the envelope keeps per-sample gain O(1).
+  let cursor = 0
+  for (let i = 0; i < sliceLength; i += 1) {
+    const frame = sliceStartFrame + i
+    const tMs = (frame / sampleRate) * 1000
+    while (cursor < points.length && points[cursor].tMs < tMs) cursor += 1
+    let gain: number
+    if (cursor === 0) {
+      gain = points[0].volume
+    } else if (cursor >= points.length) {
+      gain = points[points.length - 1].volume
+    } else {
+      const prev = points[cursor - 1]
+      const next = points[cursor]
+      const span = next.tMs - prev.tMs
+      gain =
+        span <= 0
+          ? next.volume
+          : prev.volume + ((next.volume - prev.volume) * (tMs - prev.tMs)) / span
+    }
+    if (gain <= 0) continue
+    const backgroundIndex = frame % backgroundLength
+    for (let ch = 0; ch < channels.length; ch += 1) {
+      const mixed = channels[ch][i] + sources[ch][backgroundIndex] * gain
+      channels[ch][i] = mixed > 1 ? 1 : mixed < -1 ? -1 : mixed
+    }
+  }
+}

--- a/src/lib/export/background-audio.ts
+++ b/src/lib/export/background-audio.ts
@@ -2,22 +2,27 @@ import { clipAudioVolume } from '../types'
 import type { PlannedSegment } from './plan'
 
 /**
- * Background-music gain planning shared by both export engines and unit
- * tests: turns the per-clip volumes into one piecewise-linear gain envelope
- * over the output timeline, so volume changes glide across clip boundaries
- * instead of jumping.
+ * Background-music gain planning and mixing shared by both export engines
+ * and unit tests: per-clip volumes become one piecewise-linear gain envelope
+ * over the output timeline (volume changes glide across clip boundaries),
+ * and the playlist's tracks are mixed in one after the other — the film's
+ * end cuts the music off, nothing loops.
  */
 
 /** Length of the glide between two clips with different music volumes. */
 export const VOLUME_RAMP_MS = 600
-/** Music eases in at the start of the film rather than slamming on. */
-export const FADE_IN_MS = 300
-/** …and eases out at the end rather than cutting mid-note. */
-export const FADE_OUT_MS = 600
+/** Musical ease-in at the start of the film (the "Fade in" toggle). */
+export const FADE_IN_MS = 800
+/** Musical ease-out at the end of the film (the "Fade out" toggle). */
+export const FADE_OUT_MS = 1200
+/** With fades off, a click-kill ramp too short to hear as a fade. */
+export const EDGE_RAMP_MS = 15
 
-export interface BackgroundAudioTrack {
-  blob: Blob
+export interface BackgroundAudio {
+  tracks: Array<{ blob: Blob }>
   defaultVolume: number
+  fadeIn: boolean
+  fadeOut: boolean
 }
 
 export interface GainPoint {
@@ -31,23 +36,33 @@ type GainSegment = Pick<PlannedSegment, 'offsetMs'> & {
   endMs: number
 }
 
+export interface BackgroundFades {
+  fadeIn: boolean
+  fadeOut: boolean
+}
+
 /**
  * Piecewise-linear gain envelope for the whole output timeline. Boundary
  * ramps are centered on each clip transition and clamped to the shorter
- * neighbor, so even sub-second clips keep a monotonic envelope.
+ * neighbor, so even sub-second clips keep a monotonic envelope. Disabled
+ * fades still get an inaudible edge ramp — a hard cut mid-waveform clicks.
  */
 export function planBackgroundGain(
   segments: GainSegment[],
   defaultVolume: number,
   totalMs: number,
+  fades: BackgroundFades,
 ): GainPoint[] {
   if (segments.length === 0 || totalMs <= 0) return []
   const volumes = segments.map((segment) => clipAudioVolume(segment.clip, defaultVolume))
   const durations = segments.map((segment) => segment.endMs - segment.startMs)
 
+  const fadeIn = Math.min(fades.fadeIn ? FADE_IN_MS : EDGE_RAMP_MS, totalMs / 2)
+  const fadeOut = Math.min(fades.fadeOut ? FADE_OUT_MS : EDGE_RAMP_MS, totalMs / 2)
+
   const points: GainPoint[] = [
     { tMs: 0, volume: 0 },
-    { tMs: Math.min(FADE_IN_MS, durations[0] / 2), volume: volumes[0] },
+    { tMs: fadeIn, volume: volumes[0] },
   ]
   for (let i = 1; i < segments.length; i += 1) {
     if (volumes[i] === volumes[i - 1]) continue
@@ -56,7 +71,6 @@ export function planBackgroundGain(
     points.push({ tMs: boundary - half, volume: volumes[i - 1] })
     points.push({ tMs: boundary + half, volume: volumes[i] })
   }
-  const fadeOut = Math.min(FADE_OUT_MS, durations[durations.length - 1] / 2)
   points.push({ tMs: totalMs - fadeOut, volume: volumes[volumes.length - 1] })
   points.push({ tMs: totalMs, volume: 0 })
 
@@ -84,61 +98,97 @@ export function gainAtMs(points: GainPoint[], tMs: number): number {
   return points[points.length - 1].volume
 }
 
-export interface MixBackgroundArgs {
-  /** Slice channel data, mutated in place. All channels equal length. */
-  channels: Float32Array[]
-  /** Decoded background track at the same sample rate (any channel count). */
-  background: Float32Array[]
-  sampleRate: number
-  /** Output-timeline frame index of the slice's first sample. */
-  sliceStartFrame: number
-  points: GainPoint[]
+export interface SequentialBackgroundSource {
+  trackCount: number
+  /** Decode track `index` into per-channel data; null = undecodable (the
+   * track is skipped and the next one starts in its place). */
+  getTrack: (index: number) => Promise<Float32Array[] | null>
+}
+
+export interface BackgroundMixer {
+  /** Add the playlist into a segment slice's channels, in place. Slices
+   * must be requested in output order (tracks are decoded lazily, one at a
+   * time, and released once the timeline passes them). */
+  mixInto: (channels: Float32Array[], sliceStartFrame: number) => Promise<void>
 }
 
 /**
- * Add the background track into a segment's audio slice, sample-accurately:
- * gain follows the envelope, the track loops when shorter than the film,
- * and the sum hard-clamps to [-1, 1].
+ * Sequential playlist mixer: track 0 starts at output frame 0, each next
+ * track starts where the previous one's decoded samples end, and when the
+ * playlist runs out the rest of the film simply has no music. Gain follows
+ * the envelope; the sum hard-clamps to [-1, 1].
  */
-export function mixBackgroundIntoChannels({
-  channels,
-  background,
-  sampleRate,
-  sliceStartFrame,
-  points,
-}: MixBackgroundArgs): void {
-  const backgroundLength = background[0]?.length ?? 0
-  if (backgroundLength === 0 || channels.length === 0 || points.length === 0) return
-  const sliceLength = channels[0].length
-  const sources = channels.map(
-    (_, ch) => background[Math.min(ch, background.length - 1)],
-  )
+export function createBackgroundMixer(
+  source: SequentialBackgroundSource,
+  points: GainPoint[],
+  sampleRate: number,
+): BackgroundMixer {
+  let trackIndex = -1
+  /** Output frame where the current track begins. */
+  let trackStartFrame = 0
+  let current: Float32Array[] | null = null
+  let exhausted = source.trackCount === 0 || points.length === 0
 
-  // Walking cursor into the envelope keeps per-sample gain O(1).
-  let cursor = 0
-  for (let i = 0; i < sliceLength; i += 1) {
-    const frame = sliceStartFrame + i
-    const tMs = (frame / sampleRate) * 1000
-    while (cursor < points.length && points[cursor].tMs < tMs) cursor += 1
-    let gain: number
-    if (cursor === 0) {
-      gain = points[0].volume
-    } else if (cursor >= points.length) {
-      gain = points[points.length - 1].volume
-    } else {
-      const prev = points[cursor - 1]
-      const next = points[cursor]
-      const span = next.tMs - prev.tMs
-      gain =
-        span <= 0
-          ? next.volume
-          : prev.volume + ((next.volume - prev.volume) * (tMs - prev.tMs)) / span
-    }
-    if (gain <= 0) continue
-    const backgroundIndex = frame % backgroundLength
-    for (let ch = 0; ch < channels.length; ch += 1) {
-      const mixed = channels[ch][i] + sources[ch][backgroundIndex] * gain
-      channels[ch][i] = mixed > 1 ? 1 : mixed < -1 ? -1 : mixed
+  /** Advance until the current track covers `frame` (false = playlist over). */
+  const ensureTrackFor = async (frame: number): Promise<boolean> => {
+    for (;;) {
+      if (exhausted) return false
+      if (current && frame < trackStartFrame + current[0].length) return true
+      if (current) {
+        trackStartFrame += current[0].length
+        current = null
+      }
+      trackIndex += 1
+      if (trackIndex >= source.trackCount) {
+        exhausted = true
+        return false
+      }
+      const next = await source.getTrack(trackIndex)
+      if (next && next.length > 0 && next[0].length > 0) {
+        current = next
+      }
     }
   }
+
+  const mixInto = async (channels: Float32Array[], sliceStartFrame: number): Promise<void> => {
+    if (channels.length === 0) return
+    const sliceLength = channels[0].length
+    let i = 0
+    let cursor = 0
+    while (i < sliceLength) {
+      const frame = sliceStartFrame + i
+      if (!(await ensureTrackFor(frame))) return
+      const track = current!
+      const sources = channels.map((_, ch) => track[Math.min(ch, track.length - 1)])
+      // Mix until the slice or the current track ends, whichever is first.
+      const runEnd = Math.min(sliceLength, trackStartFrame + track[0].length - sliceStartFrame)
+      for (; i < runEnd; i += 1) {
+        const outFrame = sliceStartFrame + i
+        const tMs = (outFrame / sampleRate) * 1000
+        while (cursor < points.length && points[cursor].tMs < tMs) cursor += 1
+        let gain: number
+        if (cursor === 0) {
+          gain = points[0].volume
+        } else if (cursor >= points.length) {
+          gain = points[points.length - 1].volume
+        } else {
+          const prev = points[cursor - 1]
+          const next = points[cursor]
+          const span = next.tMs - prev.tMs
+          gain =
+            span <= 0
+              ? next.volume
+              : prev.volume + ((next.volume - prev.volume) * (tMs - prev.tMs)) / span
+        }
+        if (gain <= 0) continue
+        const sourceIndex = outFrame - trackStartFrame
+        for (let ch = 0; ch < channels.length; ch += 1) {
+          const mixed = channels[ch][i] + sources[ch][sourceIndex] * gain
+          channels[ch][i] = mixed > 1 ? 1 : mixed < -1 ? -1 : mixed
+        }
+      }
+    }
+  }
+
+  return { mixInto }
 }

--- a/src/lib/export/background-audio.ts
+++ b/src/lib/export/background-audio.ts
@@ -108,8 +108,16 @@ export interface SequentialBackgroundSource {
 export interface BackgroundMixer {
   /** Add the playlist into a segment slice's channels, in place. Slices
    * must be requested in output order (tracks are decoded lazily, one at a
-   * time, and released once the timeline passes them). */
-  mixInto: (channels: Float32Array[], sliceStartFrame: number) => Promise<void>
+   * time, and released once the timeline passes them). `gainBaseMs` is the
+   * slice's position on the envelope's (planned) timeline — passing the
+   * planned segment offset keeps per-clip ramps and fades aligned with
+   * their clips even when media clamping shifted the real frame positions;
+   * it defaults to the frame-derived position. */
+  mixInto: (
+    channels: Float32Array[],
+    sliceStartFrame: number,
+    gainBaseMs?: number,
+  ) => Promise<void>
 }
 
 /**
@@ -150,7 +158,11 @@ export function createBackgroundMixer(
     }
   }
 
-  const mixInto = async (channels: Float32Array[], sliceStartFrame: number): Promise<void> => {
+  const mixInto = async (
+    channels: Float32Array[],
+    sliceStartFrame: number,
+    gainBaseMs = (sliceStartFrame / sampleRate) * 1000,
+  ): Promise<void> => {
     if (channels.length === 0) return
     const sliceLength = channels[0].length
     let i = 0
@@ -164,7 +176,7 @@ export function createBackgroundMixer(
       const runEnd = Math.min(sliceLength, trackStartFrame + track[0].length - sliceStartFrame)
       for (; i < runEnd; i += 1) {
         const outFrame = sliceStartFrame + i
-        const tMs = (outFrame / sampleRate) * 1000
+        const tMs = gainBaseMs + (i / sampleRate) * 1000
         while (cursor < points.length && points[cursor].tMs < tMs) cursor += 1
         let gain: number
         if (cursor === 0) {

--- a/src/lib/export/background-audio.ts
+++ b/src/lib/export/background-audio.ts
@@ -30,56 +30,77 @@ export interface GainPoint {
   volume: number
 }
 
-type GainSegment = Pick<PlannedSegment, 'offsetMs'> & {
-  clip: Pick<PlannedSegment['clip'], 'audioVolume'>
-  startMs: number
-  endMs: number
-}
-
 export interface BackgroundFades {
   fadeIn: boolean
   fadeOut: boolean
 }
 
+export interface SegmentGainArgs {
+  /** This clip's music volume. */
+  volume: number
+  /** The segment's REAL duration (after media clamping), in ms. */
+  durationMs: number
+  /** Ramp in from the previous clip's volume (omit at the film start). */
+  entry?: { fromVolume: number; halfMs: number }
+  /** Ramp out toward the next clip's volume (omit at the film end). */
+  exit?: { toVolume: number; halfMs: number }
+  fades: BackgroundFades
+}
+
 /**
- * Piecewise-linear gain envelope for the whole output timeline. Boundary
- * ramps are centered on each clip transition and clamped to the shorter
- * neighbor, so even sub-second clips keep a monotonic envelope. Disabled
- * fades still get an inaudible edge ramp — a hard cut mid-waveform clicks.
+ * Piecewise-linear gain envelope for ONE segment, on the segment's local
+ * timeline (0..durationMs). Built per segment from real clamped durations —
+ * planning the whole film's envelope up front drifted whenever media
+ * clamping shortened a clip. Boundary ramps are centered on the clip
+ * transition: the outgoing segment carries the first half (volume → the
+ * two clips' midpoint), the incoming segment carries the second (midpoint →
+ * its volume). Disabled film-edge fades still get an inaudible edge ramp —
+ * a hard cut mid-waveform clicks.
  */
-export function planBackgroundGain(
-  segments: GainSegment[],
-  defaultVolume: number,
-  totalMs: number,
-  fades: BackgroundFades,
-): GainPoint[] {
-  if (segments.length === 0 || totalMs <= 0) return []
-  const volumes = segments.map((segment) => clipAudioVolume(segment.clip, defaultVolume))
-  const durations = segments.map((segment) => segment.endMs - segment.startMs)
-
-  const fadeIn = Math.min(fades.fadeIn ? FADE_IN_MS : EDGE_RAMP_MS, totalMs / 2)
-  const fadeOut = Math.min(fades.fadeOut ? FADE_OUT_MS : EDGE_RAMP_MS, totalMs / 2)
-
-  const points: GainPoint[] = [
-    { tMs: 0, volume: 0 },
-    { tMs: fadeIn, volume: volumes[0] },
-  ]
-  for (let i = 1; i < segments.length; i += 1) {
-    if (volumes[i] === volumes[i - 1]) continue
-    const boundary = segments[i].offsetMs
-    const half = Math.min(VOLUME_RAMP_MS / 2, durations[i - 1] / 2, durations[i] / 2)
-    points.push({ tMs: boundary - half, volume: volumes[i - 1] })
-    points.push({ tMs: boundary + half, volume: volumes[i] })
+export function planSegmentGain({
+  volume,
+  durationMs,
+  entry,
+  exit,
+  fades,
+}: SegmentGainArgs): GainPoint[] {
+  if (durationMs <= 0) return []
+  const points: GainPoint[] = []
+  if (entry) {
+    points.push({ tMs: 0, volume: (entry.fromVolume + volume) / 2 })
+    points.push({ tMs: Math.min(entry.halfMs, durationMs / 2), volume })
+  } else {
+    const fadeIn = Math.min(fades.fadeIn ? FADE_IN_MS : EDGE_RAMP_MS, durationMs / 2)
+    points.push({ tMs: 0, volume: 0 })
+    points.push({ tMs: fadeIn, volume })
   }
-  points.push({ tMs: totalMs - fadeOut, volume: volumes[volumes.length - 1] })
-  points.push({ tMs: totalMs, volume: 0 })
-
+  if (exit) {
+    points.push({ tMs: durationMs - Math.min(exit.halfMs, durationMs / 2), volume })
+    points.push({ tMs: durationMs, volume: (volume + exit.toVolume) / 2 })
+  } else {
+    const fadeOut = Math.min(fades.fadeOut ? FADE_OUT_MS : EDGE_RAMP_MS, durationMs / 2)
+    points.push({ tMs: durationMs - fadeOut, volume })
+    points.push({ tMs: durationMs, volume: 0 })
+  }
   // Overlapping ramps (very short clips) collapse into steps instead of
   // travelling back in time.
   for (let i = 1; i < points.length; i += 1) {
     points[i].tMs = Math.max(points[i].tMs, points[i - 1].tMs)
   }
   return points
+}
+
+/** Centered boundary-ramp half length, clamped to the shorter neighbor. */
+export function boundaryRampHalfMs(aDurationMs: number, bDurationMs: number): number {
+  return Math.min(VOLUME_RAMP_MS / 2, aDurationMs / 2, bDurationMs / 2)
+}
+
+/** Music volume for one planned segment (override or default). */
+export function segmentVolume(
+  segment: Pick<PlannedSegment, 'clip'>,
+  defaultVolume: number,
+): number {
+  return clipAudioVolume(segment.clip, defaultVolume)
 }
 
 /** Envelope gain at an output-timeline position (linear between points). */
@@ -106,17 +127,15 @@ export interface SequentialBackgroundSource {
 }
 
 export interface BackgroundMixer {
-  /** Add the playlist into a segment slice's channels, in place. Slices
-   * must be requested in output order (tracks are decoded lazily, one at a
-   * time, and released once the timeline passes them). `gainBaseMs` is the
-   * slice's position on the envelope's (planned) timeline — passing the
-   * planned segment offset keeps per-clip ramps and fades aligned with
-   * their clips even when media clamping shifted the real frame positions;
-   * it defaults to the frame-derived position. */
+  /** Add the playlist into a segment slice's channels, in place, with the
+   * gain following `points` — the slice's own local envelope (its time 0 is
+   * the slice's first sample). Slices must be requested in output order
+   * (tracks are decoded lazily, one at a time, and released once the
+   * timeline passes them). */
   mixInto: (
     channels: Float32Array[],
     sliceStartFrame: number,
-    gainBaseMs?: number,
+    points: GainPoint[],
   ) => Promise<void>
 }
 
@@ -124,18 +143,17 @@ export interface BackgroundMixer {
  * Sequential playlist mixer: track 0 starts at output frame 0, each next
  * track starts where the previous one's decoded samples end, and when the
  * playlist runs out the rest of the film simply has no music. Gain follows
- * the envelope; the sum hard-clamps to [-1, 1].
+ * each slice's local envelope; the sum hard-clamps to [-1, 1].
  */
 export function createBackgroundMixer(
   source: SequentialBackgroundSource,
-  points: GainPoint[],
   sampleRate: number,
 ): BackgroundMixer {
   let trackIndex = -1
   /** Output frame where the current track begins. */
   let trackStartFrame = 0
   let current: Float32Array[] | null = null
-  let exhausted = source.trackCount === 0 || points.length === 0
+  let exhausted = source.trackCount === 0
 
   /** Advance until the current track covers `frame` (false = playlist over). */
   const ensureTrackFor = async (frame: number): Promise<boolean> => {
@@ -161,9 +179,9 @@ export function createBackgroundMixer(
   const mixInto = async (
     channels: Float32Array[],
     sliceStartFrame: number,
-    gainBaseMs = (sliceStartFrame / sampleRate) * 1000,
+    points: GainPoint[],
   ): Promise<void> => {
-    if (channels.length === 0) return
+    if (channels.length === 0 || points.length === 0) return
     const sliceLength = channels[0].length
     let i = 0
     let cursor = 0
@@ -176,7 +194,7 @@ export function createBackgroundMixer(
       const runEnd = Math.min(sliceLength, trackStartFrame + track[0].length - sliceStartFrame)
       for (; i < runEnd; i += 1) {
         const outFrame = sliceStartFrame + i
-        const tMs = gainBaseMs + (i / sampleRate) * 1000
+        const tMs = (i / sampleRate) * 1000
         while (cursor < points.length && points[cursor].tMs < tMs) cursor += 1
         let gain: number
         if (cursor === 0) {

--- a/src/lib/export/encode-realtime.ts
+++ b/src/lib/export/encode-realtime.ts
@@ -208,11 +208,15 @@ export async function exportRealtime(
           }
           // This engine paints in realtime, so the last segment's end lands
           // roughly `segment length` from now — schedule the musical
-          // fade-out to finish there.
+          // fade-out to finish there, shrinking it on short final clips
+          // (like the WebCodecs envelope) instead of dropping it.
           const isLast = segmentIndex === plan.segments.length - 1
           const segmentSec = (clamped.endMs - clamped.startMs) / 1000
-          if (isLast && options.background.fadeOut && segmentSec > 1.6) {
-            backgroundGain.gain.setTargetAtTime(0, now + segmentSec - 1.2, 0.35)
+          if (isLast && options.background.fadeOut) {
+            const fadeSec = Math.min(1.2, segmentSec / 2)
+            if (fadeSec > 0.05) {
+              backgroundGain.gain.setTargetAtTime(0, now + segmentSec - fadeSec, fadeSec / 3)
+            }
           }
         }
         const paintedMs = await paintSegment({

--- a/src/lib/export/encode-realtime.ts
+++ b/src/lib/export/encode-realtime.ts
@@ -1,6 +1,6 @@
 import { pickRecorderMimeType } from '../media'
 import { clipAudioVolume } from '../types'
-import type { BackgroundAudioTrack } from './background-audio'
+import type { BackgroundAudio } from './background-audio'
 import { clampSegmentToMedia, type ExportPlan } from './plan'
 import {
   PREVIEW_EVERY_N_FRAMES,
@@ -30,8 +30,8 @@ export interface RealtimeExportOptions {
   getPreviewCanvas?: () => HTMLCanvasElement | null
   /** Mark stamped onto each frame; null when the user purchased removal. */
   watermarkImage?: HTMLImageElement | null
-  /** Background-music track mixed under the clips (per-clip volumes). */
-  background?: BackgroundAudioTrack | null
+  /** Background-music playlist mixed under the clips (per-clip volumes). */
+  background?: BackgroundAudio | null
 }
 
 /**
@@ -97,27 +97,49 @@ export async function exportRealtime(
     dest = null
   }
 
-  // Background music rides a looping buffer source behind a gain node; the
-  // gain glides toward each clip's volume as the export reaches it (this
-  // engine paints in realtime, so Web Audio's own ramping does the work).
+  // Background music rides sequentially chained buffer sources behind a
+  // gain node: each track starts when the previous one ends (nothing
+  // loops), and the gain glides toward each clip's volume as the export
+  // reaches it — this engine paints in realtime, so Web Audio's own
+  // ramping does the work.
   let backgroundGain: GainNode | null = null
-  let backgroundSource: AudioBufferSourceNode | null = null
-  if (options.background && audioContext && dest) {
-    const backgroundBuffer = await decodeBackgroundAudio(options.background.blob)
-    if (backgroundBuffer) {
-      try {
-        backgroundSource = audioContext.createBufferSource()
-        backgroundSource.buffer = backgroundBuffer
-        backgroundSource.loop = true
-        backgroundGain = audioContext.createGain()
-        backgroundGain.gain.value = 0
-        backgroundSource.connect(backgroundGain)
-        backgroundGain.connect(dest)
-        backgroundSource.start()
-      } catch {
-        backgroundGain = null
-        backgroundSource = null
+  let stopBackground: (() => void) | null = null
+  const backgroundTracks = options.background?.tracks ?? []
+  if (backgroundTracks.length > 0 && audioContext && dest) {
+    try {
+      const gain = audioContext.createGain()
+      gain.gain.value = 0
+      gain.connect(dest)
+      let stopped = false
+      let activeSource: AudioBufferSourceNode | null = null
+      const playFrom = async (index: number): Promise<void> => {
+        if (stopped || index >= backgroundTracks.length || !audioContext) return
+        // Undecodable tracks are skipped; the next one starts in their place.
+        const buffer = await decodeBackgroundAudio(backgroundTracks[index].blob)
+        if (stopped) return
+        if (!buffer) return playFrom(index + 1)
+        const source = audioContext.createBufferSource()
+        source.buffer = buffer
+        source.connect(gain)
+        source.onended = () => {
+          void playFrom(index + 1)
+        }
+        activeSource = source
+        source.start()
       }
+      void playFrom(0)
+      stopBackground = () => {
+        stopped = true
+        try {
+          activeSource?.stop()
+        } catch {
+          // already stopped
+        }
+      }
+      backgroundGain = gain
+    } catch {
+      backgroundGain = null
+      stopBackground = null
     }
   }
 
@@ -168,11 +190,22 @@ export async function exportRealtime(
         const clamped = clampSegmentToMedia(segment, loaded.mediaDurationMs)
         if (!clamped) continue
         if (backgroundGain && audioContext && options.background) {
-          backgroundGain.gain.setTargetAtTime(
-            clipAudioVolume(segment.clip, options.background.defaultVolume),
-            audioContext.currentTime,
-            0.2,
-          )
+          const volume = clipAudioVolume(segment.clip, options.background.defaultVolume)
+          const now = audioContext.currentTime
+          if (segmentIndex === 0 && !options.background.fadeIn) {
+            // No fade-in: music opens at full clip volume.
+            backgroundGain.gain.setValueAtTime(volume, now)
+          } else {
+            backgroundGain.gain.setTargetAtTime(volume, now, 0.2)
+          }
+          // This engine paints in realtime, so the last segment's end lands
+          // roughly `segment length` from now — schedule the musical
+          // fade-out to finish there.
+          const isLast = segmentIndex === plan.segments.length - 1
+          const segmentSec = (clamped.endMs - clamped.startMs) / 1000
+          if (isLast && options.background.fadeOut && segmentSec > 1.6) {
+            backgroundGain.gain.setTargetAtTime(0, now + segmentSec - 1.2, 0.35)
+          }
         }
         const paintedMs = await paintSegment({
           video: loaded.video,
@@ -212,11 +245,7 @@ export async function exportRealtime(
     await wait(180)
     options.onProgress?.(1)
   } finally {
-    try {
-      backgroundSource?.stop()
-    } catch {
-      // already stopped
-    }
+    stopBackground?.()
     if (recorder.state !== 'inactive') recorder.stop()
     canvasStream.getTracks().forEach((t) => t.stop())
     if (audioContext) {

--- a/src/lib/export/encode-realtime.ts
+++ b/src/lib/export/encode-realtime.ts
@@ -103,6 +103,7 @@ export async function exportRealtime(
   // reaches it — this engine paints in realtime, so Web Audio's own
   // ramping does the work.
   let backgroundGain: GainNode | null = null
+  let startBackground: (() => void) | null = null
   let stopBackground: (() => void) | null = null
   const backgroundTracks = options.background?.tracks ?? []
   if (backgroundTracks.length > 0 && audioContext && dest) {
@@ -127,7 +128,12 @@ export async function exportRealtime(
         activeSource = source
         source.start()
       }
-      void playFrom(0)
+      // Deferred to the first painted segment: starting here would let the
+      // music advance through clip preload before any frame is recorded.
+      startBackground = () => {
+        startBackground = null
+        void playFrom(0)
+      }
       stopBackground = () => {
         stopped = true
         try {
@@ -139,6 +145,7 @@ export async function exportRealtime(
       backgroundGain = gain
     } catch {
       backgroundGain = null
+      startBackground = null
       stopBackground = null
     }
   }
@@ -190,6 +197,7 @@ export async function exportRealtime(
         const clamped = clampSegmentToMedia(segment, loaded.mediaDurationMs)
         if (!clamped) continue
         if (backgroundGain && audioContext && options.background) {
+          startBackground?.()
           const volume = clipAudioVolume(segment.clip, options.background.defaultVolume)
           const now = audioContext.currentTime
           if (segmentIndex === 0 && !options.background.fadeIn) {

--- a/src/lib/export/encode-realtime.ts
+++ b/src/lib/export/encode-realtime.ts
@@ -1,8 +1,11 @@
 import { pickRecorderMimeType } from '../media'
+import { clipAudioVolume } from '../types'
+import type { BackgroundAudioTrack } from './background-audio'
 import { clampSegmentToMedia, type ExportPlan } from './plan'
 import {
   PREVIEW_EVERY_N_FRAMES,
   blitPreview,
+  decodeBackgroundAudio,
   decodeClipAudio,
   drawCover,
   drawWatermark,
@@ -27,6 +30,8 @@ export interface RealtimeExportOptions {
   getPreviewCanvas?: () => HTMLCanvasElement | null
   /** Mark stamped onto each frame; null when the user purchased removal. */
   watermarkImage?: HTMLImageElement | null
+  /** Background-music track mixed under the clips (per-clip volumes). */
+  background?: BackgroundAudioTrack | null
 }
 
 /**
@@ -92,6 +97,30 @@ export async function exportRealtime(
     dest = null
   }
 
+  // Background music rides a looping buffer source behind a gain node; the
+  // gain glides toward each clip's volume as the export reaches it (this
+  // engine paints in realtime, so Web Audio's own ramping does the work).
+  let backgroundGain: GainNode | null = null
+  let backgroundSource: AudioBufferSourceNode | null = null
+  if (options.background && audioContext && dest) {
+    const backgroundBuffer = await decodeBackgroundAudio(options.background.blob)
+    if (backgroundBuffer) {
+      try {
+        backgroundSource = audioContext.createBufferSource()
+        backgroundSource.buffer = backgroundBuffer
+        backgroundSource.loop = true
+        backgroundGain = audioContext.createGain()
+        backgroundGain.gain.value = 0
+        backgroundSource.connect(backgroundGain)
+        backgroundGain.connect(dest)
+        backgroundSource.start()
+      } catch {
+        backgroundGain = null
+        backgroundSource = null
+      }
+    }
+  }
+
   const mixedStream = new MediaStream([
     ...canvasStream.getVideoTracks(),
     ...(dest?.stream.getAudioTracks() ?? []),
@@ -138,6 +167,13 @@ export async function exportRealtime(
       try {
         const clamped = clampSegmentToMedia(segment, loaded.mediaDurationMs)
         if (!clamped) continue
+        if (backgroundGain && audioContext && options.background) {
+          backgroundGain.gain.setTargetAtTime(
+            clipAudioVolume(segment.clip, options.background.defaultVolume),
+            audioContext.currentTime,
+            0.2,
+          )
+        }
         const paintedMs = await paintSegment({
           video: loaded.video,
           blob: segment.clip.blob,
@@ -168,10 +204,19 @@ export async function exportRealtime(
       throw new Error('No video frames could be exported')
     }
 
+    // Ease the music out instead of cutting it mid-note.
+    if (backgroundGain && audioContext) {
+      backgroundGain.gain.setTargetAtTime(0, audioContext.currentTime, 0.06)
+    }
     // Hold the last frame briefly so the final GOP isn't truncated.
     await wait(180)
     options.onProgress?.(1)
   } finally {
+    try {
+      backgroundSource?.stop()
+    } catch {
+      // already stopped
+    }
     if (recorder.state !== 'inactive') recorder.stop()
     canvasStream.getTracks().forEach((t) => t.stop())
     if (audioContext) {

--- a/src/lib/export/encode-realtime.ts
+++ b/src/lib/export/encode-realtime.ts
@@ -249,9 +249,12 @@ export async function exportRealtime(
       throw new Error('No video frames could be exported')
     }
 
-    // Ease the music out instead of cutting it mid-note.
+    // End-of-film safety ramp: with Fade out on it just finishes what the
+    // scheduled fade started; with it off, a click-kill too short to hear
+    // as a fade (mirrors the WebCodecs edge ramp).
     if (backgroundGain && audioContext) {
-      backgroundGain.gain.setTargetAtTime(0, audioContext.currentTime, 0.06)
+      const tau = options.background?.fadeOut ? 0.06 : 0.008
+      backgroundGain.gain.setTargetAtTime(0, audioContext.currentTime, tau)
     }
     // Hold the last frame briefly so the final GOP isn't truncated.
     await wait(180)

--- a/src/lib/export/encode-webcodecs.ts
+++ b/src/lib/export/encode-webcodecs.ts
@@ -20,10 +20,9 @@ import { deriveProjectLocation } from '../geo'
 import { isIosBrowser } from '../platform'
 import type { ClipRecord } from '../types'
 import {
-  mixBackgroundIntoChannels,
+  createBackgroundMixer,
   planBackgroundGain,
-  type BackgroundAudioTrack,
-  type GainPoint,
+  type BackgroundAudio,
 } from './background-audio'
 import { injectMp4Metadata, type Mp4Chapter } from './mp4-metadata'
 import { createOpfsExportFile } from './opfs'
@@ -118,7 +117,7 @@ export async function exportWithWebCodecs(
   onProgress?: (ratio: number) => void,
   getPreviewCanvas?: () => HTMLCanvasElement | null,
   watermarkImage?: HTMLImageElement | null,
-  background?: BackgroundAudioTrack | null,
+  background?: BackgroundAudio | null,
 ): Promise<ExportResult> {
   if (!supportsWebCodecsExport()) {
     throw new Error('WebCodecs is not available')
@@ -186,20 +185,30 @@ export async function exportWithWebCodecs(
   const multiDay = clipsSpanMultipleDays(clipsInPlan)
   const chapters: Mp4Chapter[] = []
 
-  // Background music: decoded once, mixed into each segment's audio slice
-  // at the envelope gain (per-clip volumes with ramped transitions).
-  const backgroundBuffer = background
-    ? await decodeBackgroundAudio(background.blob, AUDIO_SAMPLE_RATE)
-    : null
-  const backgroundChannels = backgroundBuffer
-    ? Array.from({ length: backgroundBuffer.numberOfChannels }, (_, ch) =>
-        backgroundBuffer.getChannelData(ch),
-      )
-    : null
-  const gainPoints: GainPoint[] =
-    backgroundChannels && background
-      ? planBackgroundGain(plan.segments, background.defaultVolume, plan.totalMs)
-      : []
+  // Background music: playlist tracks are decoded lazily (one at a time,
+  // released as the timeline passes them) and mixed into each segment's
+  // audio slice at the envelope gain — per-clip volumes with ramped
+  // transitions, plus the optional fade-in/fade-out.
+  const backgroundMixer =
+    background && background.tracks.length > 0
+      ? createBackgroundMixer(
+          {
+            trackCount: background.tracks.length,
+            getTrack: async (index) => {
+              const buffer = await decodeBackgroundAudio(
+                background.tracks[index].blob,
+                AUDIO_SAMPLE_RATE,
+              )
+              if (!buffer) return null
+              return Array.from({ length: buffer.numberOfChannels }, (_, ch) =>
+                buffer.getChannelData(ch),
+              )
+            },
+          },
+          planBackgroundGain(plan.segments, background.defaultVolume, plan.totalMs, background),
+          AUDIO_SAMPLE_RATE,
+        )
+      : null
 
   try {
     for (const [segmentIndex, segment] of plan.segments.entries()) {
@@ -250,18 +259,13 @@ export async function exportWithWebCodecs(
         // by position, so segments can never drift.
         const buffer = await decodeClipAudio(segment.clip.blob, AUDIO_SAMPLE_RATE)
         const slice = sliceSegmentAudio(buffer, clamped.startMs, segmentMs)
-        if (backgroundChannels && gainPoints.length > 0) {
-          mixBackgroundIntoChannels({
-            channels: Array.from({ length: slice.numberOfChannels }, (_, ch) =>
-              slice.getChannelData(ch),
-            ),
-            background: backgroundChannels,
-            sampleRate: AUDIO_SAMPLE_RATE,
+        if (backgroundMixer) {
+          await backgroundMixer.mixInto(
+            Array.from({ length: slice.numberOfChannels }, (_, ch) => slice.getChannelData(ch)),
             // Frames already written = the real position of this slice, even
             // when clamping shortened an earlier segment.
-            sliceStartFrame: Math.round(state.outputOffsetSec * AUDIO_SAMPLE_RATE),
-            points: gainPoints,
-          })
+            Math.round(state.outputOffsetSec * AUDIO_SAMPLE_RATE),
+          )
         }
         await audioSource.add(slice)
 

--- a/src/lib/export/encode-webcodecs.ts
+++ b/src/lib/export/encode-webcodecs.ts
@@ -19,12 +19,19 @@ import {
 import { deriveProjectLocation } from '../geo'
 import { isIosBrowser } from '../platform'
 import type { ClipRecord } from '../types'
+import {
+  mixBackgroundIntoChannels,
+  planBackgroundGain,
+  type BackgroundAudioTrack,
+  type GainPoint,
+} from './background-audio'
 import { injectMp4Metadata, type Mp4Chapter } from './mp4-metadata'
 import { createOpfsExportFile } from './opfs'
 import { clampSegmentToMedia, type ExportPlan } from './plan'
 import {
   PREVIEW_INTERVAL_MS,
   blitPreview,
+  decodeBackgroundAudio,
   decodeClipAudio,
   drawWatermark,
   loadClipVideo,
@@ -111,6 +118,7 @@ export async function exportWithWebCodecs(
   onProgress?: (ratio: number) => void,
   getPreviewCanvas?: () => HTMLCanvasElement | null,
   watermarkImage?: HTMLImageElement | null,
+  background?: BackgroundAudioTrack | null,
 ): Promise<ExportResult> {
   if (!supportsWebCodecsExport()) {
     throw new Error('WebCodecs is not available')
@@ -178,6 +186,21 @@ export async function exportWithWebCodecs(
   const multiDay = clipsSpanMultipleDays(clipsInPlan)
   const chapters: Mp4Chapter[] = []
 
+  // Background music: decoded once, mixed into each segment's audio slice
+  // at the envelope gain (per-clip volumes with ramped transitions).
+  const backgroundBuffer = background
+    ? await decodeBackgroundAudio(background.blob, AUDIO_SAMPLE_RATE)
+    : null
+  const backgroundChannels = backgroundBuffer
+    ? Array.from({ length: backgroundBuffer.numberOfChannels }, (_, ch) =>
+        backgroundBuffer.getChannelData(ch),
+      )
+    : null
+  const gainPoints: GainPoint[] =
+    backgroundChannels && background
+      ? planBackgroundGain(plan.segments, background.defaultVolume, plan.totalMs)
+      : []
+
   try {
     for (const [segmentIndex, segment] of plan.segments.entries()) {
       const input = new Input({
@@ -226,7 +249,21 @@ export async function exportWithWebCodecs(
         // (silence-padded), appended sequentially — timestamps are implied
         // by position, so segments can never drift.
         const buffer = await decodeClipAudio(segment.clip.blob, AUDIO_SAMPLE_RATE)
-        await audioSource.add(sliceSegmentAudio(buffer, clamped.startMs, segmentMs))
+        const slice = sliceSegmentAudio(buffer, clamped.startMs, segmentMs)
+        if (backgroundChannels && gainPoints.length > 0) {
+          mixBackgroundIntoChannels({
+            channels: Array.from({ length: slice.numberOfChannels }, (_, ch) =>
+              slice.getChannelData(ch),
+            ),
+            background: backgroundChannels,
+            sampleRate: AUDIO_SAMPLE_RATE,
+            // Frames already written = the real position of this slice, even
+            // when clamping shortened an earlier segment.
+            sliceStartFrame: Math.round(state.outputOffsetSec * AUDIO_SAMPLE_RATE),
+            points: gainPoints,
+          })
+        }
+        await audioSource.add(slice)
 
         const pumpShared: PumpSharedArgs = {
           startSec: clamped.startMs / 1000,

--- a/src/lib/export/encode-webcodecs.ts
+++ b/src/lib/export/encode-webcodecs.ts
@@ -263,8 +263,13 @@ export async function exportWithWebCodecs(
           await backgroundMixer.mixInto(
             Array.from({ length: slice.numberOfChannels }, (_, ch) => slice.getChannelData(ch)),
             // Frames already written = the real position of this slice, even
-            // when clamping shortened an earlier segment.
+            // when clamping shortened an earlier segment…
             Math.round(state.outputOffsetSec * AUDIO_SAMPLE_RATE),
+            // …while gains follow the PLANNED timeline: the envelope was
+            // built from planned offsets, so anchoring each slice's gain at
+            // its planned offset keeps per-clip volumes and fades on their
+            // clips even when clamping shifted the real frame positions.
+            segment.offsetMs,
           )
         }
         await audioSource.add(slice)

--- a/src/lib/export/encode-webcodecs.ts
+++ b/src/lib/export/encode-webcodecs.ts
@@ -20,8 +20,10 @@ import { deriveProjectLocation } from '../geo'
 import { isIosBrowser } from '../platform'
 import type { ClipRecord } from '../types'
 import {
+  boundaryRampHalfMs,
   createBackgroundMixer,
-  planBackgroundGain,
+  planSegmentGain,
+  segmentVolume,
   type BackgroundAudio,
 } from './background-audio'
 import { injectMp4Metadata, type Mp4Chapter } from './mp4-metadata'
@@ -187,8 +189,12 @@ export async function exportWithWebCodecs(
 
   // Background music: playlist tracks are decoded lazily (one at a time,
   // released as the timeline passes them) and mixed into each segment's
-  // audio slice at the envelope gain — per-clip volumes with ramped
-  // transitions, plus the optional fade-in/fade-out.
+  // audio slice under a per-segment gain envelope — per-clip volumes with
+  // ramped transitions, plus the optional fade-in/fade-out. Envelopes are
+  // built from each segment's REAL (clamped) duration as it is mixed, so
+  // ramps and fades stay on their clips even when clamping shifts the
+  // timeline; only ramp-length clamping peeks at the next clip's planned
+  // duration.
   const backgroundMixer =
     background && background.tracks.length > 0
       ? createBackgroundMixer(
@@ -205,10 +211,13 @@ export async function exportWithWebCodecs(
               )
             },
           },
-          planBackgroundGain(plan.segments, background.defaultVolume, plan.totalMs, background),
           AUDIO_SAMPLE_RATE,
         )
       : null
+  const plannedDurationsMs = plan.segments.map((s) => s.endMs - s.startMs)
+  /** Volume + real duration of the previous MIXED segment (dropped
+   * segments must not become ramp anchors). */
+  let previousMixed: { volume: number; durationMs: number } | null = null
 
   try {
     for (const [segmentIndex, segment] of plan.segments.entries()) {
@@ -259,18 +268,39 @@ export async function exportWithWebCodecs(
         // by position, so segments can never drift.
         const buffer = await decodeClipAudio(segment.clip.blob, AUDIO_SAMPLE_RATE)
         const slice = sliceSegmentAudio(buffer, clamped.startMs, segmentMs)
-        if (backgroundMixer) {
+        if (backgroundMixer && background) {
+          const volume = segmentVolume(segment, background.defaultVolume)
+          const nextPlanned = plan.segments[segmentIndex + 1]
           await backgroundMixer.mixInto(
             Array.from({ length: slice.numberOfChannels }, (_, ch) => slice.getChannelData(ch)),
             // Frames already written = the real position of this slice, even
-            // when clamping shortened an earlier segment…
+            // when clamping shortened an earlier segment.
             Math.round(state.outputOffsetSec * AUDIO_SAMPLE_RATE),
-            // …while gains follow the PLANNED timeline: the envelope was
-            // built from planned offsets, so anchoring each slice's gain at
-            // its planned offset keeps per-clip volumes and fades on their
-            // clips even when clamping shifted the real frame positions.
-            segment.offsetMs,
+            planSegmentGain({
+              volume,
+              durationMs: segmentMs,
+              entry: previousMixed
+                ? {
+                    fromVolume: previousMixed.volume,
+                    halfMs: boundaryRampHalfMs(
+                      previousMixed.durationMs,
+                      plannedDurationsMs[segmentIndex],
+                    ),
+                  }
+                : undefined,
+              exit: nextPlanned
+                ? {
+                    toVolume: segmentVolume(nextPlanned, background.defaultVolume),
+                    halfMs: boundaryRampHalfMs(
+                      segmentMs,
+                      plannedDurationsMs[segmentIndex + 1],
+                    ),
+                  }
+                : undefined,
+              fades: background,
+            }),
           )
+          previousMixed = { volume, durationMs: segmentMs }
         }
         await audioSource.add(slice)
 

--- a/src/lib/export/index.ts
+++ b/src/lib/export/index.ts
@@ -1,5 +1,6 @@
 import { reportError } from '../error-reporting'
 import type { ClipRecord } from '../types'
+import type { BackgroundAudioTrack } from './background-audio'
 import { exportRealtime } from './encode-realtime'
 import { exportWithWebCodecs, supportsWebCodecsExport } from './encode-webcodecs'
 import { sweepExportCache, withExportCacheReserved } from './export-cache'
@@ -34,6 +35,9 @@ export interface ExportOptions {
   getPreviewCanvas?: () => HTMLCanvasElement | null
   /** Stamp the Kody Video mark on frames (default true; off after purchase). */
   watermark?: boolean
+  /** Background-music track mixed under the clips at their per-clip volumes
+   * (looped when shorter than the film). */
+  background?: BackgroundAudioTrack | null
 }
 
 /**
@@ -77,6 +81,7 @@ async function runExport(
         options.onProgress,
         options.getPreviewCanvas,
         watermarkImage,
+        options.background,
       )
       reportSilentExportAudio({ engine: 'webcodecs', outputMime: result.mimeType })
       reportBlackExportVideo({ engine: 'webcodecs', outputMime: result.mimeType })
@@ -102,6 +107,7 @@ async function runExport(
     onProgress: options.onProgress,
     getPreviewCanvas: options.getPreviewCanvas,
     watermarkImage,
+    background: options.background,
   })
   reportSilentExportAudio({ engine: 'realtime', outputMime: result.mimeType })
   reportBlackExportVideo({ engine: 'realtime', outputMime: result.mimeType })

--- a/src/lib/export/index.ts
+++ b/src/lib/export/index.ts
@@ -1,6 +1,6 @@
 import { reportError } from '../error-reporting'
 import type { ClipRecord } from '../types'
-import type { BackgroundAudioTrack } from './background-audio'
+import type { BackgroundAudio } from './background-audio'
 import { exportRealtime } from './encode-realtime'
 import { exportWithWebCodecs, supportsWebCodecsExport } from './encode-webcodecs'
 import { sweepExportCache, withExportCacheReserved } from './export-cache'
@@ -35,9 +35,9 @@ export interface ExportOptions {
   getPreviewCanvas?: () => HTMLCanvasElement | null
   /** Stamp the Kody Video mark on frames (default true; off after purchase). */
   watermark?: boolean
-  /** Background-music track mixed under the clips at their per-clip volumes
-   * (looped when shorter than the film). */
-  background?: BackgroundAudioTrack | null
+  /** Background-music playlist mixed under the clips at their per-clip
+   * volumes; tracks play one after the other until the film ends. */
+  background?: BackgroundAudio | null
 }
 
 /**

--- a/src/lib/export/last-export.ts
+++ b/src/lib/export/last-export.ts
@@ -7,7 +7,7 @@
  */
 
 import { getDb, getSettings } from '../storage'
-import type { ClipRecord, ProjectId } from '../types'
+import type { ClipRecord, ProjectAudioMeta, ProjectId } from '../types'
 import { withExportCacheReserved } from './export-cache'
 import { readOpfsFile, removeExportEntry, streamToOpfsFile } from './opfs'
 import type { ExportResult } from './shared'
@@ -15,10 +15,20 @@ import type { ExportResult } from './shared'
 const LAST_EXPORT_PREFIX = 'last-export'
 
 /** Anything that changes the rendered output must change the signature. */
-export function exportSignature(clips: ClipRecord[], watermarked: boolean): string {
+export function exportSignature(
+  clips: ClipRecord[],
+  watermarked: boolean,
+  audio?: Pick<ProjectAudioMeta, 'addedAt' | 'durationMs' | 'defaultVolume'> | null,
+): string {
   return JSON.stringify({
     watermarked,
-    clips: clips.map((clip) => [clip.id, clip.trimStartMs, clip.trimEndMs]),
+    clips: clips.map((clip) => [
+      clip.id,
+      clip.trimStartMs,
+      clip.trimEndMs,
+      clip.audioVolume ?? null,
+    ]),
+    audio: audio ? [audio.addedAt, audio.durationMs, audio.defaultVolume] : null,
   })
 }
 

--- a/src/lib/export/last-export.ts
+++ b/src/lib/export/last-export.ts
@@ -7,7 +7,7 @@
  */
 
 import { getDb, getSettings } from '../storage'
-import type { ClipRecord, ProjectAudioMeta, ProjectId } from '../types'
+import type { ClipRecord, ProjectAudioRecord, ProjectId } from '../types'
 import { withExportCacheReserved } from './export-cache'
 import { readOpfsFile, removeExportEntry, streamToOpfsFile } from './opfs'
 import type { ExportResult } from './shared'
@@ -18,7 +18,7 @@ const LAST_EXPORT_PREFIX = 'last-export'
 export function exportSignature(
   clips: ClipRecord[],
   watermarked: boolean,
-  audio?: Pick<ProjectAudioMeta, 'addedAt' | 'durationMs' | 'defaultVolume'> | null,
+  audio?: Pick<ProjectAudioRecord, 'tracks' | 'defaultVolume' | 'fadeIn' | 'fadeOut'> | null,
 ): string {
   return JSON.stringify({
     watermarked,
@@ -28,7 +28,14 @@ export function exportSignature(
       clip.trimEndMs,
       clip.audioVolume ?? null,
     ]),
-    audio: audio ? [audio.addedAt, audio.durationMs, audio.defaultVolume] : null,
+    audio: audio
+      ? {
+          tracks: audio.tracks.map((track) => [track.id, track.durationMs]),
+          defaultVolume: audio.defaultVolume,
+          fadeIn: audio.fadeIn,
+          fadeOut: audio.fadeOut,
+        }
+      : null,
   })
 }
 

--- a/src/lib/export/shared.ts
+++ b/src/lib/export/shared.ts
@@ -415,6 +415,26 @@ async function decodeBlobAudio(blob: Blob, sampleRate: number): Promise<AudioBuf
   return offline.startRendering()
 }
 
+/**
+ * Decode the project's background-audio track for export mixing. Never
+ * contributes to the per-clip silence diagnostics — a loud music bed must
+ * not mask dead-mic clips (and a broken music decode must not fail the
+ * export, just export without music).
+ */
+export async function decodeBackgroundAudio(
+  blob: Blob,
+  sampleRate = 48000,
+): Promise<AudioBuffer | null> {
+  try {
+    return await decodeBlobAudio(blob, sampleRate)
+  } catch {
+    reportError(new Error('Background audio decode failed — exporting without music'), 'export-audio', {
+      mimeType: blob.type,
+    })
+    return null
+  }
+}
+
 export async function decodeClipAudio(
   blob: Blob,
   sampleRate = 48000,

--- a/src/lib/project-actions.ts
+++ b/src/lib/project-actions.ts
@@ -1,5 +1,6 @@
 import {
   addClip,
+  addProjectAudioTrack,
   clearUndo,
   deleteClip,
   duplicateClip,
@@ -10,14 +11,14 @@ import {
   getUndoSnapshot,
   listProjects,
   moveClip,
-  removeProjectAudio,
+  removeProjectAudioTrack,
   setLastOpenedProjectId,
-  setProjectAudio,
   undoDeleteLastClip,
   updateClipAudioVolume,
   updateClipThumbs,
   updateClipTrim,
-  updateProjectAudioDefaultVolume,
+  updateProjectAudioSettings,
+  type ProjectAudioSettings,
 } from './storage'
 import { probeAudioFile } from './audio-import'
 import { estimateExportCacheBytes } from './export/export-cache'
@@ -255,7 +256,7 @@ export async function trimClip(
   await updateClipTrim(clipId, trimStartMs, trimEndMs)
 }
 
-/** Attach a picked audio file as the project's background-music track. */
+/** Append a picked audio file to the project's background-music playlist. */
 export async function addProjectAudioFromFile(
   file: File,
   ensureProjectId: () => Promise<ProjectId>,
@@ -263,7 +264,7 @@ export async function addProjectAudioFromFile(
   // Probe first: a bad pick on /project/new must not create an empty project.
   const probed = await probeAudioFile(file)
   const projectId = await ensureProjectId()
-  return setProjectAudio({
+  return addProjectAudioTrack({
     projectId,
     blob: probed.blob,
     mimeType: probed.mimeType,
@@ -272,15 +273,15 @@ export async function addProjectAudioFromFile(
   })
 }
 
-export async function removeProjectAudioTrack(projectId: ProjectId): Promise<void> {
-  await removeProjectAudio(projectId)
+export async function removeAudioTrack(projectId: ProjectId, trackId: string): Promise<void> {
+  await removeProjectAudioTrack(projectId, trackId)
 }
 
-export async function setProjectAudioDefaultVolume(
+export async function setProjectAudioSettings(
   projectId: ProjectId,
-  volume: number,
+  settings: ProjectAudioSettings,
 ): Promise<void> {
-  await updateProjectAudioDefaultVolume(projectId, volume)
+  await updateProjectAudioSettings(projectId, settings)
 }
 
 /** Set (or clear, with null) a clip's background-music volume override. */

--- a/src/lib/project-actions.ts
+++ b/src/lib/project-actions.ts
@@ -5,15 +5,21 @@ import {
   duplicateClip,
   getClipsForProject,
   getProject,
+  getProjectAudio,
   getSettings,
   getUndoSnapshot,
   listProjects,
   moveClip,
+  removeProjectAudio,
   setLastOpenedProjectId,
+  setProjectAudio,
   undoDeleteLastClip,
+  updateClipAudioVolume,
   updateClipThumbs,
   updateClipTrim,
+  updateProjectAudioDefaultVolume,
 } from './storage'
+import { probeAudioFile } from './audio-import'
 import { estimateExportCacheBytes } from './export/export-cache'
 import { estimateStorageSpace, type StorageSpace } from './storage-space'
 import type { GeneratedThumbs } from './thumbs'
@@ -23,6 +29,7 @@ import {
   type ClipId,
   type ClipRecord,
   type Project,
+  type ProjectAudioRecord,
   type ProjectId,
 } from './types'
 
@@ -36,6 +43,8 @@ export interface ProjectSummary extends Project {
 export interface ProjectLoaderData {
   project: Project | null
   clips: ClipRecord[]
+  /** Background-audio track played under the clips (null when none is set). */
+  audio: ProjectAudioRecord | null
   canUndo: boolean
   onboardingDismissed: boolean
   /** True when the one-time "Remove Watermark" purchase is unlocked. */
@@ -108,6 +117,7 @@ export async function loadProjectPage(projectId: ProjectId): Promise<ProjectLoad
           clipIds: [],
         },
         clips: [],
+        audio: null,
         canUndo: false,
         onboardingDismissed: settings.onboardingDismissed,
         watermarkRemoved: settings.watermarkRemoved === true,
@@ -117,9 +127,10 @@ export async function loadProjectPage(projectId: ProjectId): Promise<ProjectLoad
       }
     }
 
-    const [project, clips, undo, settings, storage] = await Promise.all([
+    const [project, clips, audio, undo, settings, storage] = await Promise.all([
       getProject(projectId),
       getClipsForProject(projectId),
+      getProjectAudio(projectId),
       getUndoSnapshot(projectId),
       getSettings(),
       estimateStorageSpace(),
@@ -128,6 +139,7 @@ export async function loadProjectPage(projectId: ProjectId): Promise<ProjectLoad
       return {
         project: null,
         clips: [],
+        audio: null,
         canUndo: false,
         onboardingDismissed: settings.onboardingDismissed,
         watermarkRemoved: settings.watermarkRemoved === true,
@@ -149,6 +161,7 @@ export async function loadProjectPage(projectId: ProjectId): Promise<ProjectLoad
     return {
       project,
       clips: hydrated,
+      audio: audio ?? null,
       canUndo: !!undo,
       onboardingDismissed: settings.onboardingDismissed,
       watermarkRemoved: settings.watermarkRemoved === true,
@@ -160,6 +173,7 @@ export async function loadProjectPage(projectId: ProjectId): Promise<ProjectLoad
     return {
       project: null,
       clips: [],
+      audio: null,
       canUndo: false,
       onboardingDismissed: true,
       watermarkRemoved: false,
@@ -239,6 +253,42 @@ export async function trimClip(
   trimEndMs: number,
 ): Promise<void> {
   await updateClipTrim(clipId, trimStartMs, trimEndMs)
+}
+
+/** Attach a picked audio file as the project's background-music track. */
+export async function addProjectAudioFromFile(
+  file: File,
+  ensureProjectId: () => Promise<ProjectId>,
+): Promise<ProjectAudioRecord> {
+  // Probe first: a bad pick on /project/new must not create an empty project.
+  const probed = await probeAudioFile(file)
+  const projectId = await ensureProjectId()
+  return setProjectAudio({
+    projectId,
+    blob: probed.blob,
+    mimeType: probed.mimeType,
+    durationMs: probed.durationMs,
+    name: probed.name,
+  })
+}
+
+export async function removeProjectAudioTrack(projectId: ProjectId): Promise<void> {
+  await removeProjectAudio(projectId)
+}
+
+export async function setProjectAudioDefaultVolume(
+  projectId: ProjectId,
+  volume: number,
+): Promise<void> {
+  await updateProjectAudioDefaultVolume(projectId, volume)
+}
+
+/** Set (or clear, with null) a clip's background-music volume override. */
+export async function setClipAudioVolume(
+  clipId: ClipId,
+  volume: number | null,
+): Promise<void> {
+  await updateClipAudioVolume(clipId, volume)
 }
 
 export {

--- a/src/lib/project-transfer.test.ts
+++ b/src/lib/project-transfer.test.ts
@@ -14,15 +14,20 @@ function fakeProject(name = 'Road Trip'): Project {
   return { id: 'proj_x', name, createdAt: 1, updatedAt: 2, clipIds: ['clip_a', 'clip_b'] }
 }
 
-function fakeAudio(content = 'SONGBYTES'): ProjectAudioRecord {
+function fakeAudio(contents: string[] = ['SONGBYTES']): ProjectAudioRecord {
   return {
     projectId: 'proj_x',
-    blob: new Blob([content], { type: 'audio/mpeg' }),
-    mimeType: 'audio/mpeg',
-    durationMs: 30_000,
-    name: 'song.mp3',
+    tracks: contents.map((content, index) => ({
+      id: `track_${index}`,
+      blob: new Blob([content], { type: 'audio/mpeg' }),
+      mimeType: 'audio/mpeg',
+      durationMs: 30_000,
+      name: `song-${index + 1}.mp3`,
+      addedAt: 1700000000000 + index,
+    })),
     defaultVolume: 0.4,
-    addedAt: 1700000000000,
+    fadeIn: true,
+    fadeOut: false,
   }
 }
 
@@ -86,18 +91,28 @@ describe('project backup round trip', () => {
     expect(parsed.audio).toBeNull()
   })
 
-  it('round-trips the music track and per-clip volumes', async () => {
+  it('round-trips the music playlist, fades, and per-clip volumes', async () => {
     await markWatermarkRemoved('cs_test_transfer')
     const clips = [
       fakeClip('clip_a', 'AAAA', { audioVolume: 0.8 }),
       fakeClip('clip_b', 'BBBB'),
     ]
-    const backup = serializeProject(fakeProject('Scored'), clips, fakeAudio())
+    const backup = serializeProject(
+      fakeProject('Scored'),
+      clips,
+      fakeAudio(['SONGBYTES', 'MORESONG']),
+    )
 
     const parsed = await parseProjectBackup(backup)
-    expect(parsed.audio?.name).toBe('song.mp3')
     expect(parsed.audio?.defaultVolume).toBe(0.4)
-    expect(await parsed.audio!.blob.text()).toBe('SONGBYTES')
+    expect(parsed.audio?.fadeIn).toBe(true)
+    expect(parsed.audio?.fadeOut).toBe(false)
+    expect(parsed.audio?.tracks.map((track) => track.name)).toEqual([
+      'song-1.mp3',
+      'song-2.mp3',
+    ])
+    expect(await parsed.audio!.tracks[0].blob.text()).toBe('SONGBYTES')
+    expect(await parsed.audio!.tracks[1].blob.text()).toBe('MORESONG')
     expect(parsed.clips[0].audioVolume).toBe(0.8)
     expect(parsed.clips[1].audioVolume).toBeUndefined()
     // Clip bytes stay aligned with the trailing audio section present.
@@ -105,15 +120,18 @@ describe('project backup round trip', () => {
 
     const project = await importProjectBackup(parsed)
     const audio = await getProjectAudio(project.id)
-    expect(audio?.name).toBe('song.mp3')
     expect(audio?.defaultVolume).toBe(0.4)
-    expect(await audio!.blob.text()).toBe('SONGBYTES')
+    expect(audio?.fadeIn).toBe(true)
+    expect(audio?.fadeOut).toBe(false)
+    expect(audio?.tracks.map((track) => track.name)).toEqual(['song-1.mp3', 'song-2.mp3'])
+    expect(await audio!.tracks[0].blob.text()).toBe('SONGBYTES')
+    expect(await audio!.tracks[1].blob.text()).toBe('MORESONG')
     const imported = await getClipsForProject(project.id)
     expect(imported[0].audioVolume).toBe(0.8)
     expect(imported[1].audioVolume).toBeUndefined()
   })
 
-  it('imports a music-carrying backup on a free device, skipping the track', async () => {
+  it('imports a music-carrying backup on a free device, skipping the playlist', async () => {
     const backup = serializeProject(fakeProject('Scored'), [fakeClip('clip_a', 'AAAA')], fakeAudio())
     const parsed = await parseProjectBackup(backup)
     const project = await importProjectBackup(parsed)

--- a/src/lib/project-transfer.test.ts
+++ b/src/lib/project-transfer.test.ts
@@ -6,11 +6,24 @@ import {
   projectBackupFilename,
   serializeProject,
 } from './project-transfer'
-import { __resetDbForTests, getClipsForProject, listProjects } from './storage'
-import type { ClipRecord, Project } from './types'
+import { __resetDbForTests, getClipsForProject, getProjectAudio, listProjects } from './storage'
+import { markWatermarkRemoved } from './entitlement'
+import type { ClipRecord, Project, ProjectAudioRecord } from './types'
 
 function fakeProject(name = 'Road Trip'): Project {
   return { id: 'proj_x', name, createdAt: 1, updatedAt: 2, clipIds: ['clip_a', 'clip_b'] }
+}
+
+function fakeAudio(content = 'SONGBYTES'): ProjectAudioRecord {
+  return {
+    projectId: 'proj_x',
+    blob: new Blob([content], { type: 'audio/mpeg' }),
+    mimeType: 'audio/mpeg',
+    durationMs: 30_000,
+    name: 'song.mp3',
+    defaultVolume: 0.4,
+    addedAt: 1700000000000,
+  }
 }
 
 function fakeClip(id: string, content: string, extra: Partial<ClipRecord> = {}): ClipRecord {
@@ -65,6 +78,53 @@ describe('project backup round trip', () => {
     expect(clips[0].lat).toBe(40.2338)
     expect(clips[0].createdAt).toBe(1700000000000)
     expect(await clips[0].blob.text()).toBe('MEDIA')
+  })
+
+  it('parses backups without music with audio: null (older backups)', async () => {
+    const backup = serializeProject(fakeProject(), [fakeClip('clip_a', 'AAAA')])
+    const parsed = await parseProjectBackup(backup)
+    expect(parsed.audio).toBeNull()
+  })
+
+  it('round-trips the music track and per-clip volumes', async () => {
+    await markWatermarkRemoved('cs_test_transfer')
+    const clips = [
+      fakeClip('clip_a', 'AAAA', { audioVolume: 0.8 }),
+      fakeClip('clip_b', 'BBBB'),
+    ]
+    const backup = serializeProject(fakeProject('Scored'), clips, fakeAudio())
+
+    const parsed = await parseProjectBackup(backup)
+    expect(parsed.audio?.name).toBe('song.mp3')
+    expect(parsed.audio?.defaultVolume).toBe(0.4)
+    expect(await parsed.audio!.blob.text()).toBe('SONGBYTES')
+    expect(parsed.clips[0].audioVolume).toBe(0.8)
+    expect(parsed.clips[1].audioVolume).toBeUndefined()
+    // Clip bytes stay aligned with the trailing audio section present.
+    expect(await parsed.clips[1].blob.text()).toBe('BBBB')
+
+    const project = await importProjectBackup(parsed)
+    const audio = await getProjectAudio(project.id)
+    expect(audio?.name).toBe('song.mp3')
+    expect(audio?.defaultVolume).toBe(0.4)
+    expect(await audio!.blob.text()).toBe('SONGBYTES')
+    const imported = await getClipsForProject(project.id)
+    expect(imported[0].audioVolume).toBe(0.8)
+    expect(imported[1].audioVolume).toBeUndefined()
+  })
+
+  it('imports a music-carrying backup on a free device, skipping the track', async () => {
+    const backup = serializeProject(fakeProject('Scored'), [fakeClip('clip_a', 'AAAA')], fakeAudio())
+    const parsed = await parseProjectBackup(backup)
+    const project = await importProjectBackup(parsed)
+
+    expect((await getClipsForProject(project.id))).toHaveLength(1)
+    expect(await getProjectAudio(project.id)).toBeUndefined()
+  })
+
+  it('rejects a backup whose audio section is truncated', async () => {
+    const backup = serializeProject(fakeProject(), [fakeClip('clip_a', 'AAAA')], fakeAudio())
+    await expect(parseProjectBackup(backup.slice(0, backup.size - 4))).rejects.toThrow(/damaged/i)
   })
 
   it('reports per-clip progress during import', async () => {

--- a/src/lib/project-transfer.ts
+++ b/src/lib/project-transfer.ts
@@ -1,3 +1,4 @@
+import { isWatermarkRemoved } from './entitlement'
 import {
   addClip,
   addProjectAudioTrack,
@@ -220,7 +221,9 @@ export async function parseProjectBackup(file: Blob): Promise<ParsedBackup> {
       if (
         !Number.isInteger(track.byteLength) ||
         track.byteLength <= 0 ||
-        offset + track.byteLength > file.size
+        offset + track.byteLength > file.size ||
+        !Number.isFinite(track.durationMs) ||
+        track.durationMs <= 0
       ) {
         throw new BackupFormatError('This backup file is damaged')
       }
@@ -296,28 +299,25 @@ export async function importProjectBackup(
       done += 1
       onProgress?.(done, parsed.clips.length)
     }
-    if (parsed.audio) {
-      // Best-effort: background music is a Plus perk, so restoring a
-      // Plus-made backup on a free device keeps the clips and simply skips
-      // the playlist (addProjectAudioTrack enforces the gate). A damaged
-      // audio section must not kill an otherwise intact import either.
-      try {
-        for (const track of parsed.audio.tracks) {
-          const bytes = await track.blob.arrayBuffer()
-          await addProjectAudioTrack({
-            projectId: project.id,
-            blob: new Blob([bytes], { type: track.mimeType }),
-            mimeType: track.mimeType,
-            durationMs: track.durationMs,
-            name: track.name,
-            // Playlist settings land with the first track; later adds keep them.
-            defaultVolume: parsed.audio.defaultVolume,
-            fadeIn: parsed.audio.fadeIn,
-            fadeOut: parsed.audio.fadeOut,
-          })
-        }
-      } catch {
-        // Plus gate (or a damaged track) — clips still imported fine.
+    // Background music is a Plus perk: restoring a Plus-made backup on a
+    // free device keeps the clips and skips the playlist wholesale (checked
+    // up front — never a silent partial playlist). On entitled devices any
+    // track failure fails the import like a clip failure would, so the
+    // rollback below never leaves half the music behind.
+    if (parsed.audio && (await isWatermarkRemoved())) {
+      for (const track of parsed.audio.tracks) {
+        const bytes = await track.blob.arrayBuffer()
+        await addProjectAudioTrack({
+          projectId: project.id,
+          blob: new Blob([bytes], { type: track.mimeType }),
+          mimeType: track.mimeType,
+          durationMs: track.durationMs,
+          name: track.name,
+          // Playlist settings land with the first track; later adds keep them.
+          defaultVolume: parsed.audio.defaultVolume,
+          fadeIn: parsed.audio.fadeIn,
+          fadeOut: parsed.audio.fadeOut,
+        })
       }
     }
     return project

--- a/src/lib/project-transfer.ts
+++ b/src/lib/project-transfer.ts
@@ -1,5 +1,5 @@
-import { addClip, createProject, deleteProject, updateClipTrim } from './storage'
-import type { ClipRecord, Project } from './types'
+import { addClip, createProject, deleteProject, setProjectAudio, updateClipTrim } from './storage'
+import type { ClipRecord, Project, ProjectAudioRecord } from './types'
 
 /**
  * Single-file project backup, used both as a safety net and to move a
@@ -7,7 +7,10 @@ import type { ClipRecord, Project } from './types'
  * browser storage is separate).
  *
  * Format: `KODYVID1` magic, u32 big-endian JSON manifest length, UTF-8 JSON
- * manifest, then every clip's media bytes concatenated in manifest order.
+ * manifest, then every clip's media bytes concatenated in manifest order,
+ * then (when present) the background-audio track's bytes. Older app
+ * versions ignore the unknown manifest fields and the trailing audio bytes,
+ * so music-carrying backups still import there (clips only).
  * Thumbnails are intentionally excluded — the loader regenerates them.
  */
 const MAGIC = 'KODYVID1'
@@ -24,7 +27,18 @@ interface ManifestClip {
   lat?: number
   lng?: number
   locationAccuracyM?: number
+  /** Background-music volume override (0–1) while this clip plays. */
+  audioVolume?: number
   /** Byte length of this clip's media in the blob section. */
+  byteLength: number
+}
+
+interface ManifestAudio {
+  mimeType: string
+  durationMs: number
+  name: string
+  defaultVolume: number
+  /** Byte length of the track, appended after every clip's media bytes. */
   byteLength: number
 }
 
@@ -34,6 +48,8 @@ interface Manifest {
   exportedAt: number
   projectName: string
   clips: ManifestClip[]
+  /** Background-music track (absent on projects without one). */
+  audio?: ManifestAudio
 }
 
 export function projectBackupFilename(projectName: string): string {
@@ -47,7 +63,11 @@ export function projectBackupFilename(projectName: string): string {
 }
 
 /** Bundle a project into one shareable/downloadable backup Blob. */
-export function serializeProject(project: Project, clips: ClipRecord[]): Blob {
+export function serializeProject(
+  project: Project,
+  clips: ClipRecord[],
+  audio?: ProjectAudioRecord | null,
+): Blob {
   const manifest: Manifest = {
     version: 1,
     app: 'kody-video',
@@ -64,8 +84,18 @@ export function serializeProject(project: Project, clips: ClipRecord[]): Blob {
       lat: clip.lat,
       lng: clip.lng,
       locationAccuracyM: clip.locationAccuracyM,
+      audioVolume: clip.audioVolume,
       byteLength: clip.blob.size,
     })),
+  }
+  if (audio) {
+    manifest.audio = {
+      mimeType: audio.mimeType,
+      durationMs: audio.durationMs,
+      name: audio.name,
+      defaultVolume: audio.defaultVolume,
+      byteLength: audio.blob.size,
+    }
   }
 
   const manifestBytes = new TextEncoder().encode(JSON.stringify(manifest))
@@ -74,14 +104,22 @@ export function serializeProject(project: Project, clips: ClipRecord[]): Blob {
   new DataView(header.buffer).setUint32(MAGIC_BYTES.byteLength, manifestBytes.byteLength)
 
   // Blob composition references the clip blobs — nothing is copied here.
-  return new Blob([header, manifestBytes, ...clips.map((clip) => clip.blob)], {
-    type: 'application/octet-stream',
-  })
+  return new Blob(
+    [
+      header,
+      manifestBytes,
+      ...clips.map((clip) => clip.blob),
+      ...(audio ? [audio.blob] : []),
+    ],
+    { type: 'application/octet-stream' },
+  )
 }
 
 export interface ParsedBackup {
   projectName: string
   clips: Array<Omit<ManifestClip, 'byteLength'> & { blob: Blob }>
+  /** Background-music track, when the backup carries one. */
+  audio: (Omit<ManifestAudio, 'byteLength'> & { blob: Blob }) | null
 }
 
 /**
@@ -144,12 +182,34 @@ export async function parseProjectBackup(file: Blob): Promise<ParsedBackup> {
       lat: clip.lat,
       lng: clip.lng,
       locationAccuracyM: clip.locationAccuracyM,
+      audioVolume: typeof clip.audioVolume === 'number' ? clip.audioVolume : undefined,
       blob: file.slice(offset, offset + clip.byteLength, mimeType),
     })
     offset += clip.byteLength
   }
 
-  return { projectName: String(manifest.projectName || 'Imported project'), clips }
+  let audio: ParsedBackup['audio'] = null
+  const manifestAudio = manifest.audio
+  if (manifestAudio) {
+    if (
+      !Number.isInteger(manifestAudio.byteLength) ||
+      manifestAudio.byteLength <= 0 ||
+      offset + manifestAudio.byteLength > file.size
+    ) {
+      throw new BackupFormatError('This backup file is damaged')
+    }
+    const mimeType =
+      typeof manifestAudio.mimeType === 'string' ? manifestAudio.mimeType : 'audio/mpeg'
+    audio = {
+      mimeType,
+      durationMs: manifestAudio.durationMs,
+      name: String(manifestAudio.name || 'Audio track'),
+      defaultVolume: manifestAudio.defaultVolume,
+      blob: file.slice(offset, offset + manifestAudio.byteLength, mimeType),
+    }
+  }
+
+  return { projectName: String(manifest.projectName || 'Imported project'), clips, audio }
 }
 
 function assertImportableClip(clip: ParsedBackup['clips'][number]): void {
@@ -192,6 +252,7 @@ export async function importProjectBackup(
         lat: clip.lat,
         lng: clip.lng,
         locationAccuracyM: clip.locationAccuracyM,
+        audioVolume: clip.audioVolume,
       })
       // Restore trims (addClip resets them to the full clip).
       const trimmed = await updateClipTrim(added.id, clip.trimStartMs, clip.trimEndMs)
@@ -202,6 +263,21 @@ export async function importProjectBackup(
       await ensureClipThumbs({ ...added, ...trimmed, blob: added.blob }).catch(() => undefined)
       done += 1
       onProgress?.(done, parsed.clips.length)
+    }
+    if (parsed.audio) {
+      // Best-effort: background music is a Plus perk, so restoring a
+      // Plus-made backup on a free device keeps the clips and simply skips
+      // the track (setProjectAudio enforces the gate). A damaged audio
+      // section must not kill an otherwise intact import either.
+      const bytes = await parsed.audio.blob.arrayBuffer()
+      await setProjectAudio({
+        projectId: project.id,
+        blob: new Blob([bytes], { type: parsed.audio.mimeType }),
+        mimeType: parsed.audio.mimeType,
+        durationMs: parsed.audio.durationMs,
+        name: parsed.audio.name,
+        defaultVolume: parsed.audio.defaultVolume,
+      }).catch(() => undefined)
     }
     return project
   } catch (error) {

--- a/src/lib/project-transfer.ts
+++ b/src/lib/project-transfer.ts
@@ -1,4 +1,10 @@
-import { addClip, createProject, deleteProject, setProjectAudio, updateClipTrim } from './storage'
+import {
+  addClip,
+  addProjectAudioTrack,
+  createProject,
+  deleteProject,
+  updateClipTrim,
+} from './storage'
 import type { ClipRecord, Project, ProjectAudioRecord } from './types'
 
 /**
@@ -33,13 +39,20 @@ interface ManifestClip {
   byteLength: number
 }
 
-interface ManifestAudio {
+interface ManifestAudioTrack {
   mimeType: string
   durationMs: number
   name: string
-  defaultVolume: number
-  /** Byte length of the track, appended after every clip's media bytes. */
+  /** Byte length of this track, appended after every clip's media bytes
+   * (tracks follow in playlist order). */
   byteLength: number
+}
+
+interface ManifestAudio {
+  defaultVolume: number
+  fadeIn: boolean
+  fadeOut: boolean
+  tracks: ManifestAudioTrack[]
 }
 
 interface Manifest {
@@ -48,7 +61,7 @@ interface Manifest {
   exportedAt: number
   projectName: string
   clips: ManifestClip[]
-  /** Background-music track (absent on projects without one). */
+  /** Background-music playlist (absent on projects without one). */
   audio?: ManifestAudio
 }
 
@@ -88,13 +101,17 @@ export function serializeProject(
       byteLength: clip.blob.size,
     })),
   }
-  if (audio) {
+  if (audio && audio.tracks.length > 0) {
     manifest.audio = {
-      mimeType: audio.mimeType,
-      durationMs: audio.durationMs,
-      name: audio.name,
       defaultVolume: audio.defaultVolume,
-      byteLength: audio.blob.size,
+      fadeIn: audio.fadeIn,
+      fadeOut: audio.fadeOut,
+      tracks: audio.tracks.map((track) => ({
+        mimeType: track.mimeType,
+        durationMs: track.durationMs,
+        name: track.name,
+        byteLength: track.blob.size,
+      })),
     }
   }
 
@@ -109,17 +126,24 @@ export function serializeProject(
       header,
       manifestBytes,
       ...clips.map((clip) => clip.blob),
-      ...(audio ? [audio.blob] : []),
+      ...(audio?.tracks.map((track) => track.blob) ?? []),
     ],
     { type: 'application/octet-stream' },
   )
 }
 
+export interface ParsedBackupAudio {
+  defaultVolume: number
+  fadeIn: boolean
+  fadeOut: boolean
+  tracks: Array<Omit<ManifestAudioTrack, 'byteLength'> & { blob: Blob }>
+}
+
 export interface ParsedBackup {
   projectName: string
   clips: Array<Omit<ManifestClip, 'byteLength'> & { blob: Blob }>
-  /** Background-music track, when the backup carries one. */
-  audio: (Omit<ManifestAudio, 'byteLength'> & { blob: Blob }) | null
+  /** Background-music playlist, when the backup carries one. */
+  audio: ParsedBackupAudio | null
 }
 
 /**
@@ -190,22 +214,30 @@ export async function parseProjectBackup(file: Blob): Promise<ParsedBackup> {
 
   let audio: ParsedBackup['audio'] = null
   const manifestAudio = manifest.audio
-  if (manifestAudio) {
-    if (
-      !Number.isInteger(manifestAudio.byteLength) ||
-      manifestAudio.byteLength <= 0 ||
-      offset + manifestAudio.byteLength > file.size
-    ) {
-      throw new BackupFormatError('This backup file is damaged')
+  if (manifestAudio && Array.isArray(manifestAudio.tracks) && manifestAudio.tracks.length > 0) {
+    const tracks: ParsedBackupAudio['tracks'] = []
+    for (const track of manifestAudio.tracks) {
+      if (
+        !Number.isInteger(track.byteLength) ||
+        track.byteLength <= 0 ||
+        offset + track.byteLength > file.size
+      ) {
+        throw new BackupFormatError('This backup file is damaged')
+      }
+      const mimeType = typeof track.mimeType === 'string' ? track.mimeType : 'audio/mpeg'
+      tracks.push({
+        mimeType,
+        durationMs: track.durationMs,
+        name: String(track.name || 'Audio track'),
+        blob: file.slice(offset, offset + track.byteLength, mimeType),
+      })
+      offset += track.byteLength
     }
-    const mimeType =
-      typeof manifestAudio.mimeType === 'string' ? manifestAudio.mimeType : 'audio/mpeg'
     audio = {
-      mimeType,
-      durationMs: manifestAudio.durationMs,
-      name: String(manifestAudio.name || 'Audio track'),
       defaultVolume: manifestAudio.defaultVolume,
-      blob: file.slice(offset, offset + manifestAudio.byteLength, mimeType),
+      fadeIn: manifestAudio.fadeIn !== false,
+      fadeOut: manifestAudio.fadeOut !== false,
+      tracks,
     }
   }
 
@@ -267,17 +299,26 @@ export async function importProjectBackup(
     if (parsed.audio) {
       // Best-effort: background music is a Plus perk, so restoring a
       // Plus-made backup on a free device keeps the clips and simply skips
-      // the track (setProjectAudio enforces the gate). A damaged audio
-      // section must not kill an otherwise intact import either.
-      const bytes = await parsed.audio.blob.arrayBuffer()
-      await setProjectAudio({
-        projectId: project.id,
-        blob: new Blob([bytes], { type: parsed.audio.mimeType }),
-        mimeType: parsed.audio.mimeType,
-        durationMs: parsed.audio.durationMs,
-        name: parsed.audio.name,
-        defaultVolume: parsed.audio.defaultVolume,
-      }).catch(() => undefined)
+      // the playlist (addProjectAudioTrack enforces the gate). A damaged
+      // audio section must not kill an otherwise intact import either.
+      try {
+        for (const track of parsed.audio.tracks) {
+          const bytes = await track.blob.arrayBuffer()
+          await addProjectAudioTrack({
+            projectId: project.id,
+            blob: new Blob([bytes], { type: track.mimeType }),
+            mimeType: track.mimeType,
+            durationMs: track.durationMs,
+            name: track.name,
+            // Playlist settings land with the first track; later adds keep them.
+            defaultVolume: parsed.audio.defaultVolume,
+            fadeIn: parsed.audio.fadeIn,
+            fadeOut: parsed.audio.fadeOut,
+          })
+        }
+      } catch {
+        // Plus gate (or a damaged track) — clips still imported fine.
+      }
     }
     return project
   } catch (error) {

--- a/src/lib/storage.test.ts
+++ b/src/lib/storage.test.ts
@@ -9,18 +9,23 @@ import {
   duplicateClip,
   getClip,
   getClipsForProject,
+  getProjectAudio,
   getSettings,
   getUndoSnapshot,
   listProjects,
   moveClip,
+  removeProjectAudio,
   renameProject,
   setOnboardingDismissed,
+  setProjectAudio,
   toStoredBlob,
   undoDeleteLastClip,
+  updateClipAudioVolume,
   updateClipTrim,
+  updateProjectAudioDefaultVolume,
 } from './storage'
 import { markWatermarkRemoved } from './entitlement'
-import { MAX_PROJECTS, effectiveDurationMs } from './types'
+import { DEFAULT_AUDIO_VOLUME, MAX_PROJECTS, effectiveDurationMs } from './types'
 
 function fakeBlob(label: string): Blob {
   return new Blob([label], { type: 'video/webm' })
@@ -168,6 +173,90 @@ describe('storage layer', () => {
     const stored = await getClip(clip.id)
     expect(stored?.blob).not.toBe(original)
     expect(await stored!.blob.text()).toBe('take-1')
+  })
+
+  it('gates background music behind the Plus purchase', async () => {
+    const project = await createProject('Free plan')
+    await expect(
+      setProjectAudio({
+        projectId: project.id,
+        blob: new Blob(['song'], { type: 'audio/mpeg' }),
+        mimeType: 'audio/mpeg',
+        durationMs: 30_000,
+        name: 'song.mp3',
+      }),
+    ).rejects.toThrow(/plus/i)
+    expect(await getProjectAudio(project.id)).toBeUndefined()
+  })
+
+  it('stores, updates, and removes a project audio track', async () => {
+    await markWatermarkRemoved('cs_test_storage')
+    const project = await createProject('With music')
+    const audio = await setProjectAudio({
+      projectId: project.id,
+      blob: new Blob(['song'], { type: 'audio/mpeg' }),
+      mimeType: 'audio/mpeg',
+      durationMs: 30_000,
+      name: 'song.mp3',
+    })
+    expect(audio.defaultVolume).toBe(DEFAULT_AUDIO_VOLUME)
+    expect(await (await getProjectAudio(project.id))!.blob.text()).toBe('song')
+
+    await updateProjectAudioDefaultVolume(project.id, 0.6)
+    expect((await getProjectAudio(project.id))?.defaultVolume).toBe(0.6)
+
+    // Replacing the track keeps the chosen default volume.
+    const replaced = await setProjectAudio({
+      projectId: project.id,
+      blob: new Blob(['other'], { type: 'audio/wav' }),
+      mimeType: 'audio/wav',
+      durationMs: 12_000,
+      name: 'other.wav',
+    })
+    expect(replaced.defaultVolume).toBe(0.6)
+
+    await removeProjectAudio(project.id)
+    expect(await getProjectAudio(project.id)).toBeUndefined()
+  })
+
+  it('drops the audio track when the project is deleted', async () => {
+    await markWatermarkRemoved('cs_test_storage')
+    const project = await createProject('Doomed')
+    await setProjectAudio({
+      projectId: project.id,
+      blob: new Blob(['song'], { type: 'audio/mpeg' }),
+      mimeType: 'audio/mpeg',
+      durationMs: 30_000,
+      name: 'song.mp3',
+    })
+    await deleteProject(project.id)
+    expect(await getProjectAudio(project.id)).toBeUndefined()
+  })
+
+  it('sets, clamps, clears, and duplicates per-clip music volumes', async () => {
+    const project = await createProject('Volumes')
+    const clip = await addClip({
+      projectId: project.id,
+      blob: fakeBlob('v'),
+      mimeType: 'video/webm',
+      durationMs: 1000,
+    })
+    expect(clip.audioVolume).toBeUndefined()
+
+    await updateClipAudioVolume(clip.id, 1.7)
+    expect((await getClip(clip.id))?.audioVolume).toBe(1)
+
+    await updateClipAudioVolume(clip.id, 0.4)
+    expect((await getClip(clip.id))?.audioVolume).toBe(0.4)
+
+    // Duplicates inherit the override.
+    const copy = await duplicateClip(clip.id)
+    expect((await getClip(copy.id))?.audioVolume).toBe(0.4)
+
+    await updateClipAudioVolume(clip.id, null)
+    const cleared = await getClip(clip.id)
+    expect(cleared?.audioVolume).toBeUndefined()
+    expect(cleared && 'audioVolume' in cleared).toBe(false)
   })
 
   it('does not leak AbortError unhandled rejections when a clip put fails', async () => {

--- a/src/lib/storage.test.ts
+++ b/src/lib/storage.test.ts
@@ -3,6 +3,7 @@ import {
   DB_NAME,
   __resetDbForTests,
   addClip,
+  addProjectAudioTrack,
   createProject,
   deleteClip,
   deleteProject,
@@ -14,15 +15,14 @@ import {
   getUndoSnapshot,
   listProjects,
   moveClip,
-  removeProjectAudio,
+  removeProjectAudioTrack,
   renameProject,
   setOnboardingDismissed,
-  setProjectAudio,
   toStoredBlob,
   undoDeleteLastClip,
   updateClipAudioVolume,
   updateClipTrim,
-  updateProjectAudioDefaultVolume,
+  updateProjectAudioSettings,
 } from './storage'
 import { markWatermarkRemoved } from './entitlement'
 import { DEFAULT_AUDIO_VOLUME, MAX_PROJECTS, effectiveDurationMs } from './types'
@@ -178,7 +178,7 @@ describe('storage layer', () => {
   it('gates background music behind the Plus purchase', async () => {
     const project = await createProject('Free plan')
     await expect(
-      setProjectAudio({
+      addProjectAudioTrack({
         projectId: project.id,
         blob: new Blob(['song'], { type: 'audio/mpeg' }),
         mimeType: 'audio/mpeg',
@@ -189,40 +189,52 @@ describe('storage layer', () => {
     expect(await getProjectAudio(project.id)).toBeUndefined()
   })
 
-  it('stores, updates, and removes a project audio track', async () => {
+  it('builds a playlist of sequential tracks with shared settings', async () => {
     await markWatermarkRemoved('cs_test_storage')
     const project = await createProject('With music')
-    const audio = await setProjectAudio({
+    const first = await addProjectAudioTrack({
       projectId: project.id,
       blob: new Blob(['song'], { type: 'audio/mpeg' }),
       mimeType: 'audio/mpeg',
       durationMs: 30_000,
       name: 'song.mp3',
     })
-    expect(audio.defaultVolume).toBe(DEFAULT_AUDIO_VOLUME)
-    expect(await (await getProjectAudio(project.id))!.blob.text()).toBe('song')
+    expect(first.defaultVolume).toBe(DEFAULT_AUDIO_VOLUME)
+    expect(first.fadeIn).toBe(true)
+    expect(first.fadeOut).toBe(true)
+    expect(first.tracks).toHaveLength(1)
+    expect(await first.tracks[0].blob.text()).toBe('song')
 
-    await updateProjectAudioDefaultVolume(project.id, 0.6)
-    expect((await getProjectAudio(project.id))?.defaultVolume).toBe(0.6)
+    await updateProjectAudioSettings(project.id, { defaultVolume: 0.6, fadeOut: false })
+    let audio = await getProjectAudio(project.id)
+    expect(audio?.defaultVolume).toBe(0.6)
+    expect(audio?.fadeIn).toBe(true)
+    expect(audio?.fadeOut).toBe(false)
 
-    // Replacing the track keeps the chosen default volume.
-    const replaced = await setProjectAudio({
+    // A second track appends and keeps the chosen settings.
+    const second = await addProjectAudioTrack({
       projectId: project.id,
       blob: new Blob(['other'], { type: 'audio/wav' }),
       mimeType: 'audio/wav',
       durationMs: 12_000,
       name: 'other.wav',
     })
-    expect(replaced.defaultVolume).toBe(0.6)
+    expect(second.tracks.map((track) => track.name)).toEqual(['song.mp3', 'other.wav'])
+    expect(second.defaultVolume).toBe(0.6)
+    expect(second.fadeOut).toBe(false)
 
-    await removeProjectAudio(project.id)
+    // Removing one track keeps the playlist; removing the last drops it.
+    await removeProjectAudioTrack(project.id, second.tracks[0].id)
+    audio = await getProjectAudio(project.id)
+    expect(audio?.tracks.map((track) => track.name)).toEqual(['other.wav'])
+    await removeProjectAudioTrack(project.id, audio!.tracks[0].id)
     expect(await getProjectAudio(project.id)).toBeUndefined()
   })
 
-  it('drops the audio track when the project is deleted', async () => {
+  it('drops the audio playlist when the project is deleted', async () => {
     await markWatermarkRemoved('cs_test_storage')
     const project = await createProject('Doomed')
-    await setProjectAudio({
+    await addProjectAudioTrack({
       projectId: project.id,
       blob: new Blob(['song'], { type: 'audio/mpeg' }),
       mimeType: 'audio/mpeg',

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -399,16 +399,21 @@ export async function updateClipAudioVolume(
   volume: number | null,
 ): Promise<ClipMeta> {
   const db = await getDb()
-  const clip = await db.get('clips', clipId)
-  if (!clip) throw new Error('Clip not found')
-
+  // Read + merge + write in one transaction so a concurrent clip mutation
+  // (trim, thumbs) can never be clobbered by a stale snapshot.
+  const tx = db.transaction('clips', 'readwrite')
+  const clip = await tx.store.get(clipId)
+  if (!clip) {
+    await tx.done.catch(() => undefined)
+    throw new Error('Clip not found')
+  }
   const updated: ClipRecord = { ...clip }
   if (volume === null) {
     delete updated.audioVolume
   } else {
     updated.audioVolume = clampVolume(volume)
   }
-  await db.put('clips', updated)
+  await completeTransaction([tx.store.put(updated)], tx)
   await touchProject(clip.projectId)
   return toMeta(updated)
 }
@@ -446,7 +451,6 @@ export async function addProjectAudioTrack(
     throw new Error('Background music is part of Kody Video Plus — the one-time $0.99 unlock.')
   }
   const durableBlob = await toStoredBlob(input.blob, input.mimeType)
-  const existing = await db.get('audio', input.projectId)
   const track: ProjectAudioTrack = {
     id: newId('track'),
     blob: durableBlob,
@@ -455,6 +459,10 @@ export async function addProjectAudioTrack(
     name: input.name,
     addedAt: Date.now(),
   }
+  // Read + merge + write in one transaction so overlapping playlist
+  // mutations can never clobber each other's tracks or settings.
+  const tx = db.transaction('audio', 'readwrite')
+  const existing = await tx.store.get(input.projectId)
   const record: ProjectAudioRecord = existing
     ? { ...existing, tracks: [...existing.tracks, track] }
     : {
@@ -464,7 +472,7 @@ export async function addProjectAudioTrack(
         fadeIn: input.fadeIn ?? true,
         fadeOut: input.fadeOut ?? true,
       }
-  await db.put('audio', record)
+  await completeTransaction([tx.store.put(record)], tx)
   await touchProject(input.projectId)
   return record
 }
@@ -475,14 +483,21 @@ export async function removeProjectAudioTrack(
   trackId: string,
 ): Promise<void> {
   const db = await getDb()
-  const audio = await db.get('audio', projectId)
-  if (!audio) return
-  const tracks = audio.tracks.filter((track) => track.id !== trackId)
-  if (tracks.length === 0) {
-    await db.delete('audio', projectId)
-  } else {
-    await db.put('audio', { ...audio, tracks })
+  const tx = db.transaction('audio', 'readwrite')
+  const audio = await tx.store.get(projectId)
+  if (!audio) {
+    await tx.done
+    return
   }
+  const tracks = audio.tracks.filter((track) => track.id !== trackId)
+  await completeTransaction(
+    [
+      tracks.length === 0
+        ? tx.store.delete(projectId)
+        : tx.store.put({ ...audio, tracks }),
+    ],
+    tx,
+  )
   await touchProject(projectId)
 }
 
@@ -503,8 +518,12 @@ export async function updateProjectAudioSettings(
   settings: ProjectAudioSettings,
 ): Promise<ProjectAudioRecord> {
   const db = await getDb()
-  const audio = await db.get('audio', projectId)
-  if (!audio) throw new Error('This project has no background music')
+  const tx = db.transaction('audio', 'readwrite')
+  const audio = await tx.store.get(projectId)
+  if (!audio) {
+    await tx.done.catch(() => undefined)
+    throw new Error('This project has no background music')
+  }
   const updated: ProjectAudioRecord = {
     ...audio,
     defaultVolume:
@@ -514,7 +533,7 @@ export async function updateProjectAudioSettings(
     fadeIn: settings.fadeIn ?? audio.fadeIn,
     fadeOut: settings.fadeOut ?? audio.fadeOut,
   }
-  await db.put('audio', updated)
+  await completeTransaction([tx.store.put(updated)], tx)
   await touchProject(projectId)
   return updated
 }

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -1,8 +1,10 @@
 import { openDB, type DBSchema, type IDBPDatabase } from 'idb'
 import { removeExportEntry } from './export/opfs'
 import {
+  DEFAULT_AUDIO_VOLUME,
   FREE_PROJECTS,
   MAX_PROJECTS,
+  clampVolume,
   newId,
   type AppMeta,
   type ClipId,
@@ -10,6 +12,7 @@ import {
   type ClipRecord,
   type DeletedClipSnapshot,
   type Project,
+  type ProjectAudioRecord,
   type ProjectId,
 } from './types'
 
@@ -32,10 +35,14 @@ interface ClipsDB extends DBSchema {
     key: string
     value: AppMeta
   }
+  audio: {
+    key: ProjectId
+    value: ProjectAudioRecord
+  }
 }
 
 export const DB_NAME = 'kody-video'
-const DB_VERSION = 1
+const DB_VERSION = 2
 
 let dbPromise: Promise<IDBPDatabase<ClipsDB>> | null = null
 
@@ -58,15 +65,21 @@ async function completeTransaction(
 export function getDb(): Promise<IDBPDatabase<ClipsDB>> {
   if (!dbPromise) {
     dbPromise = openDB<ClipsDB>(DB_NAME, DB_VERSION, {
-      upgrade(db) {
-        const projects = db.createObjectStore('projects', { keyPath: 'id' })
-        projects.createIndex('by-updated', 'updatedAt')
+      upgrade(db, oldVersion) {
+        if (oldVersion < 1) {
+          const projects = db.createObjectStore('projects', { keyPath: 'id' })
+          projects.createIndex('by-updated', 'updatedAt')
 
-        const clips = db.createObjectStore('clips', { keyPath: 'id' })
-        clips.createIndex('by-project', 'projectId')
+          const clips = db.createObjectStore('clips', { keyPath: 'id' })
+          clips.createIndex('by-project', 'projectId')
 
-        db.createObjectStore('undo', { keyPath: 'clip.projectId' })
-        db.createObjectStore('meta', { keyPath: 'key' })
+          db.createObjectStore('undo', { keyPath: 'clip.projectId' })
+          db.createObjectStore('meta', { keyPath: 'key' })
+        }
+        if (oldVersion < 2) {
+          // One optional background-audio track per project.
+          db.createObjectStore('audio', { keyPath: 'projectId' })
+        }
       },
     })
   }
@@ -182,7 +195,7 @@ export async function deleteProject(id: ProjectId): Promise<void> {
   const project = await db.get('projects', id)
   if (!project) return
 
-  const tx = db.transaction(['projects', 'clips', 'undo', 'meta'], 'readwrite')
+  const tx = db.transaction(['projects', 'clips', 'undo', 'meta', 'audio'], 'readwrite')
   // Read meta before queueing writes so a failed delete cannot reject while
   // we are still awaiting get — that would reintroduce the AbortError leak.
   const settings = await tx.objectStore('meta').get('settings')
@@ -190,6 +203,7 @@ export async function deleteProject(id: ProjectId): Promise<void> {
   const ops: Array<Promise<unknown>> = [
     ...project.clipIds.map((clipId) => clips.delete(clipId)),
     tx.objectStore('undo').delete(id),
+    tx.objectStore('audio').delete(id),
     tx.objectStore('projects').delete(id),
   ]
   const dropsCachedExport = settings?.lastExport?.projectId === id
@@ -260,6 +274,8 @@ export interface AddClipInput {
   /** Original capture time — used when importing backups so chapter titles
    * keep the real recording time. Defaults to now. */
   createdAt?: number
+  /** Background-music volume override — used when importing backups. */
+  audioVolume?: number
 }
 
 /**
@@ -298,6 +314,9 @@ export async function addClip(input: AddClipInput): Promise<ClipRecord> {
     lat: input.lat,
     lng: input.lng,
     locationAccuracyM: input.locationAccuracyM,
+  }
+  if (input.audioVolume !== undefined) {
+    clip.audioVolume = clampVolume(input.audioVolume)
   }
 
   const tx = db.transaction(['clips', 'projects'], 'readwrite')
@@ -370,6 +389,89 @@ export async function updateClipTrim(
   await db.put('clips', updated)
   await touchProject(clip.projectId)
   return toMeta(updated)
+}
+
+/** Set a clip's background-music volume override; null returns it to the
+ * project audio track's default. */
+export async function updateClipAudioVolume(
+  clipId: ClipId,
+  volume: number | null,
+): Promise<ClipMeta> {
+  const db = await getDb()
+  const clip = await db.get('clips', clipId)
+  if (!clip) throw new Error('Clip not found')
+
+  const updated: ClipRecord = { ...clip }
+  if (volume === null) {
+    delete updated.audioVolume
+  } else {
+    updated.audioVolume = clampVolume(volume)
+  }
+  await db.put('clips', updated)
+  await touchProject(clip.projectId)
+  return toMeta(updated)
+}
+
+export async function getProjectAudio(
+  projectId: ProjectId,
+): Promise<ProjectAudioRecord | undefined> {
+  const db = await getDb()
+  return db.get('audio', projectId)
+}
+
+export interface SetProjectAudioInput {
+  projectId: ProjectId
+  blob: Blob
+  mimeType: string
+  durationMs: number
+  name: string
+  defaultVolume?: number
+}
+
+/** Attach (or replace) a project's background-audio track. Replacing keeps
+ * the previously chosen default volume unless a new one is given. */
+export async function setProjectAudio(input: SetProjectAudioInput): Promise<ProjectAudioRecord> {
+  const db = await getDb()
+  // Background music is a Kody Video Plus perk — enforced here so every
+  // path that could attach a track (editor picker, backup import) hits the
+  // same gate, like the project cap in createProject.
+  const settings = await getSettings()
+  if (settings.watermarkRemoved !== true) {
+    throw new Error('Background music is part of Kody Video Plus — the one-time $0.99 unlock.')
+  }
+  const durableBlob = await toStoredBlob(input.blob, input.mimeType)
+  const existing = await db.get('audio', input.projectId)
+  const record: ProjectAudioRecord = {
+    projectId: input.projectId,
+    blob: durableBlob,
+    mimeType: input.mimeType,
+    durationMs: input.durationMs,
+    name: input.name,
+    defaultVolume: clampVolume(input.defaultVolume ?? existing?.defaultVolume ?? DEFAULT_AUDIO_VOLUME),
+    addedAt: Date.now(),
+  }
+  await db.put('audio', record)
+  await touchProject(input.projectId)
+  return record
+}
+
+export async function removeProjectAudio(projectId: ProjectId): Promise<void> {
+  const db = await getDb()
+  await db.delete('audio', projectId)
+  await touchProject(projectId)
+}
+
+export async function updateProjectAudioDefaultVolume(
+  projectId: ProjectId,
+  defaultVolume: number,
+): Promise<ProjectAudioRecord> {
+  const db = await getDb()
+  const audio = await db.get('audio', projectId)
+  if (!audio) throw new Error('This project has no audio track')
+  const updated: ProjectAudioRecord = { ...audio, defaultVolume: clampVolume(defaultVolume) }
+  await db.put('audio', updated)
+  await touchProject(projectId)
+  return updated
 }
 
 export async function reorderClips(projectId: ProjectId, clipIds: ClipId[]): Promise<Project> {

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -13,6 +13,7 @@ import {
   type DeletedClipSnapshot,
   type Project,
   type ProjectAudioRecord,
+  type ProjectAudioTrack,
   type ProjectId,
 } from './types'
 
@@ -419,18 +420,23 @@ export async function getProjectAudio(
   return db.get('audio', projectId)
 }
 
-export interface SetProjectAudioInput {
+export interface AddProjectAudioTrackInput {
   projectId: ProjectId
   blob: Blob
   mimeType: string
   durationMs: number
   name: string
+  /** Initial playlist settings — only honored when this is the first track. */
   defaultVolume?: number
+  fadeIn?: boolean
+  fadeOut?: boolean
 }
 
-/** Attach (or replace) a project's background-audio track. Replacing keeps
- * the previously chosen default volume unless a new one is given. */
-export async function setProjectAudio(input: SetProjectAudioInput): Promise<ProjectAudioRecord> {
+/** Append a track to the project's background-music playlist (creating the
+ * playlist with default settings when this is the first track). */
+export async function addProjectAudioTrack(
+  input: AddProjectAudioTrackInput,
+): Promise<ProjectAudioRecord> {
   const db = await getDb()
   // Background music is a Kody Video Plus perk — enforced here so every
   // path that could attach a track (editor picker, backup import) hits the
@@ -441,18 +447,43 @@ export async function setProjectAudio(input: SetProjectAudioInput): Promise<Proj
   }
   const durableBlob = await toStoredBlob(input.blob, input.mimeType)
   const existing = await db.get('audio', input.projectId)
-  const record: ProjectAudioRecord = {
-    projectId: input.projectId,
+  const track: ProjectAudioTrack = {
+    id: newId('track'),
     blob: durableBlob,
     mimeType: input.mimeType,
     durationMs: input.durationMs,
     name: input.name,
-    defaultVolume: clampVolume(input.defaultVolume ?? existing?.defaultVolume ?? DEFAULT_AUDIO_VOLUME),
     addedAt: Date.now(),
   }
+  const record: ProjectAudioRecord = existing
+    ? { ...existing, tracks: [...existing.tracks, track] }
+    : {
+        projectId: input.projectId,
+        tracks: [track],
+        defaultVolume: clampVolume(input.defaultVolume ?? DEFAULT_AUDIO_VOLUME),
+        fadeIn: input.fadeIn ?? true,
+        fadeOut: input.fadeOut ?? true,
+      }
   await db.put('audio', record)
   await touchProject(input.projectId)
   return record
+}
+
+/** Remove one playlist track; removing the last one drops the playlist. */
+export async function removeProjectAudioTrack(
+  projectId: ProjectId,
+  trackId: string,
+): Promise<void> {
+  const db = await getDb()
+  const audio = await db.get('audio', projectId)
+  if (!audio) return
+  const tracks = audio.tracks.filter((track) => track.id !== trackId)
+  if (tracks.length === 0) {
+    await db.delete('audio', projectId)
+  } else {
+    await db.put('audio', { ...audio, tracks })
+  }
+  await touchProject(projectId)
 }
 
 export async function removeProjectAudio(projectId: ProjectId): Promise<void> {
@@ -461,14 +492,28 @@ export async function removeProjectAudio(projectId: ProjectId): Promise<void> {
   await touchProject(projectId)
 }
 
-export async function updateProjectAudioDefaultVolume(
+export interface ProjectAudioSettings {
+  defaultVolume?: number
+  fadeIn?: boolean
+  fadeOut?: boolean
+}
+
+export async function updateProjectAudioSettings(
   projectId: ProjectId,
-  defaultVolume: number,
+  settings: ProjectAudioSettings,
 ): Promise<ProjectAudioRecord> {
   const db = await getDb()
   const audio = await db.get('audio', projectId)
-  if (!audio) throw new Error('This project has no audio track')
-  const updated: ProjectAudioRecord = { ...audio, defaultVolume: clampVolume(defaultVolume) }
+  if (!audio) throw new Error('This project has no background music')
+  const updated: ProjectAudioRecord = {
+    ...audio,
+    defaultVolume:
+      settings.defaultVolume !== undefined
+        ? clampVolume(settings.defaultVolume)
+        : audio.defaultVolume,
+    fadeIn: settings.fadeIn ?? audio.fadeIn,
+    fadeOut: settings.fadeOut ?? audio.fadeOut,
+  }
   await db.put('audio', updated)
   await touchProject(projectId)
   return updated

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -45,24 +45,40 @@ export interface DeletedClipSnapshot {
   deletedAt: number
 }
 
-/** One optional background-audio track per project, played under the clips. */
-export interface ProjectAudioMeta {
-  projectId: ProjectId
+/** One entry in a project's background-music playlist. */
+export interface ProjectAudioTrack {
+  id: string
+  blob: Blob
   mimeType: string
   durationMs: number
   /** Display name (the picked file's name). */
   name: string
-  /** Baseline volume (0–1) for clips without a per-clip override. */
-  defaultVolume: number
   addedAt: number
 }
 
-export interface ProjectAudioRecord extends ProjectAudioMeta {
-  blob: Blob
+/**
+ * A project's background music: tracks play one after the other under the
+ * clips until the film ends (the last one is cut off there — nothing loops),
+ * at a default volume clips can override individually.
+ */
+export interface ProjectAudioRecord {
+  projectId: ProjectId
+  tracks: ProjectAudioTrack[]
+  /** Baseline volume (0–1) for clips without a per-clip override. */
+  defaultVolume: number
+  /** Ease the music in at the start of the film (default on). */
+  fadeIn: boolean
+  /** Ease the music out at the end of the film (default on). */
+  fadeOut: boolean
 }
 
 /** Sits under speech without drowning it — the out-of-the-box music level. */
 export const DEFAULT_AUDIO_VOLUME = 0.25
+
+/** Total playlist length — what the music can cover before going silent. */
+export function projectAudioTotalDurationMs(audio: Pick<ProjectAudioRecord, 'tracks'>): number {
+  return audio.tracks.reduce((sum, track) => sum + track.durationMs, 0)
+}
 
 export function clampVolume(volume: number): number {
   if (!Number.isFinite(volume)) return DEFAULT_AUDIO_VOLUME

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -26,6 +26,9 @@ export interface ClipMeta {
   lat?: number
   lng?: number
   locationAccuracyM?: number
+  /** Background-music volume (0–1) while this clip plays. Absent = the
+   * project audio track's default volume. */
+  audioVolume?: number
 }
 
 export interface ClipRecord extends ClipMeta {
@@ -40,6 +43,38 @@ export interface DeletedClipSnapshot {
   clip: ClipRecord
   index: number
   deletedAt: number
+}
+
+/** One optional background-audio track per project, played under the clips. */
+export interface ProjectAudioMeta {
+  projectId: ProjectId
+  mimeType: string
+  durationMs: number
+  /** Display name (the picked file's name). */
+  name: string
+  /** Baseline volume (0–1) for clips without a per-clip override. */
+  defaultVolume: number
+  addedAt: number
+}
+
+export interface ProjectAudioRecord extends ProjectAudioMeta {
+  blob: Blob
+}
+
+/** Sits under speech without drowning it — the out-of-the-box music level. */
+export const DEFAULT_AUDIO_VOLUME = 0.25
+
+export function clampVolume(volume: number): number {
+  if (!Number.isFinite(volume)) return DEFAULT_AUDIO_VOLUME
+  return Math.max(0, Math.min(1, volume))
+}
+
+/** Background-music volume while a clip plays: its override or the default. */
+export function clipAudioVolume(
+  clip: Pick<ClipMeta, 'audioVolume'>,
+  defaultVolume: number,
+): number {
+  return clampVolume(clip.audioVolume ?? defaultVolume)
 }
 
 export interface AppMeta {

--- a/src/pages/home-page.tsx
+++ b/src/pages/home-page.tsx
@@ -17,7 +17,7 @@ import {
   projectBackupFilename,
   serializeProject,
 } from '../lib/project-transfer'
-import { deleteProject, getClipsForProject, renameProject } from '../lib/storage'
+import { deleteProject, getClipsForProject, getProjectAudio, renameProject } from '../lib/storage'
 import { clearExportCache } from '../lib/export/export-cache'
 import { reportError } from '../lib/error-reporting'
 import { canPromptInstall, promptInstall, subscribeInstallPrompt } from '../lib/install-prompt'
@@ -134,7 +134,8 @@ export function HomePage(handle: Handle) {
             ? await prefetched.clips
             : await getClipsForProject(project.id)
         if (clips.length === 0) throw new Error('Nothing to back up — this project has no clips.')
-        const backup = serializeProject(project, clips)
+        const audio = await getProjectAudio(project.id)
+        const backup = serializeProject(project, clips, audio)
         const filename = projectBackupFilename(project.name)
         const sizeLabel = formatBytes(backup.size)
         // Android's share sheet fails (often silently) on very large files —

--- a/src/pages/home-page.tsx
+++ b/src/pages/home-page.tsx
@@ -35,6 +35,7 @@ import {
   NEW_PROJECT_ID,
   formatDuration,
   type ClipRecord,
+  type ProjectAudioRecord,
 } from '../lib/types'
 
 /** Android share targets get flaky well below this; bigger backups download. */
@@ -66,7 +67,11 @@ export function HomePage(handle: Handle) {
   let restoring = false
   // Prefetched when the options sheet opens so the Save-backup tap keeps its
   // user activation (Web Share needs it; an IndexedDB read can outlive it).
-  let prefetchedClips: { projectId: string; clips: Promise<ClipRecord[]> } | null = null
+  let prefetchedClips: {
+    projectId: string
+    clips: Promise<ClipRecord[]>
+    audio: Promise<ProjectAudioRecord | undefined>
+  } | null = null
 
   /** Monotonic request id: an older in-flight load (e.g. the mount load
    * resolving after a delete's refresh) must never overwrite newer state. */
@@ -129,12 +134,14 @@ export function HomePage(handle: Handle) {
       void handle.update()
       try {
         const prefetched = prefetchedClips
-        const clips =
-          prefetched && prefetched.projectId === project.id
-            ? await prefetched.clips
-            : await getClipsForProject(project.id)
+        const usePrefetch = prefetched !== null && prefetched.projectId === project.id
+        const clips = usePrefetch
+          ? await prefetched.clips
+          : await getClipsForProject(project.id)
         if (clips.length === 0) throw new Error('Nothing to back up — this project has no clips.')
-        const audio = await getProjectAudio(project.id)
+        const audio = usePrefetch
+          ? await prefetched.audio
+          : await getProjectAudio(project.id)
         const backup = serializeProject(project, clips, audio)
         const filename = projectBackupFilename(project.name)
         const sizeLabel = formatBytes(backup.size)
@@ -334,6 +341,7 @@ export function HomePage(handle: Handle) {
                     prefetchedClips = {
                       projectId: project.id,
                       clips: getClipsForProject(project.id),
+                      audio: getProjectAudio(project.id),
                     }
                     menuProject = project
                     void handle.update()

--- a/src/pages/project-page.tsx
+++ b/src/pages/project-page.tsx
@@ -8,6 +8,7 @@ import { PlaybackOverlay } from '../components/playback-overlay'
 import { RecordScreen, type ToastAction } from '../components/record-screen'
 import { createCamera } from '../lib/camera'
 import { RestoreSheet } from '../components/restore-sheet'
+import { UpsellSheet } from '../components/upsell-sheet'
 import { REMOVE_WATERMARK_LINK } from '../lib/entitlement'
 import { buildClipsZip } from '../lib/clips-zip'
 import { clearExportMarker, markExportStarted, reportError } from '../lib/error-reporting'
@@ -87,6 +88,7 @@ export function ProjectPage(handle: Handle<ProjectPageProps>) {
   let toast: ToastState | null = null
   let exportState: ExportUiState | null = null
   let restoring = false
+  let upselling = false
   /** In-flight share/save COUNT (concurrent actions must not clear each
    * other's busy state) — the export sheet must not dismiss while > 0. */
   let exportActionCount = 0
@@ -122,6 +124,7 @@ export function ProjectPage(handle: Handle<ProjectPageProps>) {
         data = {
           project: null,
           clips: [],
+          audio: null,
           canUndo: false,
           onboardingDismissed: true,
           watermarkRemoved: false,
@@ -194,6 +197,7 @@ export function ProjectPage(handle: Handle<ProjectPageProps>) {
     if (!data) return
     const clips = data.clips
     const project = data.project
+    const audio = data.audio
     if (clips.length === 0) return
     const runId = exportRun + 1
     exportRun = runId
@@ -212,7 +216,7 @@ export function ProjectPage(handle: Handle<ProjectPageProps>) {
     }
 
     const watermarked = !data.watermarkRemoved
-    const signature = exportSignature(clips, watermarked)
+    const signature = exportSignature(clips, watermarked, audio)
     // Stop camera/mic immediately rather than waiting on record-screen
     // unmount. On iOS the combined mic+camera session can hold decoder
     // slots past the first paints, and WebKit reports that race as
@@ -284,6 +288,9 @@ export function ProjectPage(handle: Handle<ProjectPageProps>) {
         const result = await exportProject(clips, {
           audioContext,
           watermark: watermarked,
+          background: audio
+            ? { blob: audio.blob, defaultVolume: audio.defaultVolume }
+            : undefined,
           getPreviewCanvas: () => previewCanvas,
           onProgress: (ratio) => {
             if (exportRun !== runId) return
@@ -438,6 +445,12 @@ export function ProjectPage(handle: Handle<ProjectPageProps>) {
             project={project}
             ensureProjectId={ensureProjectId}
             clips={clips}
+            audio={data.audio}
+            plus={data.watermarkRemoved}
+            onUpsell={() => {
+              upselling = true
+              void handle.update()
+            }}
             canUndo={data.canUndo}
             interactionLocked={overlayOpen}
             onOpenCamera={() => {
@@ -457,6 +470,7 @@ export function ProjectPage(handle: Handle<ProjectPageProps>) {
         {playing ? (
           <PlaybackOverlay
             clips={clips}
+            audio={data.audio}
             onClose={() => {
               playing = false
               void handle.update()
@@ -540,6 +554,20 @@ export function ProjectPage(handle: Handle<ProjectPageProps>) {
             onRetry={() => startExport({ force: true })}
             onReExport={() => startExport({ force: true })}
             onClose={closeExport}
+          />
+        ) : null}
+
+        {upselling ? (
+          <UpsellSheet
+            onClose={() => {
+              upselling = false
+              void handle.update()
+            }}
+            onRestore={() => {
+              upselling = false
+              restoring = true
+              void handle.update()
+            }}
           />
         ) : null}
 

--- a/src/pages/project-page.tsx
+++ b/src/pages/project-page.tsx
@@ -288,9 +288,15 @@ export function ProjectPage(handle: Handle<ProjectPageProps>) {
         const result = await exportProject(clips, {
           audioContext,
           watermark: watermarked,
-          background: audio
-            ? { blob: audio.blob, defaultVolume: audio.defaultVolume }
-            : undefined,
+          background:
+            audio && audio.tracks.length > 0
+              ? {
+                  tracks: audio.tracks.map((track) => ({ blob: track.blob })),
+                  defaultVolume: audio.defaultVolume,
+                  fadeIn: audio.fadeIn,
+                  fadeOut: audio.fadeOut,
+                }
+              : undefined,
           getPreviewCanvas: () => previewCanvas,
           onProgress: (ratio) => {
             if (exportRun !== runId) return

--- a/src/styles/editor.css
+++ b/src/styles/editor.css
@@ -484,6 +484,67 @@
   white-space: nowrap;
 }
 
+.audio-playlist-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-height: 26px;
+  flex-wrap: wrap;
+}
+
+.audio-add-track {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  min-height: 26px;
+  padding: 2px 10px;
+  border-radius: 999px;
+  font-size: 0.74rem;
+  font-weight: 600;
+  color: var(--accent);
+  background: color-mix(in srgb, var(--accent) 14%, transparent);
+  flex: 0 0 auto;
+}
+
+.audio-add-track:disabled {
+  opacity: 0.4;
+  cursor: wait;
+}
+
+.audio-coverage-hint {
+  font-size: 0.72rem;
+  font-variant-numeric: tabular-nums;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.audio-fades {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  margin-left: auto;
+  flex: 0 0 auto;
+}
+
+.audio-fade-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  font-size: 0.74rem;
+  font-weight: 600;
+  color: var(--ink-muted);
+  cursor: pointer;
+}
+
+.audio-fade-toggle input[type='checkbox'] {
+  width: 15px;
+  height: 15px;
+  accent-color: var(--accent);
+  margin: 0;
+}
+
 .audio-track-duration {
   font-size: 0.75rem;
   font-variant-numeric: tabular-nums;

--- a/src/styles/editor.css
+++ b/src/styles/editor.css
@@ -429,6 +429,138 @@
   flex: 1;
 }
 
+/* Background-music strip under the timeline */
+.audio-strip {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.audio-strip .audio-add {
+  align-self: flex-start;
+  min-height: 36px;
+  padding: 0 14px;
+  font-size: 0.84rem;
+}
+
+.audio-plus-lock {
+  display: grid;
+  place-items: center;
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  color: var(--ink-strong);
+  background: var(--accent);
+  margin-left: 2px;
+}
+
+.audio-track-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-height: 28px;
+}
+
+.audio-track-icon {
+  display: grid;
+  place-items: center;
+  width: 22px;
+  height: 22px;
+  border-radius: 7px;
+  color: var(--accent);
+  background: color-mix(in srgb, var(--accent) 16%, transparent);
+  flex: 0 0 auto;
+}
+
+.audio-track-name {
+  min-width: 0;
+  padding: 2px 0;
+  font-size: 0.84rem;
+  font-weight: 600;
+  color: var(--ink);
+  text-align: left;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.audio-track-duration {
+  font-size: 0.75rem;
+  font-variant-numeric: tabular-nums;
+  flex: 0 0 auto;
+  margin-left: auto;
+}
+
+.audio-remove {
+  width: 30px;
+  height: 30px;
+  min-height: 30px;
+  flex: 0 0 auto;
+}
+
+.audio-volume-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-height: 26px;
+}
+
+.audio-volume-label {
+  flex: 0 0 74px;
+  font-size: 0.74rem;
+  font-weight: 600;
+  color: var(--ink-muted);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.audio-volume-row input[type='range'] {
+  flex: 1 1 auto;
+  min-width: 0;
+  height: 26px;
+  accent-color: var(--accent);
+  touch-action: pan-y;
+}
+
+.audio-volume-value {
+  flex: 0 0 38px;
+  text-align: right;
+  font-size: 0.76rem;
+  font-variant-numeric: tabular-nums;
+  color: var(--ink);
+}
+
+.audio-volume-reset {
+  flex: 0 0 auto;
+  min-height: 26px;
+  padding: 2px 10px;
+  border-radius: 999px;
+  font-size: 0.72rem;
+  font-weight: 600;
+  color: var(--accent);
+  background: color-mix(in srgb, var(--accent) 14%, transparent);
+}
+
+.audio-volume-reset:disabled {
+  opacity: 0.35;
+  cursor: not-allowed;
+}
+
+/* Per-clip music-volume badge on timeline tiles */
+.clip-thumb .clip-audio-badge {
+  position: absolute;
+  left: 4px;
+  top: 4px;
+  font-size: 0.62rem;
+  color: #fff;
+  background: rgba(0, 0, 0, 0.55);
+  padding: 2px 5px;
+  border-radius: 999px;
+  font-variant-numeric: tabular-nums;
+  pointer-events: none;
+}
+
 /* Bottom clip action bar */
 .editor-actions {
   display: flex;

--- a/tests/e2e/background-music.spec.ts
+++ b/tests/e2e/background-music.spec.ts
@@ -1,0 +1,272 @@
+import { test, expect, type Page } from '@playwright/test'
+import {
+  openSeededProject,
+  seedProject,
+  unlockPlus,
+  waitForCameraReady,
+} from './helpers'
+
+/** Tiny mono 16-bit PCM WAV — decodable everywhere, generated in-test. */
+function makeWavFile(durationSec = 4, freq = 440) {
+  const rate = 8000
+  const samples = Math.round(durationSec * rate)
+  const dataSize = samples * 2
+  const buffer = Buffer.alloc(44 + dataSize)
+  buffer.write('RIFF', 0)
+  buffer.writeUInt32LE(36 + dataSize, 4)
+  buffer.write('WAVE', 8)
+  buffer.write('fmt ', 12)
+  buffer.writeUInt32LE(16, 16)
+  buffer.writeUInt16LE(1, 20)
+  buffer.writeUInt16LE(1, 22)
+  buffer.writeUInt32LE(rate, 24)
+  buffer.writeUInt32LE(rate * 2, 28)
+  buffer.writeUInt16LE(2, 32)
+  buffer.writeUInt16LE(16, 34)
+  buffer.write('data', 36)
+  buffer.writeUInt32LE(dataSize, 40)
+  for (let i = 0; i < samples; i += 1) {
+    buffer.writeInt16LE(Math.round(Math.sin((2 * Math.PI * freq * i) / rate) * 12000), 44 + i * 2)
+  }
+  return { name: 'test-song.wav', mimeType: 'audio/wav', buffer }
+}
+
+async function openEditor(page: Page): Promise<void> {
+  await page.getByRole('button', { name: 'Open editor' }).click()
+  await expect(page.locator('.editor-screen')).toBeVisible()
+}
+
+async function openPlusEditorWithClips(page: Page, clips: number): Promise<string> {
+  const projectId = await seedProject(page, { clips, clipMs: 3000 })
+  await unlockPlus(page)
+  await page.goto(`/project/${projectId}`)
+  await waitForCameraReady(page)
+  await openEditor(page)
+  return projectId
+}
+
+async function addMusic(page: Page): Promise<void> {
+  const chooserPromise = page.waitForEvent('filechooser')
+  await page.getByRole('button', { name: 'Add background music' }).click()
+  const chooser = await chooserPromise
+  await chooser.setFiles(makeWavFile())
+  await expect(page.locator('.audio-track-name')).toHaveText('test-song.wav', {
+    timeout: 15_000,
+  })
+}
+
+/** Range inputs need value + input/change events, not fill(). */
+async function setSlider(page: Page, ariaLabel: string | RegExp, value: number): Promise<void> {
+  await page.getByRole('slider', { name: ariaLabel }).evaluate((el, v) => {
+    const input = el as HTMLInputElement
+    input.value = String(v)
+    input.dispatchEvent(new Event('input', { bubbles: true }))
+    input.dispatchEvent(new Event('change', { bubbles: true }))
+  }, value)
+}
+
+async function storedAudio(page: Page) {
+  return page.evaluate(async () => {
+    const storage = await import('/src/lib/storage.ts')
+    const projects = await storage.listProjects()
+    const audio = await storage.getProjectAudio(projects[0]!.id)
+    return audio
+      ? {
+          name: audio.name,
+          durationMs: audio.durationMs,
+          defaultVolume: audio.defaultVolume,
+          size: audio.blob.size,
+        }
+      : null
+  })
+}
+
+async function storedClipVolumes(page: Page): Promise<Array<number | null>> {
+  return page.evaluate(async () => {
+    const storage = await import('/src/lib/storage.ts')
+    const projects = await storage.listProjects()
+    const clips = await storage.getClipMetasForProject(projects[0]!.id)
+    return clips.map((clip: { audioVolume?: number }) => clip.audioVolume ?? null)
+  })
+}
+
+test.describe('background music', () => {
+  test('free plan shows the locked Add music button and opens the Plus upsell', async ({
+    page,
+  }) => {
+    await openSeededProject(page, { clips: 1 })
+    await openEditor(page)
+
+    const locked = page.getByRole('button', { name: /Add background music.*Plus/ })
+    await expect(locked).toBeVisible()
+    await locked.click()
+    const sheet = page.getByRole('dialog', { name: 'Kody Video Plus' })
+    await expect(sheet).toBeVisible()
+    await expect(sheet).toContainText(/background music/i)
+    await sheet.getByRole('button', { name: 'Not now' }).click()
+    await expect(sheet).toBeHidden()
+    expect(await storedAudio(page)).toBeNull()
+  })
+
+  test('adds a track, sets default and per-clip volumes, resets, and removes', async ({
+    page,
+  }) => {
+    await openPlusEditorWithClips(page, 2)
+    await addMusic(page)
+    await expect(page.locator('.toast')).toContainText(/music added/i)
+
+    const audio = await storedAudio(page)
+    expect(audio?.name).toBe('test-song.wav')
+    expect(audio?.durationMs).toBeGreaterThan(3000)
+    expect(audio?.defaultVolume).toBeCloseTo(0.25)
+    expect(audio?.size).toBeGreaterThan(1000)
+
+    // Default volume slider persists.
+    await setSlider(page, 'Default music volume', 40)
+    await expect.poll(async () => (await storedAudio(page))?.defaultVolume).toBeCloseTo(0.4)
+
+    // Per-clip override on the selected (last) clip.
+    const tiles = page.locator('.clip-thumb[data-clip-id]')
+    await expect(tiles.last()).toHaveClass(/selected/)
+    await setSlider(page, /Music volume during clip 2/, 60)
+    await expect.poll(async () => await storedClipVolumes(page)).toEqual([null, 0.6])
+    // The override badge appears on the tile and the row drops "default".
+    await expect(tiles.last().locator('.clip-audio-badge')).toHaveText(/60%/)
+
+    // Selecting the other clip shows the default-following row.
+    await tiles.first().click()
+    await expect(page.locator('.audio-volume-label').first()).toContainText('Clip 1 · default')
+
+    // Reset returns clip 2 to the default.
+    await tiles.last().click()
+    await page.getByRole('button', { name: /Reset this clip/ }).click()
+    await expect.poll(async () => await storedClipVolumes(page)).toEqual([null, null])
+    await expect(tiles.last().locator('.clip-audio-badge')).toHaveCount(0)
+
+    // Remove the track entirely.
+    await page.getByRole('button', { name: 'Remove background music' }).click()
+    await expect(page.getByRole('button', { name: 'Add background music' })).toBeVisible()
+    expect(await storedAudio(page)).toBeNull()
+  })
+
+  test('export mixes the music at per-clip volumes with ramped transitions', async ({
+    page,
+  }) => {
+    test.slow()
+    // Two 3s fixture clips (video-only — the fixture encoder adds no audio
+    // track), so every decodable sample in the export's audio IS the music.
+    await openPlusEditorWithClips(page, 2)
+
+    const measured = await page.evaluate(async () => {
+      const storage = await import('/src/lib/storage.ts')
+      const { exportProject } = await import('/src/lib/export/index.ts')
+      const { decodeBackgroundAudio } = await import('/src/lib/export/shared.ts')
+
+      const project = (await storage.listProjects())[0]!
+      const clips = await storage.getClipsForProject(project.id)
+
+      // Synthesize a constant-amplitude sine WAV in-page as the track.
+      const rate = 8000
+      const seconds = 4
+      const samples = rate * seconds
+      const bytes = new DataView(new ArrayBuffer(44 + samples * 2))
+      const writeAscii = (offset: number, text: string) => {
+        for (let i = 0; i < text.length; i += 1) bytes.setUint8(offset + i, text.charCodeAt(i))
+      }
+      writeAscii(0, 'RIFF')
+      bytes.setUint32(4, 36 + samples * 2, true)
+      writeAscii(8, 'WAVE')
+      writeAscii(12, 'fmt ')
+      bytes.setUint32(16, 16, true)
+      bytes.setUint16(20, 1, true)
+      bytes.setUint16(22, 1, true)
+      bytes.setUint32(24, rate, true)
+      bytes.setUint32(28, rate * 2, true)
+      bytes.setUint16(32, 2, true)
+      bytes.setUint16(34, 16, true)
+      writeAscii(36, 'data')
+      bytes.setUint32(40, samples * 2, true)
+      for (let i = 0; i < samples; i += 1) {
+        bytes.setInt16(44 + i * 2, Math.round(Math.sin((2 * Math.PI * 440 * i) / rate) * 16000), true)
+      }
+      const audio = await storage.setProjectAudio({
+        projectId: project.id,
+        blob: new Blob([bytes.buffer], { type: 'audio/wav' }),
+        mimeType: 'audio/wav',
+        durationMs: seconds * 1000,
+        name: 'sine.wav',
+      })
+      // Clip 1 follows the 0.25 default; clip 2 is overridden to full volume.
+      await storage.updateClipAudioVolume(clips[1]!.id, 1)
+      const updatedClips = await storage.getClipsForProject(project.id)
+
+      const result = await exportProject(updatedClips, {
+        watermark: false,
+        background: { blob: audio.blob, defaultVolume: audio.defaultVolume },
+      })
+
+      const decoded = await decodeBackgroundAudio(result.blob, 48000)
+      if (!decoded) return null
+      const data = decoded.getChannelData(0)
+      const rms = (fromSec: number, toSec: number) => {
+        const from = Math.floor(fromSec * decoded.sampleRate)
+        const to = Math.min(Math.floor(toSec * decoded.sampleRate), data.length)
+        let sum = 0
+        for (let i = from; i < to; i += 1) sum += data[i]! * data[i]!
+        return Math.sqrt(sum / Math.max(1, to - from))
+      }
+      return {
+        durationSec: decoded.duration,
+        // Steady windows away from the fade-in and the 3s boundary ramp.
+        clip1: rms(1.0, 2.5),
+        clip2: rms(4.0, 5.5),
+        fadeIn: rms(0, 0.08),
+      }
+    })
+
+    expect(measured).not.toBeNull()
+    // Both clips carry audible music…
+    expect(measured!.clip1).toBeGreaterThan(0.02)
+    // …and the overridden clip is decisively louder (4× volume ⇒ ~4× RMS).
+    expect(measured!.clip2 / measured!.clip1).toBeGreaterThan(2)
+    expect(measured!.clip2 / measured!.clip1).toBeLessThan(8)
+    // The film opens with the fade-in, not a full-volume slam.
+    expect(measured!.fadeIn).toBeLessThan(measured!.clip1)
+    expect(measured!.durationSec).toBeGreaterThan(5.5)
+  })
+
+  test('preview playback plays the music and ramps toward each clip volume', async ({
+    page,
+  }) => {
+    await openPlusEditorWithClips(page, 2)
+    await addMusic(page)
+
+    // Clip 2 (selected) gets a louder override so the ramp is observable.
+    await setSlider(page, /Music volume during clip 2/, 80)
+    await expect.poll(async () => await storedClipVolumes(page)).toEqual([null, 0.8])
+
+    await page.getByRole('button', { name: 'Play project preview' }).click()
+    const overlay = page.locator('.playback-overlay')
+    await expect(overlay).toBeVisible()
+
+    const music = overlay.locator('audio')
+    await expect(music).toHaveCount(1)
+    // Music is playing and gliding up toward clip 1's default volume (0.25).
+    await expect
+      .poll(() => music.evaluate((el) => !(el as HTMLAudioElement).paused))
+      .toBe(true)
+    await expect
+      .poll(() => music.evaluate((el) => (el as HTMLAudioElement).volume), { timeout: 5000 })
+      .toBeGreaterThan(0.15)
+
+    // Skip to clip 2: the volume glides up toward the 0.8 override.
+    await overlay.getByRole('button', { name: 'Next clip' }).click()
+    await expect(overlay.locator('.playback-caption')).toContainText('Clip 2 / 2')
+    await expect
+      .poll(() => music.evaluate((el) => (el as HTMLAudioElement).volume), { timeout: 5000 })
+      .toBeGreaterThan(0.6)
+
+    await overlay.getByRole('button', { name: 'Stop preview' }).click()
+    await expect(overlay).toBeHidden()
+  })
+})

--- a/tests/e2e/background-music.spec.ts
+++ b/tests/e2e/background-music.spec.ts
@@ -311,9 +311,15 @@ test.describe('background music', () => {
       .poll(() => music.evaluate((el) => (el as HTMLAudioElement).volume), { timeout: 5000 })
       .toBeGreaterThan(0.15)
 
-    // Skip to clip 2: the volume glides up toward the 0.8 override.
+    // Skip to clip 2: the volume glides up toward the 0.8 override. Freeze
+    // the playhead at clip 2's start right away — otherwise the end-of-film
+    // fade-out window could shrink the target under CI load and flake the
+    // volume assertion.
     await overlay.getByRole('button', { name: 'Next clip' }).click()
     await expect(overlay.locator('.playback-caption')).toContainText('Clip 2 / 2')
+    await overlay
+      .locator('.playback-video')
+      .evaluate((el) => (el as HTMLVideoElement).pause())
     await expect
       .poll(() => music.evaluate((el) => (el as HTMLAudioElement).volume), { timeout: 5000 })
       .toBeGreaterThan(0.6)

--- a/tests/e2e/background-music.spec.ts
+++ b/tests/e2e/background-music.spec.ts
@@ -7,7 +7,7 @@ import {
 } from './helpers'
 
 /** Tiny mono 16-bit PCM WAV — decodable everywhere, generated in-test. */
-function makeWavFile(durationSec = 4, freq = 440) {
+function makeWavFile(name: string, durationSec = 4, amplitude = 12000, freq = 440) {
   const rate = 8000
   const samples = Math.round(durationSec * rate)
   const dataSize = samples * 2
@@ -26,9 +26,12 @@ function makeWavFile(durationSec = 4, freq = 440) {
   buffer.write('data', 36)
   buffer.writeUInt32LE(dataSize, 40)
   for (let i = 0; i < samples; i += 1) {
-    buffer.writeInt16LE(Math.round(Math.sin((2 * Math.PI * freq * i) / rate) * 12000), 44 + i * 2)
+    buffer.writeInt16LE(
+      Math.round(Math.sin((2 * Math.PI * freq * i) / rate) * amplitude),
+      44 + i * 2,
+    )
   }
-  return { name: 'test-song.wav', mimeType: 'audio/wav', buffer }
+  return { name, mimeType: 'audio/wav', buffer }
 }
 
 async function openEditor(page: Page): Promise<void> {
@@ -45,12 +48,16 @@ async function openPlusEditorWithClips(page: Page, clips: number): Promise<strin
   return projectId
 }
 
-async function addMusic(page: Page): Promise<void> {
+async function addMusic(
+  page: Page,
+  buttonName: string | RegExp = 'Add background music',
+  file = makeWavFile('test-song.wav'),
+): Promise<void> {
   const chooserPromise = page.waitForEvent('filechooser')
-  await page.getByRole('button', { name: 'Add background music' }).click()
+  await page.getByRole('button', { name: buttonName }).click()
   const chooser = await chooserPromise
-  await chooser.setFiles(makeWavFile())
-  await expect(page.locator('.audio-track-name')).toHaveText('test-song.wav', {
+  await chooser.setFiles(file)
+  await expect(page.locator('.audio-track-name').filter({ hasText: file.name })).toBeVisible({
     timeout: 15_000,
   })
 }
@@ -72,10 +79,16 @@ async function storedAudio(page: Page) {
     const audio = await storage.getProjectAudio(projects[0]!.id)
     return audio
       ? {
-          name: audio.name,
-          durationMs: audio.durationMs,
           defaultVolume: audio.defaultVolume,
-          size: audio.blob.size,
+          fadeIn: audio.fadeIn,
+          fadeOut: audio.fadeOut,
+          tracks: audio.tracks.map(
+            (track: { name: string; durationMs: number; blob: Blob }) => ({
+              name: track.name,
+              durationMs: track.durationMs,
+              size: track.blob.size,
+            }),
+          ),
         }
       : null
   })
@@ -108,18 +121,36 @@ test.describe('background music', () => {
     expect(await storedAudio(page)).toBeNull()
   })
 
-  test('adds a track, sets default and per-clip volumes, resets, and removes', async ({
-    page,
-  }) => {
+  test('builds a playlist: tracks, fades, default and per-clip volumes', async ({ page }) => {
     await openPlusEditorWithClips(page, 2)
     await addMusic(page)
     await expect(page.locator('.toast')).toContainText(/music added/i)
 
-    const audio = await storedAudio(page)
-    expect(audio?.name).toBe('test-song.wav')
-    expect(audio?.durationMs).toBeGreaterThan(3000)
+    let audio = await storedAudio(page)
+    expect(audio?.tracks.map((track: { name: string }) => track.name)).toEqual([
+      'test-song.wav',
+    ])
+    expect(audio?.tracks[0].durationMs).toBeGreaterThan(3000)
     expect(audio?.defaultVolume).toBeCloseTo(0.25)
-    expect(audio?.size).toBeGreaterThan(1000)
+    expect(audio?.fadeIn).toBe(true)
+    expect(audio?.fadeOut).toBe(true)
+
+    // 4s of music under a 6s film: the coverage hint appears…
+    await expect(page.locator('.audio-coverage-hint')).toContainText(/music ends at/i)
+    // …until a second track covers the rest.
+    await addMusic(page, 'Add another music track', makeWavFile('second-song.wav', 6))
+    await expect(page.locator('.audio-track-row')).toHaveCount(2)
+    await expect(page.locator('.audio-coverage-hint')).toHaveCount(0)
+    audio = await storedAudio(page)
+    expect(audio?.tracks.map((track: { name: string }) => track.name)).toEqual([
+      'test-song.wav',
+      'second-song.wav',
+    ])
+
+    // Fade toggles persist (default on).
+    await page.getByRole('checkbox', { name: /Fade the music in/ }).uncheck()
+    await expect.poll(async () => (await storedAudio(page))?.fadeIn).toBe(false)
+    await expect.poll(async () => (await storedAudio(page))?.fadeOut).toBe(true)
 
     // Default volume slider persists.
     await setSlider(page, 'Default music volume', 40)
@@ -130,7 +161,6 @@ test.describe('background music', () => {
     await expect(tiles.last()).toHaveClass(/selected/)
     await setSlider(page, /Music volume during clip 2/, 60)
     await expect.poll(async () => await storedClipVolumes(page)).toEqual([null, 0.6])
-    // The override badge appears on the tile and the row drops "default".
     await expect(tiles.last().locator('.clip-audio-badge')).toHaveText(/60%/)
 
     // Selecting the other clip shows the default-following row.
@@ -143,15 +173,15 @@ test.describe('background music', () => {
     await expect.poll(async () => await storedClipVolumes(page)).toEqual([null, null])
     await expect(tiles.last().locator('.clip-audio-badge')).toHaveCount(0)
 
-    // Remove the track entirely.
-    await page.getByRole('button', { name: 'Remove background music' }).click()
+    // Removing tracks one by one lands back on the empty Add music state.
+    await page.getByRole('button', { name: /Remove music track 2/ }).click()
+    await expect(page.locator('.audio-track-row')).toHaveCount(1)
+    await page.getByRole('button', { name: /Remove music track 1/ }).click()
     await expect(page.getByRole('button', { name: 'Add background music' })).toBeVisible()
     expect(await storedAudio(page)).toBeNull()
   })
 
-  test('export mixes the music at per-clip volumes with ramped transitions', async ({
-    page,
-  }) => {
+  test('export sequences the playlist at per-clip volumes with fades', async ({ page }) => {
     test.slow()
     // Two 3s fixture clips (video-only — the fixture encoder adds no audio
     // track), so every decodable sample in the export's audio IS the music.
@@ -165,36 +195,48 @@ test.describe('background music', () => {
       const project = (await storage.listProjects())[0]!
       const clips = await storage.getClipsForProject(project.id)
 
-      // Synthesize a constant-amplitude sine WAV in-page as the track.
-      const rate = 8000
-      const seconds = 4
-      const samples = rate * seconds
-      const bytes = new DataView(new ArrayBuffer(44 + samples * 2))
-      const writeAscii = (offset: number, text: string) => {
-        for (let i = 0; i < text.length; i += 1) bytes.setUint8(offset + i, text.charCodeAt(i))
+      // Two in-page sine WAVs: track A (4s, full amplitude) then track B
+      // (20s, HALF amplitude) — the amplitude step at the 4s hand-off
+      // proves sequential playback (looping track A would keep it loud;
+      // a broken hand-off would go silent).
+      const makeWav = (seconds: number, amplitude: number): Blob => {
+        const rate = 8000
+        const samples = rate * seconds
+        const bytes = new DataView(new ArrayBuffer(44 + samples * 2))
+        const writeAscii = (offset: number, text: string) => {
+          for (let i = 0; i < text.length; i += 1) bytes.setUint8(offset + i, text.charCodeAt(i))
+        }
+        writeAscii(0, 'RIFF')
+        bytes.setUint32(4, 36 + samples * 2, true)
+        writeAscii(8, 'WAVE')
+        writeAscii(12, 'fmt ')
+        bytes.setUint32(16, 16, true)
+        bytes.setUint16(20, 1, true)
+        bytes.setUint16(22, 1, true)
+        bytes.setUint32(24, rate, true)
+        bytes.setUint32(28, rate * 2, true)
+        bytes.setUint16(32, 2, true)
+        bytes.setUint16(34, 16, true)
+        writeAscii(36, 'data')
+        bytes.setUint32(40, samples * 2, true)
+        for (let i = 0; i < samples; i += 1) {
+          bytes.setInt16(44 + i * 2, Math.round(Math.sin((2 * Math.PI * 440 * i) / rate) * amplitude), true)
+        }
+        return new Blob([bytes.buffer], { type: 'audio/wav' })
       }
-      writeAscii(0, 'RIFF')
-      bytes.setUint32(4, 36 + samples * 2, true)
-      writeAscii(8, 'WAVE')
-      writeAscii(12, 'fmt ')
-      bytes.setUint32(16, 16, true)
-      bytes.setUint16(20, 1, true)
-      bytes.setUint16(22, 1, true)
-      bytes.setUint32(24, rate, true)
-      bytes.setUint32(28, rate * 2, true)
-      bytes.setUint16(32, 2, true)
-      bytes.setUint16(34, 16, true)
-      writeAscii(36, 'data')
-      bytes.setUint32(40, samples * 2, true)
-      for (let i = 0; i < samples; i += 1) {
-        bytes.setInt16(44 + i * 2, Math.round(Math.sin((2 * Math.PI * 440 * i) / rate) * 16000), true)
-      }
-      const audio = await storage.setProjectAudio({
+      await storage.addProjectAudioTrack({
         projectId: project.id,
-        blob: new Blob([bytes.buffer], { type: 'audio/wav' }),
+        blob: makeWav(4, 16000),
         mimeType: 'audio/wav',
-        durationMs: seconds * 1000,
-        name: 'sine.wav',
+        durationMs: 4000,
+        name: 'track-a.wav',
+      })
+      const audio = await storage.addProjectAudioTrack({
+        projectId: project.id,
+        blob: makeWav(20, 8000),
+        mimeType: 'audio/wav',
+        durationMs: 20000,
+        name: 'track-b.wav',
       })
       // Clip 1 follows the 0.25 default; clip 2 is overridden to full volume.
       await storage.updateClipAudioVolume(clips[1]!.id, 1)
@@ -202,7 +244,12 @@ test.describe('background music', () => {
 
       const result = await exportProject(updatedClips, {
         watermark: false,
-        background: { blob: audio.blob, defaultVolume: audio.defaultVolume },
+        background: {
+          tracks: audio.tracks.map((track: { blob: Blob }) => ({ blob: track.blob })),
+          defaultVolume: audio.defaultVolume,
+          fadeIn: audio.fadeIn,
+          fadeOut: audio.fadeOut,
+        },
       })
 
       const decoded = await decodeBackgroundAudio(result.blob, 48000)
@@ -217,21 +264,26 @@ test.describe('background music', () => {
       }
       return {
         durationSec: decoded.duration,
-        // Steady windows away from the fade-in and the 3s boundary ramp.
-        clip1: rms(1.0, 2.5),
-        clip2: rms(4.0, 5.5),
+        // Track A under clip 1 (gain 0.25), past the 800ms fade-in.
+        clip1: rms(1.2, 2.6),
+        // Track B under clip 2 (gain 1.0), past the 4s hand-off, before
+        // the fade-out begins at 4.8s.
+        clip2: rms(4.2, 4.7),
         fadeIn: rms(0, 0.08),
+        fadeOut: rms(5.7, 5.95),
       }
     })
 
     expect(measured).not.toBeNull()
-    // Both clips carry audible music…
+    // Clip 1 carries audible music from track A.
     expect(measured!.clip1).toBeGreaterThan(0.02)
-    // …and the overridden clip is decisively louder (4× volume ⇒ ~4× RMS).
-    expect(measured!.clip2 / measured!.clip1).toBeGreaterThan(2)
-    expect(measured!.clip2 / measured!.clip1).toBeLessThan(8)
-    // The film opens with the fade-in, not a full-volume slam.
-    expect(measured!.fadeIn).toBeLessThan(measured!.clip1)
+    // Track B at gain 1.0 vs track A at gain 0.25, half the amplitude:
+    // expected RMS ratio ≈ 2 (looping track A would read ≈ 4; silence ≈ 0).
+    expect(measured!.clip2 / measured!.clip1).toBeGreaterThan(1.4)
+    expect(measured!.clip2 / measured!.clip1).toBeLessThan(2.8)
+    // The film opens inside the fade-in and closes inside the fade-out.
+    expect(measured!.fadeIn).toBeLessThan(measured!.clip1 * 0.5)
+    expect(measured!.fadeOut).toBeLessThan(measured!.clip2 * 0.5)
     expect(measured!.durationSec).toBeGreaterThan(5.5)
   })
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Adds **background music** to the timeline editor, gated behind **Kody Video Plus** (like extra project slots and watermark removal):

- **Add music** in the editor builds a playlist of audio files (MP3/M4A/WAV…) that play **one after the other** under the film until it ends — nothing loops, and the last track is cut off at the film's end. When the music runs out before the film does, a hint ("Music ends at 0:42 of 1:10") suggests adding another track. On the free plan the button shows a lock and opens the Plus upsell sheet; the storage layer enforces the same gate so no path around the UI can attach music.
- Music plays at a **default background volume (25%)** — quiet enough to sit under speech — adjustable with the "All clips" slider.
- **Tap any clip** to set the music volume just for that clip (duck it for talking, swell it for b-roll). Overridden clips show a `♪ NN%` badge on their timeline tile, and a Reset button returns a clip to the default.
- **Fade in / Fade out toggles** (both default on) ease the music in at the start of the film (800 ms) and out at the end (1200 ms). With a fade disabled, only an inaudible 15 ms click-kill edge remains.
- Volume changes **glide across clip boundaries** instead of jumping: the preview ramps the audio element per-frame, and exports render a piecewise-linear gain envelope (600 ms boundary ramps).

## How

- **Storage**: new `audio` object store (DB v2 upgrade), one `ProjectAudioRecord` per project holding the ordered `tracks[]` plus `defaultVolume`/`fadeIn`/`fadeOut`; `ClipMeta.audioVolume` per-clip override. `addProjectAudioTrack` throws without the Plus entitlement — same pattern as the project cap in `createProject`.
- **Export**: `lib/export/background-audio.ts` is a pure, unit-tested module: envelope planning (fades + ramps) and a **lazy sequential mixer** that decodes one playlist track at a time (bounded memory on long films) and hands off sample-accurately between tracks. The WebCodecs engine mixes into each segment's audio slice; the realtime fallback chains `AudioBufferSourceNode`s behind a `GainNode` with `setTargetAtTime` ramps and a scheduled fade-out. The cached-export signature includes the full music state so stale exports re-render.
- **Preview**: `PlaybackOverlay` runs one `<audio>` element that swaps sources at track hand-offs, glides volume toward the current clip's target every frame, honors the fade-in toggle, and goes silent when the playlist runs out.
- **Backup**: the `.kodyvideo` format carries the playlist + fades backwards-compatibly (audio bytes trail the clip bytes; old parsers ignore them). Free devices importing a Plus backup keep the clips and skip the music.

## Testing

- `npm run lint` clean; `npm test` 118 passed (envelope fades on/off, sequential mixer hand-off/skip/lazy-decode, storage playlist CRUD + Plus gate + clamping, backup round-trip/truncation/free-device skip).
- `tests/e2e/background-music.spec.ts` (4 passed): upsell gate on free plan; playlist build (two tracks, coverage hint appearing/clearing, fade toggles, sliders, badges, per-track remove); preview playback ramping; and a **real export decoded and RMS-measured** — track A hands off to track B at 4 s (amplitude step proves sequencing, ~2× RMS ratio vs ~4× if looping), with fade-in and fade-out windows measurably quieter.
- Full e2e suite: 47 passed; the 4 failures (`export.spec`, `install-hint.spec`, `storage.spec`) fail identically on `main` in this VM (Sentry envelope posts tripping the no-offsite-writes assertion, and `.home-hero` visibility) — pre-existing, unrelated.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1e0b8bef-7996-4d3b-97a9-e0027b0a3838?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1e0b8bef-7996-4d3b-97a9-e0027b0a3838&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Plus background music for projects, including playlists, track removal, fade in/out, default volume, and per-clip volume controls.
  * Background music now plays during previews and is included in video exports.
  * Added audio import validation, duration feedback, and clear error messages.
  * Project backups now preserve playlists, settings, and audio volume adjustments.
  * Timeline clips display music-volume indicators when custom levels are set.
* **Documentation**
  * Updated Plus feature descriptions and backup/storage documentation.
* **Bug Fixes**
  * Audio playback gracefully skips invalid or unavailable tracks without blocking exports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->