### PR TITLE
Restart the camera preview when the app resumes without a visibility event

### DIFF
--- a/src/components/record-screen.tsx
+++ b/src/components/record-screen.tsx
@@ -580,6 +580,45 @@ export function RecordScreen(handle: Handle<RecordScreenProps>) {
     releaseWakeLock()
   }
 
+  /** True after the hidden handler released the camera — the resume path
+   * must restart it even when the browser resumes without ever reporting a
+   * visible transition (iOS Safari, installed PWAs especially). */
+  let cameraStoppedInBackground = false
+  /** Serialize restarts: resume signals arrive in bursts (visibilitychange +
+   * focus + pageshow). A second stop() epoch-invalidates the open that a
+   * concurrent camera.start() is awaiting, so overlapping runners could all
+   * finish with NO stream — one runner loops until requests stop. */
+  let restartRunning = false
+  let restartRequested = false
+
+  const restartCameraPreview = () => {
+    cameraStoppedInBackground = false
+    restartRequested = true
+    if (restartRunning) return
+    restartRunning = true
+    void (async () => {
+      try {
+        while (restartRequested) {
+          restartRequested = false
+          // If a take was somehow still running on a frozen stream, save it
+          // first.
+          if (recorder.isRecording || recording) {
+            await endRecord()
+          }
+          camera.stop()
+          // The app may have been hidden again while the take was finishing —
+          // never reopen the camera (and relight the privacy dot) in
+          // background.
+          if (document.hidden) return
+          await camera.start()
+          if (document.hidden) camera.stop()
+        }
+      } finally {
+        restartRunning = false
+      }
+    })()
+  }
+
   // Release the camera whenever the app leaves the foreground — Android keeps
   // the privacy indicator (green dot) lit as long as any track is live. An
   // in-progress take is finished and saved first; the preview restarts when
@@ -598,24 +637,37 @@ export function RecordScreen(handle: Handle<RecordScreenProps>) {
         void endRecord()
       }
       camera.stop()
+      cameraStoppedInBackground = true
       return
     }
     // Coming back to the foreground: restart the camera unconditionally.
     // Screen-off freezes the camera track at the OS level, and on some
     // Android paths no `hidden` event ever fires — a surviving stream would
-    // keep previewing (and recording!) a single stale frame forever. If a
-    // take was somehow still running on that frozen stream, save it first.
-    void (async () => {
-      if (recorder.isRecording || recording) {
-        await endRecord()
-      }
-      camera.stop()
-      // The app may have been hidden again while the take was finishing —
-      // never reopen the camera (and relight the privacy dot) in background.
-      if (document.hidden) return
-      await camera.start()
-      if (document.hidden) camera.stop()
-    })()
+    // keep previewing (and recording!) a single stale frame forever.
+    restartCameraPreview()
+  }
+
+  /** A preview that resumed broken: the hidden handler already released the
+   * camera, or the OS suspension killed/muted the track behind the live
+   * stream. A null stream without the background flag is a camera that is
+   * still starting, denied, or mid-restart — not ours to touch. */
+  const previewNeedsRestart = (): boolean => {
+    if (cameraStoppedInBackground) return true
+    const stream = camera.getStream()
+    if (!stream) return false
+    const track = stream.getVideoTracks()[0]
+    return !track || track.readyState !== 'live' || track.muted
+  }
+
+  // Turning the phone back on (or reopening a closed PWA) can resume the app
+  // with no `visibilitychange` at all — a long-standing iOS Safari behavior —
+  // leaving the preview black until a manual reload. `focus` and `pageshow`
+  // are the signals that DO fire there. Both also fire during ordinary
+  // desktop window switching, so only a genuinely broken preview restarts.
+  const onPageResume = () => {
+    if (document.hidden) return
+    if (!previewNeedsRestart()) return
+    restartCameraPreview()
   }
 
   // Desktop keyboard support (the app is designed for phones; this keeps the
@@ -706,12 +758,16 @@ export function RecordScreen(handle: Handle<RecordScreenProps>) {
 
   const bindCameraVideo = (element: HTMLVideoElement, signal: AbortSignal) => {
     document.addEventListener('visibilitychange', onVisibilityChange)
+    window.addEventListener('focus', onPageResume)
+    window.addEventListener('pageshow', onPageResume)
     window.addEventListener('keydown', onWindowKeyDown)
     window.addEventListener('keyup', onWindowKeyUp)
     // Registered before camera.attachVideo's own abort listener so an active
     // take is finished/saved before the camera stream is stopped.
     signal.addEventListener('abort', () => {
       document.removeEventListener('visibilitychange', onVisibilityChange)
+      window.removeEventListener('focus', onPageResume)
+      window.removeEventListener('pageshow', onPageResume)
       window.removeEventListener('keydown', onWindowKeyDown)
       window.removeEventListener('keyup', onWindowKeyUp)
       cleanupOnUnmount()

--- a/tests/e2e/record.spec.ts
+++ b/tests/e2e/record.spec.ts
@@ -1,9 +1,10 @@
-import { test, expect } from '@playwright/test'
+import { test, expect, type Page } from '@playwright/test'
 import {
   openNewProject,
   pressStageUntilRecording,
   recordClip,
   totalClipCount,
+  waitForCameraReady,
 } from './helpers'
 
 test.describe('camera & hold-to-record', () => {
@@ -165,5 +166,69 @@ test.describe('camera & hold-to-record', () => {
         { timeout: 15_000 },
       )
       .toEqual({ lat: 40.2338, lng: -111.6585 })
+  })
+})
+
+test.describe('camera resume after suspension', () => {
+  const activeTrackId = (page: Page) =>
+    page.evaluate(() => {
+      const video = document.querySelector<HTMLVideoElement>('.camera-video')
+      const stream = video?.srcObject as MediaStream | null
+      const track = stream?.getVideoTracks()[0]
+      return track && track.readyState === 'live' ? track.id : null
+    })
+
+  test('resuming without a visible transition restarts the camera (iOS PWA)', async ({
+    page,
+  }) => {
+    await openNewProject(page)
+
+    // Phone off / app closed: the page reports hidden, the camera stops.
+    await page.evaluate(() => {
+      Object.defineProperty(document, 'hidden', { configurable: true, get: () => true })
+      document.dispatchEvent(new Event('visibilitychange'))
+    })
+    await expect
+      .poll(() =>
+        page.evaluate(
+          () => document.querySelector<HTMLVideoElement>('.camera-video')?.srcObject === null,
+        ),
+      )
+      .toBe(true)
+
+    // Phone back on: iOS Safari (installed PWAs especially) resumes with
+    // focus/pageshow only — no visibilitychange ever fires.
+    await page.evaluate(() => {
+      Object.defineProperty(document, 'hidden', { configurable: true, get: () => false })
+      window.dispatchEvent(new Event('focus'))
+    })
+    await waitForCameraReady(page)
+    expect(await activeTrackId(page)).not.toBe(null)
+  })
+
+  test('a dead camera track on refocus restarts the preview', async ({ page }) => {
+    await openNewProject(page)
+    const staleTrackId = await page.evaluate(() => {
+      const video = document.querySelector<HTMLVideoElement>('.camera-video')!
+      const track = (video.srcObject as MediaStream).getVideoTracks()[0]!
+      // The OS killed the camera while the app was suspended.
+      track.stop()
+      return track.id
+    })
+
+    await page.evaluate(() => window.dispatchEvent(new Event('focus')))
+    await expect.poll(() => activeTrackId(page), { timeout: 15_000 }).not.toBe(null)
+    expect(await activeTrackId(page)).not.toBe(staleTrackId)
+    await waitForCameraReady(page)
+  })
+
+  test('window focus with a healthy preview does not restart the camera', async ({ page }) => {
+    await openNewProject(page)
+    const before = await activeTrackId(page)
+    expect(before).not.toBe(null)
+
+    await page.evaluate(() => window.dispatchEvent(new Event('focus')))
+    await page.waitForTimeout(600)
+    expect(await activeTrackId(page)).toBe(before)
   })
 })


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Turning the phone off (or closing the app) and coming back leaves the record screen's camera preview all black until a manual reload.

The record screen already releases the camera on `visibilitychange → hidden` and restarts it on the visible transition — but iOS Safari (installed PWAs especially) can resume the page **without ever firing a visibility transition**. The camera stays stopped (`stream === null`, `error === null`), so the stage renders a black `<video>` with no permission panel and no way to recover.

## Fix

`src/components/record-screen.tsx`:

- Also listen for `window` `focus` and `pageshow` — the signals that *do* fire on iOS resume (exactly the "reload when the tab gets focused" idea from the report).
- Those events also fire on ordinary desktop window switching, so the focus/pageshow path only restarts a preview that is actually broken: the hidden handler already released the camera (new `cameraStoppedInBackground` flag), or the OS suspension left the live stream's video track dead/muted. The `visibilitychange → visible` path keeps its unconditional restart.
- Serialize restarts: resume signals arrive in bursts (visibilitychange + focus + pageshow). A second `camera.stop()` epoch-invalidates the `getUserMedia` open that a concurrent `camera.start()` is awaiting, so overlapping restart runners could all finish with **no** stream — one runner now loops until requests stop.

## Tests

Three new Playwright e2e tests in `tests/e2e/record.spec.ts` (`camera resume after suspension`):

- resume with `focus` only (no visibilitychange) restarts the camera — reproduces the iOS PWA scenario by overriding `document.hidden`;
- a dead camera track on refocus restarts the preview;
- window focus with a healthy preview does **not** restart the camera.

Both restart tests fail without the fix and pass with it. `npm run lint`, `npm test` (95 passed), and the full e2e suite pass — except 4 failures (`export`, `install-hint` ×2, `storage`) that fail identically on untouched `main` in this VM (environment-related, not from this change).

## Demo

Headed Chromium with a fake camera: live preview → simulated phone-off (page hidden, camera released, black preview) → simulated resume with only a `focus` event → preview restarts automatically.

<a href="https://cursor.com/agents/bc-078fdb45-b58a-4207-bd17-561ef78f6830/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcamera_preview_resume_fix_demo.mp4"><img src="https://cursor.com/artifacts/c/art-457863cd-273f-4b66-97be-6e73f3cdf5f2" alt="camera_preview_resume_fix_demo.mp4" /></a>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-078fdb45-b58a-4207-bd17-561ef78f6830?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-078fdb45-b58a-4207-bd17-561ef78f6830&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved camera recovery when returning to the app after backgrounding, suspension, or page transitions.
  * Prevented overlapping camera restarts and ensured active recordings finish before recovery begins.
  * Preserved healthy camera connections while replacing stopped, ended, or muted video tracks.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->