### PR TITLE
Optimize record-start hot paths found by CPU profiling

### DIFF
--- a/src/components/record-screen.tsx
+++ b/src/components/record-screen.tsx
@@ -4,7 +4,12 @@ import '../styles/record.css'
 import type { Camera } from '../lib/camera'
 import { dragZoomValue } from '../lib/drag-zoom'
 import { getLocationFix, type LocationFix } from '../lib/location'
-import { startMicLevelMonitor, type MicLevelMonitor } from '../lib/mic-monitor'
+import { pickRecordingMimeType, warmDurationProbe } from '../lib/media'
+import {
+  startMicLevelMonitor,
+  warmMicMonitorContext,
+  type MicLevelMonitor,
+} from '../lib/mic-monitor'
 import { reportError } from '../lib/error-reporting'
 import { appendRecording, removeClip, undoLastDelete } from '../lib/project-actions'
 import { HoldRecorder } from '../lib/recorder'
@@ -123,6 +128,24 @@ export function RecordScreen(handle: Handle<RecordScreenProps>) {
   let locationTagging = props.locationTaggingEnabled ?? false
 
   const screenRecordingSupported = isScreenRecordingSupported()
+
+  // Pre-warm the first take's one-time costs while the screen sits idle
+  // (typically during the camera open): the mic-monitor AudioContext, the
+  // MediaRecorder mime probe, and the duration probe's demux module
+  // otherwise all land inside the first hold-to-record — profiling showed
+  // them as the first-take stutter right at recording start/stop.
+  let warmIdleHandle = 0
+  let warmTimerHandle = 0
+  const warmFirstTakePath = () => {
+    warmMicMonitorContext()
+    pickRecordingMimeType()
+    warmDurationProbe()
+  }
+  if (typeof window.requestIdleCallback === 'function') {
+    warmIdleHandle = window.requestIdleCallback(warmFirstTakePath, { timeout: 3000 })
+  } else {
+    warmTimerHandle = window.setTimeout(warmFirstTakePath, 1500)
+  }
 
   const storageState = () => (props.storage ? storageSeverity(props.storage.ratio) : 'ok')
 
@@ -568,6 +591,8 @@ export function RecordScreen(handle: Handle<RecordScreenProps>) {
   }
 
   const cleanupOnUnmount = () => {
+    if (warmIdleHandle) window.cancelIdleCallback?.(warmIdleHandle)
+    window.clearTimeout(warmTimerHandle)
     window.clearTimeout(countdownTimer)
     countdownTimer = 0
     cancelAnimationFrame(zoomRestoreRaf)

--- a/src/components/record-timer.tsx
+++ b/src/components/record-timer.tsx
@@ -19,10 +19,16 @@ export function RecordTimer(handle: Handle<RecordTimerProps>) {
       className={handle.props.className}
       mix={ref((node, signal) => {
         let raf = 0
+        let lastText = ''
         const tick = () => {
-          node.textContent = formatDuration(
-            Math.max(0, performance.now() - handle.props.startedAt),
-          )
+          const text = formatDuration(Math.max(0, performance.now() - handle.props.startedAt))
+          // The readout has 0.1s resolution, so ~5 of 6 frames would write
+          // the same string — and every textContent write dirties layout.
+          // Skipping no-ops keeps recording free of per-frame layout work.
+          if (text !== lastText) {
+            lastText = text
+            node.textContent = text
+          }
           raf = requestAnimationFrame(tick)
         }
         tick()

--- a/src/lib/media.test.ts
+++ b/src/lib/media.test.ts
@@ -1,0 +1,54 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+// The recording mime preference is cached at module scope (it runs inside
+// the pointerdown that starts every take), so each test re-imports a fresh
+// module instance via vi.resetModules — a top-level import would share one
+// cache across tests.
+
+class FakeMediaRecorder {
+  static probes: string[] = []
+  static supported: Set<string> = new Set()
+  static isTypeSupported(type: string): boolean {
+    FakeMediaRecorder.probes.push(type)
+    return FakeMediaRecorder.supported.has(type)
+  }
+}
+
+async function freshPickRecordingMimeType() {
+  vi.resetModules()
+  const media = await import('./media')
+  return media.pickRecordingMimeType
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  FakeMediaRecorder.probes = []
+  FakeMediaRecorder.supported = new Set()
+})
+
+describe('pickRecordingMimeType', () => {
+  it('probes the platform once and serves later takes from the cache', async () => {
+    FakeMediaRecorder.supported = new Set(['video/webm;codecs=vp9,opus'])
+    vi.stubGlobal('MediaRecorder', FakeMediaRecorder)
+    const pick = await freshPickRecordingMimeType()
+
+    const first = pick()
+    const probesAfterFirst = FakeMediaRecorder.probes.length
+    expect(first).toBe('video/webm;codecs=vp9,opus')
+    expect(probesAfterFirst).toBeGreaterThan(0)
+
+    expect(pick()).toBe(first)
+    expect(pick()).toBe(first)
+    expect(FakeMediaRecorder.probes.length).toBe(probesAfterFirst)
+  })
+
+  it('caches the empty result when nothing is supported', async () => {
+    vi.stubGlobal('MediaRecorder', FakeMediaRecorder)
+    const pick = await freshPickRecordingMimeType()
+
+    expect(pick()).toBe('')
+    const probesAfterFirst = FakeMediaRecorder.probes.length
+    expect(pick()).toBe('')
+    expect(FakeMediaRecorder.probes.length).toBe(probesAfterFirst)
+  })
+})

--- a/src/lib/media.ts
+++ b/src/lib/media.ts
@@ -300,8 +300,20 @@ export function pickRecorderMimeType(): string {
  * hardware-accelerated encoder — recording VP9 in software is what makes the
  * camera preview and the saved clip drop frames — so prefer it there.
  * Desktops have plenty of headroom, so prefer WebM for broad compatibility.
+ *
+ * The answer is static per browser session, so it's probed once and cached:
+ * this runs inside the pointerdown that starts every take, and each
+ * isTypeSupported call crosses into the platform media stack.
  */
+let cachedRecordingMimeType: string | null = null
+
 export function pickRecordingMimeType(): string {
+  if (cachedRecordingMimeType !== null) return cachedRecordingMimeType
+  cachedRecordingMimeType = probeRecordingMimeType()
+  return cachedRecordingMimeType
+}
+
+function probeRecordingMimeType(): string {
   if (typeof MediaRecorder === 'undefined') return ''
   const mobile = [
     'video/mp4;codecs=avc1.640028,mp4a.40.2',
@@ -323,6 +335,17 @@ export function pickRecordingMimeType(): string {
     if (MediaRecorder.isTypeSupported(type)) return type
   }
   return ''
+}
+
+/**
+ * Prefetch the demux module measureBlobDuration needs. Without this, the
+ * FIRST take's stop pays the mediabunny chunk fetch + parse on the main
+ * thread while the camera preview is live — visible as post-take jank.
+ * Called from an idle moment on the record screen; failures just mean the
+ * first measurement pays the import lazily as before.
+ */
+export function warmDurationProbe(): void {
+  void import('mediabunny').catch(() => undefined)
 }
 
 /**

--- a/src/lib/mic-monitor.test.ts
+++ b/src/lib/mic-monitor.test.ts
@@ -1,0 +1,92 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+// The monitor shares one AudioContext at module scope, so each test
+// re-imports a fresh module instance via vi.resetModules — a top-level
+// import would leak the shared context between tests.
+
+class FakeAnalyser {
+  fftSize = 0
+  disconnect(): void {}
+  getFloatTimeDomainData(): void {}
+}
+
+class FakeSource {
+  connect(): void {}
+  disconnect(): void {}
+}
+
+class FakeAudioContext {
+  static constructed = 0
+  state: 'suspended' | 'running' = 'suspended'
+  constructor() {
+    FakeAudioContext.constructed += 1
+  }
+  suspend(): Promise<void> {
+    this.state = 'suspended'
+    return Promise.resolve()
+  }
+  resume(): Promise<void> {
+    this.state = 'running'
+    return Promise.resolve()
+  }
+  createMediaStreamSource(): FakeSource {
+    return new FakeSource()
+  }
+  createAnalyser(): FakeAnalyser {
+    return new FakeAnalyser()
+  }
+}
+
+class FakeMediaStream {
+  private tracks: unknown[]
+  constructor(tracks: unknown[] = []) {
+    this.tracks = tracks
+  }
+  getAudioTracks(): unknown[] {
+    return this.tracks
+  }
+}
+
+const liveTrack = () => ({
+  kind: 'audio',
+  readyState: 'live',
+  addEventListener: () => undefined,
+})
+
+async function freshMicMonitor() {
+  vi.resetModules()
+  return import('./mic-monitor')
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  FakeAudioContext.constructed = 0
+})
+
+describe('warmMicMonitorContext', () => {
+  it('creates the shared context once, suspended, and takes reuse it', async () => {
+    vi.stubGlobal('AudioContext', FakeAudioContext)
+    vi.stubGlobal('MediaStream', FakeMediaStream)
+    vi.stubGlobal('window', globalThis)
+    const monitor = await freshMicMonitor()
+
+    monitor.warmMicMonitorContext()
+    monitor.warmMicMonitorContext()
+    expect(FakeAudioContext.constructed).toBe(1)
+
+    // A take starting later must reuse the pre-warmed context instead of
+    // constructing a second one on the record-start critical path.
+    const stream = new FakeMediaStream([liveTrack()]) as unknown as MediaStream
+    const handle = monitor.startMicLevelMonitor(stream, {
+      onSilent: () => undefined,
+      onSound: () => undefined,
+    })
+    expect(FakeAudioContext.constructed).toBe(1)
+    handle.stop()
+  })
+
+  it('is a no-op when AudioContext is unavailable', async () => {
+    const monitor = await freshMicMonitor()
+    expect(() => monitor.warmMicMonitorContext()).not.toThrow()
+  })
+})

--- a/src/lib/mic-monitor.ts
+++ b/src/lib/mic-monitor.ts
@@ -34,6 +34,23 @@ function acquireContext(): AudioContext | null {
 }
 
 /**
+ * Create the shared AudioContext ahead of the first take. Constructing a
+ * context spins up the platform audio stack — doing it inside the
+ * pointerdown that starts the first recording is a first-take-only stutter.
+ * Called from an idle moment on the record screen; created suspended so an
+ * idle preview never keeps the audio graph running.
+ */
+export function warmMicMonitorContext(): void {
+  if (sharedContext || typeof AudioContext === 'undefined') return
+  try {
+    sharedContext = new AudioContext()
+    void sharedContext.suspend().catch(() => undefined)
+  } catch {
+    // Leave it to acquireContext to retry per take.
+  }
+}
+
+/**
  * Watches the stream's audio track through an AnalyserNode (a passive extra
  * consumer — MediaRecorder is unaffected). Calls onSilent when the take has
  * gone a full grace period without any signal above the floor — whether from

--- a/src/lib/thumbs.ts
+++ b/src/lib/thumbs.ts
@@ -118,8 +118,11 @@ export async function captureLiveThumbs(
   if (!ctx || !posterCtx) return null
 
   try {
-    ctx.drawImage(video, 0, 0, thumbWidth, thumbHeight)
+    // ONE video readback: pulling pixels out of a live camera element is the
+    // expensive part (GPU→CPU copy), so the filmstrip thumb is scaled from
+    // the poster canvas instead of a second video draw.
     posterCtx.drawImage(video, 0, 0, posterWidth, posterHeight)
+    ctx.drawImage(posterCanvas, 0, 0, thumbWidth, thumbHeight)
   } catch {
     return null
   }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Profiled the hold-to-record interaction (CDP sampling profiler + rAF frame-delta tracking at 6× CPU throttle to emulate a mid-range phone) and cleaned up the hot paths it surfaced:

- **`captureLiveThumbs` (`src/lib/thumbs.ts`)** — the dominant long task (~100 ms throttled, firing while the preview is live): it read the live camera element back twice (poster + thumb). The filmstrip thumb now scales from the poster canvas, halving the expensive GPU→CPU video readback.
- **First-take warmup (`src/components/record-screen.tsx`)** — the first hold previously paid three one-time costs right inside the starting pointerdown / first stop: constructing the mic-monitor `AudioContext`, probing `MediaRecorder.isTypeSupported`, and fetching+parsing the mediabunny duration-probe chunk mid-preview. The record screen now pre-warms all three from an idle callback while the camera opens.
- **`pickRecordingMimeType` (`src/lib/media.ts`)** — re-probed up to 7 mime types on every take start; the answer is static per session and is now cached.
- **`RecordTimer` (`src/components/record-timer.tsx`)** — wrote an identical `textContent` string on ~5 of 6 frames (0.1 s readout at 60 fps rAF), dirtying layout every frame while recording; unchanged text no longer writes.

## Profiling evidence

Harness: Playwright + CDP (`Profiler` sampling at 100 µs, `Emulation.setCPUThrottlingRate: 6`), fake camera/mic, three consecutive takes; frame jank measured as rAF deltas in the 2 s window after each press.

| Metric (6× throttle) | Before | After |
|---|---|---|
| Press → REC pill visible (takes 1/2/3) | 98 / 78 / 52 ms | 62 / 45 / 48 ms |
| Long task at take end | 101 / 76 / 83 ms | 69 / 56 / 63 ms |
| `captureLiveThumbs` self time (take 1) | 73 ms | 42 ms |
| Worst post-press frame delta | 100 / 67 / 83 ms | 67 / 33 / 50 ms |

Stage attribution (API wrappers timing each call, unthrottled): the `AudioContext` construction (~17 ms) and the mime probe now run at idle during camera open, before the first press, and the first take's mic `getUserMedia` dropped from ~20 ms to ~3 ms (audio stack already warm) — the first take's in-press work now matches later takes.

## Testing

- New unit tests: `src/lib/media.test.ts` (mime cache), `src/lib/mic-monitor.test.ts` (warmed context reused by takes). `npm test`: 99 passed.
- `npm run lint` clean.
- Playwright e2e: 43 passed; the 4 failures (`export`, `install-hint` ×2, `storage` boot sweep) fail identically on `main` in this environment (pre-existing, unrelated).
- Manual demo in Chrome with fake media (headless VM): two hold-to-record takes, REC pill + elapsed counter during both, header total ends at 5.0 s, preview animates throughout with no black flashes.

<a href="https://cursor.com/agents/bc-90d140a8-c237-4609-9d63-30b989ba8052/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhold_to_record_two_clips_demo_trimmed.mp4"><img src="https://cursor.com/artifacts/c/art-adbc3740-6418-43a4-a4f4-068ed4311f98" alt="hold_to_record_two_clips_demo_trimmed.mp4" /></a>

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-90d140a8-c237-4609-9d63-30b989ba8052?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-90d140a8-c237-4609-9d63-30b989ba8052&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

