### PR TITLE
Redesign the trash and editor icons

### DIFF
--- a/src/components/icons.tsx
+++ b/src/components/icons.tsx
@@ -89,14 +89,18 @@ export function IconPause(handle: Handle<IconProps>) {
   )
 }
 
+/** Filmstrip: mirrors the clip timeline the editor button opens. */
 export function IconEditor(handle: Handle<IconProps>) {
   return () => (
     <svg {...baseProps(handle.props.size ?? 22)}>
-      <circle cx="6.5" cy="6.5" r="2.25" />
-      <circle cx="6.5" cy="17.5" r="2.25" />
-      <path d="M19.5 4.5L8.7 15.3" />
-      <path d="M14.2 5L19.5 10.3" />
-      <path d="M8.7 8.7L19.5 19.5" />
+      <rect x="3" y="4.5" width="18" height="15" rx="2" />
+      <path d="M7.5 4.5v15" />
+      <path d="M16.5 4.5v15" />
+      <path d="M3 9.5h4.5" />
+      <path d="M3 14.5h4.5" />
+      <path d="M16.5 9.5H21" />
+      <path d="M16.5 14.5H21" />
+      <path d="M7.5 12h9" />
     </svg>
   )
 }
@@ -112,14 +116,15 @@ export function IconDeleteLast(handle: Handle<IconProps>) {
   )
 }
 
+/** Straight-sided bin with a rounded base; sturdier than a tapered can at small sizes. */
 export function IconTrash(handle: Handle<IconProps>) {
   return () => (
     <svg {...baseProps(handle.props.size ?? 22)}>
-      <path d="M5 7h14" />
-      <path d="M9 7V5.5A1.5 1.5 0 0110.5 4h3A1.5 1.5 0 0115 5.5V7" />
-      <path d="M8 7l.7 11.2A1.5 1.5 0 0010.2 19.5h3.6a1.5 1.5 0 001.5-1.3L16 7" />
-      <path d="M10.5 11v5" />
-      <path d="M13.5 11v5" />
+      <path d="M4.5 7h15" />
+      <path d="M9.5 7V5.5A1.5 1.5 0 0111 4h2a1.5 1.5 0 011.5 1.5V7" />
+      <path d="M18 7v11a2.5 2.5 0 01-2.5 2.5h-7A2.5 2.5 0 016 18V7" />
+      <path d="M10 11v5.5" />
+      <path d="M14 11v5.5" />
     </svg>
   )
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Replaces two icons that didn't feel right:

- **Editor button** (record screen dock): the scissors glyph read as "cut", but the button opens the filmstrip timeline editor. It's now a filmstrip — the app's own editing metaphor — with sprocket rails and two stacked frames.
- **Delete button** (editor toolbar): the old trash can was narrow and tapered with a heavy lid overhang, which looked wobbly at 22px. It's now a straight-sided bin with a rounded base, a centered handle, and evenly spaced slats — sturdier and better optically balanced at small sizes.

Both stay within the icon set's conventions: 24×24 viewBox, 2px rounded strokes, ~2–3px padding.

## Before / after

![Editor button before (scissors) and after (filmstrip) in the record dock](https://cursor.com/artifacts/c/art-b360ad19-5736-4651-b9bc-830047d4d964)

![Delete button before (tapered can) and after (rounded bin) in the editor toolbar](https://cursor.com/artifacts/c/art-df749898-388d-4f86-8cfd-18d806a06c68)

## Testing

- `npm run lint` and `npm test` (95 unit tests) pass.
- `npm run build` passes (via `test:smoke`; the smoke runner itself fails on `main` too with a pre-existing duplicate `h1.brand` strict-mode violation, unrelated to this change).
- Screenshots above were captured in the real app via Playwright with the fake camera (seeded project, record screen and editor screen).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3a038315-0be8-4b7e-b256-852f952d110e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3a038315-0be8-4b7e-b256-852f952d110e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

