### PR TITLE
Stop reporting free-plan project limits to Sentry (KODY-VIDEO-B)

### DIFF
--- a/scripts/manual-smoke.mjs
+++ b/scripts/manual-smoke.mjs
@@ -77,7 +77,8 @@ try {
   // --- Home: branding + six slots ---
   await page.goto(BASE, { waitUntil: 'networkidle' })
   const title = await page.title()
-  const brand = await page.locator('h1.brand').innerText()
+  // Boot hero + React home spacer both render h1.brand on mobile viewports.
+  const brand = await page.locator('#boot-hero h1.brand').innerText()
   if (title.includes('Kody') && brand.toLowerCase().includes('kody')) {
     pass('home branding', `${title} / ${brand.replace(/\n/g, ' ')}`)
   } else {
@@ -95,10 +96,17 @@ try {
   pass('create + open project', page.url())
 
   // --- Onboarding ---
+  // Dialog mounts after the project page load promise resolves — a bare
+  // count() races and leaves the overlay blocking later clicks.
   const onboarding = page.getByRole('dialog', { name: /quick start/i })
-  if (await onboarding.count()) {
+  const onboardingVisible = await onboarding
+    .waitFor({ state: 'visible', timeout: 3000 })
+    .then(() => true)
+    .catch(() => false)
+  if (onboardingVisible) {
     await shot(page, '02-onboarding')
     await page.getByRole('button', { name: /start recording/i }).click()
+    await onboarding.waitFor({ state: 'hidden', timeout: 3000 }).catch(() => null)
     pass('onboarding visible and dismissible')
   } else {
     pass('onboarding already dismissed or not shown')
@@ -222,7 +230,7 @@ try {
   if (await saveBtn.count()) pass('export offers Save')
   else fail('export offers Save')
 
-  const upsell = exportDialog.getByRole('button', { name: /remove it — \$0\.99/i })
+  const upsell = exportDialog.getByRole('button', { name: /get plus — \$0\.99/i })
   if (await upsell.count()) pass('watermark upsell shown while locked')
   else fail('watermark upsell shown while locked')
   await exportDialog.getByRole('button', { name: /done|close/i }).first().click()
@@ -239,7 +247,7 @@ try {
     waitUntil: 'networkidle',
   })
   const celebrated = await page
-    .waitForSelector('text=/watermark removed/i', { timeout: 5000 })
+    .waitForSelector('text=/kody video plus unlocked/i', { timeout: 5000 })
     .then(() => true)
     .catch(() => false)
   if (celebrated) pass('unlock page verifies and celebrates')
@@ -263,7 +271,7 @@ try {
     .catch(() => false)
   const upsellGone =
     unlockedExport &&
-    (await page.getByRole('button', { name: /remove it — \$0\.99/i }).count()) === 0
+    (await page.getByRole('button', { name: /get plus — \$0\.99/i }).count()) === 0
   if (upsellGone) pass('purchase removes the watermark upsell')
   else fail('purchase removes the watermark upsell', `exported=${unlockedExport}`)
   await page
@@ -324,8 +332,18 @@ try {
   await page.goto(BASE, { waitUntil: 'networkidle' })
   await page.locator('.project-slot.filled .slot-open').first().click()
   await page.waitForURL(/\/project\//, { timeout: 5000 })
+  // Editor may still be up from the earlier trim/export path — return to camera.
+  const backToCamera = page.getByRole('button', { name: /back to camera/i })
+  if (await backToCamera.isVisible().catch(() => false)) {
+    await backToCamera.click()
+  }
+  await page.locator('.record-stage').waitFor({ state: 'visible', timeout: 8000 }).catch(() => null)
   const locToggle = page.getByRole('button', { name: /toggle location tagging/i })
-  if ((await locToggle.count()) === 1) pass('location tagging toggle present')
+  const locVisible = await locToggle
+    .waitFor({ state: 'visible', timeout: 5000 })
+    .then(() => true)
+    .catch(() => false)
+  if (locVisible) pass('location tagging toggle present')
   else fail('location tagging toggle present')
 
   // --- Persistence / offline / SPA fallback ---

--- a/src/lib/error-reporting.test.ts
+++ b/src/lib/error-reporting.test.ts
@@ -1,8 +1,12 @@
 import { describe, expect, it } from 'vitest'
 import {
   isCloudflareInsightsBeaconEvent,
+  isExpectedUserError,
   isMonitoringSelfTestEvent,
+  isProjectLimitEvent,
+  reportError,
 } from './error-reporting'
+import { ProjectLimitError } from './storage'
 
 describe('isMonitoringSelfTestEvent', () => {
   it('drops the setup-agent synthetic exception signature', () => {
@@ -41,6 +45,78 @@ describe('isMonitoringSelfTestEvent', () => {
 
   it('keeps events with no exception payload', () => {
     expect(isMonitoringSelfTestEvent({})).toBe(false)
+  })
+})
+
+describe('isProjectLimitEvent', () => {
+  it('drops ProjectLimitError by exception type', () => {
+    expect(
+      isProjectLimitEvent({
+        exception: {
+          values: [
+            {
+              type: 'ProjectLimitError',
+              value: 'The free plan includes 1 project — Kody Video Plus unlocks 6.',
+            },
+          ],
+        },
+      }),
+    ).toBe(true)
+  })
+
+  it('drops the free-plan copy even when typed as Error (pre-fix events)', () => {
+    expect(
+      isProjectLimitEvent({
+        exception: {
+          values: [
+            {
+              type: 'Error',
+              value:
+                'The free plan includes 1 project — Kody Video Plus unlocks 6 (and removes the watermark).',
+            },
+          ],
+        },
+      }),
+    ).toBe(true)
+  })
+
+  it('drops the hard project-cap copy', () => {
+    expect(
+      isProjectLimitEvent({
+        exception: {
+          values: [
+            {
+              type: 'Error',
+              value: 'Project limit reached (6). Delete a project to create another.',
+            },
+          ],
+        },
+      }),
+    ).toBe(true)
+  })
+
+  it('keeps unrelated application errors', () => {
+    expect(
+      isProjectLimitEvent({
+        exception: {
+          values: [{ type: 'Error', value: 'Export failed: encoder closed' }],
+        },
+      }),
+    ).toBe(false)
+  })
+})
+
+describe('isExpectedUserError / reportError', () => {
+  it('recognizes ProjectLimitError instances', () => {
+    expect(isExpectedUserError(new ProjectLimitError('capped'))).toBe(true)
+    expect(isExpectedUserError(new Error('Export failed'))).toBe(false)
+  })
+
+  it('reportError returns without throwing for ProjectLimitError', () => {
+    // Short-circuits before the idle-deferred SDK load — no capture queued.
+    expect(() =>
+      reportError(new ProjectLimitError('The free plan includes 1 project'), 'save-clip'),
+    ).not.toThrow()
   })
 })
 

--- a/src/lib/error-reporting.ts
+++ b/src/lib/error-reporting.ts
@@ -61,6 +61,21 @@ export function isMonitoringSelfTestEvent(event: FilterableSentryEvent): boolean
   )
 }
 
+/**
+ * Soft project-cap / free-plan gate (createProject). Expected UX noise —
+ * drop even if something captures outside reportError.
+ */
+export function isProjectLimitEvent(event: FilterableSentryEvent): boolean {
+  const exceptionValues = event.exception?.values ?? []
+  for (const value of exceptionValues) {
+    if (value.type === 'ProjectLimitError') return true
+    const text = value.value ?? ''
+    if (text.includes('The free plan includes 1 project')) return true
+    if (/^Project limit reached \(\d+\)/.test(text)) return true
+  }
+  return false
+}
+
 function frameUrl(frame: FilterableStackFrame): string {
   return frame.abs_path ?? frame.filename ?? ''
 }
@@ -192,6 +207,7 @@ function loadSentry(): Promise<SentryLike> {
         delete event.request
         if (isMonitoringSelfTestEvent(event)) return null
         if (isCloudflareInsightsBeaconEvent(event)) return null
+        if (isProjectLimitEvent(event)) return null
         return event
       },
     })
@@ -223,6 +239,15 @@ export function initErrorReporting(): void {
 }
 
 /**
+ * True for expected product gates that must never become crash reports.
+ * Matched by `error.name` so this module stays free of a storage import
+ * (storage pulls idb/OPFS; reportError is on the idle-deferred Sentry path).
+ */
+export function isExpectedUserError(error: unknown): boolean {
+  return error instanceof Error && error.name === 'ProjectLimitError'
+}
+
+/**
  * Explicit capture for errors we catch and surface as in-app messages
  * (export error sheet, import error banner, …) — the user sees a friendly
  * message, we see the cause. The step lands as a searchable Sentry tag.
@@ -232,6 +257,9 @@ export function reportError(
   step: string,
   extra?: Record<string, unknown>,
 ): void {
+  // Plan/project caps are product UX (toast / upsell), not failures to triage.
+  if (isExpectedUserError(error)) return
+
   if (sentry) {
     sentry.captureException(error, { tags: { step }, ...(extra ? { extra } : {}) })
     return

--- a/src/lib/storage.test.ts
+++ b/src/lib/storage.test.ts
@@ -4,6 +4,7 @@ import {
   __resetDbForTests,
   addClip,
   createProject,
+  ProjectLimitError,
   deleteClip,
   deleteProject,
   duplicateClip,
@@ -42,6 +43,7 @@ describe('storage layer', () => {
 
   it('gates the second project behind the Plus purchase', async () => {
     await createProject('Free one')
+    await expect(createProject('Second')).rejects.toBeInstanceOf(ProjectLimitError)
     await expect(createProject('Second')).rejects.toThrow(/plus/i)
   })
 
@@ -62,6 +64,7 @@ describe('storage layer', () => {
     for (let i = 0; i < MAX_PROJECTS; i += 1) {
       await createProject(`P${i + 1}`)
     }
+    await expect(createProject('Overflow')).rejects.toBeInstanceOf(ProjectLimitError)
     await expect(createProject('Overflow')).rejects.toThrow(/limit/i)
   })
 

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -133,18 +133,28 @@ export async function getProject(id: ProjectId): Promise<Project | undefined> {
   return db.get('projects', id)
 }
 
+/**
+ * Soft project-cap / free-plan gate. Surfaced in-app as guidance (toast,
+ * upsell); expected product behavior, never a crash report.
+ */
+export class ProjectLimitError extends Error {
+  override readonly name = 'ProjectLimitError'
+}
+
 export async function createProject(name?: string): Promise<Project> {
   const db = await getDb()
   const existing = await listProjects()
   const settings = await getSettings()
   if (existing.length >= settings.maxProjects) {
-    throw new Error(`Project limit reached (${settings.maxProjects}). Delete a project to create another.`)
+    throw new ProjectLimitError(
+      `Project limit reached (${settings.maxProjects}). Delete a project to create another.`,
+    )
   }
   // Free tier includes one project; the one-time Kody Video Plus purchase
   // (the watermark unlock) raises the cap to maxProjects. Enforced here so
   // every creation path (record, import) hits the same gate.
   if (settings.watermarkRemoved !== true && existing.length >= FREE_PROJECTS) {
-    throw new Error(
+    throw new ProjectLimitError(
       'The free plan includes 1 project — Kody Video Plus unlocks 6 (and removes the watermark).',
     )
   }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sentry issue [KODY-VIDEO-B](https://kent-c-dodds-tech-llc.sentry.io/issues/7652691759/) is not a crash: free users hitting `createProject`’s one-project gate throw an expected product message, and `endRecord` / other save paths report it via `reportError`.

- Introduce `ProjectLimitError` for the free-plan and hard project-cap gates in `createProject`
- Skip that typed error in `reportError` (same idea as `BackupFormatError` for bad backups)
- Drop matching events in `beforeSend` so residual captures cannot re-open triage noise
- Unit coverage for the filter helpers and instanceof throws
- Unflake `scripts/manual-smoke.mjs` (onboarding race + current Plus copy) so the smoke gate stays green

## Risk

**Low** — reporting/filter wiring only; plan limits still throw and still surface in-app toasts. No billing/auth/storage schema changes.

## Test plan

- [x] `npm run build`
- [x] `npx vitest run`
- [x] `node scripts/manual-smoke.mjs` (32/32)

## Ship

Squash-merged as `94d9151fcc2bcb3002821c69fceb34e702188450`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d673f993-6372-4a72-b197-9e7e98bf0ea5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d673f993-6372-4a72-b197-9e7e98bf0ea5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

