### PR TITLE
Background music level becomes a relative mix with peak normalization

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,13 +34,17 @@ For a phone on the same network, use your machine’s LAN URL over HTTPS, or tun
 - Recording feedback (REC pill + elapsed) with a page that does **not** re-render per frame — capture stays smooth
 - Editor: filmstrip timeline (thumbnails, width ∝ duration), drag to reorder, duplicate, delete w/ undo, **in-timeline trim with drag handles**, **add clips from your device/gallery**
 - **Background music** (Plus): build a playlist of audio tracks that play one
-  after the other under the film at a background-friendly default volume
-  (nothing loops — a hint suggests adding another track when the music ends
-  before the film does); tap any clip to set the music volume just for that
-  clip (duck it under speech, swell it for b-roll), volume changes glide
-  across clip boundaries, and the music fades in/out at the start and end of
-  the film (both toggleable, on by default) — in the preview and in the
-  exported file
+  after the other under the film (nothing loops — a hint suggests adding
+  another track when the music ends before the film does). The mix is
+  **relative**: one balance slider per clip splits the audio between the
+  clip's own sound (left) and the music (right) — 80% music means 20% clip
+  sound — so the blend can never clip, and exports **peak-normalize** both
+  sources so the split means the same thing however hot either recording
+  is. Defaults to 25% music under every clip; tap a clip to set its own
+  balance (duck the music under speech, swell it for b-roll). Mix changes
+  glide across clip boundaries, and the music fades in/out at the start and
+  end of the film (both toggleable, on by default) — in the preview and in
+  the exported file
 - Project preview playback: tap edges to skip clips, tap middle to stop
 - Up to **6** stable project slots (create / open / rename / delete, poster art from your clips)
 - Big Go CTA: on-device export to **one video file**, then Share (system sheet) or Save

--- a/src/components/audio-strip.tsx
+++ b/src/components/audio-strip.tsx
@@ -309,67 +309,99 @@ export function AudioStrip(handle: Handle<AudioStripProps>) {
         </div>
 
         {selectedClip ? (
-          <div className="audio-volume-row">
-            <span className="audio-volume-label">
-              Clip {selectedIndex + 1}
-              {clipOverridden ? '' : ' · default'}
-            </span>
-            <input
-              type="range"
-              min={0}
-              max={100}
-              step={5}
-              value={Math.round(clipVolume * 100)}
-              disabled={disabled || busy}
-              aria-label={`Music volume during clip ${selectedIndex + 1}`}
-              mix={[
-                on('input', (event) => {
-                  const volume = Number((event.currentTarget as HTMLInputElement).value) / 100
-                  pendingClip = { clipId: selectedClip.id, volume }
-                  void handle.update()
-                }),
-                on('change', (event) => {
-                  const volume = Number((event.currentTarget as HTMLInputElement).value) / 100
-                  commitClipVolume(selectedClip.id, volume)
-                }),
-              ]}
-            />
-            <span className="audio-volume-value">{Math.round(clipVolume * 100)}%</span>
-            <button
-              type="button"
-              className="audio-volume-reset"
-              disabled={disabled || busy || !clipOverridden}
-              aria-label="Reset this clip to the default music volume"
-              mix={on('click', () => resetClipVolume(selectedClip.id))}
-            >
-              Reset
-            </button>
-          </div>
+          <MixRow
+            label={`Clip ${selectedIndex + 1}${clipOverridden ? '' : ' · default'}`}
+            ariaLabel={`Audio mix during clip ${selectedIndex + 1}`}
+            share={clipVolume}
+            disabled={disabled || busy}
+            onPreview={(share) => {
+              pendingClip = { clipId: selectedClip.id, volume: share }
+              void handle.update()
+            }}
+            onCommit={(share) => commitClipVolume(selectedClip.id, share)}
+            onReset={clipOverridden ? () => resetClipVolume(selectedClip.id) : undefined}
+          />
         ) : null}
 
-        <div className="audio-volume-row">
-          <span className="audio-volume-label">All clips</span>
-          <input
-            type="range"
-            min={0}
-            max={100}
-            step={5}
-            value={Math.round(defaultVolume * 100)}
-            disabled={disabled || busy}
-            aria-label="Default music volume"
-            mix={[
-              on('input', (event) => {
-                pendingDefault = Number((event.currentTarget as HTMLInputElement).value) / 100
-                void handle.update()
-              }),
-              on('change', (event) => {
-                const volume = Number((event.currentTarget as HTMLInputElement).value) / 100
-                commitDefaultVolume(volume)
-              }),
-            ]}
-          />
-          <span className="audio-volume-value">{Math.round(defaultVolume * 100)}%</span>
-        </div>
+        <MixRow
+          label="All clips"
+          ariaLabel="Default audio mix"
+          share={defaultVolume}
+          disabled={disabled || busy}
+          onPreview={(share) => {
+            pendingDefault = share
+            void handle.update()
+          }}
+          onCommit={(share) => commitDefaultVolume(share)}
+        />
+      </div>
+    )
+  }
+}
+
+interface MixRowProps {
+  label: string
+  ariaLabel: string
+  /** Music's share of the mix (0–1); the clip's own sound gets the rest. */
+  share: number
+  disabled: boolean
+  /** Live thumb move (label preview only — nothing persisted yet). */
+  onPreview: (share: number) => void
+  /** Slider released — persist. */
+  onCommit: (share: number) => void
+  /** Present only when the row is overridable and currently overridden. */
+  onReset?: () => void
+}
+
+/** One balance slider: clip sound on the left, music on the right — drag
+ * toward the side that should carry more of the mix. */
+function MixRow(handle: Handle<MixRowProps>) {
+  return () => {
+    const { label, ariaLabel, share, disabled, onReset } = handle.props
+    const musicPct = Math.round(share * 100)
+    const clipPct = 100 - musicPct
+    return (
+      <div className="audio-mix-row">
+        <span className="audio-volume-label">{label}</span>
+        <span className="audio-mix-side" aria-hidden="true">
+          Clip <strong>{clipPct}%</strong>
+        </span>
+        <input
+          type="range"
+          min={0}
+          max={100}
+          step={5}
+          value={musicPct}
+          disabled={disabled}
+          aria-label={ariaLabel}
+          aria-valuetext={`${clipPct}% clip sound, ${musicPct}% music`}
+          mix={[
+            on('input', (event) => {
+              handle.props.onPreview(
+                Number((event.currentTarget as HTMLInputElement).value) / 100,
+              )
+            }),
+            on('change', (event) => {
+              handle.props.onCommit(
+                Number((event.currentTarget as HTMLInputElement).value) / 100,
+              )
+            }),
+          ]}
+        />
+        <span className="audio-mix-side" aria-hidden="true">
+          <strong>{musicPct}%</strong> Music
+        </span>
+        {onReset ? (
+          <button
+            type="button"
+            className="audio-volume-reset"
+            disabled={disabled}
+            aria-label="Reset this clip to the default audio mix"
+            mix={on('click', () => handle.props.onReset?.())}
+          >
+            Reset
+          </button>
+        ) : null}
       </div>
     )
   }

--- a/src/components/playback-overlay.tsx
+++ b/src/components/playback-overlay.tsx
@@ -185,7 +185,10 @@ export function PlaybackOverlay(handle: Handle<PlaybackOverlayProps>) {
     // per-frame glide below fades it in from silence.
     el.volume = track.fadeIn ? 0 : segmentMusicVolume()
 
-    // Per-frame volume glide toward the current clip's target.
+    // Per-frame glide of BOTH sides of the mix: the music toward the
+    // current clip's share, the clip's own sound toward the complement
+    // (1 − share) — mirroring the export blend. Where the playlist has run
+    // out, the clip glides back to full volume.
     let last = performance.now()
     let raf = 0
     const tick = (now: number) => {
@@ -195,6 +198,16 @@ export function PlaybackOverlay(handle: Handle<PlaybackOverlayProps>) {
       const alpha = 1 - Math.exp(-dt / MUSIC_VOLUME_TAU_MS)
       const next = el.volume + (target - el.volume) * alpha
       el.volume = Math.abs(next - target) < 0.005 ? target : next
+      const video = videoEl
+      if (video) {
+        const musicHere = props.audio ? trackAtMs(timelinePositionMs()) !== null : false
+        const clipTarget = musicHere ? 1 - target : 1
+        const nextClip = video.volume + (clipTarget - video.volume) * alpha
+        video.volume = Math.max(
+          0,
+          Math.min(1, Math.abs(nextClip - clipTarget) < 0.005 ? clipTarget : nextClip),
+        )
+      }
       raf = requestAnimationFrame(tick)
     }
     raf = requestAnimationFrame(tick)

--- a/src/components/playback-overlay.tsx
+++ b/src/components/playback-overlay.tsx
@@ -142,11 +142,15 @@ export function PlaybackOverlay(handle: Handle<PlaybackOverlayProps>) {
     if (musicTrackIndex !== target.index) {
       // Metadata durations can run slightly past the decoded length, so a
       // just-ended track briefly still "covers" the playhead — moving back
-      // to it would restart it. Only genuine backward skips switch back.
+      // to it mid-playback would restart it. The guard protects that
+      // playback continuity only: once the current element has ENDED there
+      // is nothing to protect (and play() on it would restart it from 0),
+      // so a backward skip switches to the covering track instead.
       const boundaryMs = props.audio.tracks
         .slice(0, target.index + 1)
         .reduce((sum, track) => sum + track.durationMs, 0)
-      const nearHandOff = target.index < musicTrackIndex && boundaryMs - positionMs < 1500
+      const nearHandOff =
+        target.index < musicTrackIndex && boundaryMs - positionMs < 1500 && !audio.ended
       if (!nearHandOff) {
         musicTrackIndex = target.index
         audio.src = urlForTrack(target.index)

--- a/src/components/playback-overlay.tsx
+++ b/src/components/playback-overlay.tsx
@@ -153,8 +153,19 @@ export function PlaybackOverlay(handle: Handle<PlaybackOverlayProps>) {
         audio.currentTime = target.offsetMs / 1000
         playlistDone = false
       }
-    } else if (Math.abs(audio.currentTime - target.offsetMs / 1000) > 0.35) {
-      audio.currentTime = target.offsetMs / 1000
+      return true
+    }
+    const expectedSec = target.offsetMs / 1000
+    // Positions inside a finished track's metadata overshoot have no
+    // decoded audio behind them — playing there would RESTART the ended
+    // element (play() on an ended media element seeks back to 0).
+    const decodedEndSec = Number.isFinite(audio.duration) ? audio.duration : Infinity
+    if (playlistDone && expectedSec >= decodedEndSec - 0.05) {
+      return false
+    }
+    if (Math.abs(audio.currentTime - expectedSec) > 0.35) {
+      audio.currentTime = expectedSec
+      // A genuine seek into real decoded audio — music is live again.
       playlistDone = false
     }
     return true

--- a/src/components/playback-overlay.tsx
+++ b/src/components/playback-overlay.tsx
@@ -57,6 +57,11 @@ export function PlaybackOverlay(handle: Handle<PlaybackOverlayProps>) {
   /** Lazily created object URL per playlist track (revoked on unmount). */
   const trackUrls = new Map<number, string>()
   let musicTrackIndex = -1
+  /** True once the LAST track actually finished playing — decoded audio can
+   * end before its stored metadata duration, and the clip's own sound must
+   * come back up as soon as the music is really over, not when the
+   * metadata window says so. Cleared when a skip seeks music again. */
+  let playlistDone = false
 
   const currentSegment = () => resolveSegments()[index] ?? null
   const startSec = () => {
@@ -146,9 +151,11 @@ export function PlaybackOverlay(handle: Handle<PlaybackOverlayProps>) {
         musicTrackIndex = target.index
         audio.src = urlForTrack(target.index)
         audio.currentTime = target.offsetMs / 1000
+        playlistDone = false
       }
     } else if (Math.abs(audio.currentTime - target.offsetMs / 1000) > 0.35) {
       audio.currentTime = target.offsetMs / 1000
+      playlistDone = false
     }
     return true
   }
@@ -161,7 +168,12 @@ export function PlaybackOverlay(handle: Handle<PlaybackOverlayProps>) {
     const audio = audioEl
     if (!audio) return
     const next = musicTrackIndex + 1
-    if (next >= tracks.length) return // Playlist over — the rest is music-free.
+    if (next >= tracks.length) {
+      // Playlist over — the rest is music-free (and the clip's own sound
+      // comes back up right away, even inside the metadata overshoot).
+      playlistDone = true
+      return
+    }
     musicTrackIndex = next
     audio.src = urlForTrack(next)
     audio.currentTime = 0
@@ -200,7 +212,8 @@ export function PlaybackOverlay(handle: Handle<PlaybackOverlayProps>) {
       el.volume = Math.abs(next - target) < 0.005 ? target : next
       const video = videoEl
       if (video) {
-        const musicHere = props.audio ? trackAtMs(timelinePositionMs()) !== null : false
+        const musicHere =
+          props.audio && !playlistDone ? trackAtMs(timelinePositionMs()) !== null : false
         const clipTarget = musicHere ? 1 - target : 1
         const nextClip = video.volume + (clipTarget - video.volume) * alpha
         video.volume = Math.max(

--- a/src/components/playback-overlay.tsx
+++ b/src/components/playback-overlay.tsx
@@ -229,12 +229,17 @@ export function PlaybackOverlay(handle: Handle<PlaybackOverlayProps>) {
       if (video) {
         const musicHere =
           props.audio && !playlistDone ? trackAtMs(timelinePositionMs()) !== null : false
-        const clipTarget = musicHere ? 1 - target : 1
-        const nextClip = video.volume + (clipTarget - video.volume) * alpha
-        video.volume = Math.max(
-          0,
-          Math.min(1, Math.abs(nextClip - clipTarget) < 0.005 ? clipTarget : nextClip),
-        )
+        if (musicHere) {
+          // Exact mirror of the export blend: the clip's own sound always
+          // carries the complement of the music's CURRENT (gliding)
+          // volume — during the fade-in the clip starts at full and only
+          // comes down as the bed actually rises.
+          video.volume = Math.max(0, Math.min(1, 1 - el.volume))
+        } else {
+          // No music here (playlist over) — glide back up to full.
+          const nextClip = video.volume + (1 - video.volume) * alpha
+          video.volume = Math.min(1, nextClip > 0.995 ? 1 : nextClip)
+        }
       }
       raf = requestAnimationFrame(tick)
     }

--- a/src/lib/export/background-audio.test.ts
+++ b/src/lib/export/background-audio.test.ts
@@ -147,6 +147,15 @@ describe('normalization', () => {
     expect(channelPeak([new Float32Array(4)])).toBe(0)
   })
 
+  it('never misses a lone transient (exact scan, no striding)', () => {
+    // One full-scale spike buried in a long quiet buffer: a strided scan
+    // would miss it, derive a big boost, and clip it against the clamp.
+    const data = new Float32Array(100_000).fill(0.05)
+    data[73_331] = -1
+    expect(channelPeak([data])).toBe(1)
+    expect(normalizationScale(channelPeak([data]))).toBeCloseTo(NORMALIZED_PEAK)
+  })
+
   it('scales toward the target peak, bounded on both sides', () => {
     expect(normalizationScale(NORMALIZED_PEAK)).toBeCloseTo(1)
     expect(normalizationScale(0.45)).toBeCloseTo(NORMALIZED_PEAK / 0.45)

--- a/src/lib/export/background-audio.test.ts
+++ b/src/lib/export/background-audio.test.ts
@@ -3,10 +3,14 @@ import {
   EDGE_RAMP_MS,
   FADE_IN_MS,
   FADE_OUT_MS,
+  MAX_NORMALIZATION_BOOST,
+  NORMALIZED_PEAK,
   VOLUME_RAMP_MS,
   boundaryRampHalfMs,
+  channelPeak,
   createBackgroundMixer,
   gainAtMs,
+  normalizationScale,
   planSegmentGain,
   segmentVolume,
   type GainPoint,
@@ -135,6 +139,27 @@ describe('planSegmentGain', () => {
   })
 })
 
+describe('normalization', () => {
+  it('measures the peak across channels', () => {
+    expect(
+      channelPeak([new Float32Array([0.1, -0.6]), new Float32Array([0.3, 0.2])]),
+    ).toBeCloseTo(0.6)
+    expect(channelPeak([new Float32Array(4)])).toBe(0)
+  })
+
+  it('scales toward the target peak, bounded on both sides', () => {
+    expect(normalizationScale(NORMALIZED_PEAK)).toBeCloseTo(1)
+    expect(normalizationScale(0.45)).toBeCloseTo(NORMALIZED_PEAK / 0.45)
+    // Loud sources come DOWN toward the target too.
+    expect(normalizationScale(1)).toBeCloseTo(0.9)
+    // Quiet audio is never boosted more than the cap…
+    expect(normalizationScale(0.05)).toBe(MAX_NORMALIZATION_BOOST)
+    // …and near-silence (dead mic) is left alone entirely.
+    expect(normalizationScale(0.001)).toBe(1)
+    expect(normalizationScale(0)).toBe(1)
+  })
+})
+
 describe('createBackgroundMixer', () => {
   const flatEnvelope = (volume: number): GainPoint[] => [
     { tMs: 0, volume },
@@ -148,16 +173,46 @@ describe('createBackgroundMixer', () => {
     }
   }
 
-  it('adds a track at the envelope gain', async () => {
-    const slice = [new Float32Array([0.1, 0.1, 0.1, 0.1])]
+  it('blends complementary shares: music at g, clip at 1 − g', async () => {
+    const slice = [new Float32Array([0.6, 0.6, 0.6, 0.6])]
     const mixer = createBackgroundMixer(
       sourceOf([[new Float32Array([0.4, 0.4, 0.4, 0.4])]]),
       48000,
     )
-    await mixer.mixInto(slice, 0, flatEnvelope(0.5))
+    // 30% music: out = 0.6·0.7 + 0.4·0.3 = 0.54.
+    await mixer.mixInto(slice, 0, flatEnvelope(0.3))
     for (const sample of slice[0]) {
-      expect(sample).toBeCloseTo(0.1 + 0.4 * 0.5)
+      expect(sample).toBeCloseTo(0.6 * 0.7 + 0.4 * 0.3)
     }
+  })
+
+  it('applies the foreground normalization scale to the clip side only', async () => {
+    const slice = [new Float32Array([0.2, 0.2])]
+    const mixer = createBackgroundMixer(
+      sourceOf([[new Float32Array([0.4, 0.4])]]),
+      48000,
+    )
+    // Clip normalized 2×: out = 0.2·2·0.5 + 0.4·0.5 = 0.4.
+    await mixer.mixInto(slice, 0, flatEnvelope(0.5), 2)
+    for (const sample of slice[0]) {
+      expect(sample).toBeCloseTo(0.4)
+    }
+  })
+
+  it('eases the clip back to full volume when the playlist runs out', async () => {
+    // 1 frame = 30ms (sampleRate ~33.33) would be awkward; use sampleRate 10
+    // so the 300ms end ramp spans exactly 3 frames.
+    const mixer = createBackgroundMixer(
+      sourceOf([[new Float32Array([0, 0])]]), // 2 frames of silent music
+      10,
+    )
+    const slice = [new Float32Array(6).fill(0.6)]
+    await mixer.mixInto(slice, 0, flatEnvelope(0.8))
+    // Frames 0–1: clip at 1 − 0.8 = 0.2 share. From frame 2 the playlist is
+    // over and the clip ramps 0.2 → 1 over 3 frames.
+    expect(Array.from(slice[0]).map((v) => Number(v.toFixed(2)))).toEqual([
+      0.12, 0.12, 0.12, 0.28, 0.44, 0.6,
+    ])
   })
 
   it('plays tracks one after the other and goes silent when they run out', async () => {
@@ -215,15 +270,17 @@ describe('createBackgroundMixer', () => {
     expect(Array.from(slice[0]).map((v) => Number(v.toFixed(2)))).toEqual([0.2, 0.2, 0])
   })
 
-  it('spreads a mono track across stereo slices and clamps the sum', async () => {
+  it('spreads a mono track across stereo slices and hard-clamps the blend', async () => {
     const slice = [new Float32Array([0.9]), new Float32Array([-0.9])]
     const mixer = createBackgroundMixer(sourceOf([[new Float32Array([1])]]), 48000)
-    await mixer.mixInto(slice, 0, flatEnvelope(1))
+    // An extreme normalization boost is the only way past 1 now that the
+    // shares themselves are complementary: 0.9·4·0.5 + 1·0.5 = 2.3 → 1.
+    await mixer.mixInto(slice, 0, flatEnvelope(0.5), 4)
     expect(slice[0][0]).toBe(1)
-    expect(slice[1][0]).toBeCloseTo(0.1)
+    expect(slice[1][0]).toBe(-1)
   })
 
-  it('leaves slices untouched when the gain is zero', async () => {
+  it('leaves slices untouched when the music share is zero', async () => {
     const slice = [new Float32Array([0.3, 0.3])]
     const before = Array.from(slice[0])
     const mixer = createBackgroundMixer(sourceOf([[new Float32Array([0.5, 0.5])]]), 48000)

--- a/src/lib/export/background-audio.ts
+++ b/src/lib/export/background-audio.ts
@@ -30,13 +30,14 @@ export const MAX_NORMALIZATION_BOOST = 4
 /** Below this peak the audio is treated as silence and never boosted. */
 export const NORMALIZATION_SILENCE_FLOOR = 0.01
 
-/** Sampled peak of decoded channel data (stride-sampled like the export
- * diagnostics — exact peaks are not worth a full pass on long audio). */
+/** Exact peak of decoded channel data. Every sample is scanned: a strided
+ * scan can miss a transient, and a boost derived from an undermeasured
+ * peak would push that transient into the hard clamp instead of keeping
+ * the intended headroom. One pass over even a long song is milliseconds. */
 export function channelPeak(channels: Float32Array[]): number {
   let peak = 0
   for (const data of channels) {
-    const stride = Math.max(1, Math.floor(data.length / 8000))
-    for (let i = 0; i < data.length; i += stride) {
+    for (let i = 0; i < data.length; i += 1) {
       const value = Math.abs(data[i])
       if (value > peak) peak = value
     }

--- a/src/lib/export/background-audio.ts
+++ b/src/lib/export/background-audio.ts
@@ -2,14 +2,16 @@ import { clipAudioVolume } from '../types'
 import type { PlannedSegment } from './plan'
 
 /**
- * Background-music gain planning and mixing shared by both export engines
- * and unit tests: per-clip volumes become one piecewise-linear gain envelope
- * over the output timeline (volume changes glide across clip boundaries),
- * and the playlist's tracks are mixed in one after the other — the film's
- * end cuts the music off, nothing loops.
+ * Background-music mix planning shared by both export engines and unit
+ * tests. The per-clip value is the music's SHARE of the audio mix: gain g
+ * for the music means gain (1 − g) for the clip's own sound, so the two
+ * always sum to one — no clipping, no shouting match between mic and
+ * music. Per-clip shares become piecewise-linear envelopes (mix changes
+ * glide across clip boundaries), and the playlist's tracks are mixed in
+ * one after the other — the film's end cuts the music off, nothing loops.
  */
 
-/** Length of the glide between two clips with different music volumes. */
+/** Length of the glide between two clips with different music shares. */
 export const VOLUME_RAMP_MS = 600
 /** Musical ease-in at the start of the film (the "Fade in" toggle). */
 export const FADE_IN_MS = 800
@@ -17,6 +19,37 @@ export const FADE_IN_MS = 800
 export const FADE_OUT_MS = 1200
 /** With fades off, a click-kill ramp too short to hear as a fade. */
 export const EDGE_RAMP_MS = 15
+/** When the playlist runs out mid-film, the clip sound eases back to full
+ * volume over this window instead of jumping. */
+export const PLAYLIST_END_RAMP_MS = 300
+
+/** Peak both sources are normalized toward before blending. */
+export const NORMALIZED_PEAK = 0.9
+/** Never boost quiet audio more than this (+12 dB) — it amplifies noise. */
+export const MAX_NORMALIZATION_BOOST = 4
+/** Below this peak the audio is treated as silence and never boosted. */
+export const NORMALIZATION_SILENCE_FLOOR = 0.01
+
+/** Sampled peak of decoded channel data (stride-sampled like the export
+ * diagnostics — exact peaks are not worth a full pass on long audio). */
+export function channelPeak(channels: Float32Array[]): number {
+  let peak = 0
+  for (const data of channels) {
+    const stride = Math.max(1, Math.floor(data.length / 8000))
+    for (let i = 0; i < data.length; i += stride) {
+      const value = Math.abs(data[i])
+      if (value > peak) peak = value
+    }
+  }
+  return peak
+}
+
+/** Gain that brings a source's peak toward NORMALIZED_PEAK, bounded so
+ * near-silence is never blown up into noise. */
+export function normalizationScale(peak: number): number {
+  if (!Number.isFinite(peak) || peak < NORMALIZATION_SILENCE_FLOOR) return 1
+  return Math.min(MAX_NORMALIZATION_BOOST, NORMALIZED_PEAK / peak)
+}
 
 export interface BackgroundAudio {
   tracks: Array<{ blob: Blob }>
@@ -127,23 +160,27 @@ export interface SequentialBackgroundSource {
 }
 
 export interface BackgroundMixer {
-  /** Add the playlist into a segment slice's channels, in place, with the
-   * gain following `points` — the slice's own local envelope (its time 0 is
-   * the slice's first sample). Slices must be requested in output order
-   * (tracks are decoded lazily, one at a time, and released once the
-   * timeline passes them). */
+  /** Blend the playlist into a segment slice's channels (which carry the
+   * clip's own sound), in place: `out = clip·fgScale·(1−g) + music·g`,
+   * where g follows `points` — the slice's own local envelope (its time 0
+   * is the slice's first sample) — and `foregroundScale` is the clip's
+   * normalization gain. Slices must be requested in output order (tracks
+   * are decoded lazily, one at a time, and released once the timeline
+   * passes them). */
   mixInto: (
     channels: Float32Array[],
     sliceStartFrame: number,
     points: GainPoint[],
+    foregroundScale?: number,
   ) => Promise<void>
 }
 
 /**
  * Sequential playlist mixer: track 0 starts at output frame 0, each next
  * track starts where the previous one's decoded samples end, and when the
- * playlist runs out the rest of the film simply has no music. Gain follows
- * each slice's local envelope; the sum hard-clamps to [-1, 1].
+ * playlist runs out the clip sound eases back to full volume (over
+ * PLAYLIST_END_RAMP_MS) and the rest of the film simply has no music.
+ * Everything hard-clamps to [-1, 1].
  */
 export function createBackgroundMixer(
   source: SequentialBackgroundSource,
@@ -154,6 +191,10 @@ export function createBackgroundMixer(
   let trackStartFrame = 0
   let current: Float32Array[] | null = null
   let exhausted = source.trackCount === 0
+  /** Frame where the playlist ran out, and the music share right before —
+   * the foreground ramps from (1 − that share) back to full from here. */
+  let exhaustedAtFrame: number | null = null
+  let shareAtExhaustion = 0
 
   /** Advance until the current track covers `frame` (false = playlist over). */
   const ensureTrackFor = async (frame: number): Promise<boolean> => {
@@ -176,18 +217,37 @@ export function createBackgroundMixer(
     }
   }
 
+  const clamp = (value: number): number => (value > 1 ? 1 : value < -1 ? -1 : value)
+
   const mixInto = async (
     channels: Float32Array[],
     sliceStartFrame: number,
     points: GainPoint[],
+    foregroundScale = 1,
   ): Promise<void> => {
     if (channels.length === 0 || points.length === 0) return
     const sliceLength = channels[0].length
+    const endRampFrames = Math.max(1, Math.round((PLAYLIST_END_RAMP_MS / 1000) * sampleRate))
     let i = 0
     let cursor = 0
     while (i < sliceLength) {
       const frame = sliceStartFrame + i
-      if (!(await ensureTrackFor(frame))) return
+      if (!(await ensureTrackFor(frame))) {
+        // Playlist over: no music, but the clip keeps its normalization
+        // (consistent loudness across the whole film) and its share eases
+        // from (1 − last music share) back to full instead of jumping.
+        exhaustedAtFrame ??= frame
+        for (; i < sliceLength; i += 1) {
+          const outFrame = sliceStartFrame + i
+          const ramp = Math.min(1, (outFrame - exhaustedAtFrame) / endRampFrames)
+          const foreground =
+            foregroundScale * (1 - shareAtExhaustion + shareAtExhaustion * ramp)
+          for (let ch = 0; ch < channels.length; ch += 1) {
+            channels[ch][i] = clamp(channels[ch][i] * foreground)
+          }
+        }
+        return
+      }
       const track = current!
       const sources = channels.map((_, ch) => track[Math.min(ch, track.length - 1)])
       // Mix until the slice or the current track ends, whichever is first.
@@ -196,25 +256,26 @@ export function createBackgroundMixer(
         const outFrame = sliceStartFrame + i
         const tMs = (i / sampleRate) * 1000
         while (cursor < points.length && points[cursor].tMs < tMs) cursor += 1
-        let gain: number
+        let share: number
         if (cursor === 0) {
-          gain = points[0].volume
+          share = points[0].volume
         } else if (cursor >= points.length) {
-          gain = points[points.length - 1].volume
+          share = points[points.length - 1].volume
         } else {
           const prev = points[cursor - 1]
           const next = points[cursor]
           const span = next.tMs - prev.tMs
-          gain =
+          share =
             span <= 0
               ? next.volume
               : prev.volume + ((next.volume - prev.volume) * (tMs - prev.tMs)) / span
         }
-        if (gain <= 0) continue
+        shareAtExhaustion = share
         const sourceIndex = outFrame - trackStartFrame
         for (let ch = 0; ch < channels.length; ch += 1) {
-          const mixed = channels[ch][i] + sources[ch][sourceIndex] * gain
-          channels[ch][i] = mixed > 1 ? 1 : mixed < -1 ? -1 : mixed
+          channels[ch][i] = clamp(
+            channels[ch][i] * foregroundScale * (1 - share) + sources[ch][sourceIndex] * share,
+          )
         }
       }
     }

--- a/src/lib/export/encode-realtime.ts
+++ b/src/lib/export/encode-realtime.ts
@@ -107,6 +107,9 @@ export async function exportRealtime(
   let backgroundGain: GainNode | null = null
   /** Complement gain the clips' own audio plays through (1 − music share). */
   let clipMixGain: GainNode | null = null
+  /** Set once the playlist has truly run out — later segments must stop
+   * scheduling the duck (the film's remainder is music-free). */
+  const playlistState = { done: false }
   let startBackground: (() => void) | null = null
   let stopBackground: (() => void) | null = null
   const backgroundTracks = options.background?.tracks ?? []
@@ -123,7 +126,9 @@ export async function exportRealtime(
       const playFrom = async (index: number): Promise<void> => {
         if (stopped || !audioContext) return
         if (index >= backgroundTracks.length) {
-          // Playlist over mid-film: the clip sound eases back to full.
+          // Playlist over mid-film: the clip sound eases back to full and
+          // stays there for the rest of the film.
+          playlistState.done = true
           clipGain.gain.setTargetAtTime(1, audioContext.currentTime, 0.1)
           return
         }
@@ -220,7 +225,11 @@ export async function exportRealtime(
         if (!clamped) continue
         if (backgroundGain && clipMixGain && audioContext && options.background) {
           startBackground?.()
-          const share = clipAudioVolume(segment.clip, options.background.defaultVolume)
+          // A finished playlist means the rest of the film is music-free —
+          // re-scheduling the duck would leave clip audio quiet for nothing.
+          const share = playlistState.done
+            ? 0
+            : clipAudioVolume(segment.clip, options.background.defaultVolume)
           const now = audioContext.currentTime
           if (segmentIndex === 0 && !options.background.fadeIn) {
             // No fade-in: the mix opens at the clip's shares directly.
@@ -280,10 +289,12 @@ export async function exportRealtime(
 
     // End-of-film safety ramp: with Fade out on it just finishes what the
     // scheduled fade started; with it off, a click-kill too short to hear
-    // as a fade (mirrors the WebCodecs edge ramp).
+    // as a fade (mirrors the WebCodecs edge ramp). The clip side rises to
+    // full in mirror, like the WebCodecs envelope's complement.
     if (backgroundGain && audioContext) {
       const tau = options.background?.fadeOut ? 0.06 : 0.008
       backgroundGain.gain.setTargetAtTime(0, audioContext.currentTime, tau)
+      clipMixGain?.gain.setTargetAtTime(1, audioContext.currentTime, tau)
     }
     // Hold the last frame briefly so the final GOP isn't truncated.
     await wait(180)

--- a/src/lib/export/encode-realtime.ts
+++ b/src/lib/export/encode-realtime.ts
@@ -1,6 +1,6 @@
 import { pickRecorderMimeType } from '../media'
 import { clipAudioVolume } from '../types'
-import type { BackgroundAudio } from './background-audio'
+import { channelPeak, normalizationScale, type BackgroundAudio } from './background-audio'
 import { clampSegmentToMedia, type ExportPlan } from './plan'
 import {
   PREVIEW_EVERY_N_FRAMES,
@@ -99,10 +99,14 @@ export async function exportRealtime(
 
   // Background music rides sequentially chained buffer sources behind a
   // gain node: each track starts when the previous one ends (nothing
-  // loops), and the gain glides toward each clip's volume as the export
-  // reaches it — this engine paints in realtime, so Web Audio's own
-  // ramping does the work.
+  // loops), and the gain glides toward each clip's music SHARE as the
+  // export reaches it — this engine paints in realtime, so Web Audio's own
+  // ramping does the work. Clip audio flows through a mirror gain node
+  // held at the complement (1 − share), so the two sides of the mix always
+  // sum to one. Tracks are peak-normalized via a per-source gain.
   let backgroundGain: GainNode | null = null
+  /** Complement gain the clips' own audio plays through (1 − music share). */
+  let clipMixGain: GainNode | null = null
   let startBackground: (() => void) | null = null
   let stopBackground: (() => void) | null = null
   const backgroundTracks = options.background?.tracks ?? []
@@ -111,17 +115,33 @@ export async function exportRealtime(
       const gain = audioContext.createGain()
       gain.gain.value = 0
       gain.connect(dest)
+      const clipGain = audioContext.createGain()
+      clipGain.gain.value = 1
+      clipGain.connect(dest)
       let stopped = false
       let activeSource: AudioBufferSourceNode | null = null
       const playFrom = async (index: number): Promise<void> => {
-        if (stopped || index >= backgroundTracks.length || !audioContext) return
+        if (stopped || !audioContext) return
+        if (index >= backgroundTracks.length) {
+          // Playlist over mid-film: the clip sound eases back to full.
+          clipGain.gain.setTargetAtTime(1, audioContext.currentTime, 0.1)
+          return
+        }
         // Undecodable tracks are skipped; the next one starts in their place.
         const buffer = await decodeBackgroundAudio(backgroundTracks[index].blob)
         if (stopped) return
         if (!buffer) return playFrom(index + 1)
         const source = audioContext.createBufferSource()
         source.buffer = buffer
-        source.connect(gain)
+        // Peak-normalize the track so the mix shares mean the same thing
+        // regardless of how hot the file is mastered.
+        const channels = Array.from({ length: buffer.numberOfChannels }, (_, ch) =>
+          buffer.getChannelData(ch),
+        )
+        const normalize = audioContext.createGain()
+        normalize.gain.value = normalizationScale(channelPeak(channels))
+        source.connect(normalize)
+        normalize.connect(gain)
         source.onended = () => {
           void playFrom(index + 1)
         }
@@ -143,8 +163,10 @@ export async function exportRealtime(
         }
       }
       backgroundGain = gain
+      clipMixGain = clipGain
     } catch {
       backgroundGain = null
+      clipMixGain = null
       startBackground = null
       stopBackground = null
     }
@@ -196,26 +218,30 @@ export async function exportRealtime(
       try {
         const clamped = clampSegmentToMedia(segment, loaded.mediaDurationMs)
         if (!clamped) continue
-        if (backgroundGain && audioContext && options.background) {
+        if (backgroundGain && clipMixGain && audioContext && options.background) {
           startBackground?.()
-          const volume = clipAudioVolume(segment.clip, options.background.defaultVolume)
+          const share = clipAudioVolume(segment.clip, options.background.defaultVolume)
           const now = audioContext.currentTime
           if (segmentIndex === 0 && !options.background.fadeIn) {
-            // No fade-in: music opens at full clip volume.
-            backgroundGain.gain.setValueAtTime(volume, now)
+            // No fade-in: the mix opens at the clip's shares directly.
+            backgroundGain.gain.setValueAtTime(share, now)
+            clipMixGain.gain.setValueAtTime(1 - share, now)
           } else {
-            backgroundGain.gain.setTargetAtTime(volume, now, 0.2)
+            backgroundGain.gain.setTargetAtTime(share, now, 0.2)
+            clipMixGain.gain.setTargetAtTime(1 - share, now, 0.2)
           }
           // This engine paints in realtime, so the last segment's end lands
           // roughly `segment length` from now — schedule the musical
-          // fade-out to finish there, shrinking it on short final clips
-          // (like the WebCodecs envelope) instead of dropping it.
+          // fade-out to finish there (clip sound rising back to full),
+          // shrinking it on short final clips (like the WebCodecs
+          // envelope) instead of dropping it.
           const isLast = segmentIndex === plan.segments.length - 1
           const segmentSec = (clamped.endMs - clamped.startMs) / 1000
           if (isLast && options.background.fadeOut) {
             const fadeSec = Math.min(1.2, segmentSec / 2)
             if (fadeSec > 0.05) {
               backgroundGain.gain.setTargetAtTime(0, now + segmentSec - fadeSec, fadeSec / 3)
+              clipMixGain.gain.setTargetAtTime(1, now + segmentSec - fadeSec, fadeSec / 3)
             }
           }
         }
@@ -227,7 +253,10 @@ export async function exportRealtime(
           canvas,
           ctx,
           audioContext,
-          dest,
+          // With music, clip audio joins the mix through the complement
+          // gain (and gets peak-normalized); without, straight to the mux.
+          clipDestination: clipMixGain ?? dest,
+          normalizeClip: clipMixGain !== null,
           frameCounter,
           // No mirroring needed when the encode canvas is the preview.
           getPreviewCanvas: encodingIntoPreview ? undefined : options.getPreviewCanvas,
@@ -288,7 +317,11 @@ interface PaintSegmentArgs {
   canvas: HTMLCanvasElement
   ctx: CanvasRenderingContext2D
   audioContext: AudioContext | null
-  dest: MediaStreamAudioDestinationNode | null
+  /** Where the clip's own audio joins the recording graph (the clip-mix
+   * complement gain when music is present, else the mux destination). */
+  clipDestination: AudioNode | null
+  /** Peak-normalize the clip audio (on whenever the project has music). */
+  normalizeClip: boolean
   frameCounter: { count: number }
   getPreviewCanvas?: () => HTMLCanvasElement | null
   watermarkImage: HTMLImageElement | null
@@ -304,7 +337,8 @@ async function paintSegment({
   canvas,
   ctx,
   audioContext,
-  dest,
+  clipDestination,
+  normalizeClip,
   frameCounter,
   getPreviewCanvas,
   watermarkImage,
@@ -316,7 +350,8 @@ async function paintSegment({
   await seekTo(video, startSec)
 
   let bufferSource: AudioBufferSourceNode | null = null
-  const audioBuffer = audioContext && dest ? await decodeClipAudio(blob) : null
+  let normalizeGain: GainNode | null = null
+  const audioBuffer = audioContext && clipDestination ? await decodeClipAudio(blob) : null
 
   try {
     video.muted = true
@@ -331,7 +366,7 @@ async function paintSegment({
     }
     paintFrame()
 
-    if (audioContext && dest && audioBuffer) {
+    if (audioContext && clipDestination && audioBuffer) {
       const videoLeadSec = Math.max(0, video.currentTime - startSec)
       const offset = Math.min(startSec + videoLeadSec, Math.max(0, audioBuffer.duration - 0.01))
       const available = Math.max(0, audioBuffer.duration - offset)
@@ -340,10 +375,24 @@ async function paintSegment({
         try {
           bufferSource = audioContext.createBufferSource()
           bufferSource.buffer = audioBuffer
-          bufferSource.connect(dest)
+          let clipOutput: AudioNode = bufferSource
+          if (normalizeClip) {
+            // Peak-normalize so the mix shares mean the same thing however
+            // hot (or quiet) the mic recording is.
+            const channels = Array.from(
+              { length: audioBuffer.numberOfChannels },
+              (_, ch) => audioBuffer.getChannelData(ch),
+            )
+            normalizeGain = audioContext.createGain()
+            normalizeGain.gain.value = normalizationScale(channelPeak(channels))
+            bufferSource.connect(normalizeGain)
+            clipOutput = normalizeGain
+          }
+          clipOutput.connect(clipDestination)
           bufferSource.start(audioContext.currentTime, offset, playDuration)
         } catch {
           bufferSource = null
+          normalizeGain = null
         }
       }
     }
@@ -404,6 +453,7 @@ async function paintSegment({
       // already ended
     }
     bufferSource?.disconnect()
+    normalizeGain?.disconnect()
   }
 }
 

--- a/src/lib/export/encode-webcodecs.ts
+++ b/src/lib/export/encode-webcodecs.ts
@@ -21,7 +21,9 @@ import { isIosBrowser } from '../platform'
 import type { ClipRecord } from '../types'
 import {
   boundaryRampHalfMs,
+  channelPeak,
   createBackgroundMixer,
+  normalizationScale,
   planSegmentGain,
   segmentVolume,
   type BackgroundAudio,
@@ -188,13 +190,15 @@ export async function exportWithWebCodecs(
   const chapters: Mp4Chapter[] = []
 
   // Background music: playlist tracks are decoded lazily (one at a time,
-  // released as the timeline passes them) and mixed into each segment's
-  // audio slice under a per-segment gain envelope — per-clip volumes with
-  // ramped transitions, plus the optional fade-in/fade-out. Envelopes are
-  // built from each segment's REAL (clamped) duration as it is mixed, so
-  // ramps and fades stay on their clips even when clamping shifts the
-  // timeline; only ramp-length clamping peeks at the next clip's planned
-  // duration.
+  // released as the timeline passes them) and BLENDED with each segment's
+  // audio slice under a per-segment mix envelope — the per-clip value is
+  // the music's share of the mix, the clip's own sound gets the
+  // complement, and both sources are peak-normalized first so the shares
+  // mean the same thing regardless of how hot either recording is.
+  // Envelopes are built from each segment's REAL (clamped) duration as it
+  // is mixed, so ramps and fades stay on their clips even when clamping
+  // shifts the timeline; only ramp-length clamping peeks at the next
+  // clip's planned duration.
   const backgroundMixer =
     background && background.tracks.length > 0
       ? createBackgroundMixer(
@@ -206,9 +210,18 @@ export async function exportWithWebCodecs(
                 AUDIO_SAMPLE_RATE,
               )
               if (!buffer) return null
-              return Array.from({ length: buffer.numberOfChannels }, (_, ch) =>
-                buffer.getChannelData(ch),
+              const channels = Array.from(
+                { length: buffer.numberOfChannels },
+                (_, ch) => buffer.getChannelData(ch),
               )
+              // Normalize the track in place (the decode is private).
+              const scale = normalizationScale(channelPeak(channels))
+              if (scale !== 1) {
+                for (const data of channels) {
+                  for (let i = 0; i < data.length; i += 1) data[i] *= scale
+                }
+              }
+              return channels
             },
           },
           AUDIO_SAMPLE_RATE,
@@ -271,8 +284,12 @@ export async function exportWithWebCodecs(
         if (backgroundMixer && background) {
           const volume = segmentVolume(segment, background.defaultVolume)
           const nextPlanned = plan.segments[segmentIndex + 1]
+          const sliceChannels = Array.from(
+            { length: slice.numberOfChannels },
+            (_, ch) => slice.getChannelData(ch),
+          )
           await backgroundMixer.mixInto(
-            Array.from({ length: slice.numberOfChannels }, (_, ch) => slice.getChannelData(ch)),
+            sliceChannels,
             // Frames already written = the real position of this slice, even
             // when clamping shortened an earlier segment.
             Math.round(state.outputOffsetSec * AUDIO_SAMPLE_RATE),
@@ -299,6 +316,17 @@ export async function exportWithWebCodecs(
                 : undefined,
               fades: background,
             }),
+            // Whole-clip peak (not just this trim window) so a clip's
+            // loudness doesn't change with where it is trimmed.
+            normalizationScale(
+              buffer
+                ? channelPeak(
+                    Array.from({ length: buffer.numberOfChannels }, (_, ch) =>
+                      buffer.getChannelData(ch),
+                    ),
+                  )
+                : 0,
+            ),
           )
           previousMixed = { volume, durationMs: segmentMs }
         }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -26,8 +26,9 @@ export interface ClipMeta {
   lat?: number
   lng?: number
   locationAccuracyM?: number
-  /** Background-music volume (0–1) while this clip plays. Absent = the
-   * project audio track's default volume. */
+  /** Music's share (0–1) of the audio mix while this clip plays: the clip's
+   * own sound gets the complement (0.8 music ⇒ 0.2 clip sound), so the mix
+   * can never clip. Absent = the project playlist's default share. */
   audioVolume?: number
 }
 
@@ -64,7 +65,8 @@ export interface ProjectAudioTrack {
 export interface ProjectAudioRecord {
   projectId: ProjectId
   tracks: ProjectAudioTrack[]
-  /** Baseline volume (0–1) for clips without a per-clip override. */
+  /** Music's default share (0–1) of the audio mix for clips without a
+   * per-clip override; clip sound gets the complement. */
   defaultVolume: number
   /** Ease the music in at the start of the film (default on). */
   fadeIn: boolean
@@ -72,7 +74,7 @@ export interface ProjectAudioRecord {
   fadeOut: boolean
 }
 
-/** Sits under speech without drowning it — the out-of-the-box music level. */
+/** 25% music / 75% clip sound — sits under speech without drowning it. */
 export const DEFAULT_AUDIO_VOLUME = 0.25
 
 /** Total playlist length — what the music can cover before going silent. */
@@ -85,7 +87,7 @@ export function clampVolume(volume: number): number {
   return Math.max(0, Math.min(1, volume))
 }
 
-/** Background-music volume while a clip plays: its override or the default. */
+/** Music's share of the mix while a clip plays: its override or the default. */
 export function clipAudioVolume(
   clip: Pick<ClipMeta, 'audioVolume'>,
   defaultVolume: number,

--- a/src/styles/editor.css
+++ b/src/styles/editor.css
@@ -559,16 +559,17 @@
   flex: 0 0 auto;
 }
 
-.audio-volume-row {
+/* Balance slider: clip sound on the left, music on the right. */
+.audio-mix-row {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: 7px;
   min-height: 26px;
 }
 
 .audio-volume-label {
-  flex: 0 0 74px;
-  font-size: 0.74rem;
+  flex: 0 0 64px;
+  font-size: 0.72rem;
   font-weight: 600;
   color: var(--ink-muted);
   overflow: hidden;
@@ -576,20 +577,25 @@
   white-space: nowrap;
 }
 
-.audio-volume-row input[type='range'] {
+.audio-mix-row input[type='range'] {
   flex: 1 1 auto;
-  min-width: 0;
+  min-width: 40px;
   height: 26px;
   accent-color: var(--accent);
   touch-action: pan-y;
 }
 
-.audio-volume-value {
-  flex: 0 0 38px;
-  text-align: right;
-  font-size: 0.76rem;
+.audio-mix-side {
+  flex: 0 0 auto;
+  font-size: 0.7rem;
+  color: var(--ink-muted);
   font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+
+.audio-mix-side strong {
   color: var(--ink);
+  font-weight: 700;
 }
 
 .audio-volume-reset {

--- a/tests/e2e/background-music.spec.ts
+++ b/tests/e2e/background-music.spec.ts
@@ -152,16 +152,20 @@ test.describe('background music', () => {
     await expect.poll(async () => (await storedAudio(page))?.fadeIn).toBe(false)
     await expect.poll(async () => (await storedAudio(page))?.fadeOut).toBe(true)
 
-    // Default volume slider persists.
-    await setSlider(page, 'Default music volume', 40)
+    // Default mix slider persists (value = music's share).
+    await setSlider(page, 'Default audio mix', 40)
     await expect.poll(async () => (await storedAudio(page))?.defaultVolume).toBeCloseTo(0.4)
 
-    // Per-clip override on the selected (last) clip.
+    // Per-clip override on the selected (last) clip. The row shows both
+    // sides of the balance: clip sound left, music right.
     const tiles = page.locator('.clip-thumb[data-clip-id]')
     await expect(tiles.last()).toHaveClass(/selected/)
-    await setSlider(page, /Music volume during clip 2/, 60)
+    await setSlider(page, /Audio mix during clip 2/, 60)
     await expect.poll(async () => await storedClipVolumes(page)).toEqual([null, 0.6])
     await expect(tiles.last().locator('.clip-audio-badge')).toHaveText(/60%/)
+    const clipMixRow = page.locator('.audio-mix-row').first()
+    await expect(clipMixRow).toContainText('Clip 40%')
+    await expect(clipMixRow).toContainText('60% Music')
 
     // Selecting the other clip shows the default-following row.
     await tiles.first().click()
@@ -181,7 +185,7 @@ test.describe('background music', () => {
     expect(await storedAudio(page)).toBeNull()
   })
 
-  test('export sequences the playlist at per-clip volumes with fades', async ({ page }) => {
+  test('export sequences the playlist at per-clip mixes with fades', async ({ page }) => {
     test.slow()
     // Two 3s fixture clips (video-only — the fixture encoder adds no audio
     // track), so every decodable sample in the export's audio IS the music.
@@ -195,11 +199,14 @@ test.describe('background music', () => {
       const project = (await storage.listProjects())[0]!
       const clips = await storage.getClipsForProject(project.id)
 
-      // Two in-page sine WAVs: track A (4s, full amplitude) then track B
-      // (20s, HALF amplitude) — the amplitude step at the 4s hand-off
-      // proves sequential playback (looping track A would keep it loud;
-      // a broken hand-off would go silent).
-      const makeWav = (seconds: number, amplitude: number): Blob => {
+      // Two in-page sine WAVs at DIFFERENT frequencies: track A (4s,
+      // 440 Hz, full amplitude) then track B (20s, 880 Hz, HALF
+      // amplitude). The frequency step at the 4s hand-off proves
+      // sequential playback (a looping track A would keep 440 Hz), and
+      // peak normalization should erase the 2× amplitude difference —
+      // making the RMS ratio between the windows track the mix shares
+      // alone.
+      const makeWav = (seconds: number, amplitude: number, freq: number): Blob => {
         const rate = 8000
         const samples = rate * seconds
         const bytes = new DataView(new ArrayBuffer(44 + samples * 2))
@@ -220,20 +227,20 @@ test.describe('background music', () => {
         writeAscii(36, 'data')
         bytes.setUint32(40, samples * 2, true)
         for (let i = 0; i < samples; i += 1) {
-          bytes.setInt16(44 + i * 2, Math.round(Math.sin((2 * Math.PI * 440 * i) / rate) * amplitude), true)
+          bytes.setInt16(44 + i * 2, Math.round(Math.sin((2 * Math.PI * freq * i) / rate) * amplitude), true)
         }
         return new Blob([bytes.buffer], { type: 'audio/wav' })
       }
       await storage.addProjectAudioTrack({
         projectId: project.id,
-        blob: makeWav(4, 16000),
+        blob: makeWav(4, 16000, 440),
         mimeType: 'audio/wav',
         durationMs: 4000,
         name: 'track-a.wav',
       })
       const audio = await storage.addProjectAudioTrack({
         projectId: project.id,
-        blob: makeWav(20, 8000),
+        blob: makeWav(20, 8000, 880),
         mimeType: 'audio/wav',
         durationMs: 20000,
         name: 'track-b.wav',
@@ -262,13 +269,25 @@ test.describe('background music', () => {
         for (let i = from; i < to; i += 1) sum += data[i]! * data[i]!
         return Math.sqrt(sum / Math.max(1, to - from))
       }
+      // Dominant frequency proxy: sign changes per second (~2× frequency).
+      const crossingsPerSec = (fromSec: number, toSec: number) => {
+        const from = Math.floor(fromSec * decoded.sampleRate)
+        const to = Math.min(Math.floor(toSec * decoded.sampleRate), data.length)
+        let crossings = 0
+        for (let i = from + 1; i < to; i += 1) {
+          if (data[i - 1]! < 0 !== data[i]! < 0) crossings += 1
+        }
+        return crossings / Math.max(0.001, toSec - fromSec)
+      }
       return {
         durationSec: decoded.duration,
-        // Track A under clip 1 (gain 0.25), past the 800ms fade-in.
+        // Track A under clip 1 (music share 0.25), past the 800ms fade-in.
         clip1: rms(1.2, 2.6),
-        // Track B under clip 2 (gain 1.0), past the 4s hand-off, before
+        clip1Freq: crossingsPerSec(1.2, 2.6) / 2,
+        // Track B under clip 2 (share 1.0), past the 4s hand-off, before
         // the fade-out begins at 4.8s.
         clip2: rms(4.2, 4.7),
+        clip2Freq: crossingsPerSec(4.2, 4.7) / 2,
         fadeIn: rms(0, 0.08),
         fadeOut: rms(5.7, 5.95),
       }
@@ -277,24 +296,30 @@ test.describe('background music', () => {
     expect(measured).not.toBeNull()
     // Clip 1 carries audible music from track A.
     expect(measured!.clip1).toBeGreaterThan(0.02)
-    // Track B at gain 1.0 vs track A at gain 0.25, half the amplitude:
-    // expected RMS ratio ≈ 2 (looping track A would read ≈ 4; silence ≈ 0).
-    expect(measured!.clip2 / measured!.clip1).toBeGreaterThan(1.4)
-    expect(measured!.clip2 / measured!.clip1).toBeLessThan(2.8)
+    // Sequencing: clip 1 hears track A (440 Hz), clip 2 hears track B
+    // (880 Hz) — a looping track A would keep 440 Hz after the hand-off.
+    expect(measured!.clip1Freq).toBeGreaterThan(340)
+    expect(measured!.clip1Freq).toBeLessThan(540)
+    expect(measured!.clip2Freq).toBeGreaterThan(700)
+    expect(measured!.clip2Freq).toBeLessThan(1060)
+    // Normalization + mix shares: both tracks normalize to the same peak
+    // despite track B being mastered at HALF the amplitude, so the RMS
+    // ratio tracks the shares alone (1.0 / 0.25 ≈ 4). Without
+    // normalization it would read ≈ 2.
+    expect(measured!.clip2 / measured!.clip1).toBeGreaterThan(2.8)
+    expect(measured!.clip2 / measured!.clip1).toBeLessThan(5.5)
     // The film opens inside the fade-in and closes inside the fade-out.
     expect(measured!.fadeIn).toBeLessThan(measured!.clip1 * 0.5)
     expect(measured!.fadeOut).toBeLessThan(measured!.clip2 * 0.5)
     expect(measured!.durationSec).toBeGreaterThan(5.5)
   })
 
-  test('preview playback plays the music and ramps toward each clip volume', async ({
-    page,
-  }) => {
+  test('preview playback ramps both sides of the mix per clip', async ({ page }) => {
     await openPlusEditorWithClips(page, 2)
     await addMusic(page)
 
-    // Clip 2 (selected) gets a louder override so the ramp is observable.
-    await setSlider(page, /Music volume during clip 2/, 80)
+    // Clip 2 (selected) gets a music-heavy override so the ramp is observable.
+    await setSlider(page, /Audio mix during clip 2/, 80)
     await expect.poll(async () => await storedClipVolumes(page)).toEqual([null, 0.8])
 
     await page.getByRole('button', { name: 'Play project preview' }).click()
@@ -323,6 +348,13 @@ test.describe('background music', () => {
     await expect
       .poll(() => music.evaluate((el) => (el as HTMLAudioElement).volume), { timeout: 5000 })
       .toBeGreaterThan(0.6)
+    // …and the clip's own sound ducks toward the complement (1 − 0.8).
+    await expect
+      .poll(
+        () => overlay.locator('.playback-video').evaluate((el) => (el as HTMLVideoElement).volume),
+        { timeout: 5000 },
+      )
+      .toBeLessThan(0.35)
 
     await overlay.getByRole('button', { name: 'Stop preview' }).click()
     await expect(overlay).toBeHidden()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Follow-up to #96: the per-clip music level is now the music's **share of the audio mix** rather than an absolute volume layered on top.

- Music plays at share `g`, the clip's own sound at `1 − g` — 80% music means 20% clip sound. The two sides always sum to one, so the blend can never clip and clip audio no longer fights the music.
- Exports **peak-normalize** both sources first (toward 0.9 peak, capped at +12 dB boost, never boosting near-silence), so the split means the same thing regardless of how hot the mic recording or the music file is mastered.
- The sliders are now **balance controls**: "Clip NN%" on the left, "NN% Music" on the right — drag toward the side that should carry the mix (`aria-valuetext` spells out both sides for screen readers).
- The complement follows every music move: fades counter-move (film opens/closes with clip sound at 100%), mix changes glide across clip boundaries on both sides, and when the playlist runs out mid-film the clip sound eases back to full over 300 ms.
- Preview mirrors the model live: the video element's volume glides toward `1 − share` (no normalization in preview — element playback can't boost).

Storage fields (`audioVolume`, `defaultVolume`) keep their names and 0–1 range; only the interpretation changes.

## Testing

- `npm run lint` clean; `npm test` 124 passed (new: complementary blend, foreground normalization scale, playlist-end ease-back, normalization bounds/floor).
- `tests/e2e/background-music.spec.ts` 4 passed. The export test now decodes the real output and proves **normalization** (RMS ratio between a 25%-music clip and a 100%-music clip reads ≈4 — tracking the shares alone — even though track B is mastered at half of track A's amplitude) and **sequencing** via dominant-frequency measurement (440 Hz under clip 1, 880 Hz under clip 2). The preview test asserts the clip's own sound ducks to the complement (video volume < 0.35 under an 80%-music clip).
- Full e2e: 47 passed; the 4 failures (`export.spec`, `install-hint.spec`, `storage.spec`) fail identically on `main` in this VM — pre-existing, unrelated.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1e0b8bef-7996-4d3b-97a9-e0027b0a3838?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1e0b8bef-7996-4d3b-97a9-e0027b0a3838&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added clip-level and project-wide audio mix controls showing clip and music percentage shares.
  - Added configurable music fades for preview and exported video.
  - Added smooth transitions between clip audio and background music, including restoration after playback ends.

- **Improvements**
  - Peak-normalized clip audio and background music for more consistent volume.
  - Updated audio labels, accessibility text, and control styling.
  - Expanded validation for mix ratios, normalization, and sequential music playback.

- **Documentation**
  - Clarified audio mix behavior, defaults, and per-clip settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->