### PR TITLE
Move About and Install into corner icon buttons on the home screen

### DIFF
--- a/src/components/icons.tsx
+++ b/src/components/icons.tsx
@@ -245,6 +245,28 @@ export function IconLock(handle: Handle<IconProps>) {
   )
 }
 
+/** Down arrow into a tray: install / download to this device. */
+export function IconDownload(handle: Handle<IconProps>) {
+  return () => (
+    <svg {...baseProps(handle.props.size ?? 22)}>
+      <path d="M12 3.5V14" />
+      <path d="M7.5 9.5L12 14l4.5-4.5" />
+      <path d="M4.5 16.5v2a2 2 0 002 2h11a2 2 0 002-2v-2" />
+    </svg>
+  )
+}
+
+/** Lowercase "i" in a circle: about / more information. */
+export function IconInfo(handle: Handle<IconProps>) {
+  return () => (
+    <svg {...baseProps(handle.props.size ?? 22)}>
+      <circle cx="12" cy="12" r="8.5" />
+      <path d="M12 11.25v5" />
+      <circle cx="12" cy="7.75" r="1.1" fill="currentColor" stroke="none" />
+    </svg>
+  )
+}
+
 /** Monitor with a record dot: screen recording. */
 export function IconScreen(handle: Handle<IconProps & { on?: boolean }>) {
   return () => (

--- a/src/pages/home-page.tsx
+++ b/src/pages/home-page.tsx
@@ -4,7 +4,15 @@ import { BlobImage } from '../components/blob-image'
 import { BrandMark } from '../components/brand-mark'
 import { ConfirmSheet } from '../components/confirm-sheet'
 import { HomeOptionsSheet } from '../components/home-options-sheet'
-import { IconClose, IconLock, IconMore, IconPlus, IconShareIos } from '../components/icons'
+import {
+  IconClose,
+  IconDownload,
+  IconInfo,
+  IconLock,
+  IconMore,
+  IconPlus,
+  IconShareIos,
+} from '../components/icons'
 import { UpsellSheet } from '../components/upsell-sheet'
 import { RestoreSheet } from '../components/restore-sheet'
 import { RenameSheet } from '../components/rename-sheet'
@@ -216,6 +224,28 @@ export function HomePage(handle: Handle) {
 
     return (
       <div className="screen home-screen">
+        {/* Corner buttons: 44px tap targets clear of other controls — the
+            old footer text links were too small and crowded for thumbs. */}
+        {installable ? (
+          <button
+            type="button"
+            className="btn-icon home-corner home-corner-left"
+            aria-label="Install app"
+            mix={on('click', () => {
+              void promptInstall()
+            })}
+          >
+            <IconDownload />
+          </button>
+        ) : null}
+        <a
+          className="btn-icon home-corner home-corner-right"
+          href="/about"
+          aria-label="About Kody Video"
+        >
+          <IconInfo />
+        </a>
+
         {/* On mobile, the visible brand/LCP hero lives in index.html
             (#boot-hero) so first paint is not gated on JS — this block is a
             layout spacer there. Desktop hides #boot-hero and shows this. */}
@@ -388,22 +418,7 @@ export function HomePage(handle: Handle) {
           Clips stay on this phone until you share.
           {storage
             ? ` ${formatBytes(storage.usedBytes)} of ${formatBytes(storage.quotaBytes)} used.`
-            : ''}{' '}
-          <a href="/about">About</a>
-          {installable ? (
-            <>
-              {' · '}
-              <button
-                type="button"
-                className="link-button"
-                mix={on('click', () => {
-                  void promptInstall()
-                })}
-              >
-                Install app
-              </button>
-            </>
-          ) : null}
+            : ''}
         </p>
 
         <div className="home-footer">

--- a/src/styles/home.css
+++ b/src/styles/home.css
@@ -2,6 +2,25 @@
 
 .home-screen {
   gap: 0;
+  /* Anchor for the corner buttons. */
+  position: relative;
+}
+
+/* Install (left) / About (right) corner buttons: full 44px tap targets in
+   the dead space beside the centered hero art. */
+.home-corner {
+  position: absolute;
+  top: calc(12px + var(--safe-top));
+  z-index: 5;
+  color: var(--ink);
+}
+
+.home-corner-left {
+  left: 12px;
+}
+
+.home-corner-right {
+  right: 12px;
 }
 
 .home-hero {
@@ -423,17 +442,6 @@
   padding: 0 14px;
   border-radius: 999px;
   font-size: 0.88rem;
-}
-
-.home-privacy .link-button {
-  font-size: inherit;
-}
-
-.home-privacy a {
-  color: var(--accent);
-  font-weight: 600;
-  text-decoration: underline;
-  text-underline-offset: 2px;
 }
 
 /* About page */

--- a/tests/e2e/home.spec.ts
+++ b/tests/e2e/home.spec.ts
@@ -123,9 +123,20 @@ test.describe('home & app shell', () => {
     await expect(report).toContainText(/Detected rear lenses: \d+/)
   })
 
+  test('corner buttons: About always, Install once the browser offers it', async ({ page }) => {
+    await gotoHome(page)
+    await expect(page.getByRole('link', { name: 'About Kody Video' })).toBeVisible()
+    // Headless Chromium never fires beforeinstallprompt on its own.
+    await expect(page.getByRole('button', { name: 'Install app' })).toHaveCount(0)
+    await page.evaluate(() => {
+      window.dispatchEvent(new Event('beforeinstallprompt'))
+    })
+    await expect(page.getByRole('button', { name: 'Install app' })).toBeVisible()
+  })
+
   test('about, privacy, and terms pages render', async ({ page }) => {
     await gotoHome(page)
-    await page.getByRole('link', { name: 'About' }).click()
+    await page.getByRole('link', { name: 'About Kody Video' }).click()
     await page.waitForURL(/\/about/)
     await expect(page.locator('body')).toContainText('Kody Video')
     await page.goto('/privacy')


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

The About and Install entry points on the home screen were small text links squeezed into the footer privacy line, right next to the New project / Import buttons — hard to hit on a phone. They are now proper 44px corner icon buttons:

- **Top-left**: a download icon that triggers the browser install prompt (shown only when the browser offers `beforeinstallprompt`, same condition as before)
- **Top-right**: an info ("i" in a circle) icon linking to `/about`

The footer privacy line keeps the storage-usage text but loses the links.

## How

- Two new stroke icons (`IconDownload`, `IconInfo`) in the existing 24×24 icon set
- Corner buttons reuse the existing `.btn-icon` 44px round style, absolutely positioned in the top corners (safe-area aware), in the dead space beside the centered hero art
- Removed the now-unused `.home-privacy` link styles

## Testing

- `npm run lint` and `npm test` (135 unit tests) pass
- Playwright home spec passes (11/11), including a new test that asserts the About corner link is always present and the Install corner button appears once `beforeinstallprompt` fires
- 4 e2e failures elsewhere (`export`, `install-hint`, `storage` specs) reproduce identically on unmodified `main` in this VM — pre-existing environment failures, not from this change
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-725b9548-7202-43d5-a4ea-75d7f9e48d13?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-725b9548-7202-43d5-a4ea-75d7f9e48d13&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added corner controls for accessing the About information and installing the app.
  * Added download and information icons for clearer navigation.
* **UI Improvements**
  * Improved corner-button positioning, including support for safe-area spacing.
  * Simplified the footer privacy area by removing redundant links.
* **Tests**
  * Added coverage confirming the About control remains visible and the Install option appears when available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->