### PR TITLE
Crossfade clip audio at joints instead of fading to silence

### DIFF
--- a/src/lib/export/encode-webcodecs.ts
+++ b/src/lib/export/encode-webcodecs.ts
@@ -31,6 +31,7 @@ import {
 import { injectMp4Metadata, type Mp4Chapter } from './mp4-metadata'
 import { createOpfsExportFile } from './opfs'
 import { clampSegmentToMedia, type ExportPlan } from './plan'
+import { CROSSFADE_HALF_MS, flushCarry, sliceSegmentAudio } from './segment-audio'
 import {
   PREVIEW_INTERVAL_MS,
   blitPreview,
@@ -114,7 +115,8 @@ async function pickCodecs(width: number, height: number): Promise<CodecChoice | 
  * by Mediabunny, which owns the codec-config, packet-ordering, and
  * container details we used to hand-roll (and debug, chunk by chunk, on
  * iOS). Audio is decoded per clip and appended sample-accurately, so clips
- * can never drift against their soundtrack.
+ * can never drift against their soundtrack; adjacent clips crossfade at
+ * each joint instead of dipping to silence (see segment-audio.ts).
  */
 export async function exportWithWebCodecs(
   plan: ExportPlan,
@@ -231,6 +233,14 @@ export async function exportWithWebCodecs(
   /** Volume + real duration of the previous MIXED segment (dropped
    * segments must not become ramp anchors). */
   let previousMixed: { volume: number; durationMs: number } | null = null
+  /** Tail withheld from the previous EMITTED segment for the joint
+   * crossfade (see segment-audio.ts); null until a segment emits. */
+  let crossfadeCarry: Float32Array[] | null = null
+  /** Audio frames actually appended. At a joint the audio buffer boundary
+   * sits half a crossfade before the video cut, so this can differ from
+   * outputOffsetSec by CROSSFADE_HALF_MS — the music mixer needs the real
+   * audio position. */
+  let audioFramesWritten = 0
 
   try {
     for (const [segmentIndex, segment] of plan.segments.entries()) {
@@ -268,6 +278,12 @@ export async function exportWithWebCodecs(
         }
         if (!clamped) continue
         const segmentMs = clamped.endMs - clamped.startMs
+        const hasNext = segmentIndex < plan.segments.length - 1
+        // Each joint overlaps the neighbors' audio for CROSSFADE_HALF_MS on
+        // both sides of the cut; the video gives up that half on each side
+        // (sub-frame at 30fps) so the timeline matches the overlapped audio.
+        const headChopMs = crossfadeCarry ? CROSSFADE_HALF_MS : 0
+        const tailChopMs = hasNext ? CROSSFADE_HALF_MS : 0
 
         if (choice.container === 'mp4') {
           chapters.push({
@@ -278,24 +294,36 @@ export async function exportWithWebCodecs(
 
         // Audio first: decoded per clip, sliced to the exact segment window
         // (silence-padded), appended sequentially — timestamps are implied
-        // by position, so segments can never drift.
+        // by position, so segments can never drift. Adjacent segments
+        // CROSSFADE at the joint: the previous slice withheld its tail, and
+        // this slice mixes it into its own head (see segment-audio.ts).
         const buffer = await decodeClipAudio(segment.clip.blob, AUDIO_SAMPLE_RATE)
-        const slice = sliceSegmentAudio(buffer, clamped.startMs, segmentMs)
+        const { channels: sliceChannels, carryOut } = sliceSegmentAudio({
+          source: buffer
+            ? Array.from({ length: buffer.numberOfChannels }, (_, ch) =>
+                buffer.getChannelData(ch),
+              )
+            : null,
+          startMs: clamped.startMs,
+          segmentMs,
+          sampleRate: AUDIO_SAMPLE_RATE,
+          channelCount: AUDIO_CHANNELS,
+          carryIn: crossfadeCarry,
+          hasNext,
+        })
+        crossfadeCarry = carryOut
         if (backgroundMixer && background) {
           const volume = segmentVolume(segment, background.defaultVolume)
           const nextPlanned = plan.segments[segmentIndex + 1]
-          const sliceChannels = Array.from(
-            { length: slice.numberOfChannels },
-            (_, ch) => slice.getChannelData(ch),
-          )
           await backgroundMixer.mixInto(
             sliceChannels,
             // Frames already written = the real position of this slice, even
             // when clamping shortened an earlier segment.
-            Math.round(state.outputOffsetSec * AUDIO_SAMPLE_RATE),
+            audioFramesWritten,
             planSegmentGain({
               volume,
-              durationMs: segmentMs,
+              // The slice's real span (joints shift it by half a crossfade).
+              durationMs: (sliceChannels[0]!.length / AUDIO_SAMPLE_RATE) * 1000,
               entry: previousMixed
                 ? {
                     fromVolume: previousMixed.volume,
@@ -330,11 +358,12 @@ export async function exportWithWebCodecs(
           )
           previousMixed = { volume, durationMs: segmentMs }
         }
-        await audioSource.add(slice)
+        await audioSource.add(toAudioBuffer(sliceChannels))
+        audioFramesWritten += sliceChannels[0]!.length
 
         const pumpShared: PumpSharedArgs = {
-          startSec: clamped.startMs / 1000,
-          endSec: clamped.endMs / 1000,
+          startSec: (clamped.startMs + headChopMs) / 1000,
+          endSec: (clamped.endMs - tailChopMs) / 1000,
           canvas,
           ctx,
           videoSource,
@@ -368,12 +397,19 @@ export async function exportWithWebCodecs(
           await pumpSegmentVideo({ video: loaded.video, ...pumpShared })
         }
 
-        state.outputOffsetSec += segmentMs / 1000
+        state.outputOffsetSec += (segmentMs - headChopMs - tailChopMs) / 1000
         state.doneMs += segmentMs
         onProgress?.(plan.totalMs > 0 ? Math.min(1, state.doneMs / plan.totalMs) : 1)
       } finally {
         loaded?.release()
       }
+    }
+
+    if (crossfadeCarry) {
+      // Every planned segment after the last emitted one was dropped at
+      // encode time, so the joint its tail was withheld for never happened:
+      // emit the tail so the audio track ends exactly where the video does.
+      await audioSource.add(toAudioBuffer(flushCarry(crossfadeCarry, AUDIO_SAMPLE_RATE)))
     }
 
     if (state.lastVideoTsSec < 0) {
@@ -765,56 +801,13 @@ async function pumpSegmentVideo({
   }
 }
 
-/** Boundary ramp length: long enough to kill clicks, far too short to hear. */
-const AUDIO_FADE_FRAMES = Math.round(0.003 * AUDIO_SAMPLE_RATE)
-
-/**
- * Exactly `segmentMs` of audio for a segment: the decoded clip audio sliced
- * at the trim-in point, padded with silence where the clip has less audio
- * than video. Slice edges get ~3ms fades — a hard cut mid-waveform at every
- * clip joint is an audible click, which is exactly the "audio isn't
- * seamless like the video" report.
- */
-function sliceSegmentAudio(
-  buffer: AudioBuffer | null,
-  startMs: number,
-  segmentMs: number,
-): AudioBuffer {
-  const totalFrames = Math.max(1, Math.round((segmentMs / 1000) * AUDIO_SAMPLE_RATE))
-  const slice = new AudioBuffer({
-    length: totalFrames,
+/** Wrap raw channel data in an AudioBuffer for the encoder. */
+function toAudioBuffer(channels: Float32Array[]): AudioBuffer {
+  const buffer = new AudioBuffer({
+    length: channels[0]!.length,
     sampleRate: AUDIO_SAMPLE_RATE,
-    numberOfChannels: AUDIO_CHANNELS,
+    numberOfChannels: channels.length,
   })
-  if (!buffer) return slice
-
-  const sourceRate = buffer.sampleRate
-  const sourceStartFrame = Math.floor((startMs / 1000) * sourceRate)
-  let copiedFrames = 0
-  for (let ch = 0; ch < AUDIO_CHANNELS; ch += 1) {
-    const source = buffer.getChannelData(Math.min(ch, buffer.numberOfChannels - 1))
-    const target = slice.getChannelData(ch)
-    let copied = 0
-    for (let i = 0; i < totalFrames; i += 1) {
-      const src = sourceStartFrame + i
-      if (src >= source.length) break
-      target[i] = source[src]!
-      copied += 1
-    }
-    copiedFrames = Math.max(copiedFrames, copied)
-  }
-
-  // Fade in from the cut point and out into the cut/padding.
-  const fade = Math.min(AUDIO_FADE_FRAMES, Math.floor(copiedFrames / 2))
-  if (fade > 0) {
-    for (let ch = 0; ch < AUDIO_CHANNELS; ch += 1) {
-      const target = slice.getChannelData(ch)
-      for (let i = 0; i < fade; i += 1) {
-        const gain = i / fade
-        target[i]! *= gain
-        target[copiedFrames - 1 - i]! *= gain
-      }
-    }
-  }
-  return slice
+  channels.forEach((data, ch) => buffer.copyToChannel(data, ch))
+  return buffer
 }

--- a/src/lib/export/segment-audio.test.ts
+++ b/src/lib/export/segment-audio.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it } from 'vitest'
+import {
+  CROSSFADE_HALF_MS,
+  CROSSFADE_MS,
+  EDGE_FADE_MS,
+  flushCarry,
+  sliceSegmentAudio,
+} from './segment-audio'
+
+const RATE = 48000
+const OVERLAP_FRAMES = (CROSSFADE_MS / 1000) * RATE
+const HALF_FRAMES = (CROSSFADE_HALF_MS / 1000) * RATE
+const EDGE_FRAMES = (EDGE_FADE_MS / 1000) * RATE
+
+function frames(ms: number): number {
+  return Math.round((ms / 1000) * RATE)
+}
+
+/** Mono constant-value source of `ms` milliseconds. */
+function constantSource(ms: number, value = 1): Float32Array[] {
+  return [new Float32Array(frames(ms)).fill(value)]
+}
+
+function slice(
+  overrides: Partial<Parameters<typeof sliceSegmentAudio>[0]>,
+): ReturnType<typeof sliceSegmentAudio> {
+  return sliceSegmentAudio({
+    source: constantSource(1000),
+    startMs: 0,
+    segmentMs: 1000,
+    sampleRate: RATE,
+    channelCount: 2,
+    carryIn: null,
+    hasNext: false,
+    ...overrides,
+  })
+}
+
+describe('sliceSegmentAudio', () => {
+  it('produces exactly the segment duration when the film is one clip', () => {
+    const { channels, carryOut } = slice({})
+    expect(channels).toHaveLength(2)
+    expect(channels[0]).toHaveLength(frames(1000))
+    expect(carryOut).toBeNull()
+    // Body at full gain; film edges ramp from/to silence.
+    expect(channels[0][frames(500)]).toBe(1)
+    expect(channels[0][0]).toBe(0)
+    expect(channels[0][frames(1000) - 1]).toBe(0)
+  })
+
+  it('withholds the last CROSSFADE_MS as carry when a segment follows', () => {
+    const { channels, carryOut } = slice({ hasNext: true })
+    expect(channels[0]).toHaveLength(frames(1000) - OVERLAP_FRAMES)
+    // The joint tail is NOT faded — it continues into the carry.
+    expect(channels[0][channels[0].length - 1]).toBe(1)
+    expect(carryOut).not.toBeNull()
+    expect(carryOut![0]).toHaveLength(OVERLAP_FRAMES)
+    expect(Array.from(carryOut![0])).toEqual(Array(OVERLAP_FRAMES).fill(1))
+  })
+
+  it('respects the trim-in point', () => {
+    const source = [new Float32Array(frames(1000))]
+    source[0][frames(500)] = 0.75
+    const { channels } = slice({ source, startMs: 400, segmentMs: 600 })
+    expect(channels[0][frames(100)]).toBe(0.75)
+  })
+
+  it('never withholds material past the trim-out point', () => {
+    // Source continues after the segment window with a loud marker; the
+    // carry must come from inside the window only.
+    const source = [new Float32Array(frames(1000)).fill(1)]
+    source[0].fill(9, frames(500))
+    const { carryOut } = slice({ source, segmentMs: 500, hasNext: true })
+    expect(Math.max(...carryOut![0])).toBe(1)
+  })
+
+  it('crossfades a joint with constant power instead of dipping to silence', () => {
+    const a = slice({ hasNext: true })
+    const b = slice({ carryIn: a.carryOut })
+    // Equal-gain sources: everywhere in the overlap sin+cos ∈ [1, √2] —
+    // the joint never gets quieter than either side alone.
+    const mixed = Array.from(b.channels[0].slice(0, OVERLAP_FRAMES))
+    expect(Math.min(...mixed)).toBeGreaterThanOrEqual(1)
+    expect(Math.max(...mixed)).toBeLessThanOrEqual(Math.SQRT2 + 1e-6)
+    // Mid-joint both sides contribute equally (~0.707 each).
+    expect(mixed[HALF_FRAMES]).toBeCloseTo(Math.SQRT2, 2)
+    // After the overlap the incoming clip is at full gain.
+    expect(b.channels[0][OVERLAP_FRAMES]).toBe(1)
+  })
+
+  it('hands the outgoing tail to the incoming clip even when it is silent', () => {
+    const a = slice({ hasNext: true })
+    const b = slice({ source: null, carryIn: a.carryOut })
+    // The joint still fades A out across B's (silent) head — no hard cut.
+    expect(b.channels[0][0]).toBeGreaterThan(0.99)
+    expect(b.channels[0][OVERLAP_FRAMES - 1]).toBeLessThan(0.05)
+    expect(b.channels[0][OVERLAP_FRAMES]).toBe(0)
+  })
+
+  it('pads with silence and fades out when the audio is shorter than the video', () => {
+    const { channels } = slice({ source: constantSource(600), segmentMs: 1000 })
+    expect(channels[0][frames(600)]).toBe(0)
+    expect(channels[0][frames(600) - 1]).toBe(0)
+    expect(channels[0][frames(600) - EDGE_FRAMES]).toBeCloseTo(1, 1)
+  })
+
+  it('keeps audio and video durations identical across a whole film', () => {
+    // Three clips joined by two crossfades: the video gives up
+    // CROSSFADE_HALF_MS per side of each joint, and the appended audio
+    // buffers must add up to exactly the same total.
+    const durations = [1000, 700, 1300]
+    let audioFrames = 0
+    let videoFrames = 0
+    let carry: Float32Array[] | null = null
+    durations.forEach((ms, i) => {
+      const hasNext = i < durations.length - 1
+      const result = slice({ source: constantSource(ms), segmentMs: ms, carryIn: carry, hasNext })
+      carry = result.carryOut
+      audioFrames += result.channels[0].length
+      videoFrames += frames(ms) - (carry ? HALF_FRAMES : 0) - (i > 0 ? HALF_FRAMES : 0)
+    })
+    expect(carry).toBeNull()
+    expect(audioFrames).toBe(videoFrames)
+    expect(audioFrames).toBe(frames(1000 + 700 + 1300) - 2 * OVERLAP_FRAMES)
+  })
+
+  it('spreads a mono source across both output channels', () => {
+    const { channels } = slice({})
+    expect(Array.from(channels[1])).toEqual(Array.from(channels[0]))
+  })
+})
+
+describe('flushCarry', () => {
+  it('emits half a crossfade fading to silence', () => {
+    const a = slice({ hasNext: true })
+    const flushed = flushCarry(a.carryOut!, RATE)
+    expect(flushed[0]).toHaveLength(HALF_FRAMES)
+    expect(flushed[0][0]).toBeCloseTo(1, 2)
+    expect(flushed[0][HALF_FRAMES - 1]).toBe(0)
+  })
+
+  it('restores the audio/video duration match when later segments drop', () => {
+    // One emitted segment that expected a joint: video kept
+    // durationMs − CROSSFADE_HALF_MS, audio must add up to the same.
+    const a = slice({ segmentMs: 1000, hasNext: true })
+    const flushed = flushCarry(a.carryOut!, RATE)
+    expect(a.channels[0].length + flushed[0].length).toBe(frames(1000) - HALF_FRAMES)
+  })
+})

--- a/src/lib/export/segment-audio.test.ts
+++ b/src/lib/export/segment-audio.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest'
+import { MIN_SEGMENT_MS } from './plan'
 import {
   CROSSFADE_HALF_MS,
   CROSSFADE_MS,
@@ -37,6 +38,15 @@ function slice(
 }
 
 describe('sliceSegmentAudio', () => {
+  it('is only fed segments longer than a full crossfade', () => {
+    // The exporter chops a fixed CROSSFADE_HALF_MS of video per joint side
+    // and this module withholds a fixed CROSSFADE_MS of audio per joint —
+    // safe only while the planner's minimum keeps at least half of every
+    // segment. clampSegmentToMedia drops anything under MIN_SEGMENT_MS, so
+    // this bound is what protects the chop from inverting a segment.
+    expect(MIN_SEGMENT_MS).toBeGreaterThanOrEqual(CROSSFADE_MS * 2)
+  })
+
   it('produces exactly the segment duration when the film is one clip', () => {
     const { channels, carryOut } = slice({})
     expect(channels).toHaveLength(2)

--- a/src/lib/export/segment-audio.ts
+++ b/src/lib/export/segment-audio.ts
@@ -18,7 +18,11 @@
  */
 
 /** Half the joint overlap: each neighbor contributes this much on its side
- * of the cut, and gives up this much video at the joint. */
+ * of the cut, and gives up this much video at the joint. The exporter's
+ * fixed video chops rely on every emitted segment being longer than a full
+ * crossfade — guaranteed because clampSegmentToMedia drops anything under
+ * MIN_SEGMENT_MS (see plan.ts, and the invariant test in
+ * segment-audio.test.ts). */
 export const CROSSFADE_HALF_MS = 10
 /** Full audio overlap at a joint. */
 export const CROSSFADE_MS = CROSSFADE_HALF_MS * 2

--- a/src/lib/export/segment-audio.ts
+++ b/src/lib/export/segment-audio.ts
@@ -1,0 +1,179 @@
+/**
+ * Clip-audio slicing for the WebCodecs export: one buffer per segment,
+ * appended sequentially (timestamps are implied by position), with a short
+ * equal-power CROSSFADE between adjacent clips instead of a dip to
+ * silence. The old approach faded every slice edge to zero, which read as
+ * a moment of silence at every joint; here the two neighbors overlap for
+ * CROSSFADE_HALF_MS on each side of the cut — the outgoing clip's last
+ * CROSSFADE_MS of audio fades out across the joint while the incoming
+ * clip's first CROSSFADE_MS fades in, keeping the energy roughly constant.
+ * To make room for the overlap, each clip gives up CROSSFADE_HALF_MS of
+ * VIDEO at the joint (sub-frame at 30fps), so A/V stay sample-locked.
+ *
+ * Because buffers are appended in order, the overlap cannot span two
+ * buffers: each segment WITHHOLDS its last CROSSFADE_MS of material as a
+ * `carry`, and the next segment mixes that carry into its own first
+ * CROSSFADE_MS. The withheld material always comes from inside the trim
+ * window — nothing the user trimmed away is ever heard.
+ */
+
+/** Half the joint overlap: each neighbor contributes this much on its side
+ * of the cut, and gives up this much video at the joint. */
+export const CROSSFADE_HALF_MS = 10
+/** Full audio overlap at a joint. */
+export const CROSSFADE_MS = CROSSFADE_HALF_MS * 2
+/** Click-kill ramp at the film's outer edges and into silence padding —
+ * long enough to kill clicks, far too short to hear. */
+export const EDGE_FADE_MS = 3
+
+function framesFor(ms: number, sampleRate: number): number {
+  return Math.round((ms / 1000) * sampleRate)
+}
+
+export interface SegmentAudioArgs {
+  /** Decoded clip audio, one array per source channel, or null when the
+   * clip has no decodable audio (the slice stays silent). */
+  source: readonly Float32Array[] | null
+  /** Trim-in point within the source clip, in ms. */
+  startMs: number
+  /** The segment's real (clamped) duration, in ms. */
+  segmentMs: number
+  sampleRate: number
+  channelCount: number
+  /** Withheld tail of the previous emitted segment (null at the film start). */
+  carryIn: Float32Array[] | null
+  /** Whether another segment is planned after this one. */
+  hasNext: boolean
+}
+
+export interface SegmentAudioSlice {
+  /** Exactly this segment's share of the output audio timeline. */
+  channels: Float32Array[]
+  /** Withheld tail for the next joint's crossfade (null at the film end). */
+  carryOut: Float32Array[] | null
+}
+
+/**
+ * Build one segment's audio slice: the decoded clip audio at the trim-in
+ * point, silence-padded where the clip has less audio than video, with the
+ * previous segment's withheld tail crossfaded into the head and (when a
+ * segment follows) the last CROSSFADE_MS withheld as the next carry.
+ */
+export function sliceSegmentAudio({
+  source,
+  startMs,
+  segmentMs,
+  sampleRate,
+  channelCount,
+  carryIn,
+  hasNext,
+}: SegmentAudioArgs): SegmentAudioSlice {
+  const totalFrames = Math.max(1, framesFor(segmentMs, sampleRate))
+  const overlapFrames = framesFor(CROSSFADE_MS, sampleRate)
+  const withheldFrames = hasNext ? Math.min(overlapFrames, totalFrames - 1) : 0
+  const length = totalFrames - withheldFrames
+  const sourceStart = Math.floor((startMs / 1000) * sampleRate)
+  const edgeFrames = framesFor(EDGE_FADE_MS, sampleRate)
+
+  const channels: Float32Array[] = []
+  let copiedFrames = 0
+  for (let ch = 0; ch < channelCount; ch += 1) {
+    const target = new Float32Array(length)
+    channels.push(target)
+    if (!source || source.length === 0) continue
+    const data = source[Math.min(ch, source.length - 1)]!
+    const available = Math.max(0, Math.min(length, data.length - sourceStart))
+    for (let i = 0; i < available; i += 1) {
+      target[i] = data[sourceStart + i]!
+    }
+    copiedFrames = Math.max(copiedFrames, available)
+  }
+
+  if (carryIn && carryIn.length > 0) {
+    // Joint crossfade: equal-power so two uncorrelated recordings keep a
+    // roughly constant loudness across the cut instead of dipping. The fade
+    // completes within the available room even on degenerate tiny slices.
+    const mixFrames = Math.min(overlapFrames, length, carryIn[0]!.length)
+    for (let ch = 0; ch < channelCount; ch += 1) {
+      const target = channels[ch]!
+      const tail = carryIn[Math.min(ch, carryIn.length - 1)]!
+      for (let i = 0; i < mixFrames; i += 1) {
+        const theta = ((i + 0.5) / mixFrames) * (Math.PI / 2)
+        target[i] = target[i]! * Math.sin(theta) + tail[i]! * Math.cos(theta)
+      }
+    }
+  } else if (copiedFrames > 0) {
+    // Film start: fade in from silence — a hard start mid-waveform clicks.
+    const fade = Math.min(edgeFrames, Math.floor(copiedFrames / 2))
+    for (let ch = 0; ch < channelCount; ch += 1) {
+      const target = channels[ch]!
+      for (let i = 0; i < fade; i += 1) {
+        target[i]! *= i / fade
+      }
+    }
+  }
+
+  // Fade out where the copied material meets a HARD boundary: the film's
+  // end, or silence padding when the clip's audio is shorter than its
+  // video. A joint tail is NOT hard — it continues into the carry.
+  if (copiedFrames > 0 && (copiedFrames < length || !hasNext)) {
+    const fade = Math.min(edgeFrames, Math.floor(copiedFrames / 2))
+    for (let ch = 0; ch < channelCount; ch += 1) {
+      const target = channels[ch]!
+      for (let i = 0; i < fade; i += 1) {
+        target[copiedFrames - 1 - i]! *= i / fade
+      }
+    }
+  }
+
+  if (!hasNext) return { channels, carryOut: null }
+
+  const carryOut: Float32Array[] = []
+  let carryCopied = 0
+  for (let ch = 0; ch < channelCount; ch += 1) {
+    const tail = new Float32Array(overlapFrames)
+    carryOut.push(tail)
+    if (!source || source.length === 0) continue
+    const data = source[Math.min(ch, source.length - 1)]!
+    // Only material inside the segment's window is withheld — never read
+    // past the trim-out point.
+    const available = Math.max(
+      0,
+      Math.min(withheldFrames, data.length - (sourceStart + length)),
+    )
+    for (let i = 0; i < available; i += 1) {
+      tail[i] = data[sourceStart + length + i]!
+    }
+    carryCopied = Math.max(carryCopied, available)
+  }
+  if (carryCopied > 0 && carryCopied < overlapFrames) {
+    // The audio ran out mid-carry: kill the step to zero, which the joint
+    // mix would otherwise play at high gain.
+    const fade = Math.min(edgeFrames, carryCopied)
+    for (const tail of carryOut) {
+      for (let i = 0; i < fade; i += 1) {
+        tail[carryCopied - 1 - i]! *= i / fade
+      }
+    }
+  }
+  return { channels, carryOut }
+}
+
+/**
+ * When a withheld tail is left over after the last segment (every later
+ * planned segment was dropped at encode time), emit its first
+ * CROSSFADE_HALF_MS with a fade-out. That is exactly the slack the video
+ * kept on that side of the never-realized joint, so the audio track ends
+ * where the video does.
+ */
+export function flushCarry(carry: Float32Array[], sampleRate: number): Float32Array[] {
+  const length = Math.max(1, framesFor(CROSSFADE_HALF_MS, sampleRate))
+  return carry.map((tail) => {
+    const target = new Float32Array(length)
+    const available = Math.min(length, tail.length)
+    for (let i = 0; i < available; i += 1) {
+      target[i] = tail[i]! * (1 - (i + 1) / length)
+    }
+    return target
+  })
+}

--- a/src/lib/testing/make-test-clip.ts
+++ b/src/lib/testing/make-test-clip.ts
@@ -1,9 +1,11 @@
 import {
+  AudioBufferSource,
   BufferTarget,
   CanvasSource,
   Output,
   Quality,
   WebMOutputFormat,
+  getFirstEncodableAudioCodec,
   getFirstEncodableVideoCodec,
 } from 'mediabunny'
 
@@ -16,8 +18,11 @@ import {
  * recorder starves for frames and a multi-second hold can measure under the
  * 120ms minimum take. This encodes faster than realtime via WebCodecs with
  * an exact duration instead.
+ *
+ * Pass `toneHz` for a clip WITH an audio track: a steady sine tone, which
+ * audio-continuity assertions (e.g. the clip-joint crossfade) can measure.
  */
-export async function makeTestClipBlob(durationMs: number): Promise<Blob> {
+export async function makeTestClipBlob(durationMs: number, toneHz?: number): Promise<Blob> {
   const width = 320
   const height = 568
   const fps = 15
@@ -37,7 +42,34 @@ export async function makeTestClipBlob(durationMs: number): Promise<Blob> {
     quality: new Quality({ bitrate: 400_000 }),
   })
   output.addVideoTrack(source, { frameRate: fps })
+
+  let audioSource: AudioBufferSource | null = null
+  if (toneHz) {
+    const audioCodec = await getFirstEncodableAudioCodec(['opus'], {
+      numberOfChannels: 1,
+      sampleRate: 48000,
+    })
+    if (!audioCodec) throw new Error('No encodable test audio codec')
+    audioSource = new AudioBufferSource({
+      codec: audioCodec,
+      quality: new Quality({ bitrate: 96_000 }),
+    })
+    output.addAudioTrack(audioSource)
+  }
+
   await output.start()
+
+  if (audioSource && toneHz) {
+    const rate = 48000
+    const frames = Math.max(1, Math.round((durationMs / 1000) * rate))
+    const buffer = new AudioBuffer({ length: frames, sampleRate: rate, numberOfChannels: 1 })
+    const data = buffer.getChannelData(0)
+    for (let i = 0; i < frames; i += 1) {
+      data[i] = 0.5 * Math.sin((2 * Math.PI * toneHz * i) / rate)
+    }
+    await audioSource.add(buffer)
+    audioSource.close()
+  }
 
   const totalSec = durationMs / 1000
   const frames = Math.max(2, Math.ceil(totalSec * fps))

--- a/tests/e2e/export.spec.ts
+++ b/tests/e2e/export.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect, type Page } from '@playwright/test'
-import { openSeededProject, waitForCameraReady } from './helpers'
+import { gotoHome, openSeededProject, waitForCameraReady } from './helpers'
 
 async function exportReady(page: Page): Promise<void> {
   await expect(page.getByText('Done! Your video is ready')).toBeVisible({ timeout: 60_000 })
@@ -106,5 +106,92 @@ test.describe('Go / export', () => {
       return names
     })
     expect(cacheEntries).toHaveLength(1)
+  })
+
+  test('adjacent clips crossfade audio at the joint instead of dipping to silence', async ({
+    page,
+  }) => {
+    test.slow()
+    await gotoHome(page)
+
+    const measured = await page.evaluate(async () => {
+      const storage = await import('/src/lib/storage.ts')
+      const { exportProject } = await import('/src/lib/export/index.ts')
+      const { decodeBackgroundAudio } = await import('/src/lib/export/shared.ts')
+      const { makeTestClipBlob } = await import('/src/lib/testing/make-test-clip.ts')
+
+      // Two clips carrying steady sine tones at DIFFERENT frequencies: the
+      // joint between them is exactly where the old per-slice fade-to-zero
+      // produced an audible dip to silence.
+      const project = await storage.createProject()
+      for (const toneHz of [440, 880]) {
+        await storage.addClip({
+          projectId: project.id,
+          blob: await makeTestClipBlob(2000, toneHz),
+          mimeType: 'video/webm',
+          durationMs: 2000,
+          width: 320,
+          height: 568,
+        })
+      }
+      const clips = await storage.getClipsForProject(project.id)
+      const result = await exportProject(clips, { watermark: false })
+
+      const decoded = await decodeBackgroundAudio(result.blob, 48000)
+      if (!decoded) return null
+      const data = decoded.getChannelData(0)
+      const rms = (fromSec: number, toSec: number) => {
+        const from = Math.max(0, Math.floor(fromSec * decoded.sampleRate))
+        const to = Math.min(Math.floor(toSec * decoded.sampleRate), data.length)
+        let sum = 0
+        for (let i = from; i < to; i += 1) sum += data[i]! * data[i]!
+        return Math.sqrt(sum / Math.max(1, to - from))
+      }
+      // Dominant frequency proxy: sign changes per second (~2× frequency).
+      const crossingsPerSec = (fromSec: number, toSec: number) => {
+        const from = Math.max(1, Math.floor(fromSec * decoded.sampleRate))
+        const to = Math.min(Math.floor(toSec * decoded.sampleRate), data.length)
+        let crossings = 0
+        for (let i = from; i < to; i += 1) {
+          if (data[i - 1]! < 0 !== data[i]! < 0) crossings += 1
+        }
+        return crossings / Math.max(0.001, toSec - fromSec)
+      }
+      // The video cut sits at 2s − CROSSFADE_HALF_MS on the output
+      // timeline; scan 2ms windows across the whole joint region (which
+      // also covers 2.0s, where the OLD dip landed) for the quietest spot.
+      const jointSec = 1.99
+      let jointMin = Number.POSITIVE_INFINITY
+      for (let t = jointSec - 0.04; t <= jointSec + 0.04; t += 0.001) {
+        jointMin = Math.min(jointMin, rms(t - 0.001, t + 0.001))
+      }
+      return {
+        durationSec: decoded.duration,
+        clipA: rms(0.8, 1.6),
+        clipB: rms(2.4, 3.2),
+        clipAFreq: crossingsPerSec(0.8, 1.6) / 2,
+        clipBFreq: crossingsPerSec(2.4, 3.2) / 2,
+        jointMin,
+      }
+    })
+
+    expect(measured).not.toBeNull()
+    // Both clips' own audio made it through, in order.
+    expect(measured!.clipAFreq).toBeGreaterThan(340)
+    expect(measured!.clipAFreq).toBeLessThan(540)
+    expect(measured!.clipBFreq).toBeGreaterThan(700)
+    expect(measured!.clipBFreq).toBeLessThan(1060)
+    expect(measured!.clipA).toBeGreaterThan(0.1)
+    expect(measured!.clipB).toBeGreaterThan(0.1)
+    // THE crossfade contract: the joint never dips toward silence. The old
+    // fade-to-zero read ≈0.2× of the surrounding level here; the
+    // equal-power overlap holds ≈1×.
+    expect(measured!.jointMin).toBeGreaterThan(
+      Math.min(measured!.clipA, measured!.clipB) * 0.6,
+    )
+    // Each joint trades CROSSFADE_MS of timeline for the overlap (codec
+    // padding keeps this a sanity bound, not an exact one).
+    expect(measured!.durationSec).toBeGreaterThan(3.9)
+    expect(measured!.durationSec).toBeLessThan(4.05)
   })
 })


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Replaces the per-slice ~3ms fade-to-zero at every clip joint (which read as a moment of silence between clips) with a real **equal-power crossfade**: adjacent clips overlap their audio for 10ms on each side of the cut, and each clip gives up 10ms of video at the joint (sub-frame at 30fps) so the timeline stays sample-locked to the overlapped audio.

## How

- New `src/lib/export/segment-audio.ts` holds the slicing logic as pure `Float32Array` functions (unit-testable in Node). Audio buffers are still appended sequentially — timestamps implied by position — so the overlap can't span two buffers. Instead each segment **withholds** its last 20ms of material as a `carry`, and the next segment mixes that carry into its own first 20ms with an equal-power (sin/cos) ramp. Withheld material always comes from inside the trim window, so nothing the user trimmed away is ever heard.
- `encode-webcodecs.ts` chops `CROSSFADE_HALF_MS` (10ms) of video from each side of every interior joint and advances the output clock by the chopped duration, keeping A/V sample-locked. The background-music mixer now uses a real `audioFramesWritten` counter (the audio buffer boundary sits half a crossfade before the video cut, so `outputOffsetSec` no longer equals the audio position).
- The film's outer edges and silence-padding boundaries keep the short ~3ms click-kill fades. If every planned segment after the last emitted one is dropped at encode time, the leftover carry is flushed (10ms, fading out) so the audio track ends exactly where the video does.
- The realtime `MediaRecorder` fallback engine is unchanged (it schedules audio in real time and has no fade-to-zero to begin with).

## Testing

- 11 new unit tests in `segment-audio.test.ts`: constant-power joint (never quieter than either side, ~√2 mid-joint), trim-window safety, silence padding, mono spread, carry flush, and an audio/video duration-conservation check across a 3-clip film. Full `npm test`: 146 passed.
- New e2e test in `tests/e2e/export.spec.ts`: exports two tone-bearing clips (fixture clips can now carry a sine tone) through the real WebCodecs+AAC pipeline, decodes the result, and asserts the quietest 2ms window around the joint stays above 0.6× the surrounding level. **Verified discriminative**: against the old encoder it fails at 0.21× (dip to 0.074 RMS); with the crossfade it passes (~1×).
- `npm run lint` (tsc) clean. Full e2e suite: 52 passed; the 4 failures (Sentry-telemetry offsite-write assertion, install-hint, storage sweep) reproduce identically on unmodified `main` in this VM.

Decoded waveform around the joint (440Hz clip → 880Hz clip), before on `main` vs after:

![Joint waveform before (dip to silence) vs after (crossfade)](https://cursor.com/artifacts/c/art-f47f4e2e-7949-4915-9ee2-3f952801273f)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-41d98d6a-18dc-43be-a31e-bdc0fd67f5de?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-41d98d6a-18dc-43be-a31e-bdc0fd67f5de&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added smooth audio crossfades between adjacent exported clips.
  * Preserved audio continuity and timing when clips are joined.
  * Added support for audio padding, channel normalization, and edge fades.
  * Ensured final audio tails are retained when exporting segmented video.

* **Bug Fixes**
  * Improved synchronization between exported audio and video durations.
  * Prevented volume dips and audio loss at clip transitions.

* **Tests**
  * Added coverage for crossfades, audio trimming, duration alignment, and multi-clip exports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->