### PR TITLE
Preview plays the music at the export's level and position

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,14 +37,15 @@ For a phone on the same network, use your machine’s LAN URL over HTTPS, or tun
   after the other under the film (nothing loops — a hint suggests adding
   another track when the music ends before the film does). The mix is
   **relative**: one balance slider per clip splits the audio between the
-  clip's own sound (left) and the music (right) — 80% music means 20% clip
-  sound — so the blend can never clip, and exports **peak-normalize** both
-  sources so the split means the same thing however hot either recording
-  is. Defaults to 25% music under every clip; tap a clip to set its own
-  balance (duck the music under speech, swell it for b-roll). Mix changes
-  glide across clip boundaries, and the music fades in/out at the start and
-  end of the film (both toggleable, on by default) — in the preview and in
-  the exported file
+  clip's own   sound (left) and the music (right) — 80% music means 20% clip
+  sound — so the blend can never clip, and both sources are
+  **peak-normalized** so the split means the same thing however hot either
+  recording is. Defaults to 25% music under every clip; tap a clip to set
+  its own balance (duck the music under speech, swell it for b-roll). Mix
+  changes glide across clip boundaries, and the music fades in/out at the
+  start and end of the film (both toggleable, on by default). All of it —
+  levels, normalization, fades, track hand-offs — plays the same in the
+  project preview as in the exported file
 - Project preview playback: tap edges to skip clips, tap middle to stop
 - Up to **6** stable project slots (create / open / rename / delete, poster art from your clips)
 - Big Go CTA: on-device export to **one video file**, then Share (system sheet) or Save

--- a/src/components/playback-overlay.tsx
+++ b/src/components/playback-overlay.tsx
@@ -2,7 +2,13 @@ import type { Handle } from 'remix/ui'
 import { on, ref } from 'remix/ui'
 import { planExport } from '../lib/export'
 import { FADE_OUT_MS } from '../lib/export/background-audio'
-import { clipAudioVolume, type ClipRecord, type ProjectAudioRecord } from '../lib/types'
+import { measureAudioNormalization } from '../lib/preview-audio-normalization'
+import {
+  clipAudioVolume,
+  type ClipRecord,
+  type ProjectAudioRecord,
+  type ProjectAudioTrack,
+} from '../lib/types'
 import { IconPlay } from './icons'
 import { isInteractiveTarget } from '../lib/keyboard'
 
@@ -63,6 +69,93 @@ export function PlaybackOverlay(handle: Handle<PlaybackOverlayProps>) {
    * metadata window says so. Cleared when a skip seeks music again. */
   let playlistDone = false
 
+  // Export-fidelity levels: the export peak-normalizes BOTH sources toward
+  // the same peak before blending by the mix share (a quietly mastered song
+  // is boosted up to 4×), so element volumes alone would play the music at
+  // the wrong level relative to the clips. One Web Audio gain per element
+  // carries its source's normalization scale (the element volume keeps
+  // carrying the share/fade glide) — the product is the export's gain, and
+  // gains above 1 need Web Audio anyway (element volume caps at 1).
+  let audioContext: AudioContext | null = null
+  let clipGainNode: GainNode | null = null
+  let musicGainNode: GainNode | null = null
+  let graphFailed = false
+  let appliedClipScale = 1
+  let appliedMusicScale = 1
+  /** Measured per source blob: the export's normalization gain + decoded
+   * length (kicked off when the preview opens, glides in when it lands). */
+  const measured = new Map<Blob, { scale: number; decodedDurationMs: number | null }>()
+  const measuring = new Set<Blob>()
+
+  const requestMeasure = (blob: Blob) => {
+    if (measured.has(blob) || measuring.has(blob)) return
+    measuring.add(blob)
+    void measureAudioNormalization(blob).then((info) => {
+      measured.set(blob, info)
+    })
+  }
+
+  /** Normalization gain the export applies to this source (1 until measured). */
+  const scaleFor = (blob: Blob): number => {
+    requestMeasure(blob)
+    return measured.get(blob)?.scale ?? 1
+  }
+
+  /** Track length on the output timeline. The export hands off to the next
+   * playlist track where the previous one's DECODED samples end, which can
+   * differ from the stored metadata duration — prefer the measured value. */
+  const trackDurationMs = (track: ProjectAudioTrack): number =>
+    measured.get(track.blob)?.decodedDurationMs ?? track.durationMs
+
+  /** Route both elements through per-source normalization gains. Wired only
+   * once the context is RUNNING: elements captured by a suspended graph go
+   * silent, while unwired elements still play (at share volume, just
+   * without the normalization scales). */
+  const ensureAudioGraph = () => {
+    if (graphFailed || clipGainNode || !videoEl || !audioEl) return
+    try {
+      audioContext ??= new AudioContext()
+      if (audioContext.state !== 'running') return
+      const clip = audioContext.createGain()
+      const music = audioContext.createGain()
+      // Destination first: if capturing the second element throws below,
+      // the first one is already wired through and stays audible.
+      clip.connect(audioContext.destination)
+      music.connect(audioContext.destination)
+      audioContext.createMediaElementSource(videoEl).connect(clip)
+      audioContext.createMediaElementSource(audioEl).connect(music)
+      clipGainNode = clip
+      musicGainNode = music
+      // Test observability: the gain nodes are unreachable from the DOM.
+      audioEl.dataset.clipScale = String(appliedClipScale)
+      audioEl.dataset.musicScale = String(appliedMusicScale)
+    } catch {
+      graphFailed = true
+    }
+  }
+
+  /** Glide both gains toward the export's normalization scales — the clip's
+   * from the current segment, the music's from the loaded playlist track. */
+  const applyNormalizationGains = () => {
+    ensureAudioGraph()
+    const context = audioContext
+    if (!context || !clipGainNode || !musicGainNode || !audioEl) return
+    const segment = currentSegment()
+    const clipScale = segment ? scaleFor(segment.clip.blob) : 1
+    const trackBlob = props.audio?.tracks[musicTrackIndex]?.blob
+    const musicScale = trackBlob ? scaleFor(trackBlob) : 1
+    if (clipScale !== appliedClipScale) {
+      appliedClipScale = clipScale
+      clipGainNode.gain.setTargetAtTime(clipScale, context.currentTime, 0.05)
+      audioEl.dataset.clipScale = String(clipScale)
+    }
+    if (musicScale !== appliedMusicScale) {
+      appliedMusicScale = musicScale
+      musicGainNode.gain.setTargetAtTime(musicScale, context.currentTime, 0.05)
+      audioEl.dataset.musicScale = String(musicScale)
+    }
+  }
+
   const currentSegment = () => resolveSegments()[index] ?? null
   const startSec = () => {
     const segment = currentSegment()
@@ -110,10 +203,10 @@ export function PlaybackOverlay(handle: Handle<PlaybackOverlayProps>) {
     const tracks = props.audio?.tracks ?? []
     let cursor = 0
     for (let i = 0; i < tracks.length; i += 1) {
-      if (positionMs < cursor + tracks[i].durationMs) {
+      if (positionMs < cursor + trackDurationMs(tracks[i])) {
         return { index: i, offsetMs: positionMs - cursor }
       }
-      cursor += tracks[i].durationMs
+      cursor += trackDurationMs(tracks[i])
     }
     return null
   }
@@ -148,7 +241,7 @@ export function PlaybackOverlay(handle: Handle<PlaybackOverlayProps>) {
       // so a backward skip switches to the covering track instead.
       const boundaryMs = props.audio.tracks
         .slice(0, target.index + 1)
-        .reduce((sum, track) => sum + track.durationMs, 0)
+        .reduce((sum, track) => sum + trackDurationMs(track), 0)
       const nearHandOff =
         target.index < musicTrackIndex && boundaryMs - positionMs < 1500 && !audio.ended
       if (!nearHandOff) {
@@ -196,6 +289,9 @@ export function PlaybackOverlay(handle: Handle<PlaybackOverlayProps>) {
   }
 
   const playMusic = () => {
+    // Every play request runs from a user-gesture path — the moment a
+    // suspended normalization graph is allowed to start.
+    void audioContext?.resume().catch(() => undefined)
     if (!syncMusicPosition()) return
     void audioEl?.play().catch(() => undefined)
   }
@@ -212,6 +308,20 @@ export function PlaybackOverlay(handle: Handle<PlaybackOverlayProps>) {
     // per-frame glide below fades it in from silence.
     el.volume = track.fadeIn ? 0 : segmentMusicVolume()
 
+    // Measure every source up front, one decode at a time: the scales and
+    // decoded track lengths should be ready by the time the playhead needs
+    // them (results are cached per blob, so reopening is instant).
+    void (async () => {
+      const blobs = [
+        ...track.tracks.map((t) => t.blob),
+        ...resolveSegments().map((segment) => segment.clip.blob),
+      ]
+      for (const blob of blobs) {
+        if (audioEl !== el) return
+        measured.set(blob, await measureAudioNormalization(blob))
+      }
+    })()
+
     // Per-frame glide of BOTH sides of the mix: the music toward the
     // current clip's share, the clip's own sound toward the complement
     // (1 − share) — mirroring the export blend. Where the playlist has run
@@ -221,6 +331,7 @@ export function PlaybackOverlay(handle: Handle<PlaybackOverlayProps>) {
     const tick = (now: number) => {
       const dt = Math.min(100, now - last)
       last = now
+      applyNormalizationGains()
       const target = segmentMusicVolume()
       const alpha = 1 - Math.exp(-dt / MUSIC_VOLUME_TAU_MS)
       const next = el.volume + (target - el.volume) * alpha
@@ -252,6 +363,10 @@ export function PlaybackOverlay(handle: Handle<PlaybackOverlayProps>) {
       for (const url of trackUrls.values()) URL.revokeObjectURL(url)
       trackUrls.clear()
       musicTrackIndex = -1
+      clipGainNode = null
+      musicGainNode = null
+      void audioContext?.close().catch(() => undefined)
+      audioContext = null
     })
   }
 

--- a/src/components/playback-overlay.tsx
+++ b/src/components/playback-overlay.tsx
@@ -107,6 +107,14 @@ export function PlaybackOverlay(handle: Handle<PlaybackOverlayProps>) {
   const trackDurationMs = (track: ProjectAudioTrack): number =>
     measured.get(track.blob)?.decodedDurationMs ?? track.durationMs
 
+  /** A rejected play() surfaces the tap-to-play affordance only for
+   * autoplay-policy rejections. AbortError means the attempt was merely
+   * interrupted — a deliberate pause() or a source swap landing while the
+   * promise was still pending — and flashing "Tap to play" over the
+   * controls then is wrong (and blocks the button underneath). */
+  const rejectionNeedsTap = (error: unknown): boolean =>
+    !(error instanceof DOMException && error.name === 'AbortError')
+
   /** Synchronous, gesture-time nudge for a suspended context: Safari (and
    * iOS in particular) only honors resume() called from inside a
    * user-gesture handler — the async promise continuations where playback
@@ -246,14 +254,23 @@ export function PlaybackOverlay(handle: Handle<PlaybackOverlayProps>) {
       // Metadata durations can run slightly past the decoded length, so a
       // just-ended track briefly still "covers" the playhead — moving back
       // to it mid-playback would restart it. The guard protects that
-      // playback continuity only: once the current element has ENDED there
-      // is nothing to protect (and play() on it would restart it from 0),
+      // playback continuity only, and only while the covering track's REAL
+      // (decoded) length is unknown: once measured, every position mapped
+      // into the track is backed by real audio, so realigning to it is
+      // always safe (and export-true — the export is still playing that
+      // track's tail there). Once the current element has ENDED there is
+      // also nothing to protect (play() on it would restart it from 0),
       // so a backward skip switches to the covering track instead.
       const boundaryMs = props.audio.tracks
         .slice(0, target.index + 1)
         .reduce((sum, track) => sum + trackDurationMs(track), 0)
+      const overshootPossible =
+        measured.get(props.audio.tracks[target.index].blob)?.decodedDurationMs == null
       const nearHandOff =
-        target.index < musicTrackIndex && boundaryMs - positionMs < 1500 && !audio.ended
+        overshootPossible &&
+        target.index < musicTrackIndex &&
+        boundaryMs - positionMs < 1500 &&
+        !audio.ended
       if (!nearHandOff) {
         musicTrackIndex = target.index
         audio.src = urlForTrack(target.index)
@@ -429,7 +446,8 @@ export function PlaybackOverlay(handle: Handle<PlaybackOverlayProps>) {
         void video
           .play()
           .then(() => playMusic())
-          .catch(() => {
+          .catch((error: unknown) => {
+            if (!rejectionNeedsTap(error)) return
             needsTap = true
             void handle.update()
           })
@@ -468,7 +486,8 @@ export function PlaybackOverlay(handle: Handle<PlaybackOverlayProps>) {
         playMusic()
         void handle.update()
       })
-      .catch(() => {
+      .catch((error: unknown) => {
+        if (!rejectionNeedsTap(error)) return
         needsTap = true
         void handle.update()
       })
@@ -506,7 +525,8 @@ export function PlaybackOverlay(handle: Handle<PlaybackOverlayProps>) {
               playMusic()
               void handle.update()
             })
-            .catch(() => {
+            .catch((error: unknown) => {
+              if (!rejectionNeedsTap(error)) return
               needsTap = true
               void handle.update()
             })

--- a/src/components/playback-overlay.tsx
+++ b/src/components/playback-overlay.tsx
@@ -107,6 +107,16 @@ export function PlaybackOverlay(handle: Handle<PlaybackOverlayProps>) {
   const trackDurationMs = (track: ProjectAudioTrack): number =>
     measured.get(track.blob)?.decodedDurationMs ?? track.durationMs
 
+  /** Synchronous, gesture-time nudge for a suspended context: Safari (and
+   * iOS in particular) only honors resume() called from inside a
+   * user-gesture handler — the async promise continuations where playback
+   * starts are too late there. Called at the top of every tap/key path. */
+  const resumeAudioContextFromGesture = () => {
+    if (audioContext?.state === 'suspended') {
+      void audioContext.resume().catch(() => undefined)
+    }
+  }
+
   /** Route both elements through per-source normalization gains. Wired only
    * once the context is RUNNING: elements captured by a suspended graph go
    * silent, while unwired elements still play (at share volume, just
@@ -308,6 +318,18 @@ export function PlaybackOverlay(handle: Handle<PlaybackOverlayProps>) {
     // per-frame glide below fades it in from silence.
     el.volume = track.fadeIn ? 0 : segmentMusicVolume()
 
+    // Create the context NOW — as close to the opening tap as possible, so
+    // browsers that gate Web Audio on user activation start it running
+    // (created any later, only a fresh gesture could unsuspend it).
+    try {
+      audioContext ??= new AudioContext()
+      if (audioContext.state === 'suspended') {
+        void audioContext.resume().catch(() => undefined)
+      }
+    } catch {
+      graphFailed = true
+    }
+
     // Measure every source up front, one decode at a time: the scales and
     // decoded track lengths should be ready by the time the playhead needs
     // them (results are cached per blob, so reopening is instant).
@@ -319,6 +341,13 @@ export function PlaybackOverlay(handle: Handle<PlaybackOverlayProps>) {
       for (const blob of blobs) {
         if (audioEl !== el) return
         measured.set(blob, await measureAudioNormalization(blob))
+        // A decoded track length that differs from the stored metadata
+        // duration moves the playlist's boundaries — realign the bed to
+        // the corrected (export-true) position right away instead of
+        // waiting for the next skip. Guarded inside syncMusicPosition:
+        // in-track drift under 350ms and imminent hand-offs are left
+        // alone, so an accurate metadata duration re-seeks nothing.
+        if (musicTrackIndex >= 0) syncMusicPosition()
       }
     })()
 
@@ -388,6 +417,8 @@ export function PlaybackOverlay(handle: Handle<PlaybackOverlayProps>) {
   }
 
   const goTo = (nextIndex: number) => {
+    // Skips arrive from taps/keys — the moment a suspended graph may start.
+    resumeAudioContextFromGesture()
     advancedFor = -1
     segmentProgress = 0
     needsTap = false
@@ -464,6 +495,7 @@ export function PlaybackOverlay(handle: Handle<PlaybackOverlayProps>) {
         event.preventDefault()
         // Auto-repeat while held must not rapid-toggle pause/resume.
         if (event.repeat) return
+        resumeAudioContextFromGesture()
         const video = videoEl
         if (!video) return
         if (video.paused) {
@@ -624,6 +656,7 @@ export function PlaybackOverlay(handle: Handle<PlaybackOverlayProps>) {
             type="button"
             className="playback-resume"
             mix={on('click', () => {
+              resumeAudioContextFromGesture()
               const video = videoEl
               if (video)
                 void video

--- a/src/lib/export/shared.ts
+++ b/src/lib/export/shared.ts
@@ -363,7 +363,7 @@ function audioBufferPeak(buffer: AudioBuffer): number {
  * of containers — all one path); the result is resampled when the source
  * rate differs. Returns null when there is no decodable audio.
  */
-async function decodeBlobAudio(blob: Blob, sampleRate: number): Promise<AudioBuffer | null> {
+export async function decodeBlobAudio(blob: Blob, sampleRate: number): Promise<AudioBuffer | null> {
   const input = new Input({ source: new BlobSource(blob), formats: ALL_FORMATS })
   const track = await input.getPrimaryAudioTrack()
   if (!track || !(await track.canDecode())) return null

--- a/src/lib/preview-audio-normalization.ts
+++ b/src/lib/preview-audio-normalization.ts
@@ -1,0 +1,52 @@
+import { channelPeak, normalizationScale } from './export/background-audio'
+import { decodeBlobAudio } from './export/shared'
+
+/**
+ * The export peak-normalizes both sides of the background-music mix (the
+ * clip's own sound and each playlist track) before blending them by the
+ * mix share — a quietly mastered song is boosted up to 4×. For the live
+ * preview to play the music at the level (and hand tracks off at the
+ * position) the export will render, it needs the same measurements: this
+ * module runs the export's own decode + exact peak scan per source blob,
+ * cached so a preview reopen or playlist revisit never re-decodes.
+ */
+
+export interface AudioNormalizationInfo {
+  /** Gain the export applies to this source before blending. */
+  scale: number
+  /** Decoded audio length in ms — where the export actually hands off to
+   * the next playlist track (null when the blob has no decodable audio). */
+  decodedDurationMs: number | null
+}
+
+/** Must match the export engines' mixing rate: the export computes peaks
+ * AFTER resampling, and resampling can nudge a waveform's peak. */
+const EXPORT_SAMPLE_RATE = 48000
+
+const cache = new WeakMap<Blob, Promise<AudioNormalizationInfo>>()
+
+export function measureAudioNormalization(blob: Blob): Promise<AudioNormalizationInfo> {
+  let pending = cache.get(blob)
+  if (!pending) {
+    pending = measure(blob)
+    cache.set(blob, pending)
+  }
+  return pending
+}
+
+async function measure(blob: Blob): Promise<AudioNormalizationInfo> {
+  try {
+    const buffer = await decodeBlobAudio(blob, EXPORT_SAMPLE_RATE)
+    if (!buffer) return { scale: 1, decodedDurationMs: null }
+    const channels = Array.from({ length: buffer.numberOfChannels }, (_, ch) =>
+      buffer.getChannelData(ch),
+    )
+    return {
+      scale: normalizationScale(channelPeak(channels)),
+      decodedDurationMs: Math.round(buffer.duration * 1000),
+    }
+  } catch {
+    // Same stance as the export: an undecodable source is mixed unscaled.
+    return { scale: 1, decodedDurationMs: null }
+  }
+}

--- a/tests/e2e/background-music.spec.ts
+++ b/tests/e2e/background-music.spec.ts
@@ -359,4 +359,37 @@ test.describe('background music', () => {
     await overlay.getByRole('button', { name: 'Stop preview' }).click()
     await expect(overlay).toBeHidden()
   })
+
+  test('preview plays the music at the export level: peak normalization applies', async ({
+    page,
+  }) => {
+    await openPlusEditorWithClips(page, 1)
+    // Quietly mastered song: peak ≈ 8000/32768 ≈ 0.24, so the export mixes
+    // it ≈ 3.7× hotter (0.9 / 0.24) than the raw file plays. The preview
+    // must apply the same boost — element volume alone caps at 1×.
+    await addMusic(page, 'Add background music', makeWavFile('quiet-song.wav', 8, 8000))
+
+    await page.getByRole('button', { name: 'Play project preview' }).click()
+    const overlay = page.locator('.playback-overlay')
+    await expect(overlay).toBeVisible()
+
+    const music = overlay.locator('audio')
+    await expect
+      .poll(() => music.evaluate((el) => !(el as HTMLAudioElement).paused))
+      .toBe(true)
+    // The music gain glides to the export's normalization boost once the
+    // track is measured (decode runs in the background after open)…
+    await expect
+      .poll(async () => Number((await music.getAttribute('data-music-scale')) ?? '0'), {
+        timeout: 15_000,
+      })
+      .toBeGreaterThan(3.3)
+    expect(Number(await music.getAttribute('data-music-scale'))).toBeLessThanOrEqual(4)
+    // …while the fixture clips (video-only, no audio track) stay unscaled,
+    // exactly like the export mixes them.
+    await expect(music).toHaveAttribute('data-clip-scale', '1')
+
+    await overlay.getByRole('button', { name: 'Stop preview' }).click()
+    await expect(overlay).toBeHidden()
+  })
 })

--- a/tests/e2e/background-music.spec.ts
+++ b/tests/e2e/background-music.spec.ts
@@ -378,10 +378,11 @@ test.describe('background music', () => {
       .poll(() => music.evaluate((el) => !(el as HTMLAudioElement).paused))
       .toBe(true)
     // The music gain glides to the export's normalization boost once the
-    // track is measured (decode runs in the background after open)…
+    // track is measured (decode runs in the background after open; generous
+    // timeout — parallel workers can slow the decode considerably)…
     await expect
       .poll(async () => Number((await music.getAttribute('data-music-scale')) ?? '0'), {
-        timeout: 15_000,
+        timeout: 30_000,
       })
       .toBeGreaterThan(3.3)
     expect(Number(await music.getAttribute('data-music-scale'))).toBeLessThanOrEqual(4)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

When previewing the project, the background music now plays at the level and position it will have in the exported file.

The project preview already played the music bed with the right mix shares, fades, and playlist sequencing — but since #102 the export **peak-normalizes** both the clip's own sound and each music track toward the same peak before blending (boosting quietly mastered sources up to 4×), and the preview played raw element volumes. A quiet song could sound 4× quieter in the preview than in the export. Track hand-off positions could also drift: the preview placed playlist boundaries at stored metadata durations, while the export advances tracks where their decoded samples actually end.

## How

- `src/lib/preview-audio-normalization.ts` (new): measures a source blob's normalization gain and decoded length using the export's own decode path (`decodeBlobAudio` at 48 kHz) and exact peak scan (`channelPeak` + `normalizationScale`), cached per blob so preview reopens and playlist revisits never re-decode.
- `src/components/playback-overlay.tsx`: routes the clip `<video>` and music `<audio>` through per-source Web Audio `GainNode`s carrying the export's normalization scales (gains above 1 need Web Audio — element volume caps at 1). The element volumes keep carrying the existing share/fade glide, so the product per source is exactly the export's per-sample gain: `clip·scale·(1−share)` and `music·scale·share`. The graph wires only once the `AudioContext` is running, so a suspended context can never silence the preview; measurement runs in the background after open and the scales glide in. Playlist boundary math (`trackAtMs`, backward-skip hand-off guard) now prefers decoded track lengths, matching where the export switches tracks.
- `src/lib/export/shared.ts`: exports the previously-private `decodeBlobAudio` so the preview measures with the exact decode the export mixes with.

Without background music nothing changes (the export applies no normalization then, and the preview creates no audio graph).

## Review-loop hardening (Bugbot findings addressed)

- The `AudioContext` is created at overlay-audio mount and every tap/key path nudges a suspended context synchronously inside the gesture — the only pattern Safari/iOS honor (async promise continuations are too late there).
- When a measured decoded track length lands and moves a playlist boundary, the music position re-syncs immediately; the backward-realignment guard now applies only while the covering track's decoded length is unknown (once measured, every mapped position is backed by real audio, so realigning is always safe and export-true).
- A `play()` rejected with `AbortError` (deliberate pause or source swap landing mid-attempt) no longer flashes the tap-to-play affordance over the playback controls; that affordance is for autoplay-policy rejections only.

## Testing

- New e2e test: a track mastered at ≈0.24 peak must reach the export's ≈3.7× boost (0.9 / 0.24) in the preview's music gain, while audio-less fixture clips stay at 1× — observable via `data-music-scale` / `data-clip-scale` on the preview's audio element.
- `npm run lint` and `npm test` pass; all 5 background-music e2e tests pass (including the pre-existing preview mix-ramp test, proving element-volume semantics are unchanged with the Web Audio routing active).
- Full `npm run test:e2e`: 53 passed; the 4 failures (export/install-hint/storage specs) fail identically on unmodified `main` in this VM, so they're pre-existing environment issues unrelated to this change.
- Bugbot reviewed three rounds; all findings addressed, final round clean.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ebdc310a-db51-4ce2-997b-493bc5d3ecee?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ebdc310a-db51-4ce2-997b-493bc5d3ecee&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

