### PR TITLE
Home polish: desktop centering + fold fit, slot descenders, storage gauge, Import moves to About

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ For a phone on the same network, use your machine’s LAN URL over HTTPS, or tun
 - Project **backup/import**: one `.kodyvideo` file per project (clips, trims,
   location data, background music + volumes) — a safety net, and the way to
   move a project between devices or origins (e.g. kody-video.pages.dev →
-  kody.video)
+  kody.video); ⋯ → Save backup on a slot, import from the About page
 - Installable PWA (manifest + Workbox service worker for the app shell)
 - **No accounts, no uploads, no analytics**
 

--- a/index.html
+++ b/index.html
@@ -168,6 +168,9 @@
       @media (min-width: 720px) {
         body {
           overflow: auto;
+          /* Must match global.css: BFC keeps #root margins from collapsing
+             through the 100%-tall body (phantom scroll below the fold). */
+          display: flow-root;
         }
         #boot-hero {
           display: none;

--- a/index.html
+++ b/index.html
@@ -176,6 +176,9 @@
           margin-top: 24px;
           margin-bottom: 24px;
           height: min(920px, calc(100dvh - 48px));
+          /* Must match global.css: without this the base min-height: 100%
+             wins and the frame's bottom edge falls below the fold. */
+          min-height: 0;
           border-radius: 28px;
           /* Match full stylesheet: reserve border box so 1px border + shadow
              cannot reflow the frame after CSS arrives. */

--- a/manual-test-checklist.md
+++ b/manual-test-checklist.md
@@ -39,9 +39,11 @@ npm test           # unit tests
   device** during record/export/save/zip
 - **Projects**: slots show poster art; rename via the options sheet; delete
   uses the styled confirm (no browser dialog) and frees stored clips; backup
-  downloads a `.kodyvideo` file and import restores it; import at the plan
-  limit is refused with a clear message; slot order is stable
-- **Storage**: footer shows "X of Y used"; ≥80% shows the amber banner, ≥92%
+  downloads a `.kodyvideo` file and import (About → Import a backup) restores
+  it; import at the plan limit is refused with a clear message; slot order is
+  stable
+- **Storage**: the footer storage gauge opens a "X of Y used" popover on
+  tap; ≥80% shows the amber banner, ≥92%
   turns critical; the banner offers one-tap "Clear cached exports"; the boot
   sweep removes orphaned cache files but keeps the referenced last export;
   deleting a project drops its cached export; the About page shows the cache

--- a/src/components/storage-meter.tsx
+++ b/src/components/storage-meter.tsx
@@ -1,0 +1,71 @@
+import type { Handle } from 'remix/ui'
+import { on } from 'remix/ui'
+import * as Popover from 'remix/ui/popover'
+import {
+  formatBytes,
+  formatStoragePercent,
+  storageSeverity,
+  type StorageSpace,
+} from '../lib/storage-space'
+
+interface StorageMeterProps {
+  storage: StorageSpace
+}
+
+/**
+ * Subtle device-storage gauge for the home footer: a short progress bar
+ * (replacing the old "X of Y used" text) that opens a detail popover on tap.
+ */
+export function StorageMeter(handle: Handle<StorageMeterProps>) {
+  let open = false
+  const setOpen = (next: boolean) => {
+    open = next
+    void handle.update()
+  }
+
+  return () => {
+    const { storage } = handle.props
+    const severity = storageSeverity(storage.ratio)
+    const percent = formatStoragePercent(storage.ratio)
+    const detail = `${formatBytes(storage.usedBytes)} of ${formatBytes(storage.quotaBytes)} used`
+    // Never fully empty: a hairline of fill keeps the bar readable as a gauge.
+    const fillPercent = Math.max(3, Math.round(storage.ratio * 100))
+
+    return (
+      <Popover.Context>
+        <button
+          type="button"
+          className={`storage-meter${severity === 'ok' ? '' : ` is-${severity}`}`}
+          aria-label={`Device storage: ${detail} (${percent} full)`}
+          aria-expanded={open}
+          mix={[
+            Popover.anchor({ placement: 'top', offset: 8 }),
+            on('click', () => setOpen(!open)),
+            // Focus stays on this button when the popover opens, so the
+            // surface's own Escape handler never hears the key.
+            on('keydown', (event) => {
+              if (event.key === 'Escape' && open) setOpen(false)
+            }),
+          ]}
+        >
+          <span className="storage-meter-track" aria-hidden="true">
+            <span className="storage-meter-fill" style={{ width: `${fillPercent}%` }} />
+          </span>
+        </button>
+        <div
+          className="storage-popover"
+          mix={Popover.surface({
+            open,
+            onHide: () => setOpen(false),
+            // The anchor's own click handler toggles; without this an
+            // outside-click close + toggle would cancel out.
+            closeOnAnchorClick: false,
+          })}
+        >
+          <strong>Device storage {percent} full</strong>
+          <span>{detail}</span>
+        </div>
+      </Popover.Context>
+    )
+  }
+}

--- a/src/pages/about-page.tsx
+++ b/src/pages/about-page.tsx
@@ -7,7 +7,18 @@ import { buildDateLabel, shortVersion } from '../lib/build-info'
 import { reportError } from '../lib/error-reporting'
 import { clearExportCache, estimateExportCacheBytes } from '../lib/export/export-cache'
 import { listRearCameras } from '../lib/media'
-import { estimateStorageSpace, formatBytes, type StorageSpace } from '../lib/storage-space'
+import {
+  BackupFormatError,
+  importProjectBackup,
+  parseProjectBackup,
+} from '../lib/project-transfer'
+import {
+  estimateStorageSpace,
+  formatBytes,
+  requestPersistentStorage,
+  type StorageSpace,
+} from '../lib/storage-space'
+import { navigate } from '../router'
 
 /** Prefilled GitHub issue so bug reports arrive with device context attached. */
 function reportProblemUrl(): string {
@@ -58,6 +69,9 @@ export function AboutPage(handle: Handle) {
   let clearingCache = false
   let cameraReport: string | null = null
   let inspectingCameras = false
+  let importing = false
+  let importProgress: string | null = null
+  let importError: string | null = null
 
   const refresh = async () => {
     data = await loadAboutData()
@@ -132,6 +146,33 @@ export function AboutPage(handle: Handle) {
         clearingCache = false
         void handle.update()
       })
+  }
+
+  const importBackup = (file: File) => {
+    void (async () => {
+      importing = true
+      importError = null
+      importProgress = 'Reading backup…'
+      void handle.update()
+      try {
+        const parsed = await parseProjectBackup(file)
+        const project = await importProjectBackup(parsed, (done, total) => {
+          importProgress = `Importing clip ${Math.min(done + 1, total)} of ${total}…`
+          void handle.update()
+        })
+        requestPersistentStorage()
+        // Land directly in the imported project — unambiguous success.
+        navigate(`/project/${project.id}`)
+      } catch (err) {
+        // Wrong/damaged file picked = expected user input, not a crash.
+        if (!(err instanceof BackupFormatError)) reportError(err, 'import')
+        importError = err instanceof Error ? err.message : 'Could not import that file'
+      } finally {
+        importProgress = null
+        importing = false
+        void handle.update()
+      }
+    })()
   }
 
   const onCheckForUpdates = () => {
@@ -282,6 +323,36 @@ export function AboutPage(handle: Handle) {
                 {cacheStatus}
               </p>
             ) : null}
+          </section>
+
+          <section className="about-section">
+            <h2>Backups</h2>
+            <p>
+              Every project can be saved as a single <code>.kodyvideo</code> file (⋯ →{' '}
+              <strong>Save backup</strong> on the home screen) — a safety net, and the way to move
+              a project between devices. Restore one here:
+            </p>
+            <label className={`btn btn-ghost about-import${importing ? ' is-disabled' : ''}`}>
+              Import a backup
+              <input
+                type="file"
+                accept=".kodyvideo,application/octet-stream"
+                className="visually-hidden"
+                disabled={importing}
+                mix={on('change', (event) => {
+                  const input = event.currentTarget as HTMLInputElement
+                  const file = input.files?.[0]
+                  input.value = ''
+                  if (file) importBackup(file)
+                })}
+              />
+            </label>
+            {importProgress ? (
+              <p role="status" aria-live="polite">
+                {importProgress} Keep this tab open.
+              </p>
+            ) : null}
+            {importError ? <div className="error-banner">{importError}</div> : null}
           </section>
 
           <section className="about-section">

--- a/src/pages/home-page.tsx
+++ b/src/pages/home-page.tsx
@@ -19,25 +19,14 @@ import { RenameSheet } from '../components/rename-sheet'
 import { StorageMeter } from '../components/storage-meter'
 import { downloadBlob, shareOrDownload } from '../lib/media'
 import { loadHomePage, type HomeLoaderData, type ProjectSummary } from '../lib/project-actions'
-import {
-  BackupFormatError,
-  importProjectBackup,
-  parseProjectBackup,
-  projectBackupFilename,
-  serializeProject,
-} from '../lib/project-transfer'
+import { projectBackupFilename, serializeProject } from '../lib/project-transfer'
 import { deleteProject, getClipsForProject, getProjectAudio, renameProject } from '../lib/storage'
 import { clearExportCache } from '../lib/export/export-cache'
 import { reportError } from '../lib/error-reporting'
 import { canPromptInstall, promptInstall, subscribeInstallPrompt } from '../lib/install-prompt'
 import { dismissIosInstallHint, shouldShowIosInstallHint } from '../lib/install-hint'
 import { navigate } from '../router'
-import {
-  formatBytes,
-  formatStoragePercent,
-  requestPersistentStorage,
-  storageSeverity,
-} from '../lib/storage-space'
+import { formatBytes, formatStoragePercent, storageSeverity } from '../lib/storage-space'
 import {
   FREE_PROJECTS,
   MAX_PROJECTS,
@@ -70,7 +59,6 @@ export function HomePage(handle: Handle) {
   let deleting: ProjectSummary | null = null
   let busy = false
   let notice: string | null = null
-  let importProgress: string | null = null
   let showInstallHint = shouldShowIosInstallHint()
   let upselling = false
   let restoring = false
@@ -160,45 +148,16 @@ export function HomePage(handle: Handle) {
           await downloadBlob(backup, filename)
           notice =
             `Backup (${sizeLabel}) saved to your downloads — too large for the share sheet. ` +
-            'Open kody.video and tap Import to restore it.'
+            'Open kody.video → About → Import a backup to restore it.'
         } else {
           const outcome = await shareOrDownload(backup, filename)
           if (outcome !== 'cancelled') {
-            notice = `Backup (${sizeLabel}) saved. Open kody.video (or any Kody Video) and tap Import to restore it.`
+            notice = `Backup (${sizeLabel}) saved. Open kody.video (or any Kody Video) → About → Import a backup to restore it.`
           }
         }
       } catch (err) {
         error = err instanceof Error ? err.message : 'Could not create the backup'
       } finally {
-        busy = false
-        void handle.update()
-      }
-    })()
-  }
-
-  const importBackup = (file: File) => {
-    void (async () => {
-      busy = true
-      error = null
-      notice = null
-      importProgress = 'Reading backup…'
-      void handle.update()
-      try {
-        const parsed = await parseProjectBackup(file)
-        const project = await importProjectBackup(parsed, (done, total) => {
-          importProgress = `Importing clip ${Math.min(done + 1, total)} of ${total}…`
-          void handle.update()
-        })
-        requestPersistentStorage()
-        // Land directly in the imported project — unambiguous success, and
-        // no dependence on the list revalidating behind the scenes.
-        navigate(`/project/${project.id}`)
-      } catch (err) {
-        // Wrong/damaged file picked = expected user input, not a crash.
-        if (!(err instanceof BackupFormatError)) reportError(err, 'import')
-        error = err instanceof Error ? err.message : 'Could not import that file'
-      } finally {
-        importProgress = null
         busy = false
         void handle.update()
       }
@@ -219,7 +178,6 @@ export function HomePage(handle: Handle) {
 
     const slots = Array.from({ length: MAX_PROJECTS }, (_, index) => projects[index] ?? null)
     const projectLimit = plus ? MAX_PROJECTS : FREE_PROJECTS
-    const atCap = projects.length >= projectLimit
     const severity = storage ? storageSeverity(storage.ratio) : 'ok'
     const oldestProject = projects[0] ?? null
 
@@ -271,18 +229,14 @@ export function HomePage(handle: Handle) {
         {isLegacyOrigin() ? (
           <div className="home-migrate">
             <strong>Kody Video has moved to <a href="https://kody.video">kody.video</a>.</strong>{' '}
-            Projects live in this browser per-site, so use ⋯ → Save backup here, then Import them
-            over there. This address keeps working but won&rsquo;t get updates.
+            Projects live in this browser per-site, so use ⋯ → Save backup here, then import them
+            over there (About → Import a backup). This address keeps working but won&rsquo;t get
+            updates.
           </div>
         ) : null}
 
         {error ? <div className="error-banner">{error}</div> : null}
         {notice ? <p className="home-notice">{notice}</p> : null}
-        {importProgress ? (
-          <p className="home-notice" role="status" aria-live="polite">
-            {importProgress} Keep this tab open.
-          </p>
-        ) : null}
 
         {storage && severity !== 'ok' ? (
           <div
@@ -419,58 +373,6 @@ export function HomePage(handle: Handle) {
           <span>Clips stay on this phone until you share.</span>
           {storage ? <StorageMeter storage={storage} /> : null}
         </p>
-
-        <div className="home-footer">
-          {atCap && !plus ? (
-            <button
-              type="button"
-              className="btn btn-primary"
-              mix={on('click', () => {
-                upselling = true
-                void handle.update()
-              })}
-            >
-              Get more projects
-            </button>
-          ) : (
-            <button
-              type="button"
-              className="btn btn-primary"
-              disabled={busy || atCap}
-              mix={on('click', openNewProject)}
-            >
-              {atCap ? `Limit ${MAX_PROJECTS}` : 'New project'}
-            </button>
-          )}
-          <label
-            className={`btn btn-ghost home-import${busy ? ' is-disabled' : ''}`}
-            mix={on('click', (event) => {
-              if (!atCap) return
-              event.preventDefault()
-              if (!plus) {
-                upselling = true
-                void handle.update()
-                return
-              }
-              error = `Project limit reached (${MAX_PROJECTS}). Delete a project before importing.`
-              void handle.update()
-            })}
-          >
-            Import
-            <input
-              type="file"
-              accept=".kodyvideo,application/octet-stream"
-              className="visually-hidden"
-              disabled={busy}
-              mix={on('change', (event) => {
-                const input = event.currentTarget as HTMLInputElement
-                const file = input.files?.[0]
-                input.value = ''
-                if (file) importBackup(file)
-              })}
-            />
-          </label>
-        </div>
 
         {menuProject ? (
           <HomeOptionsSheet

--- a/src/pages/home-page.tsx
+++ b/src/pages/home-page.tsx
@@ -16,6 +16,7 @@ import {
 import { UpsellSheet } from '../components/upsell-sheet'
 import { RestoreSheet } from '../components/restore-sheet'
 import { RenameSheet } from '../components/rename-sheet'
+import { StorageMeter } from '../components/storage-meter'
 import { downloadBlob, shareOrDownload } from '../lib/media'
 import { loadHomePage, type HomeLoaderData, type ProjectSummary } from '../lib/project-actions'
 import {
@@ -415,10 +416,8 @@ export function HomePage(handle: Handle) {
         </section>
 
         <p className="home-privacy">
-          Clips stay on this phone until you share.
-          {storage
-            ? ` ${formatBytes(storage.usedBytes)} of ${formatBytes(storage.quotaBytes)} used.`
-            : ''}
+          <span>Clips stay on this phone until you share.</span>
+          {storage ? <StorageMeter storage={storage} /> : null}
         </p>
 
         <div className="home-footer">

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -765,6 +765,9 @@ a {
 @media (min-width: 720px) {
   body {
     overflow: auto;
+    /* BFC so #root's 24px margins can't collapse through the 100%-tall body
+       and add phantom scrollable space below the fold. */
+    display: flow-root;
   }
 
   /* Chrome lives on #root (also reserved in index.html critical CSS) so the

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -94,6 +94,16 @@ body,
   height: 100%;
 }
 
+/* Keep the frame centered: must mirror the index.html critical CSS — this
+   stylesheet loads after it, and the margin: 0 reset above would otherwise
+   win over the critical margin auto and pin the app to the left. */
+#root {
+  width: min(480px, 100%);
+  max-width: 480px;
+  margin-left: auto;
+  margin-right: auto;
+}
+
 body {
   font-family: var(--font-body);
   color: var(--ink);
@@ -763,6 +773,9 @@ a {
     margin-top: 24px;
     margin-bottom: 24px;
     height: min(920px, calc(100dvh - 48px));
+    /* The base min-height: 100% would beat the height above and push the
+       frame's bottom edge below the fold. */
+    min-height: 0;
     border-radius: 28px;
     border: 1px solid var(--line);
     box-shadow: var(--shadow);

--- a/src/styles/home.css
+++ b/src/styles/home.css
@@ -224,7 +224,10 @@
   display: block;
   font-family: var(--font-display);
   font-size: 1.05rem;
-  line-height: 1.05;
+  /* overflow: hidden (for the ellipsis) also clips vertically — 1.05 cut
+     the descender off the "j" in "New project". 1.3 clears Fraunces
+     descenders. */
+  line-height: 1.3;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;

--- a/src/styles/home.css
+++ b/src/styles/home.css
@@ -270,16 +270,88 @@
 
 .home-privacy {
   margin: 8px 0 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-wrap: wrap;
+  column-gap: 8px;
   text-align: center;
   color: var(--ink-muted);
   /* Keep the painted box smaller than the 96×96 boot-hero art so this
      late-rendered line cannot steal LCP after the SPA mounts. */
   font-size: 0.72rem;
   line-height: 1.25;
-  max-width: 16rem;
+  max-width: 20rem;
   margin-left: auto;
   margin-right: auto;
   flex: 0 0 auto;
+}
+
+/* Storage gauge: a short, subtle bar next to the privacy line; the real
+   numbers live in the tap popover. Padding + negative margin grow the tap
+   target without disturbing the line's layout. */
+.storage-meter {
+  display: inline-flex;
+  align-items: center;
+  padding: 12px 6px;
+  margin: -12px -6px;
+  border-radius: 999px;
+}
+
+.storage-meter-track {
+  display: block;
+  width: 56px;
+  height: 5px;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--ink) 14%, transparent);
+  overflow: hidden;
+}
+
+.storage-meter-fill {
+  display: block;
+  height: 100%;
+  border-radius: inherit;
+  background: color-mix(in srgb, var(--ink-muted) 75%, transparent);
+  transition: width 240ms ease;
+}
+
+.storage-meter.is-warning .storage-meter-fill {
+  background: #e0a63a;
+}
+
+.storage-meter.is-critical .storage-meter-fill {
+  background: var(--danger);
+}
+
+.storage-popover {
+  /* Positioned by the popover anchor mixin; clear UA [popover] defaults —
+     but never display, or the closed popover leaks into the page. */
+  margin: 0;
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  padding: 8px 12px;
+  gap: 1px;
+  background: var(--toast-bg);
+  color: var(--ink);
+  font-family: var(--font-body);
+  font-size: 0.8rem;
+  line-height: 1.35;
+  text-align: center;
+  box-shadow: var(--shadow);
+  animation: rise-in 180ms ease both;
+}
+
+.storage-popover:popover-open {
+  display: flex;
+  flex-direction: column;
+}
+
+.storage-popover strong {
+  font-weight: 700;
+}
+
+.storage-popover span {
+  color: var(--ink-muted);
 }
 
 .home-footer {

--- a/src/styles/home.css
+++ b/src/styles/home.css
@@ -354,27 +354,6 @@
   color: var(--ink-muted);
 }
 
-.home-footer {
-  display: flex;
-  gap: 10px;
-  margin-top: 8px;
-  flex: 0 0 auto;
-}
-
-.home-footer .btn {
-  flex: 1;
-}
-
-.home-footer .home-import {
-  flex: 0 0 auto;
-  cursor: pointer;
-}
-
-.home-footer .home-import.is-disabled {
-  opacity: 0.45;
-  pointer-events: none;
-}
-
 .home-notice {
   margin: 10px 0 0;
   padding: 10px 12px;
@@ -578,6 +557,16 @@
   margin: 0;
   color: var(--ink-muted);
   line-height: 1.55;
+}
+
+.about-import {
+  margin-top: 10px;
+  cursor: pointer;
+}
+
+.about-import.is-disabled {
+  opacity: 0.45;
+  pointer-events: none;
 }
 
 .camera-report {

--- a/tests/e2e/helpers.ts
+++ b/tests/e2e/helpers.ts
@@ -11,10 +11,10 @@ export async function gotoHome(page: Page): Promise<void> {
   })
 }
 
-/** Home → "New project" → camera preview streaming. */
+/** Home → empty "New project" slot → camera preview streaming. */
 export async function openNewProject(page: Page): Promise<void> {
   await gotoHome(page)
-  await page.getByRole('button', { name: 'New project', exact: true }).click()
+  await page.locator('.project-slot.empty').first().click()
   await page.waitForURL(/\/project\//)
   await waitForCameraReady(page)
 }

--- a/tests/e2e/home.spec.ts
+++ b/tests/e2e/home.spec.ts
@@ -4,7 +4,7 @@ import { gotoHome, openNewProject, unlockPlus } from './helpers'
 test.describe('home & app shell', () => {
   test('onboarding shows on first camera open, dismisses for good', async ({ page }) => {
     await page.goto('/')
-    await page.getByRole('button', { name: 'New project', exact: true }).click()
+    await page.locator('.project-slot.empty').first().click()
     const overlay = page.locator('.onboarding-overlay')
     await expect(overlay).toBeVisible()
     await expect(overlay).toContainText('Hold to record')
@@ -17,11 +17,17 @@ test.describe('home & app shell', () => {
     await expect(page.locator('.onboarding-overlay')).toBeHidden()
   })
 
-  test('footer shows privacy line with storage usage', async ({ page }) => {
+  test('footer shows privacy line with a tappable storage gauge', async ({ page }) => {
     await gotoHome(page)
     const footer = page.locator('.home-privacy')
     await expect(footer).toContainText('Clips stay on this phone until you share.')
-    await expect(footer).toContainText(/of .+ used/)
+    const popover = page.locator('.storage-popover')
+    await expect(popover).toBeHidden()
+    await page.locator('.storage-meter').click()
+    await expect(popover).toBeVisible()
+    await expect(popover).toContainText(/of .+ used/)
+    await page.keyboard.press('Escape')
+    await expect(popover).toBeHidden()
   })
 
   test('free plan locks slots 2-6 behind the Plus upsell', async ({ page }) => {

--- a/tests/e2e/projects.spec.ts
+++ b/tests/e2e/projects.spec.ts
@@ -66,7 +66,9 @@ test.describe('project slots', () => {
     await page.locator('.confirm-sheet').getByRole('button', { name: 'Delete' }).click()
     await expect(page.locator('.project-slot.filled')).toHaveCount(0)
 
-    await page.locator('.home-import input[type="file"]').setInputFiles(backupPath)
+    // Import lives on the About page now.
+    await page.goto('/about')
+    await page.locator('.about-import input[type="file"]').setInputFiles(backupPath)
     // Import navigates straight into the restored project.
     await page.waitForURL(/\/project\//, { timeout: 30_000 })
     const restored = await page.evaluate(async () => {
@@ -87,7 +89,8 @@ test.describe('project slots', () => {
     const backupPath = await (await downloadPromise).path()
 
     // Still at the free 1-project cap — importing a second must be refused.
-    await page.locator('.home-import input[type="file"]').setInputFiles(backupPath)
+    await page.goto('/about')
+    await page.locator('.about-import input[type="file"]').setInputFiles(backupPath)
     await expect(page.locator('.error-banner')).toContainText(/free plan|limit/i)
     const projects = await page.evaluate(async () => {
       const storage = await import('/src/lib/storage.ts')

--- a/tests/e2e/record.spec.ts
+++ b/tests/e2e/record.spec.ts
@@ -132,7 +132,7 @@ test.describe('camera & hold-to-record', () => {
       const storage = await import('/src/lib/storage.ts')
       await storage.setOnboardingDismissed(true)
     })
-    await page.getByRole('button', { name: 'New project', exact: true }).click()
+    await page.locator('.project-slot.empty').first().click()
     const panel = page.locator('.permission-panel')
     await expect(panel).toBeVisible()
     await expect(panel).toContainText('Camera access')


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Home-screen fixes and simplification:

## Desktop frame centering + vertical fit

`global.css` loads after the `index.html` critical CSS, and its `margin: 0` reset on `#root` overrode the critical CSS's `margin-left/right: auto` — pinning the app frame to the left on desktop. The SPA stylesheet now mirrors the centering rules.

The frame also overflowed the fold: the base `min-height: 100%` beat the desktop height cap (`min(920px, calc(100dvh - 48px))`), pushing the bottom edge below the viewport (as seen in the reported production screenshot). Fixed with `min-height: 0` in the desktop media query, plus `display: flow-root` on the desktop body so `#root`'s 24px margins can't collapse through the 100%-tall body and leave 24px of phantom scroll. Verified at 1024×585, 900×600, 1280×800, 1440×900, and 1280×1100: the frame (both rounded edges) fits with even margins and zero page scroll at every size. `index.html` critical CSS is kept in sync to avoid CLS.

![Frame fully visible in a short 1024×585 viewport](https://cursor.com/artifacts/c/art-ff043d20-1d74-4e87-9218-d28a2705475b)

## Slot title descender clipping

`.project-slot strong` uses `overflow: hidden` for the ellipsis, which also clips vertically — `line-height: 1.05` cut the descender off the "j" in "New project". Bumped to `1.3`, which clears Fraunces descenders.

![New project slot with intact j descender](https://cursor.com/artifacts/c/art-17669526-c40f-433d-9da5-888eb7c8f56e)

## Storage gauge with popover (replaces the "X of Y used" text)

The storage note next to the privacy line is now a short, subtle progress bar (new `src/components/storage-meter.tsx`). Tapping it opens a `remix/ui/popover` with the percent and exact usage; it closes on Escape, outside click, or re-tap. Warning/critical levels recolor the fill amber/red using the same `storageSeverity` thresholds as the storage banner.

![Storage popover open on desktop](https://cursor.com/artifacts/c/art-c0c20984-1d5e-44c6-baa0-397e57b1aa90)

## Home footer removed; Import moves to the About page

Empty slots already create projects and locked slots already open the Plus upsell, so the footer's "New project" / "Get more projects" button was redundant — the footer is gone. Import (restore a `.kodyvideo` backup) now lives in a new **Backups** section on the About page; plan-limit enforcement already lives in `storage.createProject`, so the same "free plan / limit" errors surface there. Backup notices and the legacy-origin migration blurb now point at About → Import a backup.

![Home screen without footer buttons](https://cursor.com/artifacts/c/art-103d1601-f8c1-4683-b53b-70b03f2a1fd8)

![About page Backups section with Import](https://cursor.com/artifacts/c/art-e75fdefb-bdd2-48fe-828d-f6c07a77ed4b)

<a href="https://cursor.com/agents/bc-987dab76-291e-48ff-aa86-ff4cec98b430/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhome_gauge_and_about_import_demo.mp4"><img src="https://cursor.com/artifacts/c/art-2eb7ed4a-5533-425c-88da-ffa08eaa634d" alt="home_gauge_and_about_import_demo.mp4" /></a>

## Testing

- `npm run lint` and `npm test` (135 tests) pass.
- `npm run test:e2e`: 51 passed; the 4 `.home-hero`-visibility failures (`export.spec.ts:9`, `install-hint.spec.ts:19/:31`, `storage.spec.ts:50`) reproduce identically on `main` (pre-existing, unrelated), and `background-music.spec.ts:317` is load-flaky — it passes when run alone (verified twice).
- e2e updates in this PR: `openNewProject` and two specs click the empty slot instead of the removed footer button; the two import specs go through About → `.about-import`; the home privacy-line spec now exercises the gauge popover (open, content, Escape close).
- Playwright probes verified centering/fit at five viewport sizes and the popover open/close behaviors (Escape, outside click, anchor re-tap); mobile 390×844 checked with a real `navigator.storage.estimate`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-987dab76-291e-48ff-aa86-ff4cec98b430?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-987dab76-291e-48ff-aa86-ff4cec98b430&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

