### PR TITLE
Install corner button opens an explainer popover before prompting

### DIFF
--- a/src/pages/home-page.tsx
+++ b/src/pages/home-page.tsx
@@ -1,5 +1,6 @@
 import type { Handle } from 'remix/ui'
 import { on } from 'remix/ui'
+import * as popover from 'remix/ui/popover'
 import { BlobImage } from '../components/blob-image'
 import { BrandMark } from '../components/brand-mark'
 import { ConfirmSheet } from '../components/confirm-sheet'
@@ -73,6 +74,7 @@ export function HomePage(handle: Handle) {
   let showInstallHint = shouldShowIosInstallHint()
   let upselling = false
   let restoring = false
+  let installPopoverOpen = false
   // Prefetched when the options sheet opens so the Save-backup tap keeps its
   // user activation (Web Share needs it; an IndexedDB read can outlive it).
   let prefetchedClips: {
@@ -227,16 +229,59 @@ export function HomePage(handle: Handle) {
         {/* Corner buttons: 44px tap targets clear of other controls — the
             old footer text links were too small and crowded for thumbs. */}
         {installable ? (
-          <button
-            type="button"
-            className="btn-icon home-corner home-corner-left"
-            aria-label="Install app"
-            mix={on('click', () => {
-              void promptInstall()
-            })}
-          >
-            <IconDownload />
-          </button>
+          // A bare download glyph is ambiguous — tapping it opens a small
+          // anchored popover that says what installing gets you, with the
+          // actual Install action behind a clearly labeled button.
+          <popover.Context>
+            <button
+              type="button"
+              className="btn-icon home-corner home-corner-left"
+              aria-label="Install app"
+              mix={[
+                popover.anchor({ placement: 'bottom-start', offsetY: 8 }),
+                popover.focusOnHide(),
+                on('click', () => {
+                  installPopoverOpen = true
+                  void handle.update()
+                }),
+              ]}
+            >
+              <IconDownload />
+            </button>
+            <div
+              className="install-popover"
+              role="dialog"
+              aria-label="Install Kody Video"
+              mix={popover.surface({
+                open: installPopoverOpen,
+                onHide: () => {
+                  installPopoverOpen = false
+                  void handle.update()
+                },
+              })}
+            >
+              <strong>Install Kody Video</strong>
+              <p>
+                Full screen, works offline, and your clips are safer from browser storage cleanup.
+              </p>
+              <button
+                type="button"
+                className="btn btn-primary install-popover-action"
+                mix={[
+                  popover.focusOnShow(),
+                  on('click', async () => {
+                    // Close (and unlock scroll) before the prompt consumes
+                    // the one-shot install event and unmounts this subtree.
+                    installPopoverOpen = false
+                    await handle.update()
+                    void promptInstall()
+                  }),
+                ]}
+              >
+                Install
+              </button>
+            </div>
+          </popover.Context>
         ) : null}
         <a
           className="btn-icon home-corner home-corner-right"

--- a/src/pages/home-page.tsx
+++ b/src/pages/home-page.tsx
@@ -241,7 +241,9 @@ export function HomePage(handle: Handle) {
                 popover.anchor({ placement: 'bottom-start', offsetY: 8 }),
                 popover.focusOnHide(),
                 on('click', () => {
-                  installPopoverOpen = true
+                  // Explicit toggle (with closeOnAnchorClick: false below):
+                  // a second tap on the corner button dismisses the popover.
+                  installPopoverOpen = !installPopoverOpen
                   void handle.update()
                 }),
               ]}
@@ -254,6 +256,10 @@ export function HomePage(handle: Handle) {
               aria-label="Install Kody Video"
               mix={popover.surface({
                 open: installPopoverOpen,
+                // The anchor's own click handler owns toggling; letting the
+                // surface also request close on anchor taps double-handles
+                // the same click.
+                closeOnAnchorClick: false,
                 onHide: () => {
                   installPopoverOpen = false
                   void handle.update()
@@ -269,12 +275,17 @@ export function HomePage(handle: Handle) {
                 className="btn btn-primary install-popover-action"
                 mix={[
                   popover.focusOnShow(),
-                  on('click', async () => {
-                    // Close (and unlock scroll) before the prompt consumes
-                    // the one-shot install event and unmounts this subtree.
+                  on('click', (event) => {
+                    // Hide the native popover synchronously — its toggle
+                    // events release the scroll lock and restore focus —
+                    // because consuming the one-shot install event unmounts
+                    // this subtree without ever firing those events. Then
+                    // prompt in the same tick: Chromium wants prompt()
+                    // during the tap's transient user activation.
+                    ;(event.currentTarget as HTMLElement).closest<HTMLElement>('[popover]')?.hidePopover()
                     installPopoverOpen = false
-                    await handle.update()
                     void promptInstall()
+                    void handle.update()
                   }),
                 ]}
               >

--- a/src/styles/home.css
+++ b/src/styles/home.css
@@ -19,6 +19,36 @@
   left: 12px;
 }
 
+/* Anchored explainer for the Install corner button. Native [popover] top
+   layer: reset the UA margin/border, then match the app's sheet styling. */
+.install-popover {
+  margin: 0;
+  padding: 14px 16px;
+  width: min(272px, calc(100vw - 24px));
+  border: 1px solid var(--line);
+  border-radius: 18px;
+  background: var(--panel-bg);
+  color: var(--ink);
+  box-shadow: var(--shadow);
+}
+
+.install-popover strong {
+  display: block;
+  font-family: var(--font-display);
+  font-size: 1.05rem;
+}
+
+.install-popover p {
+  margin: 6px 0 12px;
+  color: var(--ink-muted);
+  font-size: 0.88rem;
+  line-height: 1.4;
+}
+
+.install-popover-action {
+  width: 100%;
+}
+
 .home-corner-right {
   right: 12px;
 }

--- a/tests/e2e/home.spec.ts
+++ b/tests/e2e/home.spec.ts
@@ -134,6 +134,30 @@ test.describe('home & app shell', () => {
     await expect(page.getByRole('button', { name: 'Install app' })).toBeVisible()
   })
 
+  test('install button opens an explainer popover; Install consumes the prompt', async ({
+    page,
+  }) => {
+    await gotoHome(page)
+    await page.evaluate(() => {
+      window.dispatchEvent(new Event('beforeinstallprompt'))
+    })
+    await page.getByRole('button', { name: 'Install app' }).click()
+    const explainer = page.getByRole('dialog', { name: 'Install Kody Video' })
+    await expect(explainer).toBeVisible()
+    await expect(explainer).toContainText('works offline')
+
+    // Escape / outside click dismisses without consuming the prompt.
+    await page.keyboard.press('Escape')
+    await expect(explainer).toBeHidden()
+    await page.getByRole('button', { name: 'Install app' }).click()
+    await expect(explainer).toBeVisible()
+
+    // Install consumes the one-shot prompt: popover and corner button go away.
+    await explainer.getByRole('button', { name: 'Install' }).click()
+    await expect(explainer).toBeHidden()
+    await expect(page.getByRole('button', { name: 'Install app' })).toHaveCount(0)
+  })
+
   test('about, privacy, and terms pages render', async ({ page }) => {
     await gotoHome(page)
     await page.getByRole('link', { name: 'About Kody Video' }).click()

--- a/tests/e2e/home.spec.ts
+++ b/tests/e2e/home.spec.ts
@@ -149,6 +149,13 @@ test.describe('home & app shell', () => {
     // Escape / outside click dismisses without consuming the prompt.
     await page.keyboard.press('Escape')
     await expect(explainer).toBeHidden()
+
+    // The corner button is a toggle: tap to open, tap again to dismiss.
+    await page.getByRole('button', { name: 'Install app' }).click()
+    await expect(explainer).toBeVisible()
+    await page.getByRole('button', { name: 'Install app' }).click()
+    await expect(explainer).toBeHidden()
+    await expect(page.getByRole('button', { name: 'Install app' })).toBeVisible()
     await page.getByRole('button', { name: 'Install app' }).click()
     await expect(explainer).toBeVisible()
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

The install corner button (download icon, top-left of the home screen) is a bare glyph — new users can't tell what it does, and tapping it fired the browser install prompt immediately. It now opens a small popover anchored below the button:

- **Title**: "Install Kody Video"
- **Body**: one line on what installing gets you (full screen, offline, clips safer from browser storage cleanup)
- **Action**: a labeled Install button that triggers the actual browser prompt

The corner button is an explicit toggle (tap to open, tap again to dismiss); Escape or tapping outside also dismisses without consuming the one-shot `beforeinstallprompt` event.

## How

- Built on the `remix/ui/popover` primitive (`popover.Context` / `anchor` / `surface`, native top-layer `[popover]` element) with `focusOnShow` / `focusOnHide` for focus management, and `closeOnAnchorClick: false` so the anchor's toggle handler is the single owner of anchor taps
- The Install action hides the native popover synchronously (its toggle events release the scroll lock and restore focus) and calls `promptInstall()` in the same tick, keeping `prompt()` inside the tap's transient user activation — consuming the prompt unmounts the subtree without firing those events
- Panel styling matches the app's existing sheet look (`--panel-bg`, `--line`, `--shadow`)

## Testing

- `npm run lint` and `npm test` (147 unit tests) pass
- Playwright home spec passes (12/12), including a new test: open popover, anchor-tap toggle close/reopen, Escape dismiss (prompt kept), click Install (popover hides, prompt consumed, corner button disappears)
- Cursor Bugbot's two findings (async gap before `prompt()`, anchor click double-handling) were addressed; its re-review found no issues

<a href="https://cursor.com/agents/bc-725b9548-7202-43d5-a4ea-75d7f9e48d13/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Finstall_popover_toggle_escape_install_final.mp4"><img src="https://cursor.com/artifacts/c/art-a094737f-eee2-4947-858e-53659f0cc70f" alt="install_popover_toggle_escape_install_final.mp4" /></a>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-725b9548-7202-43d5-a4ea-75d7f9e48d13?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-725b9548-7202-43d5-a4ea-75d7f9e48d13&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

