### PR TITLE
Stop localhost HMR noise from opening Sentry triage issues

### DIFF
--- a/scripts/manual-smoke.mjs
+++ b/scripts/manual-smoke.mjs
@@ -303,7 +303,8 @@ try {
 
   // --- About page: open-source + OK Video credits ---
   await page.goto(BASE, { waitUntil: 'networkidle' })
-  await page.getByRole('link', { name: /^about$/i }).click()
+  // Corner icon link — accessible name is the aria-label, not visible "About" text.
+  await page.getByRole('link', { name: /about kody video/i }).click()
   await page.waitForURL(/\/about/, { timeout: 5000 })
   await page.waitForSelector('.about-section', { timeout: 5000 }).catch(() => undefined)
   const repoLink = await page

--- a/src/lib/error-reporting.test.ts
+++ b/src/lib/error-reporting.test.ts
@@ -4,6 +4,8 @@ import {
   isExpectedUserError,
   isMonitoringSelfTestEvent,
   isProjectLimitEvent,
+  isReportingHostname,
+  reportComponentError,
   reportError,
 } from './error-reporting'
 import { ProjectLimitError } from './storage'
@@ -116,6 +118,24 @@ describe('isExpectedUserError / reportError', () => {
     // Short-circuits before the idle-deferred SDK load — no capture queued.
     expect(() =>
       reportError(new ProjectLimitError('The free plan includes 1 project'), 'save-clip'),
+    ).not.toThrow()
+  })
+})
+
+describe('isReportingHostname / local capture paths', () => {
+  it('allows only production deployment hostnames', () => {
+    expect(isReportingHostname('kody.video')).toBe(true)
+    expect(isReportingHostname('kody-video.pages.dev')).toBe(true)
+    expect(isReportingHostname('localhost')).toBe(false)
+    expect(isReportingHostname('127.0.0.1')).toBe(false)
+    expect(isReportingHostname('example.com')).toBe(false)
+  })
+
+  it('reportError and reportComponentError stay silent off reporting hosts', () => {
+    // Vitest runs on localhost — these must not load Sentry or throw.
+    expect(() => reportError(new Error('Vite HMR glitch'), 'import')).not.toThrow()
+    expect(() =>
+      reportComponentError(new ReferenceError('importProgress is not defined')),
     ).not.toThrow()
   })
 })

--- a/src/lib/error-reporting.ts
+++ b/src/lib/error-reporting.ts
@@ -7,6 +7,13 @@ const SENTRY_DSN =
 /** Only real deployments report — dev servers and test runs stay silent. */
 const REPORTING_HOSTNAMES = new Set(['kody.video', 'kody-video.pages.dev'])
 
+/** True when this origin is allowed to load Sentry / send crash reports. */
+export function isReportingHostname(hostname?: string): boolean {
+  const host =
+    hostname ?? (typeof location !== 'undefined' ? location.hostname : '')
+  return REPORTING_HOSTNAMES.has(host)
+}
+
 /**
  * Marker used by the monitoring setup agent when it throws a synthetic
  * uncaught error to verify the DSN. Not app code — drop it so drills do not
@@ -181,7 +188,10 @@ export function coarsePlatformTags(): Record<string, string> {
  * chunk (Legacy JS Array.from override + ~500KB), even though we never
  * enable replay.
  */
-function loadSentry(): Promise<SentryLike> {
+function loadSentry(): Promise<SentryLike> | null {
+  // Belt-and-suspenders: every capture path must stay silent off reporting hosts
+  // (Vite HMR glitches on localhost must never open triage issues).
+  if (!isReportingHostname()) return null
   if (sentry) return Promise.resolve(sentry)
   if (sentryLoad) return sentryLoad
 
@@ -225,10 +235,10 @@ function loadSentry(): Promise<SentryLike> {
  * critical request chain.
  */
 export function initErrorReporting(): void {
-  if (!REPORTING_HOSTNAMES.has(location.hostname)) return
+  if (!isReportingHostname()) return
 
   const start = () => {
-    void loadSentry().catch(() => undefined)
+    void loadSentry()?.catch(() => undefined)
   }
 
   if (typeof window.requestIdleCallback === 'function') {
@@ -259,6 +269,7 @@ export function reportError(
 ): void {
   // Plan/project caps are product UX (toast / upsell), not failures to triage.
   if (isExpectedUserError(error)) return
+  if (!isReportingHostname()) return
 
   if (sentry) {
     sentry.captureException(error, { tags: { step }, ...(extra ? { extra } : {}) })
@@ -266,7 +277,7 @@ export function reportError(
   }
   // SDK still loading / idle-deferred — queue via the shared loader.
   void loadSentry()
-    .then((client) => {
+    ?.then((client) => {
       client.captureException(error, { tags: { step }, ...(extra ? { extra } : {}) })
     })
     .catch(() => undefined)
@@ -279,6 +290,7 @@ export function reportError(
  */
 export function reportComponentError(error: unknown): void {
   console.error('Uncaught component error', error)
+  if (!isReportingHostname()) return
   if (sentry) {
     sentry.captureException(error, {
       mechanism: { type: 'remix.componentError', handled: false },
@@ -286,7 +298,7 @@ export function reportComponentError(error: unknown): void {
     return
   }
   void loadSentry()
-    .then((client) => {
+    ?.then((client) => {
       client.captureException(error, {
         mechanism: { type: 'remix.componentError', handled: false },
       })


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sentry [KODY-VIDEO-C](https://sentry.io/organizations/kent-c-dodds-tech-llc/issues/7653105639/) (`ReferenceError: importProgress is not defined`) was a single event from `http://localhost:5173` (release `dev`). `importProgress` is correctly declared in `HomePage`; the throw is local Vite/HMR noise, not a production logic bug.

The real product bug: `reportComponentError` / `reportError` called `loadSentry()` **without** the hostname gate that `initErrorReporting` uses. Localhost component errors therefore initialized Sentry and landed under environment `legacy-pages-dev`, spawning triage.

## Fix

- Export `isReportingHostname` and gate `loadSentry`, `reportError`, and `reportComponentError` the same way as init (only `kody.video` / `kody-video.pages.dev`).
- Unit coverage for allowed hostnames and silent local capture paths.
- Smoke: match the About corner link’s accessible name (`About Kody Video`) after #103.

## Risk

Low — isolated error-reporting wiring; production capture paths unchanged for reporting hosts.

## Test plan

- [x] `npx vitest run` (149 passed)
- [x] `npm run build`
- [x] `node scripts/manual-smoke.mjs` (32/32)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a7e74aa8-010e-4f41-b46d-77aa455aa37a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a7e74aa8-010e-4f41-b46d-77aa455aa37a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Error reporting now remains inactive on local and non-production hostnames, preventing unnecessary monitoring activity and errors.
  * Production hostname detection is handled consistently across error-reporting entry points.

* **Tests**
  * Added coverage for hostname detection and verified silent behavior in local environments.
  * Updated the About-page smoke test to find the video link using its accessible label.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->