### PR TITLE
Auto-delete projects exited in their default state

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,10 @@ device: "Already paid?" on the export sheet or a locked slot's upsell.
 
 Projects are also created lazily — "New project" opens the camera at
 `/project/new` and nothing is persisted until the first clip is recorded, so
-backing out of an untouched project leaves no empty slot behind.
+backing out of an untouched project leaves no empty slot behind. The same
+holds after creation: a project exited while still in its default state (no
+clips, default name, no music) is silently deleted when the home screen
+loads, since keeping it would change nothing the user can see.
 
 Deployment requirement: set `STRIPE_SECRET_KEY` (a restricted key with
 Checkout Sessions read access is enough) on the Cloudflare Pages project.

--- a/manual-test-checklist.md
+++ b/manual-test-checklist.md
@@ -19,9 +19,11 @@ npm test           # unit tests
   multiple holds append; Backspace-delete offers Undo and Undo restores;
   self-timer counts down and records hands-free until tapped
 - **Lazy creation & plans**: "New project" creates nothing until the first
-  clip (URL flips from `/project/new`); backing out leaves no project; free
-  plan locks slots 2–6 behind the Plus upsell; Plus unlocks 6 and blocks the
-  7th; the upsell sheet copy and buttons
+  clip (URL flips from `/project/new`); backing out leaves no project;
+  recording a clip, deleting it, and backing out auto-deletes the
+  default-state project (no notification); free plan locks slots 2–6 behind
+  the Plus upsell; Plus unlocks 6 and blocks the 7th; the upsell sheet copy
+  and buttons
 - **Location**: toggle asks permission, `aria-pressed` reflects state, new
   clips carry exact coordinates, toasts confirm on/off
 - **Editor**: opens at the most recent clip; tap selects; tiles show

--- a/src/lib/project-actions.test.ts
+++ b/src/lib/project-actions.test.ts
@@ -34,7 +34,8 @@ describe('loadHomeProjects', () => {
 
   it('keeps empty projects the user renamed', async () => {
     const project = await createProject()
-    await renameProject(project.id, 'Project X')
+    // Even a rename to a default-shaped name is deliberate.
+    await renameProject(project.id, 'Project 2')
 
     const summaries = await loadHomeProjects()
 

--- a/src/lib/project-actions.test.ts
+++ b/src/lib/project-actions.test.ts
@@ -1,0 +1,44 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import { loadHomeProjects } from './project-actions'
+import { __resetDbForTests, addClip, createProject, deleteClip, listProjects, renameProject } from './storage'
+import { markWatermarkRemoved } from './entitlement'
+
+function fakeBlob(label: string): Blob {
+  return new Blob([label], { type: 'video/webm' })
+}
+
+describe('loadHomeProjects', () => {
+  beforeEach(async () => {
+    await __resetDbForTests()
+  })
+
+  it('silently deletes projects left in their default state', async () => {
+    await markWatermarkRemoved('cs_test_actions')
+    const kept = await createProject('Ski trip')
+    const pristine = await createProject()
+    const emptied = await createProject()
+    const clip = await addClip({
+      projectId: emptied.id,
+      blob: fakeBlob('take'),
+      mimeType: 'video/webm',
+      durationMs: 700,
+    })
+    await deleteClip(clip.id)
+
+    const summaries = await loadHomeProjects()
+
+    expect(summaries.map((project) => project.id)).toEqual([kept.id])
+    expect((await listProjects()).map((project) => project.id)).toEqual([kept.id])
+    expect(pristine.name).toBe('Project 2')
+  })
+
+  it('keeps empty projects the user renamed', async () => {
+    const project = await createProject()
+    await renameProject(project.id, 'Project X')
+
+    const summaries = await loadHomeProjects()
+
+    expect(summaries.map((entry) => entry.id)).toEqual([project.id])
+    expect(summaries[0]?.clipCount).toBe(0)
+  })
+})

--- a/src/lib/project-actions.ts
+++ b/src/lib/project-actions.ts
@@ -3,6 +3,7 @@ import {
   addProjectAudioTrack,
   clearUndo,
   deleteClip,
+  deleteProjectIfPristine,
   duplicateClip,
   getClipsForProject,
   getProject,
@@ -77,7 +78,16 @@ export async function loadHomePage(): Promise<HomeLoaderData> {
 }
 
 export async function loadHomeProjects(): Promise<ProjectSummary[]> {
-  const list = await listProjects()
+  const all = await listProjects()
+  // Exiting a project still in its default state (no clips, default name,
+  // no music) must leave nothing behind, just like backing out of
+  // /project/new. Every exit path lands back here, so such projects are
+  // silently deleted before the slots render.
+  const list: Project[] = []
+  for (const project of all) {
+    if (project.clipIds.length === 0 && (await deleteProjectIfPristine(project.id))) continue
+    list.push(project)
+  }
   // Stable slot order (creation order) — OK Video-style fixed project slots
   // that don't shuffle every time you open a project.
   list.sort((a, b) => a.createdAt - b.createdAt)

--- a/src/lib/storage.test.ts
+++ b/src/lib/storage.test.ts
@@ -139,6 +139,21 @@ describe('storage layer', () => {
     expect((await listProjects())[0]?.name).toBe('Ski trip')
   })
 
+  it('deleteProjectIfPristine keeps a project renamed to a default-shaped name', async () => {
+    const project = await createProject()
+    await renameProject(project.id, 'Project 2')
+
+    expect(await deleteProjectIfPristine(project.id)).toBe(false)
+    expect((await listProjects())[0]?.name).toBe('Project 2')
+  })
+
+  it('deleteProjectIfPristine keeps a project created with a default-shaped name', async () => {
+    const project = await createProject('Project 2')
+
+    expect(await deleteProjectIfPristine(project.id)).toBe(false)
+    expect(await listProjects()).toHaveLength(1)
+  })
+
   it('deleteProjectIfPristine keeps projects with background music', async () => {
     await markWatermarkRemoved('cs_test_storage')
     const project = await createProject()

--- a/src/lib/storage.test.ts
+++ b/src/lib/storage.test.ts
@@ -8,6 +8,7 @@ import {
   ProjectLimitError,
   deleteClip,
   deleteProject,
+  deleteProjectIfPristine,
   duplicateClip,
   getClip,
   getClipsForProject,
@@ -88,6 +89,69 @@ describe('storage layer', () => {
     await deleteProject(project.id)
     expect(await listProjects()).toHaveLength(0)
     expect(await getClip(clip.id)).toBeUndefined()
+  })
+
+  it('deleteProjectIfPristine removes an untouched default-state project', async () => {
+    const project = await createProject()
+    expect(project.name).toBe('Project 1')
+
+    expect(await deleteProjectIfPristine(project.id)).toBe(true)
+    expect(await listProjects()).toHaveLength(0)
+    expect((await getSettings()).lastOpenedProjectId).toBeNull()
+    // Already gone — a second attempt is a no-op.
+    expect(await deleteProjectIfPristine(project.id)).toBe(false)
+  })
+
+  it('deleteProjectIfPristine drops an emptied project with its undo snapshot', async () => {
+    const project = await createProject()
+    const clip = await addClip({
+      projectId: project.id,
+      blob: fakeBlob('only-take'),
+      mimeType: 'video/webm',
+      durationMs: 800,
+    })
+    await deleteClip(clip.id)
+    expect(await getUndoSnapshot(project.id)).toBeTruthy()
+
+    expect(await deleteProjectIfPristine(project.id)).toBe(true)
+    expect(await listProjects()).toHaveLength(0)
+    expect(await getUndoSnapshot(project.id)).toBeUndefined()
+  })
+
+  it('deleteProjectIfPristine keeps projects with clips', async () => {
+    const project = await createProject()
+    await addClip({
+      projectId: project.id,
+      blob: fakeBlob('keeper'),
+      mimeType: 'video/webm',
+      durationMs: 800,
+    })
+
+    expect(await deleteProjectIfPristine(project.id)).toBe(false)
+    expect(await listProjects()).toHaveLength(1)
+  })
+
+  it('deleteProjectIfPristine keeps renamed projects', async () => {
+    const project = await createProject()
+    await renameProject(project.id, 'Ski trip')
+
+    expect(await deleteProjectIfPristine(project.id)).toBe(false)
+    expect((await listProjects())[0]?.name).toBe('Ski trip')
+  })
+
+  it('deleteProjectIfPristine keeps projects with background music', async () => {
+    await markWatermarkRemoved('cs_test_storage')
+    const project = await createProject()
+    await addProjectAudioTrack({
+      projectId: project.id,
+      blob: new Blob(['song'], { type: 'audio/mpeg' }),
+      mimeType: 'audio/mpeg',
+      durationMs: 30_000,
+      name: 'song.mp3',
+    })
+
+    expect(await deleteProjectIfPristine(project.id)).toBe(false)
+    expect(await listProjects()).toHaveLength(1)
   })
 
   it('appends clips, trims, reorders, duplicates, deletes, and undoes', async () => {

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -202,11 +202,49 @@ export async function renameProject(id: ProjectId, name: string): Promise<Projec
 }
 
 export async function deleteProject(id: ProjectId): Promise<void> {
-  const db = await getDb()
-  const project = await db.get('projects', id)
-  if (!project) return
+  await deleteProjectRecords(id, { onlyIfPristine: false })
+}
 
+/** Matches names produced by defaultProjectName — a rename away from the
+ * default marks the project as meaningful. */
+const DEFAULT_PROJECT_NAME_PATTERN = /^Project \d+$/
+
+/**
+ * Delete the project only when it is still indistinguishable from a freshly
+ * created one: no clips, default name, no background music. Exiting such a
+ * project should leave nothing behind — deleting it changes nothing the user
+ * can see, so it happens silently. Any leftover undo snapshot (last clip
+ * deleted, never restored) goes with it. Returns true when it was deleted.
+ */
+export async function deleteProjectIfPristine(id: ProjectId): Promise<boolean> {
+  return deleteProjectRecords(id, { onlyIfPristine: true })
+}
+
+async function deleteProjectRecords(
+  id: ProjectId,
+  options: { onlyIfPristine: boolean },
+): Promise<boolean> {
+  const db = await getDb()
   const tx = db.transaction(['projects', 'clips', 'undo', 'meta', 'audio'], 'readwrite')
+  const project = await tx.objectStore('projects').get(id)
+  if (!project) {
+    await tx.done
+    return false
+  }
+  if (options.onlyIfPristine) {
+    // Checked inside the deleting transaction: a clip save racing this
+    // delete (exiting right as a take persists) serializes against it, so a
+    // fresh clip can never survive into a half-deleted project.
+    const audio = await tx.objectStore('audio').get(id)
+    const pristine =
+      project.clipIds.length === 0 &&
+      DEFAULT_PROJECT_NAME_PATTERN.test(project.name) &&
+      (!audio || audio.tracks.length === 0)
+    if (!pristine) {
+      await tx.done
+      return false
+    }
+  }
   // Read meta before queueing writes so a failed delete cannot reject while
   // we are still awaiting get — that would reintroduce the AbortError leak.
   const settings = await tx.objectStore('meta').get('settings')
@@ -235,6 +273,7 @@ export async function deleteProject(id: ProjectId): Promise<void> {
   if (dropsCachedExport && settings?.lastExport) {
     await removeExportEntry(settings.lastExport.opfsName).catch(() => undefined)
   }
+  return true
 }
 
 export async function touchProject(id: ProjectId): Promise<void> {

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -174,13 +174,17 @@ export async function createProject(name?: string): Promise<Project> {
   }
 
   const now = Date.now()
+  const chosenName = name?.trim()
   const project: Project = {
     id: newId('proj'),
-    name: name?.trim() || defaultProjectName(existing.length + 1),
+    name: chosenName || defaultProjectName(existing.length + 1),
     createdAt: now,
     updatedAt: now,
     clipIds: [],
   }
+  // Marks eligibility for the default-state cleanup on exit — a
+  // caller-chosen name is meaningful and must never be auto-deleted.
+  if (!chosenName) project.nameIsDefault = true
   await db.put('projects', project)
   await setLastOpenedProjectId(project.id)
   return project
@@ -197,6 +201,9 @@ export async function renameProject(id: ProjectId, name: string): Promise<Projec
   const trimmed = name.trim()
   if (!trimmed) throw new Error('Name cannot be empty')
   const updated: Project = { ...project, name: trimmed, updatedAt: Date.now() }
+  // Any rename is deliberate — even one back to a "Project N"-shaped name —
+  // so the project stops being eligible for the default-state cleanup.
+  delete updated.nameIsDefault
   await db.put('projects', updated)
   return updated
 }
@@ -205,13 +212,9 @@ export async function deleteProject(id: ProjectId): Promise<void> {
   await deleteProjectRecords(id, { onlyIfPristine: false })
 }
 
-/** Matches names produced by defaultProjectName — a rename away from the
- * default marks the project as meaningful. */
-const DEFAULT_PROJECT_NAME_PATTERN = /^Project \d+$/
-
 /**
  * Delete the project only when it is still indistinguishable from a freshly
- * created one: no clips, default name, no background music. Exiting such a
+ * created one: no clips, never renamed, no background music. Exiting such a
  * project should leave nothing behind — deleting it changes nothing the user
  * can see, so it happens silently. Any leftover undo snapshot (last clip
  * deleted, never restored) goes with it. Returns true when it was deleted.
@@ -238,7 +241,7 @@ async function deleteProjectRecords(
     const audio = await tx.objectStore('audio').get(id)
     const pristine =
       project.clipIds.length === 0 &&
-      DEFAULT_PROJECT_NAME_PATTERN.test(project.name) &&
+      project.nameIsDefault === true &&
       (!audio || audio.tracks.length === 0)
     if (!pristine) {
       await tx.done

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -7,6 +7,10 @@ export interface Project {
   createdAt: number
   updatedAt: number
   clipIds: ClipId[]
+  /** True while the name is still the generated "Project N" — cleared on
+   * rename, and never set for caller-chosen names, so a deliberate name
+   * (even one shaped like "Project 2") is never mistaken for the default. */
+  nameIsDefault?: boolean
 }
 
 export interface ClipMeta {

--- a/tests/e2e/home.spec.ts
+++ b/tests/e2e/home.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test'
-import { gotoHome, openNewProject, unlockPlus } from './helpers'
+import { gotoHome, openNewProject, recordClip, unlockPlus } from './helpers'
 
 test.describe('home & app shell', () => {
   test('onboarding shows on first camera open, dismisses for good', async ({ page }) => {
@@ -42,8 +42,10 @@ test.describe('home & app shell', () => {
     await unlockPlus(page)
     const outcome = await page.evaluate(async () => {
       const storage = await import('/src/lib/storage.ts')
+      // Custom names: projects still in their default state (empty, named
+      // "Project N") are auto-deleted when the home screen loads.
       for (let i = 1; i <= 6; i += 1) {
-        await storage.createProject(`Project ${i}`)
+        await storage.createProject(`Trip ${i}`)
       }
       try {
         await storage.createProject('One too many')
@@ -157,6 +159,28 @@ test.describe('lazy project creation', () => {
       return (await storage.listProjects()).length
     })
     expect(projects).toBe(0)
+    await expect(page.locator('.project-slot.filled')).toHaveCount(0)
+  })
+
+  test('exiting a project still in its default state auto-deletes it', async ({ page }) => {
+    await openNewProject(page)
+    // The first take persists the project…
+    await recordClip(page)
+    await page.waitForURL((url) => !url.pathname.endsWith('/project/new'))
+    // …but deleting it leaves the project exactly as a fresh one: no clips,
+    // default name. Exiting must remove it silently.
+    await page.getByRole('button', { name: 'Delete last clip' }).click()
+    await expect(page.locator('.toast')).toContainText('Last clip deleted')
+    await page.getByRole('link', { name: 'Back to projects' }).click()
+    await page.waitForURL(/\/$/)
+    await expect
+      .poll(async () =>
+        page.evaluate(async () => {
+          const storage = await import('/src/lib/storage.ts')
+          return (await storage.listProjects()).length
+        }),
+      )
+      .toBe(0)
     await expect(page.locator('.project-slot.filled')).toHaveCount(0)
   })
 })

--- a/tests/e2e/home.spec.ts
+++ b/tests/e2e/home.spec.ts
@@ -42,10 +42,10 @@ test.describe('home & app shell', () => {
     await unlockPlus(page)
     const outcome = await page.evaluate(async () => {
       const storage = await import('/src/lib/storage.ts')
-      // Custom names: projects still in their default state (empty, named
-      // "Project N") are auto-deleted when the home screen loads.
+      // Explicit names (even default-shaped ones): only projects still
+      // carrying their GENERATED name are auto-deleted on home load.
       for (let i = 1; i <= 6; i += 1) {
-        await storage.createProject(`Trip ${i}`)
+        await storage.createProject(`Project ${i}`)
       }
       try {
         await storage.createProject('One too many')


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Exiting a project that is still exactly in its default state — no clips, never renamed, no background music — now deletes it silently, since keeping it would change nothing the user can see. This closes the gap that lazy creation leaves open: `/project/new` persists nothing until the first clip, but recording a clip and then deleting it (or a failed save after lazy creation) used to strand an empty "Project N" slot on the home screen.

## How it works

- `deleteProjectIfPristine` in `src/lib/storage.ts` shares the existing `deleteProject` transaction and performs the pristine check *inside* the deleting transaction, so a clip save racing the delete (exiting right as a take persists) serializes against it — a fresh clip can never survive into a half-deleted project.
- "Never renamed" is tracked explicitly: `createProject` sets `nameIsDefault` only when it generates the name, and `renameProject` clears it — so a deliberately chosen name, even one shaped like `Project 2`, is never mistaken for the default (and pre-existing projects, which lack the marker, are never swept).
- The sweep runs in `loadHomeProjects` (`src/lib/project-actions.ts`): every way of leaving a project (back link, browser/gesture back, even a killed tab) lands back on the home loader, so pristine projects are removed deterministically before the slots render, with no notification.
- A leftover undo snapshot (last clip deleted, never restored) is removed together with the project — on screen such a project is indistinguishable from a fresh one.
- Renamed projects (even empty ones), projects with clips, and projects with background music are never touched; the free-plan/cap gates benefit too, since a stranded empty project no longer occupies the single free slot.

## Testing

- New unit tests for `deleteProjectIfPristine` (deletes default-state and emptied-with-undo projects; keeps clips, renames — including default-shaped ones — and music) and for the `loadHomeProjects` sweep.
- New e2e test: record a clip, delete it, tap "Back to projects" → no project remains.
- `npm run lint` clean; `npm test` 156/156 passing; full `npm run test:e2e`: 54 passed, 4 failed — the same 4 fail identically on `main` in this VM (pre-existing Sentry/visibility environment issues, unrelated).

## Demo

Manual test in headless Chrome with fake camera flags: record a clip (project persists as "Project 1"), delete the clip, back out — the home screen shows no filled slot.

<a href="https://cursor.com/agents/bc-9042fdac-4ddc-4df4-9a92-c7156dcdbb68/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fauto_delete_default_state_project_on_exit.mp4"><img src="https://cursor.com/artifacts/c/art-96edddab-a86e-4288-84fb-fb6e38db1119" alt="auto_delete_default_state_project_on_exit.mp4" /></a>

![Home screen with no filled slot after exiting the default-state project](https://cursor.com/artifacts/c/art-25840690-481f-4804-9a36-1df53894cf8e)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9042fdac-4ddc-4df4-9a92-c7156dcdbb68?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9042fdac-4ddc-4df4-9a92-c7156dcdbb68&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Empty, untouched projects are now automatically removed from the home screen after their only clip is deleted.
  * Renamed projects, projects with music, and projects containing clips are preserved.
  * Project deletion now consistently removes all associated content.

* **Documentation**
  * Updated Plus purchase documentation and testing guidance to reflect project cleanup and lazy project creation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->