### PR TITLE
Recover from stale lazy-page chunk loads after deploys

### DIFF
--- a/src/components/lazy-page.test.ts
+++ b/src/components/lazy-page.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest'
+import { isChunkLoadError } from './lazy-page'
+
+describe('isChunkLoadError', () => {
+  it('matches Chromium / Vite dynamic import failures', () => {
+    expect(
+      isChunkLoadError(
+        new Error(
+          'Failed to fetch dynamically imported module: https://kody.video/assets/project-page-abc.js',
+        ),
+      ),
+    ).toBe(true)
+    expect(
+      isChunkLoadError(new Error('error loading dynamically imported module')),
+    ).toBe(true)
+    expect(isChunkLoadError(new Error('Loading chunk 5 failed'))).toBe(true)
+  })
+
+  it('ignores ordinary application errors', () => {
+    expect(isChunkLoadError(new Error('Project not found'))).toBe(false)
+    expect(isChunkLoadError('random string')).toBe(false)
+    expect(isChunkLoadError(null)).toBe(false)
+  })
+})

--- a/src/components/lazy-page.test.ts
+++ b/src/components/lazy-page.test.ts
@@ -14,6 +14,9 @@ describe('isChunkLoadError', () => {
       isChunkLoadError(new Error('error loading dynamically imported module')),
     ).toBe(true)
     expect(isChunkLoadError(new Error('Loading chunk 5 failed'))).toBe(true)
+    expect(
+      isChunkLoadError(new Error('Importing a module script failed.')),
+    ).toBe(true)
   })
 
   it('ignores ordinary application errors', () => {

--- a/src/components/lazy-page.tsx
+++ b/src/components/lazy-page.tsx
@@ -1,6 +1,21 @@
 import type { Handle, RemixNode } from 'remix/ui'
+import { on } from 'remix/ui'
+import { reportError } from '../lib/error-reporting'
 
 type PageComponent = (handle: Handle<any>) => () => RemixNode
+
+/** sessionStorage flag so a failed chunk load auto-reloads at most once. */
+export const LAZY_CHUNK_RELOAD_KEY = 'kody:lazy-chunk-reload'
+
+/** True for the browser errors Vite/webpack emit when a hashed chunk 404s. */
+export function isChunkLoadError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error)
+  return (
+    /Failed to fetch dynamically imported module/i.test(message) ||
+    /error loading dynamically imported module/i.test(message) ||
+    /Loading chunk [\w-]+ failed/i.test(message)
+  )
+}
 
 /**
  * Load a route page module on first visit. Keeps the home shell free of
@@ -15,6 +30,26 @@ export function lazyPage(
   let loadError: Error | null = null
   let loading: Promise<void> | null = null
 
+  const clearReloadGuard = () => {
+    try {
+      sessionStorage.removeItem(LAZY_CHUNK_RELOAD_KEY)
+    } catch {
+      // private mode / blocked storage
+    }
+  }
+
+  const tryAutoReloadOnce = (err: unknown): boolean => {
+    if (!isChunkLoadError(err)) return false
+    try {
+      if (sessionStorage.getItem(LAZY_CHUNK_RELOAD_KEY)) return false
+      sessionStorage.setItem(LAZY_CHUNK_RELOAD_KEY, '1')
+    } catch {
+      return false
+    }
+    location.reload()
+    return true
+  }
+
   return function LazyPage(handle: Handle<Record<string, unknown>>) {
     if (!Page && !loadError) {
       loading ??= loader()
@@ -22,9 +57,14 @@ export function lazyPage(
           const exported = mod[exportName]
           if (!exported) throw new Error(`Lazy page export "${exportName}" missing`)
           Page = exported
+          clearReloadGuard()
           void handle.update()
         })
         .catch((err: unknown) => {
+          reportError(err, 'lazy-page', { exportName })
+          // After a deploy, the shell can briefly point at retired chunk
+          // hashes. One automatic reload usually picks up the new assets.
+          if (tryAutoReloadOnce(err)) return
           loadError = err instanceof Error ? err : new Error(String(err))
           void handle.update()
         })
@@ -34,7 +74,30 @@ export function lazyPage(
       if (loadError) {
         return (
           <div className="screen legal-screen">
-            <p className="muted">Could not load this screen. Reload and try again.</p>
+            <p className="muted">Could not load this screen.</p>
+            <div style={{ marginTop: '16px' }}>
+              <button
+                type="button"
+                className="btn btn-secondary"
+                mix={on('click', () => {
+                  loadError = null
+                  loading = null
+                  void handle.update()
+                })}
+              >
+                Try again
+              </button>
+              {' '}
+              <button
+                type="button"
+                className="btn btn-primary"
+                mix={on('click', () => {
+                  location.reload()
+                })}
+              >
+                Reload
+              </button>
+            </div>
           </div>
         )
       }

--- a/src/components/lazy-page.tsx
+++ b/src/components/lazy-page.tsx
@@ -7,13 +7,15 @@ type PageComponent = (handle: Handle<any>) => () => RemixNode
 /** sessionStorage flag so a failed chunk load auto-reloads at most once. */
 export const LAZY_CHUNK_RELOAD_KEY = 'kody:lazy-chunk-reload'
 
-/** True for the browser errors Vite/webpack emit when a hashed chunk 404s. */
+/** True when a hashed lazy chunk failed to load (Chrome/Vite, webpack, Safari). */
 export function isChunkLoadError(error: unknown): boolean {
   const message = error instanceof Error ? error.message : String(error)
   return (
     /Failed to fetch dynamically imported module/i.test(message) ||
     /error loading dynamically imported module/i.test(message) ||
-    /Loading chunk [\w-]+ failed/i.test(message)
+    /Loading chunk [\w-]+ failed/i.test(message) ||
+    // Safari / WebKit (including installed iOS PWAs)
+    /Importing a module script failed/i.test(message)
   )
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- The “Could not load this screen” state is `lazyPage` catching a failed dynamic `import()` — most often after a PWA update when hashed chunks rotate — and then sticking forever with no retry and no Sentry report.
- Confirmed the about-page SHA link change is unrelated: production `/project/new` and the project-page chunk both load cleanly on a fresh browser; About works for the reporter; no matching Sentry issues.
- This PR auto-reloads once on chunk-load errors, adds **Try again** / **Reload** actions, and reports failures to Sentry.

## Test plan
- [x] `npm run lint`
- [x] `npm test -- src/components/lazy-page.test.ts`
- [x] e2e: about pages + lazy project creation (`home.spec.ts`)
- [ ] CI green
- [ ] After merge: open a project on phone post-update; if a stale chunk hits, page should auto-reload once instead of dead-ending

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6be90af5-cfa4-44e2-9268-c07ea6d0b38e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6be90af5-cfa4-44e2-9268-c07ea6d0b38e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved recovery when lazy-loaded pages fail to load.
  - Automatically retries recognized loading failures once and provides separate “Try again” and “Reload” actions.

- **Bug Fixes**
  - Improved detection and handling of browser and chunk-loading errors.
  - Prevented repeated automatic reloads during the same session.

- **Tests**
  - Added coverage for recognized chunk-loading failures and ordinary errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->