### PR TITLE
Keep-watermark option + stacked mark layout

### DIFF
--- a/src/components/export-overlay.tsx
+++ b/src/components/export-overlay.tsx
@@ -4,6 +4,12 @@ import { ref } from 'remix/ui'
 interface ExportOverlayProps {
   projectName: string
   progress: number
+  /**
+   * True when this export stamps the Kody mark. Engines draw it onto every
+   * encoded frame before mirroring to the preview canvas, so the live
+   * preview matches the final video.
+   */
+  watermarked: boolean
   /** Bound to the canvas the export engines mirror sampled frames onto. */
   bindPreviewCanvas: (canvas: HTMLCanvasElement | null) => void
 }
@@ -15,7 +21,7 @@ interface ExportOverlayProps {
  */
 export function ExportOverlay(handle: Handle<ExportOverlayProps>) {
   return () => {
-    const { projectName, progress } = handle.props
+    const { projectName, progress, watermarked } = handle.props
     const percent = Math.round(progress * 100)
     return (
       <div className="export-overlay" role="dialog" aria-label="Exporting video">
@@ -30,7 +36,10 @@ export function ExportOverlay(handle: Handle<ExportOverlayProps>) {
         </div>
         <div className="export-overlay-info">
           <h2>Exporting your video…</h2>
-          <p className="muted">{projectName} — keep the app open</p>
+          <p className="muted">
+            {projectName} — keep the app open
+            {watermarked ? ' · includes the Kody mark' : ''}
+          </p>
           <div className="progress-bar" aria-label="Export progress">
             <span style={{ width: `${percent}%` }} />
           </div>

--- a/src/components/export-sheet.tsx
+++ b/src/components/export-sheet.tsx
@@ -19,8 +19,11 @@ interface ExportSheetProps {
   watermarked: boolean
   /** True when the removal purchase is unlocked (may change mid-sheet). */
   purchased: boolean
+  /** Plus opt-in: keep stamping the mark on future exports. */
+  keepWatermark: boolean
   /** A share/save is in flight — dismissal would drop its result notice. */
   busy: boolean
+  onKeepWatermarkChange: (keep: boolean) => void
   onShare: () => void
   onSave: () => void
   onSaveClips: () => void
@@ -49,7 +52,9 @@ export function ExportSheet(handle: Handle<ExportSheetProps>) {
       notice,
       watermarked,
       purchased,
+      keepWatermark,
       busy,
+      onKeepWatermarkChange,
       onShare,
       onSave,
       onSaveClips,
@@ -155,10 +160,31 @@ export function ExportSheet(handle: Handle<ExportSheetProps>) {
                   </button>
                 </p>
               ) : null}
-              {watermarked && purchased ? (
-                <p className="watermark-note">
-                  This video still includes the Kody mark — tap Go again for a clean export.
-                </p>
+              {purchased ? (
+                <div className="watermark-prefs">
+                  <label className="watermark-keep-toggle">
+                    <input
+                      type="checkbox"
+                      checked={keepWatermark}
+                      disabled={busy}
+                      mix={on('change', (event) => {
+                        onKeepWatermarkChange((event.currentTarget as HTMLInputElement).checked)
+                      })}
+                    />
+                    Keep the Kody mark on exports
+                  </label>
+                  {watermarked && !keepWatermark ? (
+                    <p className="watermark-note">
+                      This video still includes the Kody mark — tap Re-export from scratch for a
+                      clean export.
+                    </p>
+                  ) : null}
+                  {!watermarked && keepWatermark ? (
+                    <p className="watermark-note">
+                      Tap Re-export from scratch to stamp the Kody mark on this video.
+                    </p>
+                  ) : null}
+                </div>
               ) : null}
             </>
           ) : null}

--- a/src/lib/entitlement.ts
+++ b/src/lib/entitlement.ts
@@ -1,4 +1,5 @@
 import { getDb, getSettings } from './storage'
+import type { AppMeta } from './types'
 
 /** Stripe Payment Link for the one-time "Remove Watermark" unlock ($0.99). */
 export const REMOVE_WATERMARK_LINK = 'https://buy.stripe.com/00wfZi71ibU30rk9hU2Ry07'
@@ -14,6 +15,17 @@ export async function markWatermarkRemoved(sessionId: string): Promise<void> {
   const db = await getDb()
   const settings = await getSettings()
   await db.put('meta', { ...settings, watermarkRemoved: true, purchaseSessionId: sessionId })
+}
+
+/**
+ * Whether new exports should stamp the Kody mark.
+ * Free plan: always. Plus: only when the user opted to keep it.
+ */
+export function shouldWatermarkExports(
+  settings: Pick<AppMeta, 'watermarkRemoved' | 'keepWatermark'>,
+): boolean {
+  if (settings.keepWatermark === true) return true
+  return settings.watermarkRemoved !== true
 }
 
 export interface VerifyResult {

--- a/src/lib/export/shared.ts
+++ b/src/lib/export/shared.ts
@@ -504,7 +504,7 @@ export function loadWatermarkImage(): Promise<HTMLImageElement | null> {
   })
 }
 
-/** The domain shown next to the watermark mark. */
+/** The domain shown under the watermark mark. */
 export function watermarkDomain(): string {
   const host = typeof location !== 'undefined' ? location.hostname : ''
   // Dev servers and IPs shouldn't end up stamped on anyone's video.
@@ -514,36 +514,76 @@ export function watermarkDomain(): string {
   return host
 }
 
-/** Stamp the Kody Video mark + domain in the bottom-right corner of a frame. */
+/** Geometry for the stacked mark-above-domain watermark in the bottom-right. */
+export function watermarkLayout(
+  width: number,
+  height: number,
+  textWidth: number,
+): {
+  size: number
+  fontSize: number
+  radius: number
+  markX: number
+  markY: number
+  textX: number
+  textY: number
+} {
+  const size = Math.round(Math.min(width, height) * 0.11)
+  const margin = Math.round(size * 0.35)
+  const fontSize = Math.max(10, Math.round(size * 0.38))
+  const gap = Math.round(size * 0.14)
+  const stackWidth = Math.max(size, textWidth)
+  const right = width - margin
+  const bottom = height - margin
+  // Right-align the wider of mark/text; center the narrower on that axis.
+  const markX = Math.round(right - stackWidth / 2 - size / 2)
+  const markY = bottom - size - gap - fontSize
+  return {
+    size,
+    fontSize,
+    radius: Math.round(size * 0.22),
+    markX,
+    markY,
+    textX: markX + size / 2,
+    textY: markY + size + gap + fontSize / 2,
+  }
+}
+
+/** Stamp the Kody Video mark above the domain in the bottom-right corner. */
 export function drawWatermark(
   ctx: CanvasRenderingContext2D,
   image: HTMLImageElement,
   width: number,
   height: number,
 ): void {
-  const size = Math.round(Math.min(width, height) * 0.11)
-  const margin = Math.round(size * 0.35)
-  const x = width - size - margin
-  const y = height - size - margin
-  const radius = Math.round(size * 0.22)
+  const domain = watermarkDomain()
+  const sizeProbe = Math.round(Math.min(width, height) * 0.11)
+  const fontSizeProbe = Math.max(10, Math.round(sizeProbe * 0.38))
 
   ctx.save()
+  ctx.font = `600 ${fontSizeProbe}px 'DM Sans', system-ui, sans-serif`
+  const { size, fontSize, radius, markX, markY, textX, textY } = watermarkLayout(
+    width,
+    height,
+    ctx.measureText(domain).width,
+  )
+
   ctx.globalAlpha = 0.5
 
   ctx.save()
   ctx.beginPath()
-  ctx.roundRect(x, y, size, size, radius)
+  ctx.roundRect(markX, markY, size, size, radius)
   ctx.clip()
-  ctx.drawImage(image, x, y, size, size)
+  ctx.drawImage(image, markX, markY, size, size)
   ctx.restore()
 
-  ctx.font = `600 ${Math.max(10, Math.round(size * 0.38))}px 'DM Sans', system-ui, sans-serif`
-  ctx.textAlign = 'right'
+  ctx.font = `600 ${fontSize}px 'DM Sans', system-ui, sans-serif`
+  ctx.textAlign = 'center'
   ctx.textBaseline = 'middle'
   ctx.fillStyle = '#fff'
   ctx.shadowColor = 'rgba(0, 0, 0, 0.6)'
   ctx.shadowBlur = Math.round(size * 0.12)
-  ctx.fillText(watermarkDomain(), x - Math.round(size * 0.22), y + Math.round(size / 2))
+  ctx.fillText(domain, textX, textY)
 
   ctx.restore()
 }

--- a/src/lib/export/watermark.test.ts
+++ b/src/lib/export/watermark.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest'
+import { shouldWatermarkExports } from '../entitlement'
+import { watermarkLayout } from './shared'
+
+describe('shouldWatermarkExports', () => {
+  it('stamps free-plan exports', () => {
+    expect(shouldWatermarkExports({ watermarkRemoved: false })).toBe(true)
+    expect(shouldWatermarkExports({})).toBe(true)
+  })
+
+  it('skips the mark after purchase by default', () => {
+    expect(shouldWatermarkExports({ watermarkRemoved: true })).toBe(false)
+    expect(shouldWatermarkExports({ watermarkRemoved: true, keepWatermark: false })).toBe(false)
+  })
+
+  it('keeps the mark after purchase when opted in', () => {
+    expect(shouldWatermarkExports({ watermarkRemoved: true, keepWatermark: true })).toBe(true)
+  })
+})
+
+describe('watermarkLayout', () => {
+  it('stacks the mark above the domain, centered, in the bottom-right', () => {
+    const width = 1080
+    const height = 1920
+    // Narrower than the mark — stack width is the mark.
+    const layout = watermarkLayout(width, height, 40)
+    const size = Math.round(Math.min(width, height) * 0.11)
+    const margin = Math.round(size * 0.35)
+    const fontSize = Math.max(10, Math.round(size * 0.38))
+    const gap = Math.round(size * 0.14)
+
+    expect(layout.size).toBe(size)
+    expect(layout.fontSize).toBe(fontSize)
+    // Mark sits above the text with a gap; text baseline is vertically centered
+    // in the text band that ends at height - margin.
+    expect(layout.markY + size + gap + fontSize).toBe(height - margin)
+    expect(layout.textY).toBe(layout.markY + size + gap + fontSize / 2)
+    // Shared horizontal center; group flush to the right margin.
+    expect(layout.textX).toBe(layout.markX + size / 2)
+    expect(layout.markX + size).toBe(width - margin)
+  })
+
+  it('widens the stack when the domain is wider than the mark', () => {
+    const width = 1080
+    const height = 1920
+    const textWidth = 200
+    const layout = watermarkLayout(width, height, textWidth)
+    const size = Math.round(Math.min(width, height) * 0.11)
+    const margin = Math.round(size * 0.35)
+    // Group right edge is approximately the text (wider); mark stays centered on it.
+    expect(Math.abs(layout.textX + textWidth / 2 - (width - margin))).toBeLessThanOrEqual(1)
+    expect(layout.textX).toBe(layout.markX + size / 2)
+  })
+})

--- a/src/lib/project-actions.ts
+++ b/src/lib/project-actions.ts
@@ -51,6 +51,10 @@ export interface ProjectLoaderData {
   onboardingDismissed: boolean
   /** True when the one-time "Remove Watermark" purchase is unlocked. */
   watermarkRemoved: boolean
+  /**
+   * Plus opt-in: keep the Kody mark on exports after purchase (default off).
+   */
+  keepWatermark: boolean
   /** Device storage estimate (null when the API is unavailable). */
   storage: StorageSpace | null
   /** Opt-in: tag new clips with device location. */
@@ -132,6 +136,7 @@ export async function loadProjectPage(projectId: ProjectId): Promise<ProjectLoad
         canUndo: false,
         onboardingDismissed: settings.onboardingDismissed,
         watermarkRemoved: settings.watermarkRemoved === true,
+        keepWatermark: settings.keepWatermark === true,
         storage,
         locationTaggingEnabled: settings.locationTaggingEnabled === true,
         error: null,
@@ -154,6 +159,7 @@ export async function loadProjectPage(projectId: ProjectId): Promise<ProjectLoad
         canUndo: false,
         onboardingDismissed: settings.onboardingDismissed,
         watermarkRemoved: settings.watermarkRemoved === true,
+        keepWatermark: settings.keepWatermark === true,
         storage,
         locationTaggingEnabled: settings.locationTaggingEnabled === true,
         error: 'Project not found',
@@ -176,6 +182,7 @@ export async function loadProjectPage(projectId: ProjectId): Promise<ProjectLoad
       canUndo: !!undo,
       onboardingDismissed: settings.onboardingDismissed,
       watermarkRemoved: settings.watermarkRemoved === true,
+      keepWatermark: settings.keepWatermark === true,
       storage,
       locationTaggingEnabled: settings.locationTaggingEnabled === true,
       error: null,
@@ -188,6 +195,7 @@ export async function loadProjectPage(projectId: ProjectId): Promise<ProjectLoad
       canUndo: false,
       onboardingDismissed: true,
       watermarkRemoved: false,
+      keepWatermark: false,
       storage: null,
       locationTaggingEnabled: false,
       error: err instanceof Error ? err.message : 'Failed to load project',

--- a/src/lib/storage.test.ts
+++ b/src/lib/storage.test.ts
@@ -20,6 +20,7 @@ import {
   removeProjectAudioTrack,
   renameProject,
   setOnboardingDismissed,
+  setKeepWatermark,
   toStoredBlob,
   undoDeleteLastClip,
   updateClipAudioVolume,
@@ -45,6 +46,14 @@ describe('storage layer', () => {
     await setOnboardingDismissed(true)
 
     expect((await getSettings()).onboardingDismissed).toBe(true)
+  })
+
+  it('defaults keepWatermark off and persists the Plus opt-in', async () => {
+    expect((await getSettings()).keepWatermark).toBeUndefined()
+    await setKeepWatermark(true)
+    expect((await getSettings()).keepWatermark).toBe(true)
+    await setKeepWatermark(false)
+    expect((await getSettings()).keepWatermark).toBe(false)
   })
 
   it('gates the second project behind the Plus purchase', async () => {

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -136,6 +136,12 @@ export async function setLocationTaggingEnabled(locationTaggingEnabled: boolean)
   await db.put('meta', { ...settings, locationTaggingEnabled })
 }
 
+export async function setKeepWatermark(keepWatermark: boolean): Promise<void> {
+  const db = await getDb()
+  const settings = await getSettings()
+  await db.put('meta', { ...settings, keepWatermark })
+}
+
 export async function listProjects(): Promise<Project[]> {
   const db = await getDb()
   const projects = await db.getAllFromIndex('projects', 'by-updated')

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -107,6 +107,11 @@ export interface AppMeta {
   /** One-time "Remove Watermark" purchase (verified via Stripe). */
   watermarkRemoved?: boolean
   purchaseSessionId?: string | null
+  /**
+   * Plus opt-in: keep stamping the Kody mark on exports even after purchase.
+   * Default off — Plus removes the watermark unless the user chooses this.
+   */
+  keepWatermark?: boolean
   /** Opt-in: tag new clips with device location. */
   locationTaggingEnabled?: boolean
   /** The persisted last export (OPFS-backed), recoverable after the share

--- a/src/pages/project-page.tsx
+++ b/src/pages/project-page.tsx
@@ -9,7 +9,7 @@ import { RecordScreen, type ToastAction } from '../components/record-screen'
 import { createCamera } from '../lib/camera'
 import { RestoreSheet } from '../components/restore-sheet'
 import { UpsellSheet } from '../components/upsell-sheet'
-import { REMOVE_WATERMARK_LINK } from '../lib/entitlement'
+import { REMOVE_WATERMARK_LINK, shouldWatermarkExports } from '../lib/entitlement'
 import { buildClipsZip } from '../lib/clips-zip'
 import { clearExportMarker, markExportStarted, reportError } from '../lib/error-reporting'
 import { exportProject, type ExportResult } from '../lib/export'
@@ -24,7 +24,7 @@ import {
   shareFile,
 } from '../lib/media'
 import { loadProjectPage, type ProjectLoaderData } from '../lib/project-actions'
-import { createProject, setOnboardingDismissed } from '../lib/storage'
+import { createProject, setKeepWatermark, setOnboardingDismissed } from '../lib/storage'
 import { requestPersistentStorage } from '../lib/storage-space'
 import { navigate } from '../router'
 import { NEW_PROJECT_ID, type ProjectId } from '../lib/types'
@@ -128,6 +128,7 @@ export function ProjectPage(handle: Handle<ProjectPageProps>) {
           canUndo: false,
           onboardingDismissed: true,
           watermarkRemoved: false,
+          keepWatermark: false,
           storage: null,
           locationTaggingEnabled: false,
           error: err instanceof Error ? err.message : 'Could not load this project.',
@@ -215,7 +216,7 @@ export function ProjectPage(handle: Handle<ProjectPageProps>) {
       audioContext = undefined
     }
 
-    const watermarked = !data.watermarkRemoved
+    const watermarked = shouldWatermarkExports(data)
     const signature = exportSignature(clips, watermarked, audio)
     // Stop camera/mic immediately rather than waiting on record-screen
     // unmount. On iOS the combined mic+camera session can hold decoder
@@ -488,6 +489,7 @@ export function ProjectPage(handle: Handle<ProjectPageProps>) {
           <ExportOverlay
             projectName={project.name}
             progress={exportState?.progress ?? 0}
+            watermarked={exportState?.watermarked === true}
             bindPreviewCanvas={bindPreviewCanvas}
           />
         ) : null}
@@ -499,7 +501,15 @@ export function ProjectPage(handle: Handle<ProjectPageProps>) {
             notice={exportState.notice}
             watermarked={exportState.watermarked}
             purchased={data.watermarkRemoved}
+            keepWatermark={data.keepWatermark}
             busy={exportActionCount > 0}
+            onKeepWatermarkChange={(keep) => {
+              data = { ...data!, keepWatermark: keep }
+              void handle.update()
+              void setKeepWatermark(keep).catch((err) => {
+                reportError(err, 'keep-watermark')
+              })
+            }}
             onRemoveWatermark={() => {
               window.open(REMOVE_WATERMARK_LINK, '_blank', 'noopener')
             }}
@@ -586,7 +596,11 @@ export function ProjectPage(handle: Handle<ProjectPageProps>) {
             onRestored={() => {
               restoring = false
               void handle.update()
-              showToast('Purchase restored — new exports are watermark-free')
+              showToast(
+                data?.keepWatermark
+                  ? 'Purchase restored — Plus unlocked (Kody mark still kept)'
+                  : 'Purchase restored — new exports are watermark-free',
+              )
               refresh()
             }}
           />

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -412,6 +412,36 @@ a {
   line-height: 1.5;
 }
 
+.watermark-prefs {
+  margin-top: 14px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+}
+
+.watermark-keep-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--ink-muted);
+  cursor: pointer;
+}
+
+.watermark-keep-toggle input[type='checkbox'] {
+  width: 16px;
+  height: 16px;
+  accent-color: var(--accent);
+  margin: 0;
+}
+
+.watermark-prefs .watermark-note {
+  margin: 0;
+  text-align: center;
+}
+
 .link-button {
   padding: 0;
   color: var(--accent);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Plus users get an opt-in **Keep the Kody mark on exports** toggle on the export sheet (default off — Plus still removes the watermark unless they choose otherwise).
- Watermark layout is restacked: brand mark **above** `kody.video`, centered relative to each other, bottom-right.
- When an export will include the mark, the export overlay notes it and the encode engines stamp it onto frames before mirroring to the live preview canvas (so the preview matches the final video).

## Test plan

- [x] Unit tests for `shouldWatermarkExports`, `watermarkLayout`, and `setKeepWatermark`
- [x] `npm test` / `npm run lint`
- [x] CI green; Bugbot clean; squash-merged; Cloudflare Pages deploy succeeded

Shipped to production via squash-merge of #112 (`58a0564`).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cf4ab5f6-920f-4055-9845-d94022ed126e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cf4ab5f6-920f-4055-9845-d94022ed126e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

