### PR TITLE
Point docs and GitHub metadata at kody.video

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,7 @@ npm run test:e2e   # Playwright e2e suite (fake camera/mic; recording, editor, p
 npm run test:smoke # Playwright UX smoke (fake camera, records + exports)
 ```
 
-**Live app:** [https://kody.video](https://kody.video) (Cloudflare Pages, builds from `main`; the original
-[kody-video.pages.dev](https://kody-video.pages.dev) origin stays live so existing on-device projects remain accessible)
+**Live app:** [https://kody.video](https://kody.video) (Cloudflare Pages, builds from `main`)
 
 For a phone on the same network, use your machine’s LAN URL over HTTPS, or tunnel (`npm run dev -- --host` plus a trusted tunnel). `getUserMedia` will fail on plain `http://<lan-ip>` in most browsers.
 
@@ -52,8 +51,8 @@ For a phone on the same network, use your machine’s LAN URL over HTTPS, or tun
 - Fallback: save clips as separate files
 - Project **backup/import**: one `.kodyvideo` file per project (clips, trims,
   location data, background music + volumes) — a safety net, and the way to
-  move a project between devices or origins (e.g. kody-video.pages.dev →
-  kody.video); ⋯ → Save backup on a slot, import from the About page
+  move a project between devices or browser origins (storage is per-origin);
+  ⋯ → Save backup on a slot, import from the About page
 - Installable PWA (manifest + Workbox service worker for the app shell)
 - **No accounts, no uploads, no analytics**
 

--- a/src/lib/project-transfer.ts
+++ b/src/lib/project-transfer.ts
@@ -10,8 +10,8 @@ import type { ClipRecord, Project, ProjectAudioRecord } from './types'
 
 /**
  * Single-file project backup, used both as a safety net and to move a
- * project between origins (e.g. kody-video.pages.dev → kody.video, whose
- * browser storage is separate).
+ * project between devices or browser origins (storage is per-origin — e.g.
+ * an older deploy → kody.video).
  *
  * Format: `KODYVID1` magic, u32 big-endian JSON manifest length, UTF-8 JSON
  * manifest, then every clip's media bytes concatenated in manifest order,

--- a/src/lib/verify-purchase.test.ts
+++ b/src/lib/verify-purchase.test.ts
@@ -23,7 +23,7 @@ afterEach(() => {
 })
 
 describe('verify-purchase function', () => {
-  const url = 'https://kody-video.pages.dev/api/verify-purchase?session_id=cs_live_abc123'
+  const url = 'https://kody.video/api/verify-purchase?session_id=cs_live_abc123'
   const env = { STRIPE_SECRET_KEY: 'rk_test_x' }
 
   it('returns 503 when the secret is not configured', async () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- GitHub repo **homepage** set to `https://kody.video` and **description** updated to cite `kody.video` (via API — already live on the repo).
- README no longer advertises `kody-video.pages.dev` as a parallel live origin.
- Backup comment + verify-purchase test example URLs now use `kody.video`.

Left intentionally: `kody-video.pages.dev` hostname checks for the legacy migration banner, Sentry, and Fathom — those still need the old host string so stragglers on that origin get nudged / monitored.

## Test plan

- [x] `npm test -- src/lib/verify-purchase.test.ts`
- [x] Confirm `gh api repos/kentcdodds/kody-video` shows homepage `https://kody.video`
- [ ] Spot-check README Live app link

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cf4ab5f6-920f-4055-9845-d94022ed126e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cf4ab5f6-920f-4055-9845-d94022ed126e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the live-app documentation to reference the current `kody.video` address.
  * Clarified project backup and transfer guidance for moving projects between devices or browser origins.
* **Tests**
  * Updated purchase-verification test references to use the current application address.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->