### PR TITLE
Watermark: higher opacity + light text drop shadow

### DIFF
--- a/src/lib/export/shared.ts
+++ b/src/lib/export/shared.ts
@@ -568,7 +568,7 @@ export function drawWatermark(
     ctx.measureText(domain).width,
   )
 
-  ctx.globalAlpha = 0.5
+  ctx.globalAlpha = 0.72
 
   ctx.save()
   ctx.beginPath()
@@ -581,8 +581,11 @@ export function drawWatermark(
   ctx.textAlign = 'center'
   ctx.textBaseline = 'middle'
   ctx.fillStyle = '#fff'
-  ctx.shadowColor = 'rgba(0, 0, 0, 0.6)'
-  ctx.shadowBlur = Math.round(size * 0.12)
+  // Soft drop under the domain so it stays readable on bright frames.
+  ctx.shadowColor = 'rgba(0, 0, 0, 0.55)'
+  ctx.shadowBlur = Math.max(2, Math.round(size * 0.05))
+  ctx.shadowOffsetX = 0
+  ctx.shadowOffsetY = Math.max(1, Math.round(size * 0.035))
   ctx.fillText(domain, textX, textY)
 
   ctx.restore()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Watermark stamp opacity raised from `0.5` → `0.72`
- Domain text uses a small downward drop shadow (modest blur + offset) instead of a soft glow, so it stays readable on bright frames

## Test plan

- [x] `npm test -- src/lib/export/watermark.test.ts`
- [ ] Export a bright clip and confirm mark + `kody.video` read clearly in the corner

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cf4ab5f6-920f-4055-9845-d94022ed126e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cf4ab5f6-920f-4055-9845-d94022ed126e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Increased watermark visibility.
  * Refined domain text shadows for a softer, more subtle appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->