### PR TITLE
kody.video domain refs + watermark opacity/shadow

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,7 @@ npm run test:e2e   # Playwright e2e suite (fake camera/mic; recording, editor, p
 npm run test:smoke # Playwright UX smoke (fake camera, records + exports)
 ```
 
-**Live app:** [https://kody.video](https://kody.video) (Cloudflare Pages, builds from `main`; the original
-[kody-video.pages.dev](https://kody-video.pages.dev) origin stays live so existing on-device projects remain accessible)
+**Live app:** [https://kody.video](https://kody.video) (Cloudflare Pages, builds from `main`)
 
 For a phone on the same network, use your machine’s LAN URL over HTTPS, or tunnel (`npm run dev -- --host` plus a trusted tunnel). `getUserMedia` will fail on plain `http://<lan-ip>` in most browsers.
 
@@ -52,8 +51,8 @@ For a phone on the same network, use your machine’s LAN URL over HTTPS, or tun
 - Fallback: save clips as separate files
 - Project **backup/import**: one `.kodyvideo` file per project (clips, trims,
   location data, background music + volumes) — a safety net, and the way to
-  move a project between devices or origins (e.g. kody-video.pages.dev →
-  kody.video); ⋯ → Save backup on a slot, import from the About page
+  move a project between devices or browser origins (storage is per-origin);
+  ⋯ → Save backup on a slot, import from the About page
 - Installable PWA (manifest + Workbox service worker for the app shell)
 - **No accounts, no uploads, no analytics**
 

--- a/src/lib/export/shared.ts
+++ b/src/lib/export/shared.ts
@@ -568,7 +568,7 @@ export function drawWatermark(
     ctx.measureText(domain).width,
   )
 
-  ctx.globalAlpha = 0.5
+  ctx.globalAlpha = 0.72
 
   ctx.save()
   ctx.beginPath()
@@ -581,8 +581,11 @@ export function drawWatermark(
   ctx.textAlign = 'center'
   ctx.textBaseline = 'middle'
   ctx.fillStyle = '#fff'
-  ctx.shadowColor = 'rgba(0, 0, 0, 0.6)'
-  ctx.shadowBlur = Math.round(size * 0.12)
+  // Soft drop under the domain so it stays readable on bright frames.
+  ctx.shadowColor = 'rgba(0, 0, 0, 0.55)'
+  ctx.shadowBlur = Math.max(2, Math.round(size * 0.05))
+  ctx.shadowOffsetX = 0
+  ctx.shadowOffsetY = Math.max(1, Math.round(size * 0.035))
   ctx.fillText(domain, textX, textY)
 
   ctx.restore()

--- a/src/lib/project-transfer.ts
+++ b/src/lib/project-transfer.ts
@@ -10,8 +10,8 @@ import type { ClipRecord, Project, ProjectAudioRecord } from './types'
 
 /**
  * Single-file project backup, used both as a safety net and to move a
- * project between origins (e.g. kody-video.pages.dev → kody.video, whose
- * browser storage is separate).
+ * project between devices or browser origins (storage is per-origin — e.g.
+ * an older deploy → kody.video).
  *
  * Format: `KODYVID1` magic, u32 big-endian JSON manifest length, UTF-8 JSON
  * manifest, then every clip's media bytes concatenated in manifest order,

--- a/src/lib/verify-purchase.test.ts
+++ b/src/lib/verify-purchase.test.ts
@@ -23,7 +23,7 @@ afterEach(() => {
 })
 
 describe('verify-purchase function', () => {
-  const url = 'https://kody-video.pages.dev/api/verify-purchase?session_id=cs_live_abc123'
+  const url = 'https://kody.video/api/verify-purchase?session_id=cs_live_abc123'
   const env = { STRIPE_SECRET_KEY: 'rk_test_x' }
 
   it('returns 503 when the secret is not configured', async () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Combines the remaining polish from #113 and #114 into one ship:

- **Domain:** GitHub repo homepage/description already point at `kody.video` (API). README + backup/test examples stop advertising `kody-video.pages.dev` as a parallel live origin. Legacy hostname checks for the migration banner / Sentry / Fathom stay on purpose.
- **Watermark:** Stamp opacity `0.5` → `0.72`, and the domain text gets a small downward drop shadow instead of a soft glow.

Supersedes #113 and #114 (closed).

## Test plan

- [x] Unit tests for verify-purchase + watermark layout
- [x] Confirm GitHub homepage is `https://kody.video`
- [ ] Export a bright clip — mark + `kody.video` readable in the corner
- [ ] Spot-check README Live app link

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cf4ab5f6-920f-4055-9845-d94022ed126e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cf4ab5f6-920f-4055-9845-d94022ed126e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

