### PR TITLE
Audio track detail view: per-track trim, level, and fades

### DIFF
--- a/.cursor/skills/ship-pr/SKILL.md
+++ b/.cursor/skills/ship-pr/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: ship-pr
+description: >
+  Babysit a PR: iterate with AI reviewers and CI until green, get it ready,
+  optionally squash-merge as Kody and watch the deploy, then send a Discord
+  summary. Medium risk waits for AI reviewer(s) and addresses valid feedback.
+  Use when a pull request needs to be shepherded to done.
+---
+
+# Ship PR
+
+## Risk → merge authority
+
+Self-assess; user policy overrides.
+
+- **Low** — green CI; nits ignorable; squash-merge when policy allows.
+- **Medium** — wait for AI reviewer(s); address **valid** feedback (ignore
+  insignificant nits / already-fixed / wrong); then merge when policy allows.
+- **High** — leave ready-for-review unless the user granted merge authority.
+
+## AI reviewers
+
+Prefer **Cursor Bugbot** (`Cursor Bugbot` check / `cursor[bot]` review comments).
+Trigger with `bugbot run` or `@cursor review` on the PR if it has not started.
+
+**CodeRabbit:** if it is rate-limited, errored, or otherwise unavailable, **do not
+wait** on it for low/medium risk — proceed with Bugbot + CI. Only wait on
+CodeRabbit when the change is **high** risk (or the user explicitly asks).
+
+## Loop
+
+1. Mark ready — `kody:@kentcdodds/github/pr/set-review-status`
+   `{ prUrl, status: 'ready' }` (or owner/repo/prNumber).
+2. Wait for CI — `gh pr checks` (or compose `loop-on-ci` / `fix-ci`).
+3. Fix failures; for **medium+**, wait on AI reviewer(s) (Bugbot first; see
+   above for CodeRabbit) and address valid feedback. Rebase only when actually
+   unmergeable.
+4. Green + (medium+: valid feedback cleared) → break.
+5. Push → repeat.
+
+## Gates ≠ CI
+
+Blocked on soak / parity CHECK / calendar gate → **end the run** and schedule a
+wake (Kody `job_schedule` + `createRun`). Don't sleep-poll or code-thrash an
+intentional time window.
+
+Batch related expand steps into fewer PRs when risk posture allows.
+
+## Merge / deploy
+
+When policy + risk allow: squash-merge via `kody:@kentcdodds/github/pr/merge`
+`{ prUrl, mergeMethod: 'squash' }`, watch deploy. Useful: `pr/get-checks`,
+`request`, `graphql` on the same package.
+
+## Done → Discord
+
+Always summarize (merged or not) with agent / PR / CI / deploy links:
+
+```javascript
+import postMessage from 'kody:@kentcdodds/discord/post-message'
+
+export default async function main() {
+	return postMessage({
+		channelId: '1491568683737157683',
+		content: '…summary with links…',
+	})
+}
+```

--- a/README.md
+++ b/README.md
@@ -41,10 +41,13 @@ For a phone on the same network, use your machine’s LAN URL over HTTPS, or tun
   **peak-normalized** so the split means the same thing however hot either
   recording is. Defaults to 25% music under every clip; tap a clip to set
   its own balance (duck the music under speech, swell it for b-roll). Mix
-  changes glide across clip boundaries, and the music fades in/out at the
-  start and end of the film (both toggleable, on by default). All of it —
-  levels, normalization, fades, track hand-offs — plays the same in the
-  project preview as in the exported file
+  changes glide across clip boundaries. Tapping a track row opens its
+  **detail view** (the audio counterpart of the clip trim view): trim the
+  track to a kept window over its waveform, set the track's level, and
+  toggle its fade in/out (on by default — each track eases in where it
+  starts and out where it ends, including the film's edges). All of it —
+  levels, normalization, fades, trims, track hand-offs — plays the same in
+  the project preview as in the exported file
 - Project preview playback: tap edges to skip clips, tap middle to stop
 - Up to **6** stable project slots (create / open / rename / delete, poster art from your clips)
 - Big Go CTA: on-device export to **one video file**, then Share (system sheet) or Save
@@ -131,7 +134,7 @@ before this feature simply lack the data and degrade gracefully.
 | clips    | Clip metadata, `Blob` media, filmstrip thumbnails     |
 | undo     | Last deleted clip per project (for Undo)              |
 | meta     | Settings (`maxProjects`, last opened id, onboarding)  |
-| audio    | Background-music playlist per project (blobs, volumes, fades) |
+| audio    | Background-music playlist per project (blobs, volumes, per-track trims/levels/fades) |
 
 Database name: `kody-video`. Blobs never leave the device unless the user explicitly shares/downloads.
 

--- a/src/components/audio-detail-strip.tsx
+++ b/src/components/audio-detail-strip.tsx
@@ -1,0 +1,397 @@
+import type { Handle } from 'remix/ui'
+import { on, ref } from 'remix/ui'
+import { decodeBlobAudio } from '../lib/export/shared'
+import {
+  formatDuration,
+  resolveAudioTrackPlayback,
+  type ProjectAudioRecord,
+  type ProjectAudioTrack,
+} from '../lib/types'
+import { IconMusic, IconPause, IconPlay } from './icons'
+
+const MIN_GAP_MS = 100
+/** Waveform resolution: enough bars to read the song's shape in the strip. */
+const WAVEFORM_BINS = 120
+/** Decode rate for the waveform — it shapes pixels, not audio. */
+const WAVEFORM_SAMPLE_RATE = 8000
+
+/** Per-track playback settings the detail view edits, saved on Done. */
+export interface AudioTrackDraft {
+  trimStartMs: number
+  trimEndMs: number
+  volume: number
+  fadeIn: boolean
+  fadeOut: boolean
+}
+
+interface AudioDetailStripProps {
+  track: ProjectAudioTrack
+  /** Playlist record — fade defaults for tracks without their own flags. */
+  playlist: ProjectAudioRecord
+  trackIndex: number
+  onDone: (draft: AudioTrackDraft) => Promise<void>
+  onCancel: () => void
+}
+
+/**
+ * Detail view for ONE background-music track, opened from its playlist row
+ * — the audio counterpart of the clip TrimStrip. Trim handles bound the
+ * kept window over a waveform, the level slider scales the track's side of
+ * the mix, and the fade toggles ease the track in/out where it starts and
+ * ends. Everything is a local draft until Done persists it (Cancel or
+ * Escape discards); the preview button auditions the kept window live.
+ */
+export function AudioDetailStrip(handle: Handle<AudioDetailStripProps>) {
+  const { props } = handle
+  const initial = resolveAudioTrackPlayback(props.track, props.playlist)
+  let startMs = initial.trimStartMs
+  let endMs = Math.min(initial.trimEndMs, props.track.durationMs)
+  let volume = initial.volume
+  let fadeIn = initial.fadeIn
+  let fadeOut = initial.fadeOut
+  let saving = false
+  let error: string | null = null
+  let activeHandle: 'start' | 'end' | null = null
+  let auditioning = false
+
+  const duration = () => Math.max(1, props.track.durationMs)
+
+  // Waveform peaks (0–1 per bin), decoded once in the background.
+  let peaks: Float32Array | null = null
+  const canvasRef: { current: HTMLCanvasElement | null } = { current: null }
+  const auditionRef: { current: HTMLAudioElement | null } = { current: null }
+  const auditionUrl = URL.createObjectURL(props.track.blob)
+
+  void (async () => {
+    const buffer = await decodeBlobAudio(props.track.blob, WAVEFORM_SAMPLE_RATE).catch(
+      () => null,
+    )
+    if (!buffer || buffer.length === 0) return
+    const data = buffer.getChannelData(0)
+    const bins = new Float32Array(WAVEFORM_BINS)
+    const binLength = data.length / WAVEFORM_BINS
+    for (let bin = 0; bin < WAVEFORM_BINS; bin += 1) {
+      const from = Math.floor(bin * binLength)
+      const to = Math.min(data.length, Math.max(from + 1, Math.ceil((bin + 1) * binLength)))
+      let peak = 0
+      // Strided scan is fine here — this shapes pixels, not gain.
+      const step = Math.max(1, Math.floor((to - from) / 64))
+      for (let i = from; i < to; i += step) {
+        const value = Math.abs(data[i])
+        if (value > peak) peak = value
+      }
+      bins[bin] = peak
+    }
+    const max = bins.reduce((a, b) => Math.max(a, b), 0)
+    if (max > 0) {
+      for (let i = 0; i < bins.length; i += 1) bins[i] /= max
+    }
+    peaks = bins
+    drawWaveform()
+  })()
+
+  function drawWaveform() {
+    const canvas = canvasRef.current
+    if (!canvas || !peaks) return
+    const dpr = window.devicePixelRatio || 1
+    const width = canvas.clientWidth || 300
+    const height = canvas.clientHeight || 64
+    canvas.width = Math.round(width * dpr)
+    canvas.height = Math.round(height * dpr)
+    const ctx = canvas.getContext('2d')
+    if (!ctx) return
+    ctx.scale(dpr, dpr)
+    ctx.clearRect(0, 0, width, height)
+    ctx.fillStyle = 'rgba(255, 255, 255, 0.55)'
+    const barWidth = Math.max(1, width / peaks.length - 1)
+    for (let i = 0; i < peaks.length; i += 1) {
+      const x = (i / peaks.length) * width
+      const barHeight = Math.max(2, peaks[i] * (height - 8))
+      ctx.fillRect(x, (height - barHeight) / 2, barWidth, barHeight)
+    }
+  }
+
+  const msFromClientX = (clientX: number, strip: HTMLElement) => {
+    const rect = strip.getBoundingClientRect()
+    if (rect.width <= 0) return 0
+    const ratio = Math.min(1, Math.max(0, (clientX - rect.left) / rect.width))
+    return Math.round(ratio * duration())
+  }
+
+  const seekAudition = (ms: number) => {
+    const el = auditionRef.current
+    if (el) el.currentTime = ms / 1000
+  }
+
+  const stopAudition = () => {
+    auditionRef.current?.pause()
+  }
+
+  const toggleAudition = () => {
+    const el = auditionRef.current
+    if (!el) return
+    if (!el.paused) {
+      el.pause()
+      return
+    }
+    // Start inside the kept window (from its start when outside it).
+    const positionMs = el.currentTime * 1000
+    if (positionMs < startMs || positionMs >= endMs - MIN_GAP_MS / 2) {
+      el.currentTime = startMs / 1000
+    }
+    el.volume = volume
+    void el.play().catch(() => undefined)
+  }
+
+  const startHandleDrag = (which: 'start' | 'end', event: PointerEvent) => {
+    if (event.button !== 0) return
+    event.preventDefault()
+    event.stopPropagation()
+    const dragHandle = event.currentTarget as HTMLButtonElement
+    const strip = dragHandle.closest('.trim-strip-track') as HTMLElement | null
+    if (!strip) return
+
+    dragHandle.setPointerCapture(event.pointerId)
+    activeHandle = which
+    void handle.update()
+
+    const onMove = (ev: PointerEvent) => {
+      const next = msFromClientX(ev.clientX, strip)
+      if (which === 'start') {
+        startMs = Math.max(0, Math.min(next, endMs - MIN_GAP_MS))
+        seekAudition(startMs)
+      } else {
+        endMs = Math.min(duration(), Math.max(next, startMs + MIN_GAP_MS))
+        seekAudition(endMs)
+      }
+      void handle.update()
+    }
+
+    const onUp = (ev: PointerEvent) => {
+      try {
+        dragHandle.releasePointerCapture(ev.pointerId)
+      } catch {
+        /* already released */
+      }
+      dragHandle.removeEventListener('pointermove', onMove)
+      dragHandle.removeEventListener('pointerup', onUp)
+      dragHandle.removeEventListener('pointercancel', onUp)
+      activeHandle = null
+      void handle.update()
+    }
+
+    dragHandle.addEventListener('pointermove', onMove)
+    dragHandle.addEventListener('pointerup', onUp)
+    dragHandle.addEventListener('pointercancel', onUp)
+
+    seekAudition(which === 'start' ? startMs : endMs)
+  }
+
+  const onDoneClick = () => {
+    void (async () => {
+      if (!(endMs > startMs)) {
+        error = 'End must be after start.'
+        void handle.update()
+        return
+      }
+      saving = true
+      error = null
+      stopAudition()
+      void handle.update()
+      try {
+        await props.onDone({
+          trimStartMs: Math.round(startMs),
+          trimEndMs: Math.round(endMs),
+          volume,
+          fadeIn,
+          fadeOut,
+        })
+      } catch (err) {
+        error = err instanceof Error ? err.message : 'Could not save the track settings'
+        saving = false
+        void handle.update()
+      }
+    })()
+  }
+
+  return () => {
+    const { track, trackIndex } = props
+    const keptMs = Math.max(0, endMs - startMs)
+    const startPct = (startMs / duration()) * 100
+    const endPct = (endMs / duration()) * 100
+    const levelPct = Math.round(volume * 100)
+
+    return (
+      <div
+        className="audio-detail-strip"
+        role="group"
+        aria-label={`Music track ${trackIndex + 1} settings`}
+        mix={ref((_node, signal) => {
+          signal.addEventListener('abort', () => {
+            auditionRef.current?.pause()
+            URL.revokeObjectURL(auditionUrl)
+          })
+        })}
+      >
+        <audio
+          src={auditionUrl}
+          preload="auto"
+          aria-hidden="true"
+          mix={[
+            ref((node, signal) => {
+              auditionRef.current = node as HTMLAudioElement
+              signal.addEventListener('abort', () => {
+                if (auditionRef.current === node) auditionRef.current = null
+              })
+            }),
+            on('play', () => {
+              auditioning = true
+              void handle.update()
+            }),
+            on('pause', () => {
+              auditioning = false
+              void handle.update()
+            }),
+            on('timeupdate', (event) => {
+              const el = event.currentTarget as HTMLAudioElement
+              // The audition plays the kept window only.
+              if (el.currentTime * 1000 >= endMs) el.pause()
+            }),
+          ]}
+        />
+
+        <div className="trim-strip-meta">
+          <span className="audio-detail-name" title={track.name}>
+            <IconMusic size={14} />
+            {track.name}
+          </span>
+          <span className="trim-kept-label">{formatDuration(keptMs)} kept</span>
+          {error ? <span className="trim-error">{error}</span> : null}
+        </div>
+
+        <div className="trim-strip-track audio-detail-track">
+          <canvas
+            className="audio-detail-wave"
+            aria-hidden="true"
+            mix={ref((node, signal) => {
+              canvasRef.current = node as HTMLCanvasElement
+              drawWaveform()
+              signal.addEventListener('abort', () => {
+                if (canvasRef.current === node) canvasRef.current = null
+              })
+            })}
+          />
+
+          <div className="trim-dim trim-dim-left" style={{ width: `${startPct}%` }} aria-hidden />
+          <div
+            className="trim-dim trim-dim-right"
+            style={{ width: `${100 - endPct}%` }}
+            aria-hidden
+          />
+
+          <div
+            className="trim-selection"
+            style={{ left: `${startPct}%`, width: `${Math.max(0, endPct - startPct)}%` }}
+            aria-hidden
+          />
+
+          <button
+            type="button"
+            className={`trim-handle trim-handle-left${activeHandle === 'start' ? ' active' : ''}`}
+            style={{ left: `${startPct}%` }}
+            aria-label="Trim music start"
+            mix={on('pointerdown', (event) => startHandleDrag('start', event))}
+          />
+          <button
+            type="button"
+            className={`trim-handle trim-handle-right${activeHandle === 'end' ? ' active' : ''}`}
+            style={{ left: `${endPct}%` }}
+            aria-label="Trim music end"
+            mix={on('pointerdown', (event) => startHandleDrag('end', event))}
+          />
+        </div>
+
+        <div className="audio-detail-controls">
+          <button
+            type="button"
+            className="btn btn-ghost audio-detail-audition"
+            aria-label={auditioning ? 'Pause the music preview' : 'Preview the kept music'}
+            mix={on('click', () => toggleAudition())}
+          >
+            {auditioning ? <IconPause size={16} /> : <IconPlay size={16} />}
+            Preview
+          </button>
+          <div className="audio-detail-level">
+            <span className="audio-volume-label">Level</span>
+            <input
+              type="range"
+              min={0}
+              max={100}
+              step={5}
+              value={levelPct}
+              aria-label="Track level"
+              aria-valuetext={`${levelPct}% level`}
+              mix={[
+                on('input', (event) => {
+                  volume = Number((event.currentTarget as HTMLInputElement).value) / 100
+                  const el = auditionRef.current
+                  if (el) el.volume = volume
+                  void handle.update()
+                }),
+              ]}
+            />
+            <strong className="audio-detail-level-value">{levelPct}%</strong>
+          </div>
+          <span className="audio-fades" role="group" aria-label="Track fades">
+            <label className="audio-fade-toggle">
+              <input
+                type="checkbox"
+                checked={fadeIn}
+                aria-label="Fade this track in"
+                mix={on('change', (event) => {
+                  fadeIn = (event.currentTarget as HTMLInputElement).checked
+                  void handle.update()
+                })}
+              />
+              Fade in
+            </label>
+            <label className="audio-fade-toggle">
+              <input
+                type="checkbox"
+                checked={fadeOut}
+                aria-label="Fade this track out"
+                mix={on('change', (event) => {
+                  fadeOut = (event.currentTarget as HTMLInputElement).checked
+                  void handle.update()
+                })}
+              />
+              Fade out
+            </label>
+          </span>
+        </div>
+
+        <div className="trim-strip-actions">
+          <button
+            type="button"
+            className="btn btn-ghost"
+            disabled={saving}
+            mix={on('click', () => {
+              stopAudition()
+              props.onCancel()
+            })}
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            className="btn btn-primary"
+            disabled={saving}
+            mix={on('click', onDoneClick)}
+          >
+            {saving ? 'Saving…' : 'Done'}
+          </button>
+        </div>
+      </div>
+    )
+  }
+}

--- a/src/components/audio-strip.tsx
+++ b/src/components/audio-strip.tsx
@@ -9,6 +9,8 @@ import {
   setProjectAudioSettings,
 } from '../lib/project-actions'
 import {
+  audioTrackKeptMs,
+  audioTrackLevel,
   clipAudioVolume,
   formatDuration,
   projectAudioTotalDurationMs,
@@ -33,26 +35,29 @@ interface AudioStripProps {
   plus: boolean
   /** Open the Plus upsell sheet (owned by the page, like restore). */
   onUpsell: () => void
+  /** Open a track's detail view (trim, level, fades) — owned by the editor
+   * screen, like the clip trim view. */
+  onEditTrack: (trackId: string) => void
   showToast: (message: string) => void
   refresh: () => void
 }
 
 /**
  * Background-music panel under the timeline: build a playlist of tracks
- * (played one after the other until the film ends), toggle the fade in/out,
- * set the default volume, and dial the music volume for the selected clip.
- * Volume writes persist on slider release; the label tracks the thumb live.
+ * (played one after the other until the film ends), set the default mix,
+ * and dial the music volume for the selected clip. Tapping a track row
+ * opens its detail view (trim, level, fades — the audio counterpart of the
+ * clip trim view). Volume writes persist on slider release; the label
+ * tracks the thumb live.
  */
 export function AudioStrip(handle: Handle<AudioStripProps>) {
   const { props } = handle
   let busy = false
   const fileInputRef: { current: HTMLInputElement | null } = { current: null }
-  /** Slider/toggle values mid-edit / awaiting the post-write refresh — they
-   * keep the controls steady until props catch up with what was persisted. */
+  /** Slider values mid-edit / awaiting the post-write refresh — they keep
+   * the controls steady until props catch up with what was persisted. */
   let pendingDefault: number | null = null
   let pendingClip: { clipId: ClipId; volume: number } | null = null
-  let pendingFadeIn: boolean | null = null
-  let pendingFadeOut: boolean | null = null
 
   const setBusy = (next: boolean) => {
     busy = next
@@ -89,8 +94,6 @@ export function AudioStrip(handle: Handle<AudioStripProps>) {
         reportError(err, 'project-audio')
         pendingDefault = null
         pendingClip = null
-        pendingFadeIn = null
-        pendingFadeOut = null
         props.showToast('Could not save that change — try again')
         props.refresh()
         void handle.update()
@@ -113,15 +116,6 @@ export function AudioStrip(handle: Handle<AudioStripProps>) {
         setBusy(false)
       }
     })()
-  }
-
-  const setFade = (which: 'fadeIn' | 'fadeOut', enabled: boolean) => {
-    const audio = props.audio
-    if (!audio) return
-    if (which === 'fadeIn') pendingFadeIn = enabled
-    else pendingFadeOut = enabled
-    void handle.update()
-    persist(setProjectAudioSettings(audio.projectId, { [which]: enabled }))
   }
 
   const commitDefaultVolume = (volume: number) => {
@@ -212,8 +206,6 @@ export function AudioStrip(handle: Handle<AudioStripProps>) {
     if (pendingDefault !== null && Math.abs(audio.defaultVolume - pendingDefault) < 0.005) {
       pendingDefault = null
     }
-    if (pendingFadeIn !== null && audio.fadeIn === pendingFadeIn) pendingFadeIn = null
-    if (pendingFadeOut !== null && audio.fadeOut === pendingFadeOut) pendingFadeOut = null
     if (
       pendingClip !== null &&
       (selectedClip?.id !== pendingClip.clipId ||
@@ -240,29 +232,49 @@ export function AudioStrip(handle: Handle<AudioStripProps>) {
     return (
       <div key="audio-strip" className="audio-strip has-track">
         {fileInput}
-        {audio.tracks.map((track, trackIndex) => (
-          <div key={track.id} className="audio-track-row">
-            <span className="audio-track-icon" aria-hidden="true">
-              <IconMusic size={16} />
-            </span>
-            <span
-              className="audio-track-name"
-              title={audio.tracks.length > 1 ? `Track ${trackIndex + 1}: ${track.name}` : track.name}
-            >
-              {track.name}
-            </span>
-            <span className="audio-track-duration muted">{formatDuration(track.durationMs)}</span>
-            <button
-              type="button"
-              className="btn-icon audio-remove"
-              disabled={disabled || busy}
-              aria-label={`Remove music track ${trackIndex + 1} (${track.name})`}
-              mix={on('click', () => removeTrack(track.id))}
-            >
-              <IconClose size={16} />
-            </button>
-          </div>
-        ))}
+        {audio.tracks.map((track, trackIndex) => {
+          const keptMs = audioTrackKeptMs(track)
+          const trimmed = keptMs < track.durationMs
+          const levelPct = Math.round(audioTrackLevel(track) * 100)
+          return (
+            <div key={track.id} className="audio-track-row">
+              <button
+                type="button"
+                className="audio-track-open"
+                disabled={disabled || busy}
+                aria-label={`Edit music track ${trackIndex + 1} (${track.name})`}
+                title="Trim, level, and fades"
+                mix={on('click', () => props.onEditTrack(track.id))}
+              >
+                <span className="audio-track-icon" aria-hidden="true">
+                  <IconMusic size={16} />
+                </span>
+                <span
+                  className="audio-track-name"
+                  title={
+                    audio.tracks.length > 1 ? `Track ${trackIndex + 1}: ${track.name}` : track.name
+                  }
+                >
+                  {track.name}
+                </span>
+                <span className="audio-track-duration muted">
+                  {formatDuration(keptMs)}
+                  {trimmed ? ' kept' : ''}
+                  {levelPct < 100 ? ` · ${levelPct}%` : ''}
+                </span>
+              </button>
+              <button
+                type="button"
+                className="btn-icon audio-remove"
+                disabled={disabled || busy}
+                aria-label={`Remove music track ${trackIndex + 1} (${track.name})`}
+                mix={on('click', () => removeTrack(track.id))}
+              >
+                <IconClose size={16} />
+              </button>
+            </div>
+          )
+        })}
 
         <div className="audio-playlist-row">
           <button
@@ -280,32 +292,6 @@ export function AudioStrip(handle: Handle<AudioStripProps>) {
               Music ends at {formatDuration(musicMs)} of {formatDuration(props.projectDurationMs)}
             </span>
           ) : null}
-          <span className="audio-fades" role="group" aria-label="Music fades">
-            <label className="audio-fade-toggle">
-              <input
-                type="checkbox"
-                checked={pendingFadeIn ?? audio.fadeIn}
-                disabled={disabled || busy}
-                aria-label="Fade the music in at the start"
-                mix={on('change', (event) => {
-                  setFade('fadeIn', (event.currentTarget as HTMLInputElement).checked)
-                })}
-              />
-              Fade in
-            </label>
-            <label className="audio-fade-toggle">
-              <input
-                type="checkbox"
-                checked={pendingFadeOut ?? audio.fadeOut}
-                disabled={disabled || busy}
-                aria-label="Fade the music out at the end"
-                mix={on('change', (event) => {
-                  setFade('fadeOut', (event.currentTarget as HTMLInputElement).checked)
-                })}
-              />
-              Fade out
-            </label>
-          </span>
         </div>
 
         {selectedClip ? (

--- a/src/components/editor-screen.tsx
+++ b/src/components/editor-screen.tsx
@@ -7,6 +7,7 @@ import {
   importDeviceClips,
   moveSelectedClip,
   removeClip,
+  setAudioTrackSettings,
   trimClip,
   undoLastDelete,
 } from '../lib/project-actions'
@@ -19,6 +20,7 @@ import {
   type ProjectAudioRecord,
   type ProjectId,
 } from '../lib/types'
+import { AudioDetailStrip } from './audio-detail-strip'
 import { AudioStrip } from './audio-strip'
 import { EditorClipPreview, type EditorClipPreviewHandle } from './editor-clip-preview'
 import {
@@ -65,6 +67,9 @@ export function EditorScreen(handle: Handle<EditorScreenProps>) {
   const { props } = handle
   let selectedClipId: ClipId | null = props.clips.at(-1)?.id ?? null
   let trimming = false
+  /** Track whose detail view (trim, level, fades) is open — the audio
+   * counterpart of `trimming`. */
+  let editingTrackId: string | null = null
   let importing = false
   const fileInputRef: { current: HTMLInputElement | null } = { current: null }
   const previewApi: { current: EditorClipPreviewHandle | null } = { current: null }
@@ -130,9 +135,15 @@ export function EditorScreen(handle: Handle<EditorScreenProps>) {
     void handle.update()
   }
 
+  const setEditingTrackId = (next: string | null) => {
+    editingTrackId = next
+    void handle.update()
+  }
+
   const openTrim = (clip: ClipRecord) => {
     previewApi.current?.pause()
     trimming = true
+    editingTrackId = null
     // Seek after the commit: entering trim can remount the preview (the trim
     // override changes its remount key), and the seek must land on the new
     // element so the stage opens on the trim-start frame.
@@ -176,12 +187,14 @@ export function EditorScreen(handle: Handle<EditorScreenProps>) {
       if (trimming) {
         previewApi.current?.pause()
         setTrimming(false)
+      } else if (editingTrackId) {
+        setEditingTrackId(null)
       } else {
         props.onOpenCamera()
       }
       return
     }
-    if (trimming) return
+    if (trimming || editingTrackId) return
     switch (event.code) {
       case 'ArrowLeft':
       case 'ArrowRight': {
@@ -275,12 +288,17 @@ export function EditorScreen(handle: Handle<EditorScreenProps>) {
     const resolvedSelectedId = resolveSelectedId()
     const selected = clips.find((c) => c.id === resolvedSelectedId) ?? null
     const selectedIndex = selected ? clips.findIndex((c) => c.id === selected.id) : -1
+    // Derive the edited track from the loaded audio (no state syncing) —
+    // a removed track simply closes its detail view on the next render.
+    const editingTrack = editingTrackId
+      ? (props.audio?.tracks.find((track) => track.id === editingTrackId) ?? null)
+      : null
 
     refineFilmstrips()
 
     return (
       <div
-        className={`editor-screen${trimming ? ' is-trimming' : ''}${importing ? ' is-importing' : ''}`}
+        className={`editor-screen${trimming ? ' is-trimming' : ''}${editingTrack ? ' is-audio-editing' : ''}${importing ? ' is-importing' : ''}`}
         mix={ref((_node, signal) => {
           window.addEventListener('keydown', onWindowKeyDown)
           signal.addEventListener('abort', () => {
@@ -379,6 +397,19 @@ export function EditorScreen(handle: Handle<EditorScreenProps>) {
                 setTrimming(false)
               }}
             />
+          ) : editingTrack && props.audio ? (
+            <AudioDetailStrip
+              key={editingTrack.id}
+              track={editingTrack}
+              playlist={props.audio}
+              trackIndex={props.audio.tracks.findIndex((track) => track.id === editingTrack.id)}
+              onCancel={() => setEditingTrackId(null)}
+              onDone={async (draft) => {
+                await setAudioTrackSettings(props.audio!.projectId, editingTrack.id, draft)
+                props.refresh()
+                setEditingTrackId(null)
+              }}
+            />
           ) : (
             <Timeline
               projectId={project.id}
@@ -396,7 +427,7 @@ export function EditorScreen(handle: Handle<EditorScreenProps>) {
             />
           )}
 
-          {!trimming ? (
+          {!trimming && !editingTrack ? (
             <AudioStrip
               ensureProjectId={props.ensureProjectId}
               audio={props.audio}
@@ -406,12 +437,17 @@ export function EditorScreen(handle: Handle<EditorScreenProps>) {
               disabled={importing}
               plus={props.plus}
               onUpsell={props.onUpsell}
+              onEditTrack={(trackId) => {
+                previewApi.current?.pause()
+                trimming = false
+                setEditingTrackId(trackId)
+              }}
               showToast={props.showToast}
               refresh={props.refresh}
             />
           ) : null}
 
-          {!trimming ? (
+          {!trimming && !editingTrack ? (
             <div className="editor-actions" role="toolbar" aria-label="Clip actions">
               <ActionButton
                 label="Delete"

--- a/src/components/playback-overlay.tsx
+++ b/src/components/playback-overlay.tsx
@@ -446,6 +446,10 @@ export function PlaybackOverlay(handle: Handle<PlaybackOverlayProps>) {
           const mediaEndSec = Number.isFinite(el.duration) ? el.duration : Infinity
           if (endSec < mediaEndSec - 0.05 && el.currentTime >= endSec - 0.03) {
             advanceMusicTrack()
+            // A trimmed LAST track still has media past its kept window —
+            // the playlist ending here must silence the element (an
+            // untrimmed last track ends itself via 'ended').
+            if (playlistDone) el.pause()
           }
         }
       }

--- a/src/components/playback-overlay.tsx
+++ b/src/components/playback-overlay.tsx
@@ -1,10 +1,11 @@
 import type { Handle } from 'remix/ui'
 import { on, ref } from 'remix/ui'
 import { planExport } from '../lib/export'
-import { FADE_OUT_MS } from '../lib/export/background-audio'
+import { FADE_IN_MS, FADE_OUT_MS } from '../lib/export/background-audio'
 import { measureAudioNormalization } from '../lib/preview-audio-normalization'
 import {
   clipAudioVolume,
+  resolveAudioTrackPlayback,
   type ClipRecord,
   type ProjectAudioRecord,
   type ProjectAudioTrack,
@@ -101,11 +102,21 @@ export function PlaybackOverlay(handle: Handle<PlaybackOverlayProps>) {
     return measured.get(blob)?.scale ?? 1
   }
 
-  /** Track length on the output timeline. The export hands off to the next
-   * playlist track where the previous one's DECODED samples end, which can
-   * differ from the stored metadata duration — prefer the measured value. */
-  const trackDurationMs = (track: ProjectAudioTrack): number =>
-    measured.get(track.blob)?.decodedDurationMs ?? track.durationMs
+  /** The track's playback settings (trim window, level, fades) resolved
+   * against the playlist defaults. */
+  const trackPlayback = (track: ProjectAudioTrack) =>
+    resolveAudioTrackPlayback(track, props.audio!)
+
+  /** Track length on the output timeline: the KEPT (trimmed) window,
+   * clamped to the real media. The export hands off to the next playlist
+   * track where the previous one's DECODED samples end, which can differ
+   * from the stored metadata duration — prefer the measured value. */
+  const trackDurationMs = (track: ProjectAudioTrack): number => {
+    const mediaMs = measured.get(track.blob)?.decodedDurationMs ?? track.durationMs
+    const playback = trackPlayback(track)
+    const endMs = Math.min(playback.trimEndMs, mediaMs)
+    return Math.max(0, endMs - Math.min(playback.trimStartMs, endMs))
+  }
 
   /** A rejected play() surfaces the tap-to-play affordance only for
    * autoplay-policy rejections. AbortError means the attempt was merely
@@ -152,16 +163,19 @@ export function PlaybackOverlay(handle: Handle<PlaybackOverlayProps>) {
     }
   }
 
-  /** Glide both gains toward the export's normalization scales — the clip's
-   * from the current segment, the music's from the loaded playlist track. */
+  /** Glide both gains toward the export's music-side gains — the clip's
+   * normalization from the current segment, the music's normalization
+   * shaped by the loaded track's level and interior fades. */
   const applyNormalizationGains = () => {
     ensureAudioGraph()
     const context = audioContext
     if (!context || !clipGainNode || !musicGainNode || !audioEl) return
     const segment = currentSegment()
     const clipScale = segment ? scaleFor(segment.clip.blob) : 1
-    const trackBlob = props.audio?.tracks[musicTrackIndex]?.blob
-    const musicScale = trackBlob ? scaleFor(trackBlob) : 1
+    const currentTrack = props.audio?.tracks[musicTrackIndex]
+    const musicScale = currentTrack
+      ? scaleFor(currentTrack.blob) * trackMusicGain(currentTrack)
+      : 1
     if (clipScale !== appliedClipScale) {
       appliedClipScale = clipScale
       clipGainNode.gain.setTargetAtTime(clipScale, context.currentTime, 0.05)
@@ -195,14 +209,53 @@ export function PlaybackOverlay(handle: Handle<PlaybackOverlayProps>) {
     return clipAudioVolume(segment.clip, track.defaultVolume) * fadeOutScale()
   }
 
-  /** Mirror the export's end-of-film fade-out in the live preview: inside
-   * the final FADE_OUT_MS the music target scales down toward silence. */
-  const fadeOutScale = () => {
-    if (!props.audio?.fadeOut) return 1
+  const filmTotalMs = () => {
     const segs = resolveSegments()
     const last = segs[segs.length - 1]
-    if (!last) return 1
-    const totalMs = last.offsetMs + (last.endMs - last.startMs)
+    return last ? last.offsetMs + (last.endMs - last.startMs) : 0
+  }
+
+  /** Whether this track's kept window ends before the film does — its own
+   * fade-out is interior then (a film-end cut fades via fadeOutScale). */
+  const trackEndsBeforeFilm = (index: number): boolean => {
+    const tracks = props.audio?.tracks ?? []
+    let end = 0
+    for (let i = 0; i <= index && i < tracks.length; i += 1) {
+      end += trackDurationMs(tracks[i])
+    }
+    return end < filmTotalMs()
+  }
+
+  /** The export's per-track music gain at the element's position: the
+   * track's level shaped by its interior fades (fade-in only for tracks
+   * starting mid-film, fade-out only when the track ends before the film —
+   * the film-edge fades ride the element volume instead). */
+  const trackMusicGain = (track: ProjectAudioTrack): number => {
+    const playback = trackPlayback(track)
+    let gain = playback.volume
+    const el = audioEl
+    if (!el) return gain
+    const posMs = el.currentTime * 1000 - playback.trimStartMs
+    if (playback.fadeIn && musicTrackIndex > 0 && posMs < FADE_IN_MS) {
+      gain *= Math.max(0, posMs / FADE_IN_MS)
+    }
+    if (playback.fadeOut && trackEndsBeforeFilm(musicTrackIndex)) {
+      const tailMs = trackDurationMs(track) - posMs
+      if (tailMs < FADE_OUT_MS) gain *= Math.max(0, tailMs / FADE_OUT_MS)
+    }
+    return gain
+  }
+
+  /** Mirror the export's end-of-film fade-out in the live preview: when
+   * the track playing at the film's end has fade-out on, the music target
+   * scales down toward silence inside the final FADE_OUT_MS. */
+  const fadeOutScale = () => {
+    const audio = props.audio
+    if (!audio) return 1
+    const totalMs = filmTotalMs()
+    if (totalMs <= 0) return 1
+    const covering = trackAtMs(Math.max(0, totalMs - 1))
+    if (!covering || !trackPlayback(audio.tracks[covering.index]).fadeOut) return 1
     const remainingMs = totalMs - timelinePositionMs()
     return Math.max(0, Math.min(1, remainingMs / FADE_OUT_MS))
   }
@@ -274,12 +327,15 @@ export function PlaybackOverlay(handle: Handle<PlaybackOverlayProps>) {
       if (!nearHandOff) {
         musicTrackIndex = target.index
         audio.src = urlForTrack(target.index)
-        audio.currentTime = target.offsetMs / 1000
+        // offsetMs is inside the KEPT window — media time adds the trim.
+        audio.currentTime =
+          (trackPlayback(props.audio.tracks[target.index]).trimStartMs + target.offsetMs) / 1000
         playlistDone = false
       }
       return true
     }
-    const expectedSec = target.offsetMs / 1000
+    const expectedSec =
+      (trackPlayback(props.audio.tracks[target.index]).trimStartMs + target.offsetMs) / 1000
     // Positions inside a finished track's metadata overshoot have no
     // decoded audio behind them — playing there would RESTART the ended
     // element (play() on an ended media element seeks back to 0).
@@ -311,7 +367,7 @@ export function PlaybackOverlay(handle: Handle<PlaybackOverlayProps>) {
     }
     musicTrackIndex = next
     audio.src = urlForTrack(next)
-    audio.currentTime = 0
+    audio.currentTime = trackPlayback(tracks[next]).trimStartMs / 1000
     if (videoEl && !videoEl.paused) void audio.play().catch(() => undefined)
   }
 
@@ -331,9 +387,11 @@ export function PlaybackOverlay(handle: Handle<PlaybackOverlayProps>) {
     const track = props.audio
     if (!track) return
     audioEl = el
-    // No fade-in means the music opens at full clip volume; otherwise the
-    // per-frame glide below fades it in from silence.
-    el.volume = track.fadeIn ? 0 : segmentMusicVolume()
+    // No fade-in on the opening track means the music starts at the clip's
+    // volume; otherwise the per-frame glide below fades it in from silence.
+    const firstTrack = track.tracks[0]
+    const opensWithFade = firstTrack ? trackPlayback(firstTrack).fadeIn : track.fadeIn
+    el.volume = opensWithFade ? 0 : segmentMusicVolume()
 
     // Create the context NOW — as close to the opening tap as possible, so
     // browsers that gate Web Audio on user activation start it running
@@ -378,6 +436,19 @@ export function PlaybackOverlay(handle: Handle<PlaybackOverlayProps>) {
       const dt = Math.min(100, now - last)
       last = now
       applyNormalizationGains()
+      // A trimmed track never reaches its media's end, so 'ended' cannot
+      // fire — hand off to the next track at the kept window's edge.
+      if (!el.paused && musicTrackIndex >= 0 && props.audio) {
+        const playing = props.audio.tracks[musicTrackIndex]
+        if (playing) {
+          const endSec =
+            (trackPlayback(playing).trimStartMs + trackDurationMs(playing)) / 1000
+          const mediaEndSec = Number.isFinite(el.duration) ? el.duration : Infinity
+          if (endSec < mediaEndSec - 0.05 && el.currentTime >= endSec - 0.03) {
+            advanceMusicTrack()
+          }
+        }
+      }
       const target = segmentMusicVolume()
       const alpha = 1 - Math.exp(-dt / MUSIC_VOLUME_TAU_MS)
       const next = el.volume + (target - el.volume) * alpha

--- a/src/lib/export/background-audio.test.ts
+++ b/src/lib/export/background-audio.test.ts
@@ -9,6 +9,7 @@ import {
   boundaryRampHalfMs,
   channelPeak,
   createBackgroundMixer,
+  filmEdgeFades,
   gainAtMs,
   normalizationScale,
   planSegmentGain,
@@ -136,6 +137,61 @@ describe('planSegmentGain', () => {
   it('reads the clip override through segmentVolume', () => {
     expect(segmentVolume({ clip: { audioVolume: 0.7 } } as never, 0.25)).toBe(0.7)
     expect(segmentVolume({ clip: {} } as never, 0.25)).toBe(0.25)
+  })
+})
+
+describe('filmEdgeFades', () => {
+  const blob = new Blob(['x'])
+  const playlist = { defaultVolume: 0.25, fadeIn: true, fadeOut: true }
+
+  it('reads the film edges from the tracks that play there', () => {
+    const fades = filmEdgeFades(
+      {
+        ...playlist,
+        tracks: [
+          { blob, durationMs: 4_000, fadeIn: false },
+          { blob, durationMs: 20_000, fadeOut: false },
+        ],
+      },
+      6_000,
+    )
+    // The first track opens the film without a fade; the film's end lands
+    // inside track 2, whose fade-out is off.
+    expect(fades).toEqual({ fadeIn: false, fadeOut: false })
+  })
+
+  it('inherits playlist flags for tracks without their own', () => {
+    expect(
+      filmEdgeFades({ ...playlist, tracks: [{ blob, durationMs: 20_000 }] }, 6_000),
+    ).toEqual({ fadeIn: true, fadeOut: true })
+  })
+
+  it('respects trimmed lengths when finding the film-end track', () => {
+    const fades = filmEdgeFades(
+      {
+        ...playlist,
+        tracks: [
+          // Kept window 2s — the film's end at 5s lands in track 2.
+          { blob, durationMs: 20_000, trimStartMs: 3_000, trimEndMs: 5_000 },
+          { blob, durationMs: 20_000, fadeOut: false },
+        ],
+      },
+      5_000,
+    )
+    expect(fades.fadeOut).toBe(false)
+  })
+
+  it('needs no film-end fade when the playlist runs out early', () => {
+    expect(
+      filmEdgeFades({ ...playlist, tracks: [{ blob, durationMs: 3_000 }] }, 10_000),
+    ).toEqual({ fadeIn: true, fadeOut: false })
+  })
+
+  it('handles an empty playlist', () => {
+    expect(filmEdgeFades({ ...playlist, tracks: [] }, 10_000)).toEqual({
+      fadeIn: false,
+      fadeOut: false,
+    })
   })
 })
 
@@ -295,6 +351,70 @@ describe('createBackgroundMixer', () => {
     const mixer = createBackgroundMixer(sourceOf([[new Float32Array([0.5, 0.5])]]), 48000)
     await mixer.mixInto(slice, 0, flatEnvelope(0))
     expect(Array.from(slice[0])).toEqual(before)
+  })
+
+  it('scales the music side by the track level, leaving the clip side alone', async () => {
+    const slice = [new Float32Array([0.6, 0.6])]
+    const mixer = createBackgroundMixer(
+      {
+        ...sourceOf([[new Float32Array([0.4, 0.4])]]),
+        getTrackPlayback: () => ({ volume: 0.5, fadeIn: false, fadeOut: false }),
+      },
+      48000,
+    )
+    // out = clip·(1 − g) + music·g·level = 0.6·0.5 + 0.4·0.5·0.5 = 0.4.
+    await mixer.mixInto(slice, 0, flatEnvelope(0.5))
+    for (const sample of slice[0]) {
+      expect(sample).toBeCloseTo(0.4)
+    }
+  })
+
+  it('fades a mid-film track in and an early-ending track out', async () => {
+    // sampleRate 10: FADE_IN_MS (800ms) = 8 frames, FADE_OUT_MS (1200ms) =
+    // 12 frames, both clamped to half of each 4-frame track (2 frames).
+    const mixer = createBackgroundMixer(
+      {
+        ...sourceOf([
+          [new Float32Array(4).fill(0.4)],
+          [new Float32Array(4).fill(0.4)],
+        ]),
+        getTrackPlayback: () => ({ volume: 1, fadeIn: true, fadeOut: true }),
+        totalFrames: 100,
+      },
+      10,
+    )
+    const slice = [new Float32Array(8)]
+    await mixer.mixInto(slice, 0, flatEnvelope(1))
+    const samples = Array.from(slice[0]).map((v) => Number(v.toFixed(2)))
+    // Track 0 starts the film — its fade-in belongs to the share envelope,
+    // so it opens at full level; its end (before the film's) fades out.
+    expect(samples.slice(0, 2)).toEqual([0.4, 0.4])
+    expect(samples[2]).toBeCloseTo(0.4 * (2 / 2), 2)
+    expect(samples[3]).toBeCloseTo(0.4 * (1 / 2), 2)
+    // Track 1 starts mid-film — it fades in…
+    expect(samples[4]).toBeCloseTo(0, 2)
+    expect(samples[5]).toBeCloseTo(0.4 * (1 / 2), 2)
+    // …and fades out at its own end.
+    expect(samples[6]).toBeCloseTo(0.4 * (2 / 2), 2)
+    expect(samples[7]).toBeCloseTo(0.4 * (1 / 2), 2)
+  })
+
+  it('skips a track\u2019s own fade-out when the film cuts it off', async () => {
+    const mixer = createBackgroundMixer(
+      {
+        ...sourceOf([[new Float32Array(4).fill(0.4)]]),
+        getTrackPlayback: () => ({ volume: 1, fadeIn: true, fadeOut: true }),
+        // The film ends where (or before) the track does — the share
+        // envelope's film-edge fade covers that cut instead.
+        totalFrames: 4,
+      },
+      10,
+    )
+    const slice = [new Float32Array(4)]
+    await mixer.mixInto(slice, 0, flatEnvelope(1))
+    expect(Array.from(slice[0]).map((v) => Number(v.toFixed(2)))).toEqual([
+      0.4, 0.4, 0.4, 0.4,
+    ])
   })
 
   it('decodes each track at most once (lazy, in order)', async () => {

--- a/src/lib/export/background-audio.ts
+++ b/src/lib/export/background-audio.ts
@@ -1,4 +1,8 @@
-import { clipAudioVolume } from '../types'
+import {
+  clipAudioVolume,
+  resolveAudioTrackPlayback,
+  type AudioTrackPlaybackFields,
+} from '../types'
 import type { PlannedSegment } from './plan'
 
 /**
@@ -52,11 +56,43 @@ export function normalizationScale(peak: number): number {
   return Math.min(MAX_NORMALIZATION_BOOST, NORMALIZED_PEAK / peak)
 }
 
+export interface BackgroundAudioTrack extends AudioTrackPlaybackFields {
+  blob: Blob
+}
+
 export interface BackgroundAudio {
-  tracks: Array<{ blob: Blob }>
+  tracks: BackgroundAudioTrack[]
   defaultVolume: number
+  /** Playlist-level fade defaults for tracks without their own flags. */
   fadeIn: boolean
   fadeOut: boolean
+}
+
+/**
+ * Film-edge fades for the share envelope, read from the tracks that
+ * actually play at the film's edges: the first track's fade-in opens the
+ * film, and the fade-out belongs to whichever track the film's end cuts
+ * off. When the playlist runs out before the film ends there is no music
+ * at the film's end to fade (the playlist-end ramp already eased the clip
+ * sound back), so fadeOut is false.
+ */
+export function filmEdgeFades(
+  background: BackgroundAudio,
+  filmDurationMs: number,
+): BackgroundFades {
+  const first = background.tracks[0]
+  const fadeIn = first ? resolveAudioTrackPlayback(first, background).fadeIn : false
+  let cursor = 0
+  let fadeOut = false
+  for (const track of background.tracks) {
+    const playback = resolveAudioTrackPlayback(track, background)
+    if (filmDurationMs <= cursor + playback.keptMs) {
+      fadeOut = playback.fadeOut
+      break
+    }
+    cursor += playback.keptMs
+  }
+  return { fadeIn, fadeOut }
 }
 
 export interface GainPoint {
@@ -153,11 +189,31 @@ export function gainAtMs(points: GainPoint[], tMs: number): number {
   return points[points.length - 1].volume
 }
 
+/** How one playlist track sits in the music side of the mix. */
+export interface TrackMixPlayback {
+  /** Track level (0–1) — scales the music's contribution only; the clip
+   * side keeps its complement of the share. */
+  volume: number
+  /** Ease this track in where it starts mid-film (the film-start fade
+   * lives in the share envelope instead). */
+  fadeIn: boolean
+  /** Ease this track out where it ends before the film does (a film-end
+   * cut fades via the share envelope instead). */
+  fadeOut: boolean
+}
+
 export interface SequentialBackgroundSource {
   trackCount: number
-  /** Decode track `index` into per-channel data; null = undecodable (the
-   * track is skipped and the next one starts in its place). */
+  /** Decode track `index` into per-channel data (already trimmed to its
+   * kept window); null = undecodable (the track is skipped and the next
+   * one starts in its place). */
   getTrack: (index: number) => Promise<Float32Array[] | null>
+  /** Per-track level + interior fades; absent = unity, no fades. */
+  getTrackPlayback?: (index: number) => TrackMixPlayback
+  /** Film length in output frames — a track whose end lands at or past it
+   * is cut by the film (its own fade-out is skipped; the share envelope's
+   * film-edge fade covers that cut). */
+  totalFrames?: number
 }
 
 export interface BackgroundMixer {
@@ -196,6 +252,32 @@ export function createBackgroundMixer(
    * the foreground ramps from (1 − that share) back to full from here. */
   let exhaustedAtFrame: number | null = null
   let shareAtExhaustion = 0
+  /** The current track's level and precomputed fade windows (in frames of
+   * the track's own timeline; 0 = that fade is off). */
+  let trackVolume = 1
+  let fadeInFrames = 0
+  let fadeOutFrames = 0
+
+  const framesOf = (ms: number) => Math.max(1, Math.round((ms / 1000) * sampleRate))
+
+  const applyTrackPlayback = () => {
+    const playback = source.getTrackPlayback?.(trackIndex)
+    const trackFrames = current![0].length
+    trackVolume = playback?.volume ?? 1
+    // The film-start fade lives in the share envelope — a track fade-in on
+    // top of it would fade twice — so it only applies to tracks that start
+    // mid-film. Same for a film-end cut and the track fade-out.
+    const endsBeforeFilm =
+      source.totalFrames === undefined || trackStartFrame + trackFrames < source.totalFrames
+    fadeInFrames =
+      playback?.fadeIn && trackStartFrame > 0
+        ? Math.min(framesOf(FADE_IN_MS), Math.floor(trackFrames / 2))
+        : 0
+    fadeOutFrames =
+      playback?.fadeOut && endsBeforeFilm
+        ? Math.min(framesOf(FADE_OUT_MS), Math.floor(trackFrames / 2))
+        : 0
+  }
 
   /** Advance until the current track covers `frame` (false = playlist over). */
   const ensureTrackFor = async (frame: number): Promise<boolean> => {
@@ -214,6 +296,7 @@ export function createBackgroundMixer(
       const next = await source.getTrack(trackIndex)
       if (next && next.length > 0 && next[0].length > 0) {
         current = next
+        applyTrackPlayback()
       }
     }
   }
@@ -273,9 +356,21 @@ export function createBackgroundMixer(
         }
         shareAtExhaustion = share
         const sourceIndex = outFrame - trackStartFrame
+        // The music side alone carries the track's level and fades — the
+        // clip keeps the complement of the SHARE, so a quiet track never
+        // makes the clip louder or softer.
+        let musicGain = trackVolume
+        if (fadeInFrames > 0 && sourceIndex < fadeInFrames) {
+          musicGain *= sourceIndex / fadeInFrames
+        }
+        const tailFrames = track[0].length - sourceIndex
+        if (fadeOutFrames > 0 && tailFrames < fadeOutFrames) {
+          musicGain *= tailFrames / fadeOutFrames
+        }
         for (let ch = 0; ch < channels.length; ch += 1) {
           channels[ch][i] = clamp(
-            channels[ch][i] * foregroundScale * (1 - share) + sources[ch][sourceIndex] * share,
+            channels[ch][i] * foregroundScale * (1 - share) +
+              sources[ch][sourceIndex] * share * musicGain,
           )
         }
       }

--- a/src/lib/export/encode-realtime.ts
+++ b/src/lib/export/encode-realtime.ts
@@ -133,11 +133,10 @@ export async function exportRealtime(
       clipGain.gain.value = 1
       clipGain.connect(dest)
       let stopped = false
-      /** True once a track actually started — the FILM-start fade rides the
-       * master gain glide, so only tracks starting mid-film fade themselves
-       * in (matches the mixer's trackStartFrame > 0 gate, even when skipped
-       * tracks leave the first playable one at a later index). */
-      let anyTrackStarted = false
+      /** Output position where the next track starts (the kept windows
+       * played so far) — the realtime mirror of the mixer's
+       * trackStartFrame, used to gate interior fades the same way. */
+      let playlistPositionMs = 0
       let activeSource: AudioBufferSourceNode | null = null
       const playFrom = async (index: number): Promise<void> => {
         if (stopped || !audioContext) return
@@ -171,15 +170,18 @@ export async function exportRealtime(
         const normalize = audioContext.createGain()
         normalize.gain.value = trackGain
         const now = audioContext.currentTime
-        // Interior fades: the film-start fade rides the master gain glide
-        // below, so a track fade-in only applies mid-film; a fade-out past
-        // the film's end simply never gets heard.
-        if (anyTrackStarted && playback.fadeIn) {
+        const trackStartMs = playlistPositionMs
+        playlistPositionMs += keptSec * 1000
+        // Interior fades only, matching the WebCodecs mixer: the
+        // film-start fade rides the master gain glide below, so a track
+        // fade-in applies only mid-film — and a track the film cuts off
+        // fades via the scheduled film-end fade instead of its own.
+        if (playback.fadeIn && trackStartMs > 0) {
           const fadeSec = Math.min(FADE_IN_MS / 1000, keptSec / 2)
           normalize.gain.setValueAtTime(0, now)
           normalize.gain.linearRampToValueAtTime(trackGain, now + fadeSec)
         }
-        if (playback.fadeOut) {
+        if (playback.fadeOut && playlistPositionMs < plan.totalMs) {
           const fadeSec = Math.min(FADE_OUT_MS / 1000, keptSec / 2)
           normalize.gain.setValueAtTime(trackGain, now + keptSec - fadeSec)
           normalize.gain.linearRampToValueAtTime(0, now + keptSec)
@@ -190,7 +192,6 @@ export async function exportRealtime(
           void playFrom(index + 1)
         }
         activeSource = source
-        anyTrackStarted = true
         source.start(now, trimStartSec, keptSec)
       }
       // Deferred to the first painted segment: starting here would let the

--- a/src/lib/export/encode-realtime.ts
+++ b/src/lib/export/encode-realtime.ts
@@ -133,6 +133,11 @@ export async function exportRealtime(
       clipGain.gain.value = 1
       clipGain.connect(dest)
       let stopped = false
+      /** True once a track actually started — the FILM-start fade rides the
+       * master gain glide, so only tracks starting mid-film fade themselves
+       * in (matches the mixer's trackStartFrame > 0 gate, even when skipped
+       * tracks leave the first playable one at a later index). */
+      let anyTrackStarted = false
       let activeSource: AudioBufferSourceNode | null = null
       const playFrom = async (index: number): Promise<void> => {
         if (stopped || !audioContext) return
@@ -169,7 +174,7 @@ export async function exportRealtime(
         // Interior fades: the film-start fade rides the master gain glide
         // below, so a track fade-in only applies mid-film; a fade-out past
         // the film's end simply never gets heard.
-        if (index > 0 && playback.fadeIn) {
+        if (anyTrackStarted && playback.fadeIn) {
           const fadeSec = Math.min(FADE_IN_MS / 1000, keptSec / 2)
           normalize.gain.setValueAtTime(0, now)
           normalize.gain.linearRampToValueAtTime(trackGain, now + fadeSec)
@@ -185,6 +190,7 @@ export async function exportRealtime(
           void playFrom(index + 1)
         }
         activeSource = source
+        anyTrackStarted = true
         source.start(now, trimStartSec, keptSec)
       }
       // Deferred to the first painted segment: starting here would let the

--- a/src/lib/export/encode-realtime.ts
+++ b/src/lib/export/encode-realtime.ts
@@ -1,6 +1,13 @@
 import { pickRecorderMimeType } from '../media'
-import { clipAudioVolume } from '../types'
-import { channelPeak, normalizationScale, type BackgroundAudio } from './background-audio'
+import { clipAudioVolume, resolveAudioTrackPlayback } from '../types'
+import {
+  FADE_IN_MS,
+  FADE_OUT_MS,
+  channelPeak,
+  filmEdgeFades,
+  normalizationScale,
+  type BackgroundAudio,
+} from './background-audio'
 import { clampSegmentToMedia, type ExportPlan } from './plan'
 import {
   PREVIEW_EVERY_N_FRAMES,
@@ -113,6 +120,10 @@ export async function exportRealtime(
   let startBackground: (() => void) | null = null
   let stopBackground: (() => void) | null = null
   const backgroundTracks = options.background?.tracks ?? []
+  /** Film-edge fades come from the tracks at the film's edges. */
+  const backgroundEdgeFades = options.background
+    ? filmEdgeFades(options.background, plan.totalMs)
+    : null
   if (backgroundTracks.length > 0 && audioContext && dest) {
     try {
       const gain = audioContext.createGain()
@@ -136,22 +147,45 @@ export async function exportRealtime(
         const buffer = await decodeBackgroundAudio(backgroundTracks[index].blob)
         if (stopped) return
         if (!buffer) return playFrom(index + 1)
+        // Only the kept (trimmed) window plays, at the track's own level.
+        const playback = resolveAudioTrackPlayback(backgroundTracks[index], options.background!)
+        const trimStartSec = Math.min(playback.trimStartMs / 1000, buffer.duration)
+        const trimEndSec = Math.min(playback.trimEndMs / 1000, buffer.duration)
+        const keptSec = Math.max(0, trimEndSec - trimStartSec)
+        if (keptSec < 0.05) return playFrom(index + 1)
         const source = audioContext.createBufferSource()
         source.buffer = buffer
         // Peak-normalize the track so the mix shares mean the same thing
-        // regardless of how hot the file is mastered.
+        // regardless of how hot the file is mastered (whole-file peak, so
+        // loudness doesn't change with where the track is trimmed), then
+        // apply the track's level on top.
         const channels = Array.from({ length: buffer.numberOfChannels }, (_, ch) =>
           buffer.getChannelData(ch),
         )
+        const trackGain = normalizationScale(channelPeak(channels)) * playback.volume
         const normalize = audioContext.createGain()
-        normalize.gain.value = normalizationScale(channelPeak(channels))
+        normalize.gain.value = trackGain
+        const now = audioContext.currentTime
+        // Interior fades: the film-start fade rides the master gain glide
+        // below, so a track fade-in only applies mid-film; a fade-out past
+        // the film's end simply never gets heard.
+        if (index > 0 && playback.fadeIn) {
+          const fadeSec = Math.min(FADE_IN_MS / 1000, keptSec / 2)
+          normalize.gain.setValueAtTime(0, now)
+          normalize.gain.linearRampToValueAtTime(trackGain, now + fadeSec)
+        }
+        if (playback.fadeOut) {
+          const fadeSec = Math.min(FADE_OUT_MS / 1000, keptSec / 2)
+          normalize.gain.setValueAtTime(trackGain, now + keptSec - fadeSec)
+          normalize.gain.linearRampToValueAtTime(0, now + keptSec)
+        }
         source.connect(normalize)
         normalize.connect(gain)
         source.onended = () => {
           void playFrom(index + 1)
         }
         activeSource = source
-        source.start()
+        source.start(now, trimStartSec, keptSec)
       }
       // Deferred to the first painted segment: starting here would let the
       // music advance through clip preload before any frame is recorded.
@@ -231,7 +265,7 @@ export async function exportRealtime(
             ? 0
             : clipAudioVolume(segment.clip, options.background.defaultVolume)
           const now = audioContext.currentTime
-          if (segmentIndex === 0 && !options.background.fadeIn) {
+          if (segmentIndex === 0 && !backgroundEdgeFades?.fadeIn) {
             // No fade-in: the mix opens at the clip's shares directly.
             backgroundGain.gain.setValueAtTime(share, now)
             clipMixGain.gain.setValueAtTime(1 - share, now)
@@ -246,7 +280,7 @@ export async function exportRealtime(
           // envelope) instead of dropping it.
           const isLast = segmentIndex === plan.segments.length - 1
           const segmentSec = (clamped.endMs - clamped.startMs) / 1000
-          if (isLast && options.background.fadeOut) {
+          if (isLast && backgroundEdgeFades?.fadeOut) {
             const fadeSec = Math.min(1.2, segmentSec / 2)
             if (fadeSec > 0.05) {
               backgroundGain.gain.setTargetAtTime(0, now + segmentSec - fadeSec, fadeSec / 3)
@@ -292,7 +326,7 @@ export async function exportRealtime(
     // as a fade (mirrors the WebCodecs edge ramp). The clip side rises to
     // full in mirror, like the WebCodecs envelope's complement.
     if (backgroundGain && audioContext) {
-      const tau = options.background?.fadeOut ? 0.06 : 0.008
+      const tau = backgroundEdgeFades?.fadeOut ? 0.06 : 0.008
       backgroundGain.gain.setTargetAtTime(0, audioContext.currentTime, tau)
       clipMixGain?.gain.setTargetAtTime(1, audioContext.currentTime, tau)
     }

--- a/src/lib/export/encode-webcodecs.ts
+++ b/src/lib/export/encode-webcodecs.ts
@@ -18,11 +18,12 @@ import {
 } from 'mediabunny'
 import { deriveProjectLocation } from '../geo'
 import { isIosBrowser } from '../platform'
-import type { ClipRecord } from '../types'
+import { resolveAudioTrackPlayback, type ClipRecord } from '../types'
 import {
   boundaryRampHalfMs,
   channelPeak,
   createBackgroundMixer,
+  filmEdgeFades,
   normalizationScale,
   planSegmentGain,
   segmentVolume,
@@ -216,19 +217,47 @@ export async function exportWithWebCodecs(
                 { length: buffer.numberOfChannels },
                 (_, ch) => buffer.getChannelData(ch),
               )
-              // Normalize the track in place (the decode is private).
+              // Normalize the track in place (the decode is private) over
+              // the WHOLE file, not just the kept window — a track's
+              // loudness must not change with where it is trimmed.
               const scale = normalizationScale(channelPeak(channels))
               if (scale !== 1) {
                 for (const data of channels) {
                   for (let i = 0; i < data.length; i += 1) data[i] *= scale
                 }
               }
-              return channels
+              // Only the kept (trimmed) window plays; the next track
+              // starts where it ends.
+              const playback = resolveAudioTrackPlayback(background.tracks[index], background)
+              const startFrame = Math.min(
+                channels[0].length,
+                Math.round((playback.trimStartMs / 1000) * AUDIO_SAMPLE_RATE),
+              )
+              const endFrame = Number.isFinite(playback.trimEndMs)
+                ? Math.min(
+                    channels[0].length,
+                    Math.round((playback.trimEndMs / 1000) * AUDIO_SAMPLE_RATE),
+                  )
+                : channels[0].length
+              if (endFrame <= startFrame) return null
+              if (startFrame === 0 && endFrame === channels[0].length) return channels
+              return channels.map((data) => data.subarray(startFrame, endFrame))
             },
+            getTrackPlayback: (index) => {
+              const playback = resolveAudioTrackPlayback(background.tracks[index], background)
+              return {
+                volume: playback.volume,
+                fadeIn: playback.fadeIn,
+                fadeOut: playback.fadeOut,
+              }
+            },
+            totalFrames: Math.round((plan.totalMs / 1000) * AUDIO_SAMPLE_RATE),
           },
           AUDIO_SAMPLE_RATE,
         )
       : null
+  /** Film-edge fades come from the tracks at the film's edges. */
+  const backgroundEdgeFades = background ? filmEdgeFades(background, plan.totalMs) : null
   const plannedDurationsMs = plan.segments.map((s) => s.endMs - s.startMs)
   /** Volume + real duration of the previous MIXED segment (dropped
    * segments must not become ramp anchors). */
@@ -342,7 +371,7 @@ export async function exportWithWebCodecs(
                     ),
                   }
                 : undefined,
-              fades: background,
+              fades: backgroundEdgeFades ?? background,
             }),
             // Whole-clip peak (not just this trim window) so a clip's
             // loudness doesn't change with where it is trimmed.

--- a/src/lib/export/last-export.ts
+++ b/src/lib/export/last-export.ts
@@ -30,7 +30,17 @@ export function exportSignature(
     ]),
     audio: audio
       ? {
-          tracks: audio.tracks.map((track) => [track.id, track.durationMs]),
+          tracks: audio.tracks.map((track) => [
+            track.id,
+            track.durationMs,
+            // Per-track playback settings, resolved so an explicit value
+            // equal to the default signs identically to no value.
+            track.trimStartMs ?? 0,
+            track.trimEndMs ?? track.durationMs,
+            track.volume ?? 1,
+            track.fadeIn ?? audio.fadeIn,
+            track.fadeOut ?? audio.fadeOut,
+          ]),
           defaultVolume: audio.defaultVolume,
           fadeIn: audio.fadeIn,
           fadeOut: audio.fadeOut,

--- a/src/lib/project-actions.ts
+++ b/src/lib/project-actions.ts
@@ -19,7 +19,9 @@ import {
   updateClipThumbs,
   updateClipTrim,
   updateProjectAudioSettings,
+  updateProjectAudioTrack,
   type ProjectAudioSettings,
+  type ProjectAudioTrackSettings,
 } from './storage'
 import { probeAudioFile } from './audio-import'
 import { estimateExportCacheBytes } from './export/export-cache'
@@ -297,6 +299,15 @@ export async function addProjectAudioFromFile(
 
 export async function removeAudioTrack(projectId: ProjectId, trackId: string): Promise<void> {
   await removeProjectAudioTrack(projectId, trackId)
+}
+
+/** Update one playlist track's playback settings (trim, level, fades). */
+export async function setAudioTrackSettings(
+  projectId: ProjectId,
+  trackId: string,
+  settings: ProjectAudioTrackSettings,
+): Promise<void> {
+  await updateProjectAudioTrack(projectId, trackId, settings)
 }
 
 export async function setProjectAudioSettings(

--- a/src/lib/project-transfer.test.ts
+++ b/src/lib/project-transfer.test.ts
@@ -131,6 +131,45 @@ describe('project backup round trip', () => {
     expect(imported[1].audioVolume).toBeUndefined()
   })
 
+  it('round-trips per-track playback settings (trim, level, fades)', async () => {
+    await markWatermarkRemoved('cs_test_transfer')
+    const audio = fakeAudio(['SONGBYTES', 'MORESONG'])
+    audio.tracks[0] = {
+      ...audio.tracks[0],
+      trimStartMs: 2_000,
+      trimEndMs: 11_000,
+      volume: 0.6,
+      fadeIn: false,
+      fadeOut: true,
+    }
+    const backup = serializeProject(fakeProject('Scored'), [fakeClip('clip_a', 'AAAA')], audio)
+
+    const parsed = await parseProjectBackup(backup)
+    expect(parsed.audio?.tracks[0]).toMatchObject({
+      trimStartMs: 2_000,
+      trimEndMs: 11_000,
+      volume: 0.6,
+      fadeIn: false,
+      fadeOut: true,
+    })
+    // The second track carries no per-track settings at all.
+    expect(parsed.audio?.tracks[1].trimStartMs).toBeUndefined()
+    expect(parsed.audio?.tracks[1].volume).toBeUndefined()
+    expect(parsed.audio?.tracks[1].fadeIn).toBeUndefined()
+
+    const project = await importProjectBackup(parsed)
+    const imported = await getProjectAudio(project.id)
+    expect(imported?.tracks[0]).toMatchObject({
+      trimStartMs: 2_000,
+      trimEndMs: 11_000,
+      volume: 0.6,
+      fadeIn: false,
+      fadeOut: true,
+    })
+    expect(imported?.tracks[1].trimStartMs).toBeUndefined()
+    expect(imported?.tracks[1].volume).toBeUndefined()
+  })
+
   it('imports a music-carrying backup on a free device, skipping the playlist', async () => {
     const backup = serializeProject(fakeProject('Scored'), [fakeClip('clip_a', 'AAAA')], fakeAudio())
     const parsed = await parseProjectBackup(backup)

--- a/src/lib/project-transfer.ts
+++ b/src/lib/project-transfer.ts
@@ -5,6 +5,7 @@ import {
   createProject,
   deleteProject,
   updateClipTrim,
+  updateProjectAudioTrack,
 } from './storage'
 import type { ClipRecord, Project, ProjectAudioRecord } from './types'
 
@@ -44,6 +45,13 @@ interface ManifestAudioTrack {
   mimeType: string
   durationMs: number
   name: string
+  /** Per-track playback settings (absent = whole track, full level,
+   * playlist-default fades). Older app versions ignore these. */
+  trimStartMs?: number
+  trimEndMs?: number
+  volume?: number
+  fadeIn?: boolean
+  fadeOut?: boolean
   /** Byte length of this track, appended after every clip's media bytes
    * (tracks follow in playlist order). */
   byteLength: number
@@ -111,6 +119,11 @@ export function serializeProject(
         mimeType: track.mimeType,
         durationMs: track.durationMs,
         name: track.name,
+        trimStartMs: track.trimStartMs,
+        trimEndMs: track.trimEndMs,
+        volume: track.volume,
+        fadeIn: track.fadeIn,
+        fadeOut: track.fadeOut,
         byteLength: track.blob.size,
       })),
     }
@@ -228,10 +241,17 @@ export async function parseProjectBackup(file: Blob): Promise<ParsedBackup> {
         throw new BackupFormatError('This backup file is damaged')
       }
       const mimeType = typeof track.mimeType === 'string' ? track.mimeType : 'audio/mpeg'
+      const finiteOrUndefined = (value: unknown): number | undefined =>
+        typeof value === 'number' && Number.isFinite(value) && value >= 0 ? value : undefined
       tracks.push({
         mimeType,
         durationMs: track.durationMs,
         name: String(track.name || 'Audio track'),
+        trimStartMs: finiteOrUndefined(track.trimStartMs),
+        trimEndMs: finiteOrUndefined(track.trimEndMs),
+        volume: finiteOrUndefined(track.volume),
+        fadeIn: typeof track.fadeIn === 'boolean' ? track.fadeIn : undefined,
+        fadeOut: typeof track.fadeOut === 'boolean' ? track.fadeOut : undefined,
         blob: file.slice(offset, offset + track.byteLength, mimeType),
       })
       offset += track.byteLength
@@ -307,7 +327,7 @@ export async function importProjectBackup(
     if (parsed.audio && (await isWatermarkRemoved())) {
       for (const track of parsed.audio.tracks) {
         const bytes = await track.blob.arrayBuffer()
-        await addProjectAudioTrack({
+        const record = await addProjectAudioTrack({
           projectId: project.id,
           blob: new Blob([bytes], { type: track.mimeType }),
           mimeType: track.mimeType,
@@ -318,6 +338,22 @@ export async function importProjectBackup(
           fadeIn: parsed.audio.fadeIn,
           fadeOut: parsed.audio.fadeOut,
         })
+        // Restore the track's own playback settings (trim, level, fades).
+        if (
+          track.trimStartMs !== undefined ||
+          track.trimEndMs !== undefined ||
+          track.volume !== undefined ||
+          track.fadeIn !== undefined ||
+          track.fadeOut !== undefined
+        ) {
+          await updateProjectAudioTrack(project.id, record.tracks.at(-1)!.id, {
+            trimStartMs: track.trimStartMs,
+            trimEndMs: track.trimEndMs,
+            volume: track.volume,
+            fadeIn: track.fadeIn,
+            fadeOut: track.fadeOut,
+          })
+        }
       }
     }
     return project

--- a/src/lib/storage.test.ts
+++ b/src/lib/storage.test.ts
@@ -381,6 +381,15 @@ describe('storage layer', () => {
     expect(nudged.tracks[0].trimStartMs).toBe(2_000)
     expect(nudged.tracks[0].trimEndMs).toBe(2_000)
 
+    // Non-finite trim requests keep the stored values — NaN never persists.
+    const junkTrim = await updateProjectAudioTrack(project.id, trackId, {
+      trimStartMs: Number.NaN,
+      trimEndMs: 10_000,
+    })
+    expect(junkTrim.tracks[0].trimStartMs).toBe(2_000)
+    expect(junkTrim.tracks[0].trimEndMs).toBe(10_000)
+    await updateProjectAudioTrack(project.id, trackId, { trimEndMs: 1_000 })
+
     // The level clamps to 0–1 and junk falls back to full volume.
     expect(
       (await updateProjectAudioTrack(project.id, trackId, { volume: 7 })).tracks[0].volume,

--- a/src/lib/storage.test.ts
+++ b/src/lib/storage.test.ts
@@ -24,6 +24,7 @@ import {
   toStoredBlob,
   undoDeleteLastClip,
   updateClipAudioVolume,
+  updateProjectAudioTrack,
   updateClipTrim,
   updateProjectAudioSettings,
 } from './storage'
@@ -344,6 +345,62 @@ describe('storage layer', () => {
     expect(audio?.tracks.map((track) => track.name)).toEqual(['other.wav'])
     await removeProjectAudioTrack(project.id, audio!.tracks[0].id)
     expect(await getProjectAudio(project.id)).toBeUndefined()
+  })
+
+  it('updates one track\u2019s playback settings with clamped trim and level', async () => {
+    await markWatermarkRemoved('cs_test_storage')
+    const project = await createProject('Track settings')
+    const record = await addProjectAudioTrack({
+      projectId: project.id,
+      blob: new Blob(['song'], { type: 'audio/mpeg' }),
+      mimeType: 'audio/mpeg',
+      durationMs: 30_000,
+      name: 'song.mp3',
+    })
+    const trackId = record.tracks[0].id
+
+    const updated = await updateProjectAudioTrack(project.id, trackId, {
+      trimStartMs: 2_000,
+      trimEndMs: 45_000,
+      volume: 0.6,
+      fadeIn: false,
+    })
+    expect(updated.tracks[0]).toMatchObject({
+      trimStartMs: 2_000,
+      trimEndMs: 30_000,
+      volume: 0.6,
+      fadeIn: false,
+    })
+    // Untouched fields survive; fadeOut still inherits from the playlist.
+    expect(updated.tracks[0].fadeOut).toBeUndefined()
+    expect(updated.defaultVolume).toBe(DEFAULT_AUDIO_VOLUME)
+
+    // Partial updates keep the other side of the trim window, and the end
+    // can never cross the start.
+    const nudged = await updateProjectAudioTrack(project.id, trackId, { trimEndMs: 1_000 })
+    expect(nudged.tracks[0].trimStartMs).toBe(2_000)
+    expect(nudged.tracks[0].trimEndMs).toBe(2_000)
+
+    // The level clamps to 0–1 and junk falls back to full volume.
+    expect(
+      (await updateProjectAudioTrack(project.id, trackId, { volume: 7 })).tracks[0].volume,
+    ).toBe(1)
+    expect(
+      (await updateProjectAudioTrack(project.id, trackId, { volume: Number.NaN })).tracks[0]
+        .volume,
+    ).toBe(1)
+
+    // The settings persist.
+    const stored = await getProjectAudio(project.id)
+    expect(stored?.tracks[0]).toMatchObject({ trimStartMs: 2_000, trimEndMs: 2_000, volume: 1 })
+
+    await expect(
+      updateProjectAudioTrack(project.id, 'missing-track', { volume: 0.5 }),
+    ).rejects.toThrow(/track not found/i)
+    const empty = await createProject('No music yet')
+    await expect(
+      updateProjectAudioTrack(empty.id, trackId, { volume: 0.5 }),
+    ).rejects.toThrow(/no background music/i)
   })
 
   it('drops the audio playlist when the project is deleted', async () => {

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -592,9 +592,13 @@ export async function updateProjectAudioTrack(
     throw new Error(!audio ? 'This project has no background music' : 'Music track not found')
   }
   const updatedTrack: ProjectAudioTrack = { ...track }
+  // Non-finite trim requests fall back to the stored values — a NaN must
+  // never persist (it would poison every consumer's playback math).
+  const finiteOr = (value: number | undefined, fallback: number): number =>
+    value !== undefined && Number.isFinite(value) ? value : fallback
   if (settings.trimStartMs !== undefined || settings.trimEndMs !== undefined) {
-    const requestedStart = settings.trimStartMs ?? track.trimStartMs ?? 0
-    const requestedEnd = settings.trimEndMs ?? track.trimEndMs ?? track.durationMs
+    const requestedStart = finiteOr(settings.trimStartMs, track.trimStartMs ?? 0)
+    const requestedEnd = finiteOr(settings.trimEndMs, track.trimEndMs ?? track.durationMs)
     const start = Math.max(0, Math.min(requestedStart, track.durationMs))
     updatedTrack.trimStartMs = start
     updatedTrack.trimEndMs = Math.max(start, Math.min(requestedEnd, track.durationMs))

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -568,6 +568,53 @@ export async function removeProjectAudio(projectId: ProjectId): Promise<void> {
   await touchProject(projectId)
 }
 
+export interface ProjectAudioTrackSettings {
+  trimStartMs?: number
+  trimEndMs?: number
+  volume?: number
+  fadeIn?: boolean
+  fadeOut?: boolean
+}
+
+/** Update one playlist track's playback settings (trim window, level,
+ * fades). Trim values clamp into the media like updateClipTrim. */
+export async function updateProjectAudioTrack(
+  projectId: ProjectId,
+  trackId: string,
+  settings: ProjectAudioTrackSettings,
+): Promise<ProjectAudioRecord> {
+  const db = await getDb()
+  const tx = db.transaction('audio', 'readwrite')
+  const audio = await tx.store.get(projectId)
+  const track = audio?.tracks.find((t) => t.id === trackId)
+  if (!audio || !track) {
+    await tx.done.catch(() => undefined)
+    throw new Error(!audio ? 'This project has no background music' : 'Music track not found')
+  }
+  const updatedTrack: ProjectAudioTrack = { ...track }
+  if (settings.trimStartMs !== undefined || settings.trimEndMs !== undefined) {
+    const requestedStart = settings.trimStartMs ?? track.trimStartMs ?? 0
+    const requestedEnd = settings.trimEndMs ?? track.trimEndMs ?? track.durationMs
+    const start = Math.max(0, Math.min(requestedStart, track.durationMs))
+    updatedTrack.trimStartMs = start
+    updatedTrack.trimEndMs = Math.max(start, Math.min(requestedEnd, track.durationMs))
+  }
+  if (settings.volume !== undefined) {
+    updatedTrack.volume = Number.isFinite(settings.volume)
+      ? Math.max(0, Math.min(1, settings.volume))
+      : 1
+  }
+  if (settings.fadeIn !== undefined) updatedTrack.fadeIn = settings.fadeIn
+  if (settings.fadeOut !== undefined) updatedTrack.fadeOut = settings.fadeOut
+  const updated: ProjectAudioRecord = {
+    ...audio,
+    tracks: audio.tracks.map((t) => (t.id === trackId ? updatedTrack : t)),
+  }
+  await completeTransaction([tx.store.put(updated)], tx)
+  await touchProject(projectId)
+  return updated
+}
+
 export interface ProjectAudioSettings {
   defaultVolume?: number
   fadeIn?: boolean

--- a/src/lib/types.test.ts
+++ b/src/lib/types.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, it } from 'vitest'
-import { effectiveDurationMs, formatDuration } from './types'
+import {
+  audioTrackKeptMs,
+  audioTrackLevel,
+  effectiveDurationMs,
+  formatDuration,
+  projectAudioTotalDurationMs,
+  resolveAudioTrackPlayback,
+} from './types'
 
 describe('duration helpers', () => {
   it('computes effective duration from trim points', () => {
@@ -15,5 +22,87 @@ describe('duration helpers', () => {
   it('formats short and long durations', () => {
     expect(formatDuration(1500)).toBe('1.5s')
     expect(formatDuration(61500)).toBe('1:01.5')
+  })
+})
+
+describe('audio track playback helpers', () => {
+  const playlist = { fadeIn: true, fadeOut: false }
+
+  it('defaults to the whole track at full level with playlist fades', () => {
+    const playback = resolveAudioTrackPlayback({ durationMs: 30_000 }, playlist)
+    expect(playback).toEqual({
+      trimStartMs: 0,
+      trimEndMs: 30_000,
+      keptMs: 30_000,
+      volume: 1,
+      fadeIn: true,
+      fadeOut: false,
+    })
+  })
+
+  it('resolves explicit trim, level, and fades', () => {
+    const playback = resolveAudioTrackPlayback(
+      {
+        durationMs: 30_000,
+        trimStartMs: 5_000,
+        trimEndMs: 12_000,
+        volume: 0.6,
+        fadeIn: false,
+        fadeOut: true,
+      },
+      playlist,
+    )
+    expect(playback).toEqual({
+      trimStartMs: 5_000,
+      trimEndMs: 12_000,
+      keptMs: 7_000,
+      volume: 0.6,
+      fadeIn: false,
+      fadeOut: true,
+    })
+  })
+
+  it('clamps trim points into the media and against each other', () => {
+    const playback = resolveAudioTrackPlayback(
+      { durationMs: 10_000, trimStartMs: 9_000, trimEndMs: 40_000 },
+      playlist,
+    )
+    expect(playback.trimEndMs).toBe(10_000)
+    expect(playback.keptMs).toBe(1_000)
+    // A start past the end collapses to an empty window, never negative.
+    expect(
+      resolveAudioTrackPlayback(
+        { durationMs: 10_000, trimStartMs: 8_000, trimEndMs: 4_000 },
+        playlist,
+      ).keptMs,
+    ).toBe(0)
+  })
+
+  it('keeps an unknown track length open-ended', () => {
+    const playback = resolveAudioTrackPlayback({ trimStartMs: 2_000 }, playlist)
+    expect(playback.trimStartMs).toBe(2_000)
+    expect(playback.trimEndMs).toBe(Infinity)
+  })
+
+  it('clamps the level and treats junk as full volume', () => {
+    expect(audioTrackLevel({})).toBe(1)
+    expect(audioTrackLevel({ volume: 0.4 })).toBe(0.4)
+    expect(audioTrackLevel({ volume: 3 })).toBe(1)
+    expect(audioTrackLevel({ volume: -1 })).toBe(0)
+    expect(audioTrackLevel({ volume: Number.NaN })).toBe(1)
+  })
+
+  it('sums kept (trimmed) lengths for the playlist coverage', () => {
+    expect(audioTrackKeptMs({ durationMs: 8_000, trimStartMs: 1_000, trimEndMs: 5_000 })).toBe(
+      4_000,
+    )
+    expect(
+      projectAudioTotalDurationMs({
+        tracks: [
+          { durationMs: 8_000, trimStartMs: 1_000, trimEndMs: 5_000 },
+          { durationMs: 6_000 },
+        ] as never,
+      }),
+    ).toBe(10_000)
   })
 })

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -59,6 +59,17 @@ export interface ProjectAudioTrack {
   /** Display name (the picked file's name). */
   name: string
   addedAt: number
+  /** Kept range of the track (defaults to the whole file). Only this
+   * window plays; the next track starts where it ends. */
+  trimStartMs?: number
+  trimEndMs?: number
+  /** Track level (0–1) applied to the music side of the mix while this
+   * track plays (default 1 — the clip mix share is unaffected). */
+  volume?: number
+  /** Ease this track in/out where it starts/ends. Absent = inherit the
+   * playlist's fade flags (kept for records made before per-track fades). */
+  fadeIn?: boolean
+  fadeOut?: boolean
 }
 
 /**
@@ -72,18 +83,75 @@ export interface ProjectAudioRecord {
   /** Music's default share (0–1) of the audio mix for clips without a
    * per-clip override; clip sound gets the complement. */
   defaultVolume: number
-  /** Ease the music in at the start of the film (default on). */
+  /** Playlist-level fade defaults, inherited by tracks without their own
+   * fadeIn/fadeOut flags (records made before per-track fades). */
   fadeIn: boolean
-  /** Ease the music out at the end of the film (default on). */
   fadeOut: boolean
 }
 
 /** 25% music / 75% clip sound — sits under speech without drowning it. */
 export const DEFAULT_AUDIO_VOLUME = 0.25
 
+/** The fields that shape how one playlist track plays back. `durationMs`
+ * is optional so export-side track shapes (which may not know it) fit. */
+export interface AudioTrackPlaybackFields {
+  durationMs?: number
+  trimStartMs?: number
+  trimEndMs?: number
+  volume?: number
+  fadeIn?: boolean
+  fadeOut?: boolean
+}
+
+export interface AudioTrackPlayback {
+  trimStartMs: number
+  /** Infinity when the track length is unknown (export shapes without
+   * durationMs and no explicit trim end). */
+  trimEndMs: number
+  keptMs: number
+  volume: number
+  fadeIn: boolean
+  fadeOut: boolean
+}
+
+/** Resolve a track's playback settings against its playlist's defaults:
+ * trim clamped into the media, level defaulting to full, fades falling back
+ * to the playlist flags. */
+export function resolveAudioTrackPlayback(
+  track: AudioTrackPlaybackFields,
+  playlist: { fadeIn: boolean; fadeOut: boolean },
+): AudioTrackPlayback {
+  const durationMs = track.durationMs ?? Infinity
+  const trimEndMs = Math.max(0, Math.min(track.trimEndMs ?? durationMs, durationMs))
+  const trimStartMs = Math.max(0, Math.min(track.trimStartMs ?? 0, trimEndMs))
+  return {
+    trimStartMs,
+    trimEndMs,
+    keptMs: Math.max(0, trimEndMs - trimStartMs),
+    volume: audioTrackLevel(track),
+    fadeIn: track.fadeIn ?? playlist.fadeIn,
+    fadeOut: track.fadeOut ?? playlist.fadeOut,
+  }
+}
+
+/** The track's kept (trimmed) length. */
+export function audioTrackKeptMs(
+  track: Pick<ProjectAudioTrack, 'durationMs' | 'trimStartMs' | 'trimEndMs'>,
+): number {
+  const end = Math.max(0, Math.min(track.trimEndMs ?? track.durationMs, track.durationMs))
+  const start = Math.max(0, Math.min(track.trimStartMs ?? 0, end))
+  return Math.max(0, end - start)
+}
+
+/** The track's level (0–1) on the music side of the mix; default full. */
+export function audioTrackLevel(track: Pick<AudioTrackPlaybackFields, 'volume'>): number {
+  if (track.volume === undefined || !Number.isFinite(track.volume)) return 1
+  return Math.max(0, Math.min(1, track.volume))
+}
+
 /** Total playlist length — what the music can cover before going silent. */
 export function projectAudioTotalDurationMs(audio: Pick<ProjectAudioRecord, 'tracks'>): number {
-  return audio.tracks.reduce((sum, track) => sum + track.durationMs, 0)
+  return audio.tracks.reduce((sum, track) => sum + audioTrackKeptMs(track), 0)
 }
 
 export function clampVolume(volume: number): number {

--- a/src/pages/project-page.tsx
+++ b/src/pages/project-page.tsx
@@ -292,7 +292,15 @@ export function ProjectPage(handle: Handle<ProjectPageProps>) {
           background:
             audio && audio.tracks.length > 0
               ? {
-                  tracks: audio.tracks.map((track) => ({ blob: track.blob })),
+                  tracks: audio.tracks.map((track) => ({
+                    blob: track.blob,
+                    durationMs: track.durationMs,
+                    trimStartMs: track.trimStartMs,
+                    trimEndMs: track.trimEndMs,
+                    volume: track.volume,
+                    fadeIn: track.fadeIn,
+                    fadeOut: track.fadeOut,
+                  })),
                   defaultVolume: audio.defaultVolume,
                   fadeIn: audio.fadeIn,
                   fadeOut: audio.fadeOut,

--- a/src/styles/editor.css
+++ b/src/styles/editor.css
@@ -57,7 +57,8 @@
   transform-origin: center top;
 }
 
-.editor-screen.is-trimming .editor-stage {
+.editor-screen.is-trimming .editor-stage,
+.editor-screen.is-audio-editing .editor-stage {
   flex: 0.9 1 auto;
 }
 
@@ -612,6 +613,119 @@
 .audio-volume-reset:disabled {
   opacity: 0.35;
   cursor: not-allowed;
+}
+
+/* Track rows open the audio detail view */
+.audio-track-open {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex: 1 1 auto;
+  min-width: 0;
+  min-height: 28px;
+  padding: 0;
+  margin: 0;
+  background: none;
+  border: none;
+  text-align: left;
+  cursor: pointer;
+  border-radius: 8px;
+}
+
+.audio-track-open:disabled {
+  opacity: 0.5;
+  cursor: wait;
+}
+
+.audio-track-open:hover .audio-track-name,
+.audio-track-open:focus-visible .audio-track-name {
+  color: var(--accent);
+}
+
+/* Audio track detail view (the audio counterpart of the trim strip) */
+.audio-detail-strip {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  min-height: calc(var(--editor-tile-h) + 52px);
+  animation: editor-trim-in 200ms ease both;
+}
+
+.audio-detail-name {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+  font-size: 0.84rem;
+  font-weight: 600;
+  color: var(--ink);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.audio-detail-name svg {
+  flex: 0 0 auto;
+  color: var(--accent);
+}
+
+.audio-detail-track {
+  background: color-mix(in srgb, var(--accent) 8%, var(--bg-soft));
+}
+
+.audio-detail-wave {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  border-radius: 14px;
+  pointer-events: none;
+}
+
+.audio-detail-controls {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-height: 30px;
+  flex-wrap: wrap;
+}
+
+.audio-detail-audition {
+  min-height: 30px;
+  padding: 0 12px;
+  font-size: 0.78rem;
+  flex: 0 0 auto;
+}
+
+.audio-detail-level {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  flex: 1 1 140px;
+  min-width: 120px;
+}
+
+.audio-detail-level .audio-volume-label {
+  flex: 0 0 auto;
+}
+
+.audio-detail-level input[type='range'] {
+  flex: 1 1 auto;
+  min-width: 40px;
+  height: 26px;
+  accent-color: var(--accent);
+  touch-action: pan-y;
+}
+
+.audio-detail-level-value {
+  flex: 0 0 auto;
+  font-size: 0.74rem;
+  color: var(--ink);
+  font-variant-numeric: tabular-nums;
+}
+
+.audio-detail-strip .audio-fades {
+  margin-left: 0;
 }
 
 /* Per-clip music-volume badge on timeline tiles */

--- a/tests/e2e/background-music.spec.ts
+++ b/tests/e2e/background-music.spec.ts
@@ -83,10 +83,24 @@ async function storedAudio(page: Page) {
           fadeIn: audio.fadeIn,
           fadeOut: audio.fadeOut,
           tracks: audio.tracks.map(
-            (track: { name: string; durationMs: number; blob: Blob }) => ({
+            (track: {
+              name: string
+              durationMs: number
+              blob: Blob
+              trimStartMs?: number
+              trimEndMs?: number
+              volume?: number
+              fadeIn?: boolean
+              fadeOut?: boolean
+            }) => ({
               name: track.name,
               durationMs: track.durationMs,
               size: track.blob.size,
+              trimStartMs: track.trimStartMs ?? null,
+              trimEndMs: track.trimEndMs ?? null,
+              volume: track.volume ?? null,
+              trackFadeIn: track.fadeIn ?? null,
+              trackFadeOut: track.fadeOut ?? null,
             }),
           ),
         }
@@ -147,11 +161,6 @@ test.describe('background music', () => {
       'second-song.wav',
     ])
 
-    // Fade toggles persist (default on).
-    await page.getByRole('checkbox', { name: /Fade the music in/ }).uncheck()
-    await expect.poll(async () => (await storedAudio(page))?.fadeIn).toBe(false)
-    await expect.poll(async () => (await storedAudio(page))?.fadeOut).toBe(true)
-
     // Default mix slider persists (value = music's share).
     await setSlider(page, 'Default audio mix', 40)
     await expect.poll(async () => (await storedAudio(page))?.defaultVolume).toBeCloseTo(0.4)
@@ -185,6 +194,64 @@ test.describe('background music', () => {
     expect(await storedAudio(page)).toBeNull()
   })
 
+  test('track detail view trims, levels, and fades one track', async ({ page }) => {
+    await openPlusEditorWithClips(page, 1)
+    await addMusic(page)
+
+    // A track row opens its detail view — the audio counterpart of Trim.
+    await page.getByRole('button', { name: /Edit music track 1/ }).click()
+    const detail = page.locator('.audio-detail-strip')
+    await expect(detail).toBeVisible()
+    await expect(detail.locator('.trim-handle-left')).toBeVisible()
+    await expect(detail.locator('.trim-handle-right')).toBeVisible()
+    // The timeline, mix rows, and clip actions yield to the detail view.
+    await expect(page.locator('.audio-strip')).toHaveCount(0)
+    await expect(page.locator('.editor-actions')).toHaveCount(0)
+
+    // Escape closes it without saving.
+    await page.keyboard.press('Escape')
+    await expect(detail).toBeHidden()
+    await expect(page.locator('.audio-strip')).toBeVisible()
+
+    // Reopen; drag the end handle to about the middle of the 4s track.
+    await page.getByRole('button', { name: /Edit music track 1/ }).click()
+    const handle = detail.locator('.trim-handle-right')
+    const handleBox = await handle.boundingBox()
+    const trackBox = await detail.locator('.trim-strip-track').boundingBox()
+    if (!handleBox || !trackBox) throw new Error('trim geometry unavailable')
+    const y = handleBox.y + handleBox.height / 2
+    await page.mouse.move(handleBox.x + handleBox.width / 2, y)
+    await page.mouse.down()
+    await page.mouse.move(trackBox.x + trackBox.width * 0.5, y, { steps: 8 })
+    await page.mouse.up()
+    await expect(detail.locator('.trim-kept-label')).toContainText(/kept/)
+
+    // Level + fades are per-track drafts, saved together on Done.
+    await setSlider(page, 'Track level', 60)
+    await detail.getByRole('checkbox', { name: 'Fade this track in' }).uncheck()
+    await detail.getByRole('button', { name: 'Done' }).click()
+    await expect(detail).toBeHidden()
+
+    const audio = await storedAudio(page)
+    const track = audio!.tracks[0]
+    expect(track.trimStartMs).toBe(0)
+    expect(track.trimEndMs).not.toBeNull()
+    expect(track.trimEndMs!).toBeGreaterThan(1000)
+    expect(track.trimEndMs!).toBeLessThan(track.durationMs)
+    expect(track.volume).toBeCloseTo(0.6)
+    expect(track.trackFadeIn).toBe(false)
+    expect(track.trackFadeOut).toBe(true)
+
+    // The row reflects the kept length and level…
+    await expect(page.locator('.audio-track-duration')).toContainText(/kept · 60%/)
+    // …and Cancel discards a fresh draft (the level stays 60%).
+    await page.getByRole('button', { name: /Edit music track 1/ }).click()
+    await setSlider(page, 'Track level', 20)
+    await detail.getByRole('button', { name: 'Cancel' }).click()
+    await expect(detail).toBeHidden()
+    await expect.poll(async () => (await storedAudio(page))?.tracks[0]?.volume).toBeCloseTo(0.6)
+  })
+
   test('export sequences the playlist at per-clip mixes with fades', async ({ page }) => {
     test.slow()
     // Two 3s fixture clips (video-only — the fixture encoder adds no audio
@@ -199,14 +266,22 @@ test.describe('background music', () => {
       const project = (await storage.listProjects())[0]!
       const clips = await storage.getClipsForProject(project.id)
 
-      // Two in-page sine WAVs at DIFFERENT frequencies: track A (4s,
-      // 440 Hz, full amplitude) then track B (20s, 880 Hz, HALF
-      // amplitude). The frequency step at the 4s hand-off proves
-      // sequential playback (a looping track A would keep 440 Hz), and
-      // peak normalization should erase the 2× amplitude difference —
-      // making the RMS ratio between the windows track the mix shares
-      // alone.
-      const makeWav = (seconds: number, amplitude: number, freq: number): Blob => {
+      // Two in-page sine WAVs at DIFFERENT frequencies: track A (8s,
+      // 110 Hz for the first 2s then 440 Hz, full amplitude, TRIMMED to
+      // its 2s–6s window) then track B (20s, 880 Hz, HALF amplitude, at
+      // HALF level). Track A's trim proves the kept window is honored on
+      // both sides: the film never hears the 110 Hz intro (trim start),
+      // and the hand-off to track B lands at 4s (trim end — an untrimmed
+      // 8s track A would still be playing 440 Hz there). Peak
+      // normalization should erase the 2× amplitude difference, so the
+      // RMS ratio between the windows tracks the shares × track B's
+      // level.
+      const makeWav = (
+        seconds: number,
+        amplitude: number,
+        freq: number,
+        introFreq?: number,
+      ): Blob => {
         const rate = 8000
         const samples = rate * seconds
         const bytes = new DataView(new ArrayBuffer(44 + samples * 2))
@@ -227,24 +302,39 @@ test.describe('background music', () => {
         writeAscii(36, 'data')
         bytes.setUint32(40, samples * 2, true)
         for (let i = 0; i < samples; i += 1) {
-          bytes.setInt16(44 + i * 2, Math.round(Math.sin((2 * Math.PI * freq * i) / rate) * amplitude), true)
+          const f = introFreq !== undefined && i < rate * 2 ? introFreq : freq
+          bytes.setInt16(44 + i * 2, Math.round(Math.sin((2 * Math.PI * f * i) / rate) * amplitude), true)
         }
         return new Blob([bytes.buffer], { type: 'audio/wav' })
       }
-      await storage.addProjectAudioTrack({
+      const first = await storage.addProjectAudioTrack({
         projectId: project.id,
-        blob: makeWav(4, 16000, 440),
+        blob: makeWav(8, 16000, 440, 110),
         mimeType: 'audio/wav',
-        durationMs: 4000,
+        durationMs: 8000,
         name: 'track-a.wav',
       })
-      const audio = await storage.addProjectAudioTrack({
+      // Keep track A's 2s–6s window; explicit fade-out off keeps the
+      // hand-off crisp for the frequency windows below.
+      await storage.updateProjectAudioTrack(project.id, first.tracks[0].id, {
+        trimStartMs: 2000,
+        trimEndMs: 6000,
+        fadeOut: false,
+      })
+      const added = await storage.addProjectAudioTrack({
         projectId: project.id,
         blob: makeWav(20, 8000, 880),
         mimeType: 'audio/wav',
         durationMs: 20000,
         name: 'track-b.wav',
       })
+      // Track B plays at HALF level; explicit fade-in off keeps the
+      // post-hand-off measurement window clean.
+      const audio = await storage.updateProjectAudioTrack(
+        project.id,
+        added.tracks[1].id,
+        { volume: 0.5, fadeIn: false },
+      )
       // Clip 1 follows the 0.25 default; clip 2 is overridden to full volume.
       await storage.updateClipAudioVolume(clips[1]!.id, 1)
       const updatedClips = await storage.getClipsForProject(project.id)
@@ -252,7 +342,25 @@ test.describe('background music', () => {
       const result = await exportProject(updatedClips, {
         watermark: false,
         background: {
-          tracks: audio.tracks.map((track: { blob: Blob }) => ({ blob: track.blob })),
+          tracks: audio.tracks.map(
+            (track: {
+              blob: Blob
+              durationMs: number
+              trimStartMs?: number
+              trimEndMs?: number
+              volume?: number
+              fadeIn?: boolean
+              fadeOut?: boolean
+            }) => ({
+              blob: track.blob,
+              durationMs: track.durationMs,
+              trimStartMs: track.trimStartMs,
+              trimEndMs: track.trimEndMs,
+              volume: track.volume,
+              fadeIn: track.fadeIn,
+              fadeOut: track.fadeOut,
+            }),
+          ),
           defaultVolume: audio.defaultVolume,
           fadeIn: audio.fadeIn,
           fadeOut: audio.fadeOut,
@@ -296,18 +404,22 @@ test.describe('background music', () => {
     expect(measured).not.toBeNull()
     // Clip 1 carries audible music from track A.
     expect(measured!.clip1).toBeGreaterThan(0.02)
-    // Sequencing: clip 1 hears track A (440 Hz), clip 2 hears track B
-    // (880 Hz) — a looping track A would keep 440 Hz after the hand-off.
+    // Sequencing + trims: clip 1 hears track A's KEPT window (440 Hz — a
+    // window starting at the file's real 0 would mix in the 110 Hz intro
+    // and read far lower), and clip 2 hears track B (880 Hz) because
+    // track A's trimmed end hands off at 4s (untrimmed, its 8s file
+    // would still be playing 440 Hz there).
     expect(measured!.clip1Freq).toBeGreaterThan(340)
     expect(measured!.clip1Freq).toBeLessThan(540)
     expect(measured!.clip2Freq).toBeGreaterThan(700)
     expect(measured!.clip2Freq).toBeLessThan(1060)
-    // Normalization + mix shares: both tracks normalize to the same peak
-    // despite track B being mastered at HALF the amplitude, so the RMS
-    // ratio tracks the shares alone (1.0 / 0.25 ≈ 4). Without
-    // normalization it would read ≈ 2.
-    expect(measured!.clip2 / measured!.clip1).toBeGreaterThan(2.8)
-    expect(measured!.clip2 / measured!.clip1).toBeLessThan(5.5)
+    // Normalization + shares + track level: both tracks normalize to the
+    // same peak despite track B being mastered at HALF the amplitude, so
+    // the RMS ratio tracks the shares (1.0 / 0.25 = 4) × track B's 0.5
+    // level ≈ 2. Without normalization it would read ≈ 1; with track B's
+    // level ignored, ≈ 4.
+    expect(measured!.clip2 / measured!.clip1).toBeGreaterThan(1.35)
+    expect(measured!.clip2 / measured!.clip1).toBeLessThan(2.8)
     // The film opens inside the fade-in and closes inside the fade-out.
     expect(measured!.fadeIn).toBeLessThan(measured!.clip1 * 0.5)
     expect(measured!.fadeOut).toBeLessThan(measured!.clip2 * 0.5)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Tapping a background-music track row now opens an **audio detail view** — the audio counterpart of the clip Trim view:

- **Trim**: two handles over a decoded waveform bound the track's kept window; only that window plays, and the next playlist track starts where it ends. A hidden audition player previews the kept selection (handles seek it, like trim handles seek the stage video).
- **Level**: a per-track volume (0–100%) that scales the music side of the mix only — the clip side keeps its complement of the share, so a quiet track never changes clip loudness.
- **Fades**: the old playlist-wide Fade in / Fade out toggles moved here as per-track settings — each track eases in where it starts and out where it ends (including the film's edges). Tracks without explicit flags inherit the playlist's stored flags, so existing projects keep their behavior at the film edges and additionally get eased hand-offs between songs.

Everything is a local draft until **Done** persists it; Cancel/Escape discards, mirroring the Trim view.

## How

- `ProjectAudioTrack` gains optional `trimStartMs`, `trimEndMs`, `volume`, `fadeIn`, `fadeOut`; `resolveAudioTrackPlayback` in `src/lib/types.ts` resolves them against playlist defaults. New `updateProjectAudioTrack` in `src/lib/storage.ts` clamps and persists them.
- **WebCodecs engine**: tracks decode → whole-file peak normalization (loudness independent of trim) → slice to the kept window. The sequential mixer applies per-track level and *interior* fades sample-accurately; film-edge fades stay in the share envelope (so the clip side still carries the complement), now derived from the tracks actually playing at the film's edges (`filmEdgeFades`).
- **Realtime fallback**: `source.start(now, trimStart, kept)` plus gain automation for level and fades.
- **Live preview** mirrors it all: kept windows drive the playlist hand-offs (a per-frame check advances at a trimmed end, where `ended` can't fire), the track level and interior fades ride the Web Audio normalization gain, and the film-end fade follows the covering track's flag.
- Export signature, `.kodyvideo` backup manifest, and the playlist coverage hint all account for the new fields (older app versions ignore the unknown manifest fields).

## Testing

- 16 new unit tests: storage clamping, playback resolution helpers, mixer level/interior-fade math, film-edge fade derivation, backup round-trip.
- New e2e test drives the detail view UI (open, Escape, trim drag, level, fades, Done persists, Cancel discards).
- The export e2e now proves trim + level end-to-end: track A carries a 110 Hz intro that its trim must skip and an 8 s file whose trimmed end must hand off at 4 s; track B plays at half level, verified by the RMS ratio.
- Full e2e suite: 57 passed; the 4 remaining failures (`install-hint`, `storage` sweep, one `projects` flake) fail identically on `main` in this VM.

Manual walkthrough in a fake-media Chrome (settings verified persisted in IndexedDB afterwards):

<a href="https://cursor.com/agents/bc-d24d55de-20cf-44b2-8efa-b32e7cd653fa/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Faudio_track_detail_view_trim_level_fades_demo.mp4"><img src="https://cursor.com/artifacts/c/art-f9105061-cc43-4e74-9392-e47ea2e6b7e1" alt="audio_track_detail_view_trim_level_fades_demo.mp4" /></a>

![Audio detail view with waveform, trim handles, level and fades](https://cursor.com/artifacts/c/art-ce9ef3d0-9bc1-4428-9d30-29dec2f8a852)

![Track row after saving: kept duration and level](https://cursor.com/artifacts/c/art-efaa9a30-4480-43c7-873f-b8a700195cbd)

Also adds the `ship-pr` skill to `.cursor/skills/` so agents no longer need to fetch it from Kody.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d24d55de-20cf-44b2-8efa-b32e7cd653fa?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d24d55de-20cf-44b2-8efa-b32e7cd653fa&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added per-track background music editing for trimming, volume, fade-in, and fade-out settings.
  * Added waveform previews with draggable trim handles and bounded playback controls.
  * Track rows now show kept duration and adjusted volume.
  * Audio settings are preserved in project backups and applied consistently during preview and export.

* **Bug Fixes**
  * Improved validation and clamping for trim ranges and volume values.
  * Exported audio now respects each track’s selected playback range and settings.
  * Updated background music documentation with the new editing options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->