### PR TITLE
Check for updates when returning to the app

### DIFF
--- a/src/lib/app-update.test.ts
+++ b/src/lib/app-update.test.ts
@@ -1,0 +1,168 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  checkForUpdates,
+  probeForUpdates,
+  registerUpdateHandles,
+  resetAppUpdateForTests,
+} from './app-update'
+
+function mockRegistration(
+  overrides: Partial<ServiceWorkerRegistration> = {},
+): ServiceWorkerRegistration {
+  return {
+    installing: null,
+    waiting: null,
+    active: null,
+    update: vi.fn().mockResolvedValue(undefined),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    ...overrides,
+  } as unknown as ServiceWorkerRegistration
+}
+
+type Listener = EventListenerOrEventListenerObject
+
+function createDomStub(initialVisibility: DocumentVisibilityState = 'visible') {
+  const listeners = new Map<string, Set<Listener>>()
+  let visibilityState = initialVisibility
+
+  const dispatch = (type: string) => {
+    const event = { type } as Event
+    for (const listener of listeners.get(type) ?? []) {
+      if (typeof listener === 'function') listener(event)
+      else listener.handleEvent(event)
+    }
+  }
+
+  const target = {
+    addEventListener(type: string, listener: Listener) {
+      if (!listeners.has(type)) listeners.set(type, new Set())
+      listeners.get(type)!.add(listener)
+    },
+    removeEventListener(type: string, listener: Listener) {
+      listeners.get(type)?.delete(listener)
+    },
+    dispatchEvent(event: Event) {
+      dispatch(event.type)
+      return true
+    },
+    get visibilityState() {
+      return visibilityState
+    },
+    setVisibility(next: DocumentVisibilityState) {
+      visibilityState = next
+    },
+  }
+
+  vi.stubGlobal('document', target)
+  vi.stubGlobal('window', target)
+  return { ...target, dispatch }
+}
+
+describe('app-update resume checks', () => {
+  beforeEach(() => {
+    resetAppUpdateForTests({ minIntervalMs: 1_000 })
+  })
+
+  afterEach(() => {
+    resetAppUpdateForTests()
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  it('probes the service worker when the document becomes visible again', () => {
+    const dom = createDomStub('visible')
+    const update = vi.fn().mockResolvedValue(undefined)
+    const reg = mockRegistration({ update })
+    const now = vi.spyOn(Date, 'now').mockReturnValue(0)
+    registerUpdateHandles(reg, vi.fn())
+    now.mockReturnValue(2_000)
+
+    dom.setVisibility('hidden')
+    dom.dispatch('visibilitychange')
+    expect(update).not.toHaveBeenCalled()
+
+    dom.setVisibility('visible')
+    dom.dispatch('visibilitychange')
+    expect(update).toHaveBeenCalledTimes(1)
+  })
+
+  it('probes on focus when the tab is visible (iOS resume path)', () => {
+    const dom = createDomStub('visible')
+    const update = vi.fn().mockResolvedValue(undefined)
+    const reg = mockRegistration({ update })
+    const now = vi.spyOn(Date, 'now').mockReturnValue(0)
+    registerUpdateHandles(reg, vi.fn())
+    now.mockReturnValue(2_000)
+
+    dom.dispatch('focus')
+    expect(update).toHaveBeenCalledTimes(1)
+  })
+
+  it('throttles rapid resume signals into a single probe', () => {
+    const dom = createDomStub('visible')
+    const update = vi.fn().mockResolvedValue(undefined)
+    const reg = mockRegistration({ update })
+    const now = vi.spyOn(Date, 'now').mockReturnValue(0)
+    registerUpdateHandles(reg, vi.fn())
+    now.mockReturnValue(2_000)
+
+    dom.dispatch('focus')
+    dom.dispatch('pageshow')
+    dom.dispatch('visibilitychange')
+    expect(update).toHaveBeenCalledTimes(1)
+  })
+
+  it('skips the first post-register resume burst', () => {
+    const dom = createDomStub('visible')
+    const update = vi.fn().mockResolvedValue(undefined)
+    const reg = mockRegistration({ update })
+    const now = vi.spyOn(Date, 'now').mockReturnValue(0)
+    registerUpdateHandles(reg, vi.fn())
+    // Still inside the min-interval window after registration.
+    now.mockReturnValue(500)
+    dom.dispatch('focus')
+    expect(update).not.toHaveBeenCalled()
+  })
+
+  it('probeForUpdates does not apply the waiting worker', () => {
+    createDomStub()
+    const apply = vi.fn()
+    const update = vi.fn().mockResolvedValue(undefined)
+    const reg = mockRegistration({
+      update,
+      waiting: {} as ServiceWorker,
+    })
+    registerUpdateHandles(reg, apply)
+    probeForUpdates()
+    expect(update).toHaveBeenCalledTimes(1)
+    expect(apply).not.toHaveBeenCalled()
+  })
+})
+
+describe('checkForUpdates (manual)', () => {
+  beforeEach(() => {
+    resetAppUpdateForTests()
+  })
+
+  afterEach(() => {
+    resetAppUpdateForTests()
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  it('returns unavailable when no registration is set', async () => {
+    await expect(checkForUpdates()).resolves.toBe('unavailable')
+  })
+
+  it('returns current when update finds no new worker', async () => {
+    createDomStub()
+    vi.useFakeTimers()
+    const reg = mockRegistration()
+    registerUpdateHandles(reg, vi.fn())
+    const resultPromise = checkForUpdates()
+    await vi.advanceTimersByTimeAsync(1_500)
+    await expect(resultPromise).resolves.toBe('current')
+    vi.useRealTimers()
+  })
+})

--- a/src/lib/app-update.ts
+++ b/src/lib/app-update.ts
@@ -1,11 +1,19 @@
 /**
- * Manual update checking for the About page. The service worker registration
- * and the apply function come from the `useRegisterSW` hook in app.tsx; this
- * module just holds them so any screen can trigger a check.
+ * Service-worker update helpers. Registration + apply come from
+ * `registerSW` in app.tsx; this module holds them so any screen can
+ * trigger a check, and so the app can re-check when the user returns.
  */
 
 let registration: ServiceWorkerRegistration | null = null
 let applyUpdate: ((reloadPage?: boolean) => Promise<void>) | null = null
+
+/** Minimum gap between quiet resume probes (visibility/focus/pageshow burst). */
+const DEFAULT_RESUME_MIN_INTERVAL_MS = 30_000
+
+let resumeChecksAttached = false
+let lastQuietProbeAt = 0
+let quietProbeInFlight = false
+let resumeMinIntervalMs = DEFAULT_RESUME_MIN_INTERVAL_MS
 
 export function registerUpdateHandles(
   reg: ServiceWorkerRegistration | null | undefined,
@@ -13,6 +21,10 @@ export function registerUpdateHandles(
 ): void {
   registration = reg ?? null
   applyUpdate = apply
+  // The initial registerSW({ immediate: true }) already probed once —
+  // don't fire again from the first focus/pageshow burst after load.
+  lastQuietProbeAt = Date.now()
+  attachResumeUpdateChecks()
 }
 
 export type UpdateCheckResult = 'updated' | 'current' | 'downloading' | 'unavailable'
@@ -72,6 +84,53 @@ export async function checkForUpdates(): Promise<UpdateCheckResult> {
   return 'current'
 }
 
+/**
+ * Quietly ask the service worker whether a newer version exists. Does not
+ * apply the update — when one is found, vite-plugin-pwa's `onNeedRefresh`
+ * shows the existing toast so the user can choose when to reload.
+ */
+export function probeForUpdates(): void {
+  const reg = registration
+  if (!reg || quietProbeInFlight) return
+  quietProbeInFlight = true
+  lastQuietProbeAt = Date.now()
+  void reg
+    .update()
+    .catch(() => undefined)
+    .finally(() => {
+      quietProbeInFlight = false
+    })
+}
+
+function shouldProbeOnResume(): boolean {
+  if (!registration) return false
+  if (typeof document !== 'undefined' && document.visibilityState === 'hidden') {
+    return false
+  }
+  return Date.now() - lastQuietProbeAt >= resumeMinIntervalMs
+}
+
+function onAppResume(): void {
+  if (!shouldProbeOnResume()) return
+  probeForUpdates()
+}
+
+function onVisibilityChange(): void {
+  if (document.visibilityState !== 'visible') return
+  onAppResume()
+}
+
+function attachResumeUpdateChecks(): void {
+  if (resumeChecksAttached) return
+  if (typeof document === 'undefined' || typeof window === 'undefined') return
+  resumeChecksAttached = true
+  document.addEventListener('visibilitychange', onVisibilityChange)
+  // iOS Safari sometimes skips visibilitychange on PWA resume — focus and
+  // pageshow cover that long-standing gap (same pattern as the camera).
+  window.addEventListener('focus', onAppResume)
+  window.addEventListener('pageshow', onAppResume)
+}
+
 async function applyAndReload(
   apply: (reloadPage?: boolean) => Promise<void>,
 ): Promise<UpdateCheckResult> {
@@ -88,4 +147,23 @@ async function applyAndReload(
     window.location.reload()
   }, 1500)
   return 'updated'
+}
+
+/** Test-only: reset module listeners/state between Vitest cases. */
+export function resetAppUpdateForTests(options?: {
+  minIntervalMs?: number
+}): void {
+  if (resumeChecksAttached && typeof document !== 'undefined') {
+    document.removeEventListener('visibilitychange', onVisibilityChange)
+  }
+  if (resumeChecksAttached && typeof window !== 'undefined') {
+    window.removeEventListener('focus', onAppResume)
+    window.removeEventListener('pageshow', onAppResume)
+  }
+  registration = null
+  applyUpdate = null
+  resumeChecksAttached = false
+  lastQuietProbeAt = 0
+  quietProbeInFlight = false
+  resumeMinIntervalMs = options?.minIntervalMs ?? DEFAULT_RESUME_MIN_INTERVAL_MS
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

We were only discovering new service-worker versions on first load (`registerSW({ immediate: true })`) or when someone tapped **Check for updates** on About. Returning to a backgrounded PWA did not re-probe, so users sometimes had to go find that button manually.

## Change

When the service worker registration is available, quietly call `registration.update()` on app resume:

- `visibilitychange` → visible
- `focus` / `pageshow` (iOS Safari often skips `visibilitychange`)

This does **not** auto-apply. If an update is found, the existing “A new version of Kody Video is ready” toast still offers **Update**. The About button keeps its apply-immediately behavior for an explicit check.

Resume probes are throttled (30s) so the post-load focus/pageshow burst and rapid event cascades do not spam `update()`.

## Test plan

- [x] Unit tests for visibility/focus/pageshow probe, throttle, and quiet (non-applying) probe
- [x] `npm run lint`
- [ ] Manual: install a build, deploy a newer SW, background the PWA, return → toast appears without visiting About

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f817f1c0-d989-4c27-b30c-db52a87bfbd6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f817f1c0-d989-4c27-b30c-db52a87bfbd6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

