### PR TITLE
Preview music audible everywhere: drop Web Audio capture, add the bed to the editor clip stage

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,10 @@ For a phone on the same network, use your machine’s LAN URL over HTTPS, or tun
   changes glide across clip boundaries, and the music fades in/out at the
   start and end of the film (both toggleable, on by default). All of it —
   levels, normalization, fades, track hand-offs — plays the same in the
-  project preview as in the exported file
+  previews as in the exported file: the project preview runs the whole
+  film's bed, and the editor's clip stage plays the music under the
+  selected clip from its exact spot on the film's timeline (normalization
+  boosts cap at the browser's volume ceiling in previews)
 - Project preview playback: tap edges to skip clips, tap middle to stop
 - Up to **6** stable project slots (create / open / rename / delete, poster art from your clips)
 - Big Go CTA: on-device export to **one video file**, then Share (system sheet) or Save

--- a/README.md
+++ b/README.md
@@ -37,14 +37,15 @@ For a phone on the same network, use your machine’s LAN URL over HTTPS, or tun
   after the other under the film (nothing loops — a hint suggests adding
   another track when the music ends before the film does). The mix is
   **relative**: one balance slider per clip splits the audio between the
-  clip's own sound (left) and the music (right) — 80% music means 20% clip
-  sound — so the blend can never clip, and exports **peak-normalize** both
-  sources so the split means the same thing however hot either recording
-  is. Defaults to 25% music under every clip; tap a clip to set its own
-  balance (duck the music under speech, swell it for b-roll). Mix changes
-  glide across clip boundaries, and the music fades in/out at the start and
-  end of the film (both toggleable, on by default) — in the preview and in
-  the exported file
+  clip's own   sound (left) and the music (right) — 80% music means 20% clip
+  sound — so the blend can never clip, and both sources are
+  **peak-normalized** so the split means the same thing however hot either
+  recording is. Defaults to 25% music under every clip; tap a clip to set
+  its own balance (duck the music under speech, swell it for b-roll). Mix
+  changes glide across clip boundaries, and the music fades in/out at the
+  start and end of the film (both toggleable, on by default). All of it —
+  levels, normalization, fades, track hand-offs — plays the same in the
+  project preview as in the exported file
 - Project preview playback: tap edges to skip clips, tap middle to stop
 - Up to **6** stable project slots (create / open / rename / delete, poster art from your clips)
 - Big Go CTA: on-device export to **one video file**, then Share (system sheet) or Save

--- a/src/components/editor-clip-preview.tsx
+++ b/src/components/editor-clip-preview.tsx
@@ -297,7 +297,11 @@ export function EditorClipPreview(handle: Handle<EditorClipPreviewProps>) {
         resyncMusicIfPlaying()
       }
       const position = filmPositionMs()
-      const mix = musicShare() * (position === null ? 1 : fadeScaleAt(position))
+      // Live playlist coverage at the playhead — the playhead can pass the
+      // last decoded sample before the `ended` handler runs, and the mix
+      // must go to zero there like the export's (no bed past the playlist).
+      const musicHere = !musicExhausted && position !== null && trackAtMs(position) !== null
+      const mix = musicHere ? musicShare() * fadeScaleAt(position) : 0
       const trackBlob = props.audio?.tracks[musicTrackIndex]?.blob
       const musicScale = trackBlob ? (peekAudioNormalization(trackBlob)?.scale ?? 1) : 1
       musicVol = glide(musicVol, musicElementVolume(mix, musicScale))
@@ -305,12 +309,9 @@ export function EditorClipPreview(handle: Handle<EditorClipPreviewProps>) {
       const video = media
       if (video) {
         // The clip ducks only under a bed that is actually SOUNDING here:
-        // live playlist coverage (the playhead can pass the last decoded
-        // sample before the `ended` handler runs) and a playing element (a
-        // rejected music play() must not leave the clip quietly ducked
-        // under silence).
-        const covered =
-          !musicExhausted && position !== null && trackAtMs(position) !== null && !el.paused
+        // playlist coverage plus a playing element (a rejected music
+        // play() must not leave the clip quietly ducked under silence).
+        const covered = musicHere && !el.paused
         const clipScale = peekAudioNormalization(props.clip.blob)?.scale ?? 1
         // Where the playlist covers this clip the export blends the clip
         // at its normalized complement; where it doesn't, the clip's own

--- a/src/components/editor-clip-preview.tsx
+++ b/src/components/editor-clip-preview.tsx
@@ -17,6 +17,10 @@ import {
   type ProjectAudioTrack,
 } from '../lib/types'
 
+/** Smoothing time constant for level moves (~settles in 3×) — matches the
+ * project preview's glide feel. */
+const MIX_GLIDE_TAU_MS = 200
+
 export interface EditorClipPreviewHandle {
   seekToMs: (timeMs: number) => void
   pause: () => void
@@ -263,7 +267,21 @@ export function EditorClipPreview(handle: Handle<EditorClipPreviewProps>) {
     // asynchronously and the video element remounts on trim changes —
     // recomputing every frame keeps both sides correct.
     let raf = 0
-    const tick = () => {
+    let last = performance.now()
+    /** Gliding element volumes (null = snap to the first computed target).
+     * Stepping them instead can click — e.g. the export eases the clip
+     * back over PLAYLIST_END_RAMP_MS when the playlist runs out. */
+    let musicVol: number | null = null
+    let clipVol: number | null = null
+    const tick = (now: number) => {
+      const dt = Math.min(100, now - last)
+      last = now
+      const alpha = 1 - Math.exp(-dt / MIX_GLIDE_TAU_MS)
+      const glide = (current: number | null, target: number): number => {
+        if (current === null) return target
+        const next = current + (target - current) * alpha
+        return Math.abs(next - target) < 0.005 ? target : next
+      }
       // A playlist edit (add / remove / reorder) swaps the record identity
       // while this stage stays mounted — the loaded track index and cached
       // URLs belong to the old playlist then.
@@ -271,24 +289,34 @@ export function EditorClipPreview(handle: Handle<EditorClipPreviewProps>) {
         audioFor = props.audio
         resetMusicForPlaylistChange()
       }
+      // A timeline edit (reorder, delete, another clip's trim) moves this
+      // clip's film offset — a playing bed must follow to the new
+      // export-true position instead of playing on from the old one.
+      if (planFor !== props.clips) {
+        resolveSegments()
+        resyncMusicIfPlaying()
+      }
       const position = filmPositionMs()
       const mix = musicShare() * (position === null ? 1 : fadeScaleAt(position))
       const trackBlob = props.audio?.tracks[musicTrackIndex]?.blob
       const musicScale = trackBlob ? (peekAudioNormalization(trackBlob)?.scale ?? 1) : 1
-      el.volume = musicElementVolume(mix, musicScale)
+      musicVol = glide(musicVol, musicElementVolume(mix, musicScale))
+      el.volume = musicVol
       const video = media
       if (video) {
-        // Live per-frame coverage (same stance as the project preview):
-        // the playhead can sit past the playlist's last decoded sample
-        // before the element's `ended` handler runs, and the clip must not
-        // stay ducked under music that is not playing.
+        // The clip ducks only under a bed that is actually SOUNDING here:
+        // live playlist coverage (the playhead can pass the last decoded
+        // sample before the `ended` handler runs) and a playing element (a
+        // rejected music play() must not leave the clip quietly ducked
+        // under silence).
         const covered =
-          !musicExhausted && position !== null && trackAtMs(position) !== null
+          !musicExhausted && position !== null && trackAtMs(position) !== null && !el.paused
         const clipScale = peekAudioNormalization(props.clip.blob)?.scale ?? 1
         // Where the playlist covers this clip the export blends the clip
         // at its normalized complement; where it doesn't, the clip's own
         // sound plays at its normalized full level.
-        video.volume = covered ? clipElementVolume(mix, clipScale) : Math.min(1, clipScale)
+        clipVol = glide(clipVol, covered ? clipElementVolume(mix, clipScale) : Math.min(1, clipScale))
+        video.volume = clipVol
       }
       raf = requestAnimationFrame(tick)
     }

--- a/src/components/editor-clip-preview.tsx
+++ b/src/components/editor-clip-preview.tsx
@@ -1,8 +1,19 @@
 import type { Handle } from 'remix/ui'
-import { on } from 'remix/ui'
+import { on, ref } from 'remix/ui'
+import { planExport } from '../lib/export'
+import {
+  clipElementVolume,
+  musicElementVolume,
+  peekAudioNormalization,
+} from '../lib/preview-audio-normalization'
 import { BlobVideo } from './blob-video'
 import { IconPause, IconPlay } from './icons'
-import type { ClipRecord } from '../lib/types'
+import {
+  clipAudioVolume,
+  type ClipRecord,
+  type ProjectAudioRecord,
+  type ProjectAudioTrack,
+} from '../lib/types'
 
 export interface EditorClipPreviewHandle {
   seekToMs: (timeMs: number) => void
@@ -11,6 +22,12 @@ export interface EditorClipPreviewHandle {
 
 interface EditorClipPreviewProps {
   clip: ClipRecord
+  /** All of the project's clips, in timeline order — the selected clip's
+   * position on the OUTPUT timeline decides which part of the music
+   * playlist plays under it. */
+  clips: ClipRecord[]
+  /** Background-music playlist (null when none / not unlocked). */
+  audio: ProjectAudioRecord | null
   apiRef?: { current: EditorClipPreviewHandle | null }
 }
 
@@ -27,6 +44,8 @@ function nudgeFrame(video: HTMLVideoElement): void {
 /**
  * Stage preview for the selected timeline clip.
  * Tap toggles playback within the trimmed range; expose seek for trim handles.
+ * When the project has background music, the bed plays under the clip at the
+ * level and playlist position the export will render for this clip.
  */
 export function EditorClipPreview(handle: Handle<EditorClipPreviewProps>) {
   const { props } = handle
@@ -40,6 +59,153 @@ export function EditorClipPreview(handle: Handle<EditorClipPreviewProps>) {
    * drag would paint no frames until the pointer rests; instead the newest
    * target waits for `seeked` and is applied then. */
   let pendingSeekSec: number | null = null
+
+  // Music bed under the clip. Plain element volumes carry the export's
+  // normalization scales (see preview-audio-normalization.ts) — the music
+  // at share × scale, the clip's own sound at (1 − share) × its scale.
+  let musicEl: HTMLAudioElement | null = null
+  const trackUrls = new Map<number, string>()
+  let musicTrackIndex = -1
+  /** True when the playlist ran out before/at this clip's film position. */
+  let musicExhausted = false
+
+  // Segment plan cached per clips identity (same pattern as the overlay).
+  let planFor: ClipRecord[] | null = null
+  let segments: ReturnType<typeof planExport>['segments'] = []
+  const resolveSegments = () => {
+    if (planFor !== props.clips) {
+      planFor = props.clips
+      segments = planExport(props.clips).segments
+    }
+    return segments
+  }
+
+  /** The selected clip's planned segment (null when it gets dropped from
+   * the export plan, e.g. a degenerate trim). */
+  const ownSegment = () => resolveSegments().find((s) => s.clip.id === props.clip.id) ?? null
+
+  /** Film (output-timeline) position for the current video time, clamped
+   * into the clip's exported window — while trimming, the stage plays the
+   * whole clip, including parts outside the trim that never export. */
+  const filmPositionMs = (): number | null => {
+    const segment = ownSegment()
+    if (!segment) return null
+    const videoMs = (media?.currentTime ?? 0) * 1000
+    const elapsed = Math.max(0, Math.min(videoMs - segment.startMs, segment.endMs - segment.startMs))
+    return segment.offsetMs + elapsed
+  }
+
+  const trackDurationMs = (track: ProjectAudioTrack): number =>
+    peekAudioNormalization(track.blob)?.decodedDurationMs ?? track.durationMs
+
+  /** Playlist track + in-track offset covering a film position (null when
+   * the playlist has already run out there). */
+  const trackAtMs = (positionMs: number): { index: number; offsetMs: number } | null => {
+    const tracks = props.audio?.tracks ?? []
+    let cursor = 0
+    for (let i = 0; i < tracks.length; i += 1) {
+      if (positionMs < cursor + trackDurationMs(tracks[i])) {
+        return { index: i, offsetMs: positionMs - cursor }
+      }
+      cursor += trackDurationMs(tracks[i])
+    }
+    return null
+  }
+
+  const urlForTrack = (trackIndex: number): string => {
+    let url = trackUrls.get(trackIndex)
+    if (!url) {
+      url = URL.createObjectURL(props.audio!.tracks[trackIndex].blob)
+      trackUrls.set(trackIndex, url)
+    }
+    return url
+  }
+
+  /** This clip's music share of the mix (its override or the default). */
+  const musicShare = (): number =>
+    props.audio ? clipAudioVolume(props.clip, props.audio.defaultVolume) : 0
+
+  /** Put the bed at the export-true position for the current video time and
+   * start it (no-op when there is no music to play there). */
+  const playMusic = () => {
+    const audio = musicEl
+    if (!audio || !props.audio) return
+    const positionMs = filmPositionMs()
+    const target = positionMs === null ? null : trackAtMs(positionMs)
+    if (!target) {
+      musicExhausted = true
+      audio.pause()
+      return
+    }
+    musicExhausted = false
+    if (musicTrackIndex !== target.index) {
+      musicTrackIndex = target.index
+      audio.src = urlForTrack(target.index)
+    }
+    if (Math.abs(audio.currentTime - target.offsetMs / 1000) > 0.05) {
+      audio.currentTime = target.offsetMs / 1000
+    }
+    void audio.play().catch(() => undefined)
+  }
+
+  const pauseMusic = () => {
+    musicEl?.pause()
+  }
+
+  /** A track ran out mid-clip — hand off to the next one. */
+  const advanceMusicTrack = () => {
+    const tracks = props.audio?.tracks ?? []
+    const audio = musicEl
+    if (!audio) return
+    const next = musicTrackIndex + 1
+    if (next >= tracks.length) {
+      musicExhausted = true
+      return
+    }
+    musicTrackIndex = next
+    audio.src = urlForTrack(next)
+    audio.currentTime = 0
+    if (media && !media.paused) void audio.play().catch(() => undefined)
+  }
+
+  const bindMusic = (el: HTMLAudioElement, signal: AbortSignal) => {
+    musicEl = el
+    // Kick the normalization measurements now so the levels are right by
+    // the time playback starts (cached across previews and the overlay).
+    for (const track of props.audio?.tracks ?? []) peekAudioNormalization(track.blob)
+    peekAudioNormalization(props.clip.blob)
+
+    // Per-frame level hold: constant share for one clip, but the measured
+    // scales land asynchronously and the video element remounts on trim
+    // changes — recomputing every frame keeps both sides correct.
+    let raf = 0
+    const tick = () => {
+      const share = musicShare()
+      const trackBlob = props.audio?.tracks[musicTrackIndex]?.blob
+      const musicScale = trackBlob ? (peekAudioNormalization(trackBlob)?.scale ?? 1) : 1
+      el.volume = musicElementVolume(share, musicScale)
+      const video = media
+      if (video) {
+        const covered = !musicExhausted
+        const clipScale = peekAudioNormalization(props.clip.blob)?.scale ?? 1
+        // Where the playlist covers this clip the export blends the clip
+        // at its normalized complement; where it doesn't, the clip's own
+        // sound plays at its normalized full level.
+        video.volume = covered ? clipElementVolume(share, clipScale) : Math.min(1, clipScale)
+      }
+      raf = requestAnimationFrame(tick)
+    }
+    raf = requestAnimationFrame(tick)
+
+    signal.addEventListener('abort', () => {
+      cancelAnimationFrame(raf)
+      el.pause()
+      if (musicEl === el) musicEl = null
+      for (const url of trackUrls.values()) URL.revokeObjectURL(url)
+      trackUrls.clear()
+      musicTrackIndex = -1
+    })
+  }
 
   const setPlaying = (next: boolean) => {
     if (playing === next) return
@@ -114,10 +280,16 @@ export function EditorClipPreview(handle: Handle<EditorClipPreviewProps>) {
     // A stale scrub target must not yank playback once it starts.
     pendingSeekSec = null
 
+    // Start the bed inside the same gesture — a promise continuation is too
+    // late for WebKit's user-activation window.
+    playMusic()
     void video
       .play()
       .then(() => setPlaying(true))
-      .catch(() => setPlaying(false))
+      .catch(() => {
+        pauseMusic()
+        setPlaying(false)
+      })
   }
 
   return () => {
@@ -125,9 +297,20 @@ export function EditorClipPreview(handle: Handle<EditorClipPreviewProps>) {
     const startSec = clip.trimStartMs / 1000
     const endSec = clip.trimEndMs / 1000
     const remountKey = `${clip.id}:${clip.blob.size}:${clip.blob.type}:${clip.trimStartMs}:${clip.trimEndMs}`
+    const hasMusic = (props.audio?.tracks.length ?? 0) > 0
 
     return (
       <div className="editor-clip-preview-wrap">
+        {hasMusic ? (
+          <audio
+            preload="auto"
+            aria-hidden="true"
+            mix={[
+              ref((node, signal) => bindMusic(node as HTMLAudioElement, signal)),
+              on('ended', () => advanceMusicTrack()),
+            ]}
+          />
+        ) : null}
         <BlobVideo
           key={remountKey}
           blob={clip.blob}
@@ -166,7 +349,15 @@ export function EditorClipPreview(handle: Handle<EditorClipPreviewProps>) {
                 setPlaying(false)
               }
             }),
-            on('pause', () => setPlaying(false)),
+            // Every pause path (tap, trim-end stop, imperative pause, the
+            // OS backgrounding the tab) silences the bed. Starting it stays
+            // on the explicit toggle path only — nudgeFrame's play/pause
+            // frame-paint dance also fires 'play', and hooking the bed
+            // there would blip the music on every scrub.
+            on('pause', () => {
+              pauseMusic()
+              setPlaying(false)
+            }),
             on('play', () => setPlaying(true)),
             on('click', togglePlayback),
           ]}

--- a/src/components/editor-clip-preview.tsx
+++ b/src/components/editor-clip-preview.tsx
@@ -178,13 +178,20 @@ export function EditorClipPreview(handle: Handle<EditorClipPreviewProps>) {
       audio.pause()
       return
     }
+    // offsetMs is inside the KEPT window — media time adds the trim.
+    const expectedSec = trackMediaSec(props.audio, target.index, target.offsetMs)
+    // Positions inside a finished track's metadata overshoot have no
+    // decoded audio behind them — playing there would RESTART the ended
+    // element (play() on an ended media element seeks back to 0).
+    const decodedEndSec = Number.isFinite(audio.duration) ? audio.duration : Infinity
+    if (musicExhausted && musicTrackIndex === target.index && expectedSec >= decodedEndSec - 0.05) {
+      return
+    }
     musicExhausted = false
     if (musicTrackIndex !== target.index) {
       musicTrackIndex = target.index
       audio.src = urlForTrack(target.index)
     }
-    // offsetMs is inside the KEPT window — media time adds the trim.
-    const expectedSec = trackMediaSec(props.audio, target.index, target.offsetMs)
     if (Math.abs(audio.currentTime - expectedSec) > 0.05) {
       audio.currentTime = expectedSec
     }
@@ -309,10 +316,13 @@ export function EditorClipPreview(handle: Handle<EditorClipPreviewProps>) {
         }
       }
       const position = filmPositionMs()
-      // Live playlist coverage at the playhead — the playhead can pass the
-      // last decoded sample before the `ended` handler runs, and the mix
-      // must go to zero there like the export's (no bed past the playlist).
-      const musicHere = !musicExhausted && position !== null && trackAtMs(position) !== null
+      // The mix envelope is nonzero only where a bed is actually SOUNDING:
+      // live playlist coverage (the playhead can pass the last decoded
+      // sample before the `ended` handler runs — no bed past the playlist,
+      // like the export) AND a playing element (a rejected music play()
+      // must not leave the clip ducked under silence).
+      const musicHere =
+        !musicExhausted && position !== null && trackAtMs(position) !== null && !el.paused
       const mix = musicHere ? musicShare() * fadeScaleAt(position) : 0
       // The element's volume is the export's music-side gain: envelope ×
       // normalization boost × the track's level and interior fades.
@@ -326,15 +336,12 @@ export function EditorClipPreview(handle: Handle<EditorClipPreviewProps>) {
       el.volume = musicVol
       const video = media
       if (video) {
-        // The clip ducks only under a bed that is actually SOUNDING here:
-        // playlist coverage plus a playing element (a rejected music
-        // play() must not leave the clip quietly ducked under silence).
-        const covered = musicHere && !el.paused
         const clipScale = peekAudioNormalization(props.clip.blob)?.scale ?? 1
-        // Where the playlist covers this clip the export blends the clip
-        // at its normalized complement; where it doesn't, the clip's own
-        // sound plays at its normalized full level.
-        clipVol = glide(clipVol, covered ? clipElementVolume(mix, clipScale) : Math.min(1, clipScale))
+        // The clip's own sound stays coupled to the SAME gliding mix, like
+        // the project preview and the export's playlist-end ease: it
+        // carries the normalized complement under a sounding bed and
+        // returns to its normalized full level exactly as the mix falls.
+        clipVol = glide(clipVol, clipElementVolume(mix, clipScale))
         video.volume = clipVol
       }
       raf = requestAnimationFrame(tick)

--- a/src/components/editor-clip-preview.tsx
+++ b/src/components/editor-clip-preview.tsx
@@ -66,10 +66,17 @@ export function EditorClipPreview(handle: Handle<EditorClipPreviewProps>) {
   // normalization scales (see preview-audio-normalization.ts) — the music
   // at share × scale, the clip's own sound at (1 − share) × its scale.
   let musicEl: HTMLAudioElement | null = null
-  const trackUrls = new Map<number, string>()
+  /** Object URLs keyed by track BLOB — the stage outlives playlist edits
+   * (it is keyed by clip id), so index-keyed URLs would go stale when a
+   * track is removed or reordered. */
+  const trackUrls = new Map<Blob, string>()
   let musicTrackIndex = -1
   /** True when the playlist ran out before/at this clip's film position. */
   let musicExhausted = false
+  /** The playlist record the bed state belongs to — an edit (add / remove /
+   * reorder / new load) swaps the record identity and invalidates the
+   * loaded track index. */
+  let audioFor: ProjectAudioRecord | null = null
 
   // Segment plan cached per clips identity (same pattern as the overlay).
   let planFor: ClipRecord[] | null = null
@@ -137,12 +144,28 @@ export function EditorClipPreview(handle: Handle<EditorClipPreviewProps>) {
   }
 
   const urlForTrack = (trackIndex: number): string => {
-    let url = trackUrls.get(trackIndex)
+    const blob = props.audio!.tracks[trackIndex].blob
+    let url = trackUrls.get(blob)
     if (!url) {
-      url = URL.createObjectURL(props.audio!.tracks[trackIndex].blob)
-      trackUrls.set(trackIndex, url)
+      url = URL.createObjectURL(blob)
+      trackUrls.set(blob, url)
     }
     return url
+  }
+
+  /** The playlist changed under a mounted stage — drop every cached URL and
+   * the loaded-track state, then realign the bed if it should be playing. */
+  const resetMusicForPlaylistChange = () => {
+    for (const url of trackUrls.values()) URL.revokeObjectURL(url)
+    trackUrls.clear()
+    musicTrackIndex = -1
+    musicExhausted = false
+    const audio = musicEl
+    if (!audio) return
+    const wasAudible = media !== null && !media.paused
+    audio.pause()
+    audio.removeAttribute('src')
+    if (wasAudible) playMusic()
   }
 
   /** This clip's music share of the mix (its override or the default). */
@@ -241,6 +264,13 @@ export function EditorClipPreview(handle: Handle<EditorClipPreviewProps>) {
     // recomputing every frame keeps both sides correct.
     let raf = 0
     const tick = () => {
+      // A playlist edit (add / remove / reorder) swaps the record identity
+      // while this stage stays mounted — the loaded track index and cached
+      // URLs belong to the old playlist then.
+      if (audioFor !== props.audio) {
+        audioFor = props.audio
+        resetMusicForPlaylistChange()
+      }
       const position = filmPositionMs()
       const mix = musicShare() * (position === null ? 1 : fadeScaleAt(position))
       const trackBlob = props.audio?.tracks[musicTrackIndex]?.blob
@@ -248,7 +278,12 @@ export function EditorClipPreview(handle: Handle<EditorClipPreviewProps>) {
       el.volume = musicElementVolume(mix, musicScale)
       const video = media
       if (video) {
-        const covered = !musicExhausted
+        // Live per-frame coverage (same stance as the project preview):
+        // the playhead can sit past the playlist's last decoded sample
+        // before the element's `ended` handler runs, and the clip must not
+        // stay ducked under music that is not playing.
+        const covered =
+          !musicExhausted && position !== null && trackAtMs(position) !== null
         const clipScale = peekAudioNormalization(props.clip.blob)?.scale ?? 1
         // Where the playlist covers this clip the export blends the clip
         // at its normalized complement; where it doesn't, the clip's own

--- a/src/components/editor-clip-preview.tsx
+++ b/src/components/editor-clip-preview.tsx
@@ -1,8 +1,10 @@
 import type { Handle } from 'remix/ui'
 import { on, ref } from 'remix/ui'
 import { planExport } from '../lib/export'
+import { FADE_IN_MS, FADE_OUT_MS } from '../lib/export/background-audio'
 import {
   clipElementVolume,
+  measureAudioNormalization,
   musicElementVolume,
   peekAudioNormalization,
 } from '../lib/preview-audio-normalization'
@@ -86,13 +88,35 @@ export function EditorClipPreview(handle: Handle<EditorClipPreviewProps>) {
 
   /** Film (output-timeline) position for the current video time, clamped
    * into the clip's exported window — while trimming, the stage plays the
-   * whole clip, including parts outside the trim that never export. */
+   * whole clip, including parts outside the trim that never export. The
+   * mapping always follows the SAVED trims (the plan the export would
+   * render right now); draft handle positions only exist inside TrimStrip
+   * until Done commits them, and threading them through here would remount
+   * the stage video on every drag. */
   const filmPositionMs = (): number | null => {
     const segment = ownSegment()
     if (!segment) return null
     const videoMs = (media?.currentTime ?? 0) * 1000
     const elapsed = Math.max(0, Math.min(videoMs - segment.startMs, segment.endMs - segment.startMs))
     return segment.offsetMs + elapsed
+  }
+
+  /** The export's film-edge fade envelope at a film position: the music
+   * eases in over the first FADE_IN_MS and out over the last FADE_OUT_MS
+   * (when the toggles are on) — the first/last clips must sound like the
+   * exported film, not open at full level. */
+  const fadeScaleAt = (positionMs: number): number => {
+    const audio = props.audio
+    if (!audio) return 1
+    const segs = resolveSegments()
+    const last = segs[segs.length - 1]
+    const totalMs = last ? last.offsetMs + (last.endMs - last.startMs) : 0
+    const fadeIn = audio.fadeIn ? Math.max(0, Math.min(1, positionMs / FADE_IN_MS)) : 1
+    const fadeOut =
+      audio.fadeOut && totalMs > 0
+        ? Math.max(0, Math.min(1, (totalMs - positionMs) / FADE_OUT_MS))
+        : 1
+    return Math.min(fadeIn, fadeOut)
   }
 
   const trackDurationMs = (track: ProjectAudioTrack): number =>
@@ -152,6 +176,34 @@ export function EditorClipPreview(handle: Handle<EditorClipPreviewProps>) {
     musicEl?.pause()
   }
 
+  /** A landed measurement can move the playlist's boundaries (decoded
+   * lengths replace metadata durations) — realign a PLAYING bed to the
+   * corrected, export-true position. Small in-track drift is left alone,
+   * same stance as the project preview, so accurate metadata re-seeks
+   * nothing. */
+  const resyncMusicIfPlaying = () => {
+    const audio = musicEl
+    if (!audio || audio.paused) return
+    const positionMs = filmPositionMs()
+    const target = positionMs === null ? null : trackAtMs(positionMs)
+    if (!target) {
+      musicExhausted = true
+      audio.pause()
+      return
+    }
+    musicExhausted = false
+    if (musicTrackIndex !== target.index) {
+      musicTrackIndex = target.index
+      audio.src = urlForTrack(target.index)
+      audio.currentTime = target.offsetMs / 1000
+      void audio.play().catch(() => undefined)
+      return
+    }
+    if (Math.abs(audio.currentTime - target.offsetMs / 1000) > 0.35) {
+      audio.currentTime = target.offsetMs / 1000
+    }
+  }
+
   /** A track ran out mid-clip — hand off to the next one. */
   const advanceMusicTrack = () => {
     const tracks = props.audio?.tracks ?? []
@@ -170,20 +222,30 @@ export function EditorClipPreview(handle: Handle<EditorClipPreviewProps>) {
 
   const bindMusic = (el: HTMLAudioElement, signal: AbortSignal) => {
     musicEl = el
-    // Kick the normalization measurements now so the levels are right by
-    // the time playback starts (cached across previews and the overlay).
-    for (const track of props.audio?.tracks ?? []) peekAudioNormalization(track.blob)
-    peekAudioNormalization(props.clip.blob)
+    // Measure every source now (one decode at a time, cached across
+    // previews and the overlay) so the levels and playlist boundaries are
+    // right by the time playback starts — and realign a bed that already
+    // started if a landed measurement moved a boundary under it.
+    void (async () => {
+      const blobs = [...(props.audio?.tracks ?? []).map((t) => t.blob), props.clip.blob]
+      for (const blob of blobs) {
+        if (musicEl !== el) return
+        await measureAudioNormalization(blob)
+        resyncMusicIfPlaying()
+      }
+    })()
 
-    // Per-frame level hold: constant share for one clip, but the measured
-    // scales land asynchronously and the video element remounts on trim
-    // changes — recomputing every frame keeps both sides correct.
+    // Per-frame level hold: constant share for one clip (times the film's
+    // edge-fade envelope at the playhead), but the measured scales land
+    // asynchronously and the video element remounts on trim changes —
+    // recomputing every frame keeps both sides correct.
     let raf = 0
     const tick = () => {
-      const share = musicShare()
+      const position = filmPositionMs()
+      const mix = musicShare() * (position === null ? 1 : fadeScaleAt(position))
       const trackBlob = props.audio?.tracks[musicTrackIndex]?.blob
       const musicScale = trackBlob ? (peekAudioNormalization(trackBlob)?.scale ?? 1) : 1
-      el.volume = musicElementVolume(share, musicScale)
+      el.volume = musicElementVolume(mix, musicScale)
       const video = media
       if (video) {
         const covered = !musicExhausted
@@ -191,7 +253,7 @@ export function EditorClipPreview(handle: Handle<EditorClipPreviewProps>) {
         // Where the playlist covers this clip the export blends the clip
         // at its normalized complement; where it doesn't, the clip's own
         // sound plays at its normalized full level.
-        video.volume = covered ? clipElementVolume(share, clipScale) : Math.min(1, clipScale)
+        video.volume = covered ? clipElementVolume(mix, clipScale) : Math.min(1, clipScale)
       }
       raf = requestAnimationFrame(tick)
     }

--- a/src/components/editor-screen.tsx
+++ b/src/components/editor-screen.tsx
@@ -355,6 +355,8 @@ export function EditorScreen(handle: Handle<EditorScreenProps>) {
                     }
                   : selected
               }
+              clips={clips}
+              audio={props.audio}
               apiRef={previewApi}
             />
           ) : (

--- a/src/components/playback-overlay.tsx
+++ b/src/components/playback-overlay.tsx
@@ -2,7 +2,12 @@ import type { Handle } from 'remix/ui'
 import { on, ref } from 'remix/ui'
 import { planExport } from '../lib/export'
 import { FADE_OUT_MS } from '../lib/export/background-audio'
-import { measureAudioNormalization } from '../lib/preview-audio-normalization'
+import {
+  clipElementVolume,
+  measureAudioNormalization,
+  musicElementVolume,
+  peekAudioNormalization,
+} from '../lib/preview-audio-normalization'
 import {
   clipAudioVolume,
   type ClipRecord,
@@ -71,41 +76,21 @@ export function PlaybackOverlay(handle: Handle<PlaybackOverlayProps>) {
 
   // Export-fidelity levels: the export peak-normalizes BOTH sources toward
   // the same peak before blending by the mix share (a quietly mastered song
-  // is boosted up to 4×), so element volumes alone would play the music at
-  // the wrong level relative to the clips. One Web Audio gain per element
-  // carries its source's normalization scale (the element volume keeps
-  // carrying the share/fade glide) — the product is the export's gain, and
-  // gains above 1 need Web Audio anyway (element volume caps at 1).
-  let audioContext: AudioContext | null = null
-  let clipGainNode: GainNode | null = null
-  let musicGainNode: GainNode | null = null
-  let graphFailed = false
-  let appliedClipScale = 1
-  let appliedMusicScale = 1
-  /** Measured per source blob: the export's normalization gain + decoded
-   * length (kicked off when the preview opens, glides in when it lands). */
-  const measured = new Map<Blob, { scale: number; decodedDurationMs: number | null }>()
-  const measuring = new Set<Blob>()
+  // is boosted up to 4×). The previews carry those measured scales through
+  // plain element volumes, clamped to the ceiling of 1 — deliberately NOT
+  // through a Web Audio media-element graph, whose captured elements go
+  // permanently silent on WebKit/iOS whenever the context is not running.
+  // See preview-audio-normalization.ts for the trade-off.
 
-  const requestMeasure = (blob: Blob) => {
-    if (measured.has(blob) || measuring.has(blob)) return
-    measuring.add(blob)
-    void measureAudioNormalization(blob).then((info) => {
-      measured.set(blob, info)
-    })
-  }
-
-  /** Normalization gain the export applies to this source (1 until measured). */
-  const scaleFor = (blob: Blob): number => {
-    requestMeasure(blob)
-    return measured.get(blob)?.scale ?? 1
-  }
+  /** Normalization gain the export applies to this source (1 until the
+   * background measurement lands). */
+  const scaleFor = (blob: Blob): number => peekAudioNormalization(blob)?.scale ?? 1
 
   /** Track length on the output timeline. The export hands off to the next
    * playlist track where the previous one's DECODED samples end, which can
    * differ from the stored metadata duration — prefer the measured value. */
   const trackDurationMs = (track: ProjectAudioTrack): number =>
-    measured.get(track.blob)?.decodedDurationMs ?? track.durationMs
+    peekAudioNormalization(track.blob)?.decodedDurationMs ?? track.durationMs
 
   /** A rejected play() surfaces the tap-to-play affordance only for
    * autoplay-policy rejections. AbortError means the attempt was merely
@@ -114,65 +99,6 @@ export function PlaybackOverlay(handle: Handle<PlaybackOverlayProps>) {
    * controls then is wrong (and blocks the button underneath). */
   const rejectionNeedsTap = (error: unknown): boolean =>
     !(error instanceof DOMException && error.name === 'AbortError')
-
-  /** Synchronous, gesture-time nudge for a suspended context: Safari (and
-   * iOS in particular) only honors resume() called from inside a
-   * user-gesture handler — the async promise continuations where playback
-   * starts are too late there. Called at the top of every tap/key path. */
-  const resumeAudioContextFromGesture = () => {
-    if (audioContext?.state === 'suspended') {
-      void audioContext.resume().catch(() => undefined)
-    }
-  }
-
-  /** Route both elements through per-source normalization gains. Wired only
-   * once the context is RUNNING: elements captured by a suspended graph go
-   * silent, while unwired elements still play (at share volume, just
-   * without the normalization scales). */
-  const ensureAudioGraph = () => {
-    if (graphFailed || clipGainNode || !videoEl || !audioEl) return
-    try {
-      audioContext ??= new AudioContext()
-      if (audioContext.state !== 'running') return
-      const clip = audioContext.createGain()
-      const music = audioContext.createGain()
-      // Destination first: if capturing the second element throws below,
-      // the first one is already wired through and stays audible.
-      clip.connect(audioContext.destination)
-      music.connect(audioContext.destination)
-      audioContext.createMediaElementSource(videoEl).connect(clip)
-      audioContext.createMediaElementSource(audioEl).connect(music)
-      clipGainNode = clip
-      musicGainNode = music
-      // Test observability: the gain nodes are unreachable from the DOM.
-      audioEl.dataset.clipScale = String(appliedClipScale)
-      audioEl.dataset.musicScale = String(appliedMusicScale)
-    } catch {
-      graphFailed = true
-    }
-  }
-
-  /** Glide both gains toward the export's normalization scales — the clip's
-   * from the current segment, the music's from the loaded playlist track. */
-  const applyNormalizationGains = () => {
-    ensureAudioGraph()
-    const context = audioContext
-    if (!context || !clipGainNode || !musicGainNode || !audioEl) return
-    const segment = currentSegment()
-    const clipScale = segment ? scaleFor(segment.clip.blob) : 1
-    const trackBlob = props.audio?.tracks[musicTrackIndex]?.blob
-    const musicScale = trackBlob ? scaleFor(trackBlob) : 1
-    if (clipScale !== appliedClipScale) {
-      appliedClipScale = clipScale
-      clipGainNode.gain.setTargetAtTime(clipScale, context.currentTime, 0.05)
-      audioEl.dataset.clipScale = String(clipScale)
-    }
-    if (musicScale !== appliedMusicScale) {
-      appliedMusicScale = musicScale
-      musicGainNode.gain.setTargetAtTime(musicScale, context.currentTime, 0.05)
-      audioEl.dataset.musicScale = String(musicScale)
-    }
-  }
 
   const currentSegment = () => resolveSegments()[index] ?? null
   const startSec = () => {
@@ -265,7 +191,7 @@ export function PlaybackOverlay(handle: Handle<PlaybackOverlayProps>) {
         .slice(0, target.index + 1)
         .reduce((sum, track) => sum + trackDurationMs(track), 0)
       const overshootPossible =
-        measured.get(props.audio.tracks[target.index].blob)?.decodedDurationMs == null
+        peekAudioNormalization(props.audio.tracks[target.index].blob)?.decodedDurationMs == null
       const nearHandOff =
         overshootPossible &&
         target.index < musicTrackIndex &&
@@ -316,9 +242,6 @@ export function PlaybackOverlay(handle: Handle<PlaybackOverlayProps>) {
   }
 
   const playMusic = () => {
-    // Every play request runs from a user-gesture path — the moment a
-    // suspended normalization graph is allowed to start.
-    void audioContext?.resume().catch(() => undefined)
     if (!syncMusicPosition()) return
     void audioEl?.play().catch(() => undefined)
   }
@@ -331,21 +254,13 @@ export function PlaybackOverlay(handle: Handle<PlaybackOverlayProps>) {
     const track = props.audio
     if (!track) return
     audioEl = el
-    // No fade-in means the music opens at full clip volume; otherwise the
-    // per-frame glide below fades it in from silence.
-    el.volume = track.fadeIn ? 0 : segmentMusicVolume()
-
-    // Create the context NOW — as close to the opening tap as possible, so
-    // browsers that gate Web Audio on user activation start it running
-    // (created any later, only a fresh gesture could unsuspend it).
-    try {
-      audioContext ??= new AudioContext()
-      if (audioContext.state === 'suspended') {
-        void audioContext.resume().catch(() => undefined)
-      }
-    } catch {
-      graphFailed = true
-    }
+    // No fade-in means the music opens at the clip's mix level; otherwise
+    // the per-frame glide below fades it in from silence. `mix` is the
+    // export envelope's value (share × film-edge fades), tracked apart
+    // from the element volume so the normalization scales can multiply on
+    // top without distorting the glide.
+    let mix = track.fadeIn ? 0 : segmentMusicVolume()
+    el.volume = mix
 
     // Measure every source up front, one decode at a time: the scales and
     // decoded track lengths should be ready by the time the playhead needs
@@ -357,7 +272,7 @@ export function PlaybackOverlay(handle: Handle<PlaybackOverlayProps>) {
       ]
       for (const blob of blobs) {
         if (audioEl !== el) return
-        measured.set(blob, await measureAudioNormalization(blob))
+        await measureAudioNormalization(blob)
         // A decoded track length that differs from the stored metadata
         // duration moves the playlist's boundaries — realign the bed to
         // the corrected (export-true) position right away instead of
@@ -368,35 +283,46 @@ export function PlaybackOverlay(handle: Handle<PlaybackOverlayProps>) {
       }
     })()
 
-    // Per-frame glide of BOTH sides of the mix: the music toward the
-    // current clip's share, the clip's own sound toward the complement
-    // (1 − share) — mirroring the export blend. Where the playlist has run
-    // out, the clip glides back to full volume.
+    // Per-frame glide of BOTH sides of the mix: the export envelope value
+    // glides toward the current clip's share (0 where the playlist has run
+    // out), and each element's volume is its side of the blend times its
+    // source's normalization scale, clamped to the element ceiling.
     let last = performance.now()
     let raf = 0
+    let reportedClipScale = ''
+    let reportedMusicScale = ''
     const tick = (now: number) => {
       const dt = Math.min(100, now - last)
       last = now
-      applyNormalizationGains()
-      const target = segmentMusicVolume()
+      const musicHere =
+        !playlistDone && trackAtMs(timelinePositionMs()) !== null
+      const target = musicHere ? segmentMusicVolume() : 0
       const alpha = 1 - Math.exp(-dt / MUSIC_VOLUME_TAU_MS)
-      const next = el.volume + (target - el.volume) * alpha
-      el.volume = Math.abs(next - target) < 0.005 ? target : next
+      const next = mix + (target - mix) * alpha
+      mix = Math.abs(next - target) < 0.005 ? target : next
+      const trackBlob = props.audio?.tracks[musicTrackIndex]?.blob
+      const musicScale = trackBlob ? scaleFor(trackBlob) : 1
+      el.volume = musicElementVolume(mix, musicScale)
       const video = videoEl
+      const segment = currentSegment()
+      const clipScale = segment ? scaleFor(segment.clip.blob) : 1
       if (video) {
-        const musicHere =
-          props.audio && !playlistDone ? trackAtMs(timelinePositionMs()) !== null : false
-        if (musicHere) {
-          // Exact mirror of the export blend: the clip's own sound always
-          // carries the complement of the music's CURRENT (gliding)
-          // volume — during the fade-in the clip starts at full and only
-          // comes down as the bed actually rises.
-          video.volume = Math.max(0, Math.min(1, 1 - el.volume))
-        } else {
-          // No music here (playlist over) — glide back up to full.
-          const nextClip = video.volume + (1 - video.volume) * alpha
-          video.volume = Math.min(1, nextClip > 0.995 ? 1 : nextClip)
-        }
+        // The clip's own sound carries the complement of the CURRENT
+        // (gliding) mix — during the fade-in it starts at full and only
+        // comes down as the bed actually rises. After the playlist ends it
+        // keeps its normalization, exactly like the export's foreground.
+        video.volume = clipElementVolume(mix, clipScale)
+      }
+      // Test observability for the applied normalization scales.
+      const clipScaleText = String(clipScale)
+      if (clipScaleText !== reportedClipScale) {
+        reportedClipScale = clipScaleText
+        el.dataset.clipScale = clipScaleText
+      }
+      const musicScaleText = String(musicScale)
+      if (musicScaleText !== reportedMusicScale) {
+        reportedMusicScale = musicScaleText
+        el.dataset.musicScale = musicScaleText
       }
       raf = requestAnimationFrame(tick)
     }
@@ -409,10 +335,6 @@ export function PlaybackOverlay(handle: Handle<PlaybackOverlayProps>) {
       for (const url of trackUrls.values()) URL.revokeObjectURL(url)
       trackUrls.clear()
       musicTrackIndex = -1
-      clipGainNode = null
-      musicGainNode = null
-      void audioContext?.close().catch(() => undefined)
-      audioContext = null
     })
   }
 
@@ -434,8 +356,6 @@ export function PlaybackOverlay(handle: Handle<PlaybackOverlayProps>) {
   }
 
   const goTo = (nextIndex: number) => {
-    // Skips arrive from taps/keys — the moment a suspended graph may start.
-    resumeAudioContextFromGesture()
     advancedFor = -1
     segmentProgress = 0
     needsTap = false
@@ -514,7 +434,6 @@ export function PlaybackOverlay(handle: Handle<PlaybackOverlayProps>) {
         event.preventDefault()
         // Auto-repeat while held must not rapid-toggle pause/resume.
         if (event.repeat) return
-        resumeAudioContextFromGesture()
         const video = videoEl
         if (!video) return
         if (video.paused) {
@@ -676,7 +595,6 @@ export function PlaybackOverlay(handle: Handle<PlaybackOverlayProps>) {
             type="button"
             className="playback-resume"
             mix={on('click', () => {
-              resumeAudioContextFromGesture()
               const video = videoEl
               if (video)
                 void video

--- a/src/components/playback-overlay.tsx
+++ b/src/components/playback-overlay.tsx
@@ -2,7 +2,13 @@ import type { Handle } from 'remix/ui'
 import { on, ref } from 'remix/ui'
 import { planExport } from '../lib/export'
 import { FADE_OUT_MS } from '../lib/export/background-audio'
-import { clipAudioVolume, type ClipRecord, type ProjectAudioRecord } from '../lib/types'
+import { measureAudioNormalization } from '../lib/preview-audio-normalization'
+import {
+  clipAudioVolume,
+  type ClipRecord,
+  type ProjectAudioRecord,
+  type ProjectAudioTrack,
+} from '../lib/types'
 import { IconPlay } from './icons'
 import { isInteractiveTarget } from '../lib/keyboard'
 
@@ -63,6 +69,93 @@ export function PlaybackOverlay(handle: Handle<PlaybackOverlayProps>) {
    * metadata window says so. Cleared when a skip seeks music again. */
   let playlistDone = false
 
+  // Export-fidelity levels: the export peak-normalizes BOTH sources toward
+  // the same peak before blending by the mix share (a quietly mastered song
+  // is boosted up to 4×), so element volumes alone would play the music at
+  // the wrong level relative to the clips. One Web Audio gain per element
+  // carries its source's normalization scale (the element volume keeps
+  // carrying the share/fade glide) — the product is the export's gain, and
+  // gains above 1 need Web Audio anyway (element volume caps at 1).
+  let audioContext: AudioContext | null = null
+  let clipGainNode: GainNode | null = null
+  let musicGainNode: GainNode | null = null
+  let graphFailed = false
+  let appliedClipScale = 1
+  let appliedMusicScale = 1
+  /** Measured per source blob: the export's normalization gain + decoded
+   * length (kicked off when the preview opens, glides in when it lands). */
+  const measured = new Map<Blob, { scale: number; decodedDurationMs: number | null }>()
+  const measuring = new Set<Blob>()
+
+  const requestMeasure = (blob: Blob) => {
+    if (measured.has(blob) || measuring.has(blob)) return
+    measuring.add(blob)
+    void measureAudioNormalization(blob).then((info) => {
+      measured.set(blob, info)
+    })
+  }
+
+  /** Normalization gain the export applies to this source (1 until measured). */
+  const scaleFor = (blob: Blob): number => {
+    requestMeasure(blob)
+    return measured.get(blob)?.scale ?? 1
+  }
+
+  /** Track length on the output timeline. The export hands off to the next
+   * playlist track where the previous one's DECODED samples end, which can
+   * differ from the stored metadata duration — prefer the measured value. */
+  const trackDurationMs = (track: ProjectAudioTrack): number =>
+    measured.get(track.blob)?.decodedDurationMs ?? track.durationMs
+
+  /** Route both elements through per-source normalization gains. Wired only
+   * once the context is RUNNING: elements captured by a suspended graph go
+   * silent, while unwired elements still play (at share volume, just
+   * without the normalization scales). */
+  const ensureAudioGraph = () => {
+    if (graphFailed || clipGainNode || !videoEl || !audioEl) return
+    try {
+      audioContext ??= new AudioContext()
+      if (audioContext.state !== 'running') return
+      const clip = audioContext.createGain()
+      const music = audioContext.createGain()
+      // Destination first: if capturing the second element throws below,
+      // the first one is already wired through and stays audible.
+      clip.connect(audioContext.destination)
+      music.connect(audioContext.destination)
+      audioContext.createMediaElementSource(videoEl).connect(clip)
+      audioContext.createMediaElementSource(audioEl).connect(music)
+      clipGainNode = clip
+      musicGainNode = music
+      // Test observability: the gain nodes are unreachable from the DOM.
+      audioEl.dataset.clipScale = String(appliedClipScale)
+      audioEl.dataset.musicScale = String(appliedMusicScale)
+    } catch {
+      graphFailed = true
+    }
+  }
+
+  /** Glide both gains toward the export's normalization scales — the clip's
+   * from the current segment, the music's from the loaded playlist track. */
+  const applyNormalizationGains = () => {
+    ensureAudioGraph()
+    const context = audioContext
+    if (!context || !clipGainNode || !musicGainNode || !audioEl) return
+    const segment = currentSegment()
+    const clipScale = segment ? scaleFor(segment.clip.blob) : 1
+    const trackBlob = props.audio?.tracks[musicTrackIndex]?.blob
+    const musicScale = trackBlob ? scaleFor(trackBlob) : 1
+    if (clipScale !== appliedClipScale) {
+      appliedClipScale = clipScale
+      clipGainNode.gain.setTargetAtTime(clipScale, context.currentTime, 0.05)
+      audioEl.dataset.clipScale = String(clipScale)
+    }
+    if (musicScale !== appliedMusicScale) {
+      appliedMusicScale = musicScale
+      musicGainNode.gain.setTargetAtTime(musicScale, context.currentTime, 0.05)
+      audioEl.dataset.musicScale = String(musicScale)
+    }
+  }
+
   const currentSegment = () => resolveSegments()[index] ?? null
   const startSec = () => {
     const segment = currentSegment()
@@ -110,10 +203,10 @@ export function PlaybackOverlay(handle: Handle<PlaybackOverlayProps>) {
     const tracks = props.audio?.tracks ?? []
     let cursor = 0
     for (let i = 0; i < tracks.length; i += 1) {
-      if (positionMs < cursor + tracks[i].durationMs) {
+      if (positionMs < cursor + trackDurationMs(tracks[i])) {
         return { index: i, offsetMs: positionMs - cursor }
       }
-      cursor += tracks[i].durationMs
+      cursor += trackDurationMs(tracks[i])
     }
     return null
   }
@@ -148,7 +241,7 @@ export function PlaybackOverlay(handle: Handle<PlaybackOverlayProps>) {
       // so a backward skip switches to the covering track instead.
       const boundaryMs = props.audio.tracks
         .slice(0, target.index + 1)
-        .reduce((sum, track) => sum + track.durationMs, 0)
+        .reduce((sum, track) => sum + trackDurationMs(track), 0)
       const nearHandOff =
         target.index < musicTrackIndex && boundaryMs - positionMs < 1500 && !audio.ended
       if (!nearHandOff) {
@@ -196,6 +289,9 @@ export function PlaybackOverlay(handle: Handle<PlaybackOverlayProps>) {
   }
 
   const playMusic = () => {
+    // Every play request runs from a user-gesture path — the moment a
+    // suspended normalization graph is allowed to start.
+    void audioContext?.resume().catch(() => undefined)
     if (!syncMusicPosition()) return
     void audioEl?.play().catch(() => undefined)
   }
@@ -212,6 +308,20 @@ export function PlaybackOverlay(handle: Handle<PlaybackOverlayProps>) {
     // per-frame glide below fades it in from silence.
     el.volume = track.fadeIn ? 0 : segmentMusicVolume()
 
+    // Measure every source up front, one decode at a time: the scales and
+    // decoded track lengths should be ready by the time the playhead needs
+    // them (results are cached per blob, so reopening is instant).
+    void (async () => {
+      const blobs = [
+        ...track.tracks.map((t) => t.blob),
+        ...resolveSegments().map((segment) => segment.clip.blob),
+      ]
+      for (const blob of blobs) {
+        if (audioEl !== el) return
+        measured.set(blob, await measureAudioNormalization(blob))
+      }
+    })()
+
     // Per-frame glide of BOTH sides of the mix: the music toward the
     // current clip's share, the clip's own sound toward the complement
     // (1 − share) — mirroring the export blend. Where the playlist has run
@@ -221,6 +331,7 @@ export function PlaybackOverlay(handle: Handle<PlaybackOverlayProps>) {
     const tick = (now: number) => {
       const dt = Math.min(100, now - last)
       last = now
+      applyNormalizationGains()
       const target = segmentMusicVolume()
       const alpha = 1 - Math.exp(-dt / MUSIC_VOLUME_TAU_MS)
       const next = el.volume + (target - el.volume) * alpha
@@ -252,6 +363,10 @@ export function PlaybackOverlay(handle: Handle<PlaybackOverlayProps>) {
       for (const url of trackUrls.values()) URL.revokeObjectURL(url)
       trackUrls.clear()
       musicTrackIndex = -1
+      clipGainNode = null
+      musicGainNode = null
+      void audioContext?.close().catch(() => undefined)
+      audioContext = null
     })
   }
 

--- a/src/components/playback-overlay.tsx
+++ b/src/components/playback-overlay.tsx
@@ -107,6 +107,14 @@ export function PlaybackOverlay(handle: Handle<PlaybackOverlayProps>) {
   const trackDurationMs = (track: ProjectAudioTrack): number =>
     measured.get(track.blob)?.decodedDurationMs ?? track.durationMs
 
+  /** A rejected play() surfaces the tap-to-play affordance only for
+   * autoplay-policy rejections. AbortError means the attempt was merely
+   * interrupted — a deliberate pause() or a source swap landing while the
+   * promise was still pending — and flashing "Tap to play" over the
+   * controls then is wrong (and blocks the button underneath). */
+  const rejectionNeedsTap = (error: unknown): boolean =>
+    !(error instanceof DOMException && error.name === 'AbortError')
+
   /** Synchronous, gesture-time nudge for a suspended context: Safari (and
    * iOS in particular) only honors resume() called from inside a
    * user-gesture handler — the async promise continuations where playback
@@ -246,14 +254,23 @@ export function PlaybackOverlay(handle: Handle<PlaybackOverlayProps>) {
       // Metadata durations can run slightly past the decoded length, so a
       // just-ended track briefly still "covers" the playhead — moving back
       // to it mid-playback would restart it. The guard protects that
-      // playback continuity only: once the current element has ENDED there
-      // is nothing to protect (and play() on it would restart it from 0),
+      // playback continuity only, and only while the covering track's REAL
+      // (decoded) length is unknown: once measured, every position mapped
+      // into the track is backed by real audio, so realigning to it is
+      // always safe (and export-true — the export is still playing that
+      // track's tail there). Once the current element has ENDED there is
+      // also nothing to protect (play() on it would restart it from 0),
       // so a backward skip switches to the covering track instead.
       const boundaryMs = props.audio.tracks
         .slice(0, target.index + 1)
         .reduce((sum, track) => sum + trackDurationMs(track), 0)
+      const overshootPossible =
+        measured.get(props.audio.tracks[target.index].blob)?.decodedDurationMs == null
       const nearHandOff =
-        target.index < musicTrackIndex && boundaryMs - positionMs < 1500 && !audio.ended
+        overshootPossible &&
+        target.index < musicTrackIndex &&
+        boundaryMs - positionMs < 1500 &&
+        !audio.ended
       if (!nearHandOff) {
         musicTrackIndex = target.index
         audio.src = urlForTrack(target.index)
@@ -429,7 +446,8 @@ export function PlaybackOverlay(handle: Handle<PlaybackOverlayProps>) {
         void video
           .play()
           .then(() => playMusic())
-          .catch(() => {
+          .catch((error: unknown) => {
+            if (!rejectionNeedsTap(error)) return
             needsTap = true
             void handle.update()
           })
@@ -468,7 +486,8 @@ export function PlaybackOverlay(handle: Handle<PlaybackOverlayProps>) {
         playMusic()
         void handle.update()
       })
-      .catch(() => {
+      .catch((error: unknown) => {
+        if (!rejectionNeedsTap(error)) return
         needsTap = true
         void handle.update()
       })
@@ -506,7 +525,8 @@ export function PlaybackOverlay(handle: Handle<PlaybackOverlayProps>) {
               playMusic()
               void handle.update()
             })
-            .catch(() => {
+            .catch((error: unknown) => {
+              if (!rejectionNeedsTap(error)) return
               needsTap = true
               void handle.update()
             })

--- a/src/components/playback-overlay.tsx
+++ b/src/components/playback-overlay.tsx
@@ -107,6 +107,16 @@ export function PlaybackOverlay(handle: Handle<PlaybackOverlayProps>) {
   const trackDurationMs = (track: ProjectAudioTrack): number =>
     measured.get(track.blob)?.decodedDurationMs ?? track.durationMs
 
+  /** Synchronous, gesture-time nudge for a suspended context: Safari (and
+   * iOS in particular) only honors resume() called from inside a
+   * user-gesture handler — the async promise continuations where playback
+   * starts are too late there. Called at the top of every tap/key path. */
+  const resumeAudioContextFromGesture = () => {
+    if (audioContext?.state === 'suspended') {
+      void audioContext.resume().catch(() => undefined)
+    }
+  }
+
   /** Route both elements through per-source normalization gains. Wired only
    * once the context is RUNNING: elements captured by a suspended graph go
    * silent, while unwired elements still play (at share volume, just
@@ -308,6 +318,18 @@ export function PlaybackOverlay(handle: Handle<PlaybackOverlayProps>) {
     // per-frame glide below fades it in from silence.
     el.volume = track.fadeIn ? 0 : segmentMusicVolume()
 
+    // Create the context NOW — as close to the opening tap as possible, so
+    // browsers that gate Web Audio on user activation start it running
+    // (created any later, only a fresh gesture could unsuspend it).
+    try {
+      audioContext ??= new AudioContext()
+      if (audioContext.state === 'suspended') {
+        void audioContext.resume().catch(() => undefined)
+      }
+    } catch {
+      graphFailed = true
+    }
+
     // Measure every source up front, one decode at a time: the scales and
     // decoded track lengths should be ready by the time the playhead needs
     // them (results are cached per blob, so reopening is instant).
@@ -319,6 +341,13 @@ export function PlaybackOverlay(handle: Handle<PlaybackOverlayProps>) {
       for (const blob of blobs) {
         if (audioEl !== el) return
         measured.set(blob, await measureAudioNormalization(blob))
+        // A decoded track length that differs from the stored metadata
+        // duration moves the playlist's boundaries — realign the bed to
+        // the corrected (export-true) position right away instead of
+        // waiting for the next skip. Guarded inside syncMusicPosition:
+        // in-track drift under 350ms and imminent hand-offs are left
+        // alone, so an accurate metadata duration re-seeks nothing.
+        if (musicTrackIndex >= 0) syncMusicPosition()
       }
     })()
 
@@ -388,6 +417,8 @@ export function PlaybackOverlay(handle: Handle<PlaybackOverlayProps>) {
   }
 
   const goTo = (nextIndex: number) => {
+    // Skips arrive from taps/keys — the moment a suspended graph may start.
+    resumeAudioContextFromGesture()
     advancedFor = -1
     segmentProgress = 0
     needsTap = false
@@ -464,6 +495,7 @@ export function PlaybackOverlay(handle: Handle<PlaybackOverlayProps>) {
         event.preventDefault()
         // Auto-repeat while held must not rapid-toggle pause/resume.
         if (event.repeat) return
+        resumeAudioContextFromGesture()
         const video = videoEl
         if (!video) return
         if (video.paused) {
@@ -624,6 +656,7 @@ export function PlaybackOverlay(handle: Handle<PlaybackOverlayProps>) {
             type="button"
             className="playback-resume"
             mix={on('click', () => {
+              resumeAudioContextFromGesture()
               const video = videoEl
               if (video)
                 void video

--- a/src/lib/export/shared.ts
+++ b/src/lib/export/shared.ts
@@ -363,7 +363,7 @@ function audioBufferPeak(buffer: AudioBuffer): number {
  * of containers — all one path); the result is resampled when the source
  * rate differs. Returns null when there is no decodable audio.
  */
-async function decodeBlobAudio(blob: Blob, sampleRate: number): Promise<AudioBuffer | null> {
+export async function decodeBlobAudio(blob: Blob, sampleRate: number): Promise<AudioBuffer | null> {
   const input = new Input({ source: new BlobSource(blob), formats: ALL_FORMATS })
   const track = await input.getPrimaryAudioTrack()
   if (!track || !(await track.canDecode())) return null

--- a/src/lib/preview-audio-normalization.ts
+++ b/src/lib/preview-audio-normalization.ts
@@ -1,0 +1,52 @@
+import { channelPeak, normalizationScale } from './export/background-audio'
+import { decodeBlobAudio } from './export/shared'
+
+/**
+ * The export peak-normalizes both sides of the background-music mix (the
+ * clip's own sound and each playlist track) before blending them by the
+ * mix share — a quietly mastered song is boosted up to 4×. For the live
+ * preview to play the music at the level (and hand tracks off at the
+ * position) the export will render, it needs the same measurements: this
+ * module runs the export's own decode + exact peak scan per source blob,
+ * cached so a preview reopen or playlist revisit never re-decodes.
+ */
+
+export interface AudioNormalizationInfo {
+  /** Gain the export applies to this source before blending. */
+  scale: number
+  /** Decoded audio length in ms — where the export actually hands off to
+   * the next playlist track (null when the blob has no decodable audio). */
+  decodedDurationMs: number | null
+}
+
+/** Must match the export engines' mixing rate: the export computes peaks
+ * AFTER resampling, and resampling can nudge a waveform's peak. */
+const EXPORT_SAMPLE_RATE = 48000
+
+const cache = new WeakMap<Blob, Promise<AudioNormalizationInfo>>()
+
+export function measureAudioNormalization(blob: Blob): Promise<AudioNormalizationInfo> {
+  let pending = cache.get(blob)
+  if (!pending) {
+    pending = measure(blob)
+    cache.set(blob, pending)
+  }
+  return pending
+}
+
+async function measure(blob: Blob): Promise<AudioNormalizationInfo> {
+  try {
+    const buffer = await decodeBlobAudio(blob, EXPORT_SAMPLE_RATE)
+    if (!buffer) return { scale: 1, decodedDurationMs: null }
+    const channels = Array.from({ length: buffer.numberOfChannels }, (_, ch) =>
+      buffer.getChannelData(ch),
+    )
+    return {
+      scale: normalizationScale(channelPeak(channels)),
+      decodedDurationMs: Math.round(buffer.duration * 1000),
+    }
+  } catch {
+    // Same stance as the export: an undecodable source is mixed unscaled.
+    return { scale: 1, decodedDurationMs: null }
+  }
+}

--- a/src/lib/preview-audio-normalization.ts
+++ b/src/lib/preview-audio-normalization.ts
@@ -5,10 +5,19 @@ import { decodeBlobAudio } from './export/shared'
  * The export peak-normalizes both sides of the background-music mix (the
  * clip's own sound and each playlist track) before blending them by the
  * mix share — a quietly mastered song is boosted up to 4×. For the live
- * preview to play the music at the level (and hand tracks off at the
- * position) the export will render, it needs the same measurements: this
+ * previews to play the music at the level (and hand tracks off at the
+ * position) the export will render, they need the same measurements: this
  * module runs the export's own decode + exact peak scan per source blob,
  * cached so a preview reopen or playlist revisit never re-decodes.
+ *
+ * Levels are applied through plain element volumes, NOT a Web Audio
+ * media-element graph: `createMediaElementSource` permanently captures an
+ * element's output, and on WebKit/iOS a context that is not (yet) running
+ * turns that into total silence with no way back. Element volume caps at
+ * 1, so normalization boosts are clamped into the ceiling — the default
+ * 25% music share times the maximum 4× boost lands exactly at 1.0, and
+ * louder shares play at the ceiling (slightly under the export's level,
+ * but always audible everywhere).
  */
 
 export interface AudioNormalizationInfo {
@@ -24,14 +33,28 @@ export interface AudioNormalizationInfo {
 const EXPORT_SAMPLE_RATE = 48000
 
 const cache = new WeakMap<Blob, Promise<AudioNormalizationInfo>>()
+/** Landed measurements, for synchronous (per-frame) reads. */
+const resolved = new WeakMap<Blob, AudioNormalizationInfo>()
 
 export function measureAudioNormalization(blob: Blob): Promise<AudioNormalizationInfo> {
   let pending = cache.get(blob)
   if (!pending) {
-    pending = measure(blob)
+    pending = measure(blob).then((info) => {
+      resolved.set(blob, info)
+      return info
+    })
     cache.set(blob, pending)
   }
   return pending
+}
+
+/** Synchronous view of a blob's measurement: the info once the decode has
+ * landed, null (after kicking the decode off) until then. */
+export function peekAudioNormalization(blob: Blob): AudioNormalizationInfo | null {
+  const info = resolved.get(blob)
+  if (info) return info
+  void measureAudioNormalization(blob)
+  return null
 }
 
 async function measure(blob: Blob): Promise<AudioNormalizationInfo> {
@@ -49,4 +72,16 @@ async function measure(blob: Blob): Promise<AudioNormalizationInfo> {
     // Same stance as the export: an undecodable source is mixed unscaled.
     return { scale: 1, decodedDurationMs: null }
   }
+}
+
+/** Element volume for the music bed at one moment: the export's normalized
+ * level (mix share × normalization boost), clamped to the volume ceiling. */
+export function musicElementVolume(mix: number, scale: number): number {
+  return Math.max(0, Math.min(1, mix * scale))
+}
+
+/** Element volume for the clip's own sound under the bed: the export's
+ * normalized complement, clamped to the volume ceiling. */
+export function clipElementVolume(mix: number, scale: number): number {
+  return Math.max(0, Math.min(1, (1 - mix) * scale))
 }

--- a/tests/e2e/background-music.spec.ts
+++ b/tests/e2e/background-music.spec.ts
@@ -434,10 +434,25 @@ test.describe('background music', () => {
       .poll(() => stage.locator('video').evaluate((el) => (el as HTMLVideoElement).volume))
       .toBeLessThan(0.8)
 
-    // When the clip stops (trim end or tap), the bed stops with it.
-    await stage.locator('video').evaluate((el) => (el as HTMLVideoElement).pause())
+    // When the clip stops at its trim end, the bed stops with it.
+    await expect
+      .poll(() => stage.locator('video').evaluate((el) => (el as HTMLVideoElement).paused), {
+        timeout: 15_000,
+      })
+      .toBe(true)
     await expect
       .poll(() => music.evaluate((el) => (el as HTMLAudioElement).paused))
       .toBe(true)
+
+    // Replaying after the clip ended (currentTime parked at the trim end)
+    // must realign the bed to the clip's START position again — the seek
+    // to the trim start happens in the same gesture that starts the bed.
+    await page.getByRole('button', { name: 'Play clip preview' }).click()
+    await expect
+      .poll(() => music.evaluate((el) => !(el as HTMLAudioElement).paused))
+      .toBe(true)
+    const replayAt = await music.evaluate((el) => (el as HTMLAudioElement).currentTime)
+    expect(replayAt).toBeGreaterThan(2.8)
+    expect(replayAt).toBeLessThan(4.5)
   })
 })

--- a/tests/e2e/background-music.spec.ts
+++ b/tests/e2e/background-music.spec.ts
@@ -359,4 +359,37 @@ test.describe('background music', () => {
     await overlay.getByRole('button', { name: 'Stop preview' }).click()
     await expect(overlay).toBeHidden()
   })
+
+  test('preview plays the music at the export level: peak normalization applies', async ({
+    page,
+  }) => {
+    await openPlusEditorWithClips(page, 1)
+    // Quietly mastered song: peak ≈ 8000/32768 ≈ 0.24, so the export mixes
+    // it ≈ 3.7× hotter (0.9 / 0.24) than the raw file plays. The preview
+    // must apply the same boost — element volume alone caps at 1×.
+    await addMusic(page, 'Add background music', makeWavFile('quiet-song.wav', 8, 8000))
+
+    await page.getByRole('button', { name: 'Play project preview' }).click()
+    const overlay = page.locator('.playback-overlay')
+    await expect(overlay).toBeVisible()
+
+    const music = overlay.locator('audio')
+    await expect
+      .poll(() => music.evaluate((el) => !(el as HTMLAudioElement).paused))
+      .toBe(true)
+    // The music gain glides to the export's normalization boost once the
+    // track is measured (decode runs in the background after open)…
+    await expect
+      .poll(async () => Number((await music.getAttribute('data-music-scale')) ?? '0'), {
+        timeout: 15_000,
+      })
+      .toBeGreaterThan(3.3)
+    expect(Number(await music.getAttribute('data-music-scale'))).toBeLessThanOrEqual(4)
+    // …while the fixture clips (video-only, no audio track) stay unscaled,
+    // exactly like the export mixes them.
+    await expect(music).toHaveAttribute('data-clip-scale', '1')
+
+    await overlay.getByRole('button', { name: 'Stop preview' }).click()
+    await expect(overlay).toBeHidden()
+  })
 })

--- a/tests/e2e/background-music.spec.ts
+++ b/tests/e2e/background-music.spec.ts
@@ -366,7 +366,8 @@ test.describe('background music', () => {
     await openPlusEditorWithClips(page, 1)
     // Quietly mastered song: peak ≈ 8000/32768 ≈ 0.24, so the export mixes
     // it ≈ 3.7× hotter (0.9 / 0.24) than the raw file plays. The preview
-    // must apply the same boost — element volume alone caps at 1×.
+    // carries the same boost in the music element's volume (0.25 share ×
+    // ≈3.7 ≈ 0.92) — without it the volume would sit at the bare 0.25.
     await addMusic(page, 'Add background music', makeWavFile('quiet-song.wav', 8, 8000))
 
     await page.getByRole('button', { name: 'Play project preview' }).click()
@@ -377,7 +378,12 @@ test.describe('background music', () => {
     await expect
       .poll(() => music.evaluate((el) => !(el as HTMLAudioElement).paused))
       .toBe(true)
-    // The music gain glides to the export's normalization boost once the
+    // Freeze the playhead so the short film can't end (and its fade-out
+    // window can't shrink the target) while the polls below run under load.
+    await overlay
+      .locator('.playback-video')
+      .evaluate((el) => (el as HTMLVideoElement).pause())
+    // The reported normalization scale reaches the export's boost once the
     // track is measured (decode runs in the background after open; generous
     // timeout — parallel workers can slow the decode considerably)…
     await expect
@@ -386,11 +392,52 @@ test.describe('background music', () => {
       })
       .toBeGreaterThan(3.3)
     expect(Number(await music.getAttribute('data-music-scale'))).toBeLessThanOrEqual(4)
-    // …while the fixture clips (video-only, no audio track) stay unscaled,
+    // …and the element volume glides to share × boost ≈ 0.92.
+    await expect
+      .poll(() => music.evaluate((el) => (el as HTMLAudioElement).volume), { timeout: 10_000 })
+      .toBeGreaterThan(0.85)
+    // The fixture clips (video-only, no audio track) stay unscaled,
     // exactly like the export mixes them.
     await expect(music).toHaveAttribute('data-clip-scale', '1')
 
     await overlay.getByRole('button', { name: 'Stop preview' }).click()
     await expect(overlay).toBeHidden()
+  })
+
+  test('editor clip preview plays the bed at the clip film position and level', async ({
+    page,
+  }) => {
+    // Two 3s clips; the LAST one is selected by default, so its film
+    // position starts at 3s — the bed must start 3s into the song, not at 0.
+    await openPlusEditorWithClips(page, 2)
+    await addMusic(page, 'Add background music', makeWavFile('quiet-song.wav', 8, 8000))
+
+    const stage = page.locator('.editor-clip-preview-wrap')
+    const music = stage.locator('audio')
+    await expect(music).toHaveCount(1)
+
+    await page.getByRole('button', { name: 'Play clip preview' }).click()
+    await expect
+      .poll(() => music.evaluate((el) => !(el as HTMLAudioElement).paused))
+      .toBe(true)
+    // Position: export-true playlist offset for clip 2 (≈3s into the song).
+    const startedAt = await music.evaluate((el) => (el as HTMLAudioElement).currentTime)
+    expect(startedAt).toBeGreaterThan(2.8)
+    expect(startedAt).toBeLessThan(4.5)
+    // Level: 0.25 share × ≈3.7 normalization boost ⇒ element volume ≈ 0.92.
+    await expect
+      .poll(() => music.evaluate((el) => (el as HTMLAudioElement).volume), { timeout: 30_000 })
+      .toBeGreaterThan(0.85)
+    // The clip's own sound ducks to the complement of the mix (fixture
+    // clips decode no audio, so their normalization scale stays 1).
+    await expect
+      .poll(() => stage.locator('video').evaluate((el) => (el as HTMLVideoElement).volume))
+      .toBeLessThan(0.8)
+
+    // When the clip stops (trim end or tap), the bed stops with it.
+    await stage.locator('video').evaluate((el) => (el as HTMLVideoElement).pause())
+    await expect
+      .poll(() => music.evaluate((el) => (el as HTMLAudioElement).paused))
+      .toBe(true)
   })
 })

--- a/tests/e2e/background-music.spec.ts
+++ b/tests/e2e/background-music.spec.ts
@@ -378,10 +378,11 @@ test.describe('background music', () => {
       .poll(() => music.evaluate((el) => !(el as HTMLAudioElement).paused))
       .toBe(true)
     // The music gain glides to the export's normalization boost once the
-    // track is measured (decode runs in the background after open)…
+    // track is measured (decode runs in the background after open; generous
+    // timeout — parallel workers can slow the decode considerably)…
     await expect
       .poll(async () => Number((await music.getAttribute('data-music-scale')) ?? '0'), {
-        timeout: 15_000,
+        timeout: 30_000,
       })
       .toBeGreaterThan(3.3)
     expect(Number(await music.getAttribute('data-music-scale'))).toBeLessThanOrEqual(4)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Follow-up to #105 — Kent reports total silence on both preview surfaces. Two fixes:

1. **Project preview can no longer go silent.** #105 routed the preview's video and music elements through `createMediaElementSource` gain nodes to carry the export's peak-normalization boosts (which can exceed 1×). But a captured element outputs ONLY through the graph, and on WebKit/iOS a context that is not (yet) running turns that into permanent silence with no recovery — the e2e suite masked this because Playwright runs Chromium with `--autoplay-policy=no-user-gesture-required`. The normalization scales now ride plain element volumes, clamped to the ceiling of 1: music at `min(1, share × musicScale)`, clip at `min(1, (1 − share) × clipScale)`. The default 25% music share times the maximum 4× boost lands exactly at 1.0, so the audible result is fully preserved; extreme cases (high share + very quiet master) play at the ceiling — slightly under the export's level, but loud and audible on every browser.
2. **The editor's clip stage now plays the music bed** (it never did): under the selected clip at the clip's mix share (same capped-volume normalization, including the film-edge fade envelope at the playhead) and from the clip's exact position on the output timeline — clip 2 of two 3s clips starts the song 3s in, matching the export. Playlist tracks hand off mid-clip; every video pause path silences the bed, and starting it stays on the explicit toggle path so `nudgeFrame`'s frame-paint play/pause can't blip the music during trim scrubs.

## How

- `src/lib/preview-audio-normalization.ts`: adds a synchronous `peekAudioNormalization` facade over the cached export-identical decode + peak scan, plus the shared capped-volume helpers (`musicElementVolume`, `clipElementVolume`) used by both surfaces. The module doc records the Web Audio trade-off.
- `src/lib/preview-music-bed.ts` (new): shared playlist geometry and per-track gain for both previews — kept (trimmed) windows clamped to decoded media, trim-shifted seeks, track levels, interior fades, and film-edge fade scales. This is where #116 (per-track trim/level/fades, merged from `main` mid-review) integrates with the element-volume architecture.
- `src/components/playback-overlay.tsx`: removes the AudioContext/gain-node graph and gesture-resume plumbing; the per-frame glide tracks the export envelope (`mix`) directly and derives both element volumes from it (× normalization scale × track level/interior fades). Decoded-length playlist boundaries, fade mirroring, and the AbortError tap-affordance fix from #105 are retained.
- `src/components/editor-clip-preview.tsx`: renders a music element when the project has a playlist, maps the video time to the film position via the export planner, seeks the right track/offset (trim-shifted) on play, and glides both element volumes per frame, coupled to the same mix envelope as the overlay.
- `src/components/editor-screen.tsx`: passes `clips` and `audio` into the stage preview.

## Review-loop hardening (7 Bugbot rounds)

- Bed realigns when a landed measurement moves a playlist boundary; film-edge fades apply at the clip stage's playhead.
- Object URLs keyed by track blob + full bed reset when the playlist record changes identity under the mounted stage; timeline edits mid-playback resync the bed.
- The mix envelope is nonzero only under a bed that is actually sounding (live playlist coverage AND a playing element); the clip volume stays coupled to the same gliding mix, so playlist exhaustion eases both sides together like the export; both element volumes glide (τ 200ms).
- `playMusic` ports the overlay's metadata-overshoot guard (resuming into a finished track's phantom tail no longer restarts it from 0).
- One finding ("replay reads a stale pre-seek currentTime") was disproven empirically — the `currentTime` getter reflects the pending seek synchronously — and is guarded by a regression test either way.
- Trim-mode bed positioning intentionally follows SAVED trims (draft handle positions live inside TrimStrip until Done; threading them through would remount the stage video on every drag) — documented in code.
- Final round: clean.

## Testing

- Verified in Chromium under the **default** autoplay policy (no e2e flag), driving the real UI: the overlay's music element plays at volume 0.922 (0.25 share × 3.69 measured boost) with the clip ducked to 0.75 and the end-of-film fade-out engaging.
- New e2e: editor clip stage starts the bed ≈3s into the song for clip 2, at ≈0.92 volume, ducks the clip to 0.75, stops the bed when the clip parks at its trim end, and realigns it on replay.
- Updated e2e: overlay normalization test asserts the element volume reaches ≈0.92 (previously only the gain-node scale attribute).
- `npm run lint`, `npm test` (135), all background-music e2e tests pass including #116's track-detail test; full e2e: 59 passed, same 3 pre-existing environment failures as `main`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ebdc310a-db51-4ce2-997b-493bc5d3ecee?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ebdc310a-db51-4ce2-997b-493bc5d3ecee&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

