### PR TITLE
Fix empty IndexedDB schema from /api/diag (KODY-VIDEO-E)

### DIFF
--- a/functions/api/diag.ts
+++ b/functions/api/diag.ts
@@ -42,35 +42,39 @@ const PAGE = `<!doctype html>
       log('ua: ' + navigator.userAgent)
 
       // 1. Is the data alive in this origin's IndexedDB? (read-only)
+      // Never call indexedDB.open(name) without a version on a missing DB —
+      // that creates an empty version-1 database with zero stores. The app
+      // then upgrades oldVersion=1 → 2 and only adds 'audio', leaving
+      // projects/clips/meta missing (Sentry NotFoundError in getSettings).
       try {
-        const db = await new Promise((resolve, reject) => {
-          const req = indexedDB.open('kody-video')
-          req.onsuccess = () => resolve(req.result)
-          req.onerror = () => reject(req.error)
-          req.onblocked = () => reject(new Error('open blocked by another tab'))
-        })
-        const stores = [...db.objectStoreNames]
-        log('idb stores: ' + (stores.join(', ') || '(none)'))
-        if (stores.includes('projects')) {
-          const tx = db.transaction(stores.filter((s) => ['projects', 'clips'].includes(s)), 'readonly')
-          const projects = await new Promise((resolve, reject) => {
-            const req = tx.objectStore('projects').getAll()
-            req.onsuccess = () => resolve(req.result)
-            req.onerror = () => reject(req.error)
-          })
-          const clipCount = stores.includes('clips')
-            ? await new Promise((resolve, reject) => {
-                const req = tx.objectStore('clips').count()
-                req.onsuccess = () => resolve(req.result)
-                req.onerror = () => reject(req.error)
-              })
-            : 'n/a'
-          log('PROJECTS HERE: ' + projects.length + ' (clips: ' + clipCount + ')')
-          for (const p of projects.slice(0, 8)) {
-            log('  - "' + p.name + '" clips=' + (p.clipIds?.length ?? '?'))
+        const db = await openExistingKodyDb()
+        if (!db) {
+          log('idb: (no database yet on this origin)')
+        } else {
+          const stores = [...db.objectStoreNames]
+          log('idb version: ' + db.version)
+          log('idb stores: ' + (stores.join(', ') || '(none)'))
+          if (stores.includes('projects')) {
+            const tx = db.transaction(stores.filter((s) => ['projects', 'clips'].includes(s)), 'readonly')
+            const projects = await new Promise((resolve, reject) => {
+              const req = tx.objectStore('projects').getAll()
+              req.onsuccess = () => resolve(req.result)
+              req.onerror = () => reject(req.error)
+            })
+            const clipCount = stores.includes('clips')
+              ? await new Promise((resolve, reject) => {
+                  const req = tx.objectStore('clips').count()
+                  req.onsuccess = () => resolve(req.result)
+                  req.onerror = () => reject(req.error)
+                })
+              : 'n/a'
+            log('PROJECTS HERE: ' + projects.length + ' (clips: ' + clipCount + ')')
+            for (const p of projects.slice(0, 8)) {
+              log('  - "' + p.name + '" clips=' + (p.clipIds?.length ?? '?'))
+            }
           }
+          db.close()
         }
-        db.close()
       } catch (err) {
         log('idb: FAILED - ' + err)
       }
@@ -130,6 +134,33 @@ const PAGE = `<!doctype html>
         } catch {}
         location.replace('/?fresh=' + Date.now())
       })
+
+      /**
+       * Open the app DB only when it already exists. A version-less open on a
+       * missing DB would create an empty schema the app cannot heal from
+       * without a version bump.
+       */
+      async function openExistingKodyDb() {
+        const name = 'kody-video'
+        if (typeof indexedDB.databases === 'function') {
+          const listed = await indexedDB.databases()
+          if (!listed.some((d) => d.name === name)) return null
+        }
+        return new Promise((resolve, reject) => {
+          const req = indexedDB.open(name)
+          req.onupgradeneeded = (event) => {
+            // Missing DB: abort the implicit create so we leave nothing behind.
+            if (event.oldVersion === 0) event.target.transaction.abort()
+          }
+          req.onsuccess = () => resolve(req.result)
+          req.onerror = () => {
+            // Abort of a fresh create surfaces as AbortError — treat as missing.
+            if (req.error && req.error.name === 'AbortError') resolve(null)
+            else reject(req.error)
+          }
+          req.onblocked = () => reject(new Error('open blocked by another tab'))
+        })
+      }
     </script>
   </body>
 </html>

--- a/scripts/manual-smoke.mjs
+++ b/scripts/manual-smoke.mjs
@@ -372,7 +372,9 @@ try {
   }
   if (download) {
     const backupPath = await download.path()
-    await page.locator('.home-import input[type=file]').setInputFiles(backupPath)
+    // Import lives on the About page (moved off the home screen).
+    await page.goto(`${BASE}/about`, { waitUntil: 'networkidle' })
+    await page.locator('.about-import input[type=file]').setInputFiles(backupPath)
     // Import now lands directly inside the imported project.
     const openedImported = await page
       .waitForURL(/\/project\//, { timeout: 20000 })

--- a/src/lib/storage.test.ts
+++ b/src/lib/storage.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 import {
   DB_NAME,
+  DB_VERSION,
   __resetDbForTests,
   addClip,
   addProjectAudioTrack,
@@ -12,6 +13,7 @@ import {
   duplicateClip,
   getClip,
   getClipsForProject,
+  getDb,
   getProjectAudio,
   getSettings,
   getUndoSnapshot,
@@ -47,6 +49,53 @@ describe('storage layer', () => {
     await setOnboardingDismissed(true)
 
     expect((await getSettings()).onboardingDismissed).toBe(true)
+  })
+
+  it('heals a DB left empty by a version-less open (diag-style)', async () => {
+    // /api/diag used to call indexedDB.open('kody-video') with no version.
+    // On a fresh origin that creates an empty version-1 database; the app's
+    // oldVersion-gated upgrade then only added 'audio' and getSettings threw
+    // NotFoundError for the missing 'meta' store.
+    const empty = await new Promise<IDBDatabase>((resolve, reject) => {
+      const req = indexedDB.open(DB_NAME)
+      req.onsuccess = () => resolve(req.result)
+      req.onerror = () => reject(req.error ?? new Error('open failed'))
+    })
+    expect(empty.version).toBe(1)
+    expect([...empty.objectStoreNames]).toEqual([])
+    empty.close()
+
+    const settings = await getSettings()
+    expect(settings.key).toBe('settings')
+    const db = await getDb()
+    expect(db.version).toBe(DB_VERSION)
+    expect([...db.objectStoreNames].sort()).toEqual([
+      'audio',
+      'clips',
+      'meta',
+      'projects',
+      'undo',
+    ])
+  })
+
+  it('heals a v2 DB that only has the audio store', async () => {
+    // Simulate the post-diag corrupt state: version 2, stores = ['audio'].
+    const corrupt = await new Promise<IDBDatabase>((resolve, reject) => {
+      const req = indexedDB.open(DB_NAME, 2)
+      req.onupgradeneeded = () => {
+        req.result.createObjectStore('audio', { keyPath: 'projectId' })
+      }
+      req.onsuccess = () => resolve(req.result)
+      req.onerror = () => reject(req.error ?? new Error('open failed'))
+    })
+    expect([...corrupt.objectStoreNames]).toEqual(['audio'])
+    corrupt.close()
+
+    await expect(getSettings()).resolves.toMatchObject({ key: 'settings' })
+    const db = await getDb()
+    expect(db.version).toBe(DB_VERSION)
+    expect(db.objectStoreNames.contains('meta')).toBe(true)
+    expect(db.objectStoreNames.contains('projects')).toBe(true)
   })
 
   it('defaults keepWatermark off and persists the Plus opt-in', async () => {

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -43,7 +43,8 @@ interface ClipsDB extends DBSchema {
 }
 
 export const DB_NAME = 'kody-video'
-const DB_VERSION = 2
+/** Bumped when a migration must re-run for already-open clients. */
+export const DB_VERSION = 3
 
 let dbPromise: Promise<IDBPDatabase<ClipsDB>> | null = null
 
@@ -63,24 +64,41 @@ async function completeTransaction(
   await Promise.all([...ops, tx.done])
 }
 
+/**
+ * Ensure every object store exists. Version gates alone are not enough: a
+ * version-less `indexedDB.open('kody-video')` (e.g. a diagnostic page) can
+ * create an empty version-1 DB, after which `oldVersion < 1` skips the
+ * original stores and only `audio` is added on the v2 bump.
+ */
+export function ensureObjectStores(db: {
+  objectStoreNames: DOMStringList
+  createObjectStore: IDBPDatabase<ClipsDB>['createObjectStore']
+}): void {
+  if (!db.objectStoreNames.contains('projects')) {
+    const projects = db.createObjectStore('projects', { keyPath: 'id' })
+    projects.createIndex('by-updated', 'updatedAt')
+  }
+  if (!db.objectStoreNames.contains('clips')) {
+    const clips = db.createObjectStore('clips', { keyPath: 'id' })
+    clips.createIndex('by-project', 'projectId')
+  }
+  if (!db.objectStoreNames.contains('undo')) {
+    db.createObjectStore('undo', { keyPath: 'clip.projectId' })
+  }
+  if (!db.objectStoreNames.contains('meta')) {
+    db.createObjectStore('meta', { keyPath: 'key' })
+  }
+  if (!db.objectStoreNames.contains('audio')) {
+    // One optional background-audio playlist per project.
+    db.createObjectStore('audio', { keyPath: 'projectId' })
+  }
+}
+
 export function getDb(): Promise<IDBPDatabase<ClipsDB>> {
   if (!dbPromise) {
     dbPromise = openDB<ClipsDB>(DB_NAME, DB_VERSION, {
-      upgrade(db, oldVersion) {
-        if (oldVersion < 1) {
-          const projects = db.createObjectStore('projects', { keyPath: 'id' })
-          projects.createIndex('by-updated', 'updatedAt')
-
-          const clips = db.createObjectStore('clips', { keyPath: 'id' })
-          clips.createIndex('by-project', 'projectId')
-
-          db.createObjectStore('undo', { keyPath: 'clip.projectId' })
-          db.createObjectStore('meta', { keyPath: 'key' })
-        }
-        if (oldVersion < 2) {
-          // One optional background-audio track per project.
-          db.createObjectStore('audio', { keyPath: 'projectId' })
-        }
+      upgrade(db) {
+        ensureObjectStores(db)
       },
     })
   }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes [KODY-VIDEO-E](https://sentry.io/organizations/kent-c-dodds-tech-llc/issues/7654708953/): `NotFoundError: One of the specified object stores was not found` in `getSettings`.

### Root cause

`/api/diag` called `indexedDB.open('kody-video')` with no version. On a fresh origin that **creates an empty version-1 database** (zero object stores). The app then opened at version 2; `upgrade` saw `oldVersion === 1` so it skipped the v1 stores and only created `audio`. Home load → `getSettings` → `db.get('meta', …)` → NotFoundError.

Reproduced locally with `fake-indexeddb`; matches the two production events (Chrome/Linux, `step: load-home`, release `fb00d85` — the diag deploy — ~7s apart, consistent with the iframe probe).

### Fix

1. **`/api/diag`** — open the DB only when it already exists (`indexedDB.databases()` when available; abort the upgrade if a missing DB would be created).
2. **`storage.ts`** — bump `DB_VERSION` to 3 and ensure every store by `objectStoreNames.contains`, so already-corrupt v2 DBs heal on next open.
3. **`manual-smoke.mjs`** — point backup-import at `.about-import` (Import moved to About; smoke was timing out on the old home locator).

### Siblings

- **KODY-VIDEO-D** (`NotFoundError: The object can not be found here.`, Safari/iOS, no stack) — unrelated; not included.

## Test plan

- [x] `npm run build`
- [x] `npx vitest run` (201 tests, including new heal regressions)
- [x] `node scripts/manual-smoke.mjs` (32/32)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-111c0715-07e4-4d9e-805c-83f291250d58?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-111c0715-07e4-4d9e-805c-83f291250d58&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved IndexedDB diagnostics to report missing databases without creating empty ones.
  * Existing databases now display their version and recover missing storage components automatically.
  * Improved backup import smoke-test coverage for the About page.

* **Tests**
  * Added regression coverage for restoring and accessing databases with incomplete or outdated storage structures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->