### PR TITLE
Shorten update notice and keep it above the logo

### DIFF
--- a/index.html
+++ b/index.html
@@ -122,12 +122,15 @@
         margin-left: auto;
         margin-right: auto;
       }
+      /* Below #app (z-index 1) so in-app overlays (e.g. the update toast)
+         can paint above the LCP brand. Transparent #app regions still let
+         this hero show through on the home route. */
       #boot-hero {
         position: absolute;
         top: calc(12px + var(--safe-top));
         left: 0;
         right: 0;
-        z-index: 2;
+        z-index: 0;
         display: flex;
         flex-direction: column;
         align-items: center;

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -55,10 +55,12 @@ export function App(handle: Handle) {
       />
       {needRefresh ? (
         <div className="update-toast" role="status">
-          <span>A new version of Kody Video is ready</span>
-          <button type="button" mix={on('click', applyUpdate)}>
-            Update
-          </button>
+          <span>
+            <button type="button" mix={on('click', applyUpdate)}>
+              Update
+            </button>{' '}
+            available
+          </span>
         </div>
       ) : null}
     </div>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -574,13 +574,17 @@ a {
 .update-toast {
   position: absolute;
   top: calc(10px + var(--safe-top));
-  left: 50%;
-  transform: translateX(-50%);
-  /* Above #boot-hero (z-index 0) and in-app sheets/overlays. */
+  /* Center with left/right + max-content — not translateX(-50%) — so the
+     rise-in animation's transform cannot un-center the pill. Stacks above
+     #boot-hero (z-index 0) via #app's stacking context. */
+  left: 0;
+  right: 0;
+  width: max-content;
+  max-width: calc(100% - 24px);
+  margin-inline: auto;
   z-index: 20;
   display: flex;
   align-items: center;
-  max-width: calc(100% - 24px);
   background: var(--toast-bg);
   border: 1px solid var(--line);
   color: var(--ink);

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -576,10 +576,10 @@ a {
   top: calc(10px + var(--safe-top));
   left: 50%;
   transform: translateX(-50%);
+  /* Above #boot-hero (z-index 0) and in-app sheets/overlays. */
   z-index: 20;
   display: flex;
   align-items: center;
-  gap: 12px;
   max-width: calc(100% - 24px);
   background: var(--toast-bg);
   border: 1px solid var(--line);
@@ -587,6 +587,7 @@ a {
   padding: 10px 14px;
   border-radius: 999px;
   font-size: 0.9rem;
+  white-space: nowrap;
   box-shadow: var(--shadow);
   animation: rise-in 220ms ease both;
 }
@@ -594,6 +595,7 @@ a {
 .update-toast button {
   color: var(--accent);
   font-weight: 700;
+  padding: 0;
 }
 
 .toast {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Change the PWA update toast from “A new version of Kody Video is ready” + a separate Update button to **Update available**, with **Update** as the clickable action.
- Fix stacking so the toast paints above the home `#boot-hero` logo (`#boot-hero` sits under `#app`; transparent home regions still show the LCP brand through).
- Fix centering: stop using `translateX(-50%)`, which the `rise-in` animation was overwriting and shoving the pill sideways under the logo.

## Test plan
- [x] Forced toast on mobile home: copy reads “Update available”; only “Update” is the accent action.
- [x] Confirmed via `elementsFromPoint` that the toast stacks above `#boot-hero`.
- [x] Confirmed toast is horizontally centered with the brand art.
- [ ] Spot-check on a real update (or About → check for updates path) that tapping Update still reloads.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2db57972-be66-43a8-b110-92ee8f6bf06e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2db57972-be66-43a8-b110-92ee8f6bf06e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * In-app overlays now appear correctly above the boot hero, while transparent areas continue to reveal it.
  * Improved the update notification’s positioning and layout for more consistent display across screen sizes.

* **UI Improvements**
  * Simplified the update message to “Update available.”
  * Refined notification sizing, text wrapping, and button spacing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->