### PR TITLE
Fix zoom HUD and REC timer jitter from mid-take re-renders

### DIFF
--- a/src/components/record-screen.tsx
+++ b/src/components/record-screen.tsx
@@ -193,12 +193,27 @@ export function RecordScreen(handle: Handle<RecordScreenProps>) {
   // Live zoom readout: updated imperatively (no component update) so
   // drag-to-zoom mid-recording never causes a re-render. Fades out shortly
   // after the value stops changing.
+  //
+  // The label is rendered as a real (vdom-owned) text child and updates
+  // mutate that node's data. An EMPTY vnode gets its children bulk-cleared
+  // by the reconciler on every re-render, so an imperative-only label was
+  // wiped whenever anything re-rendered mid-take — the HUD pill collapsed
+  // to its padding and re-expanded on the next pointermove: visible jitter.
   let zoomHudEl: HTMLDivElement | null = null
   let zoomHudTimer = 0
+  let zoomHudLabel = '1×'
   const showZoomHud = (value: number) => {
     const hud = zoomHudEl
     if (!hud) return
-    hud.textContent = formatZoomLabel(value)
+    const label = formatZoomLabel(value)
+    if (label !== zoomHudLabel) {
+      zoomHudLabel = label
+      // Mutate the existing text node (never replace it) so re-renders keep
+      // patching the node that is actually on screen.
+      const textNode = hud.firstChild
+      if (textNode) textNode.nodeValue = label
+      else hud.textContent = label
+    }
     hud.classList.add('is-visible')
     window.clearTimeout(zoomHudTimer)
     zoomHudTimer = window.setTimeout(() => {
@@ -907,7 +922,11 @@ export function RecordScreen(handle: Handle<RecordScreenProps>) {
               })
               dragZoomMoved = true
               dragZoomLastValue = next
-              camera.setZoom(next)
+              // silent: nothing that reads camera.zoom is visible mid-take,
+              // and the trailing re-render sync would compete with the
+              // encoder (and used to blank the HUD/timer text — see the
+              // zoom-hud comment above).
+              camera.setZoom(next, { silent: true })
               showZoomHud(next)
             }),
             on('pointerup', (event) => {
@@ -985,7 +1004,9 @@ export function RecordScreen(handle: Handle<RecordScreenProps>) {
                 window.clearTimeout(zoomHudTimer)
               })
             })}
-          />
+          >
+            {zoomHudLabel}
+          </div>
 
           {needsPermission ? (
             <div className="permission-panel">

--- a/src/components/record-timer.tsx
+++ b/src/components/record-timer.tsx
@@ -9,11 +9,21 @@ interface RecordTimerProps {
 }
 
 /**
- * Self-updating elapsed readout. Writes textContent directly from rAF so the
- * rest of the page never re-renders while recording — re-rendering the whole
- * screen 60×/s is what made the camera preview and encoder drop frames.
+ * Self-updating elapsed readout. Writes the text node directly from rAF so
+ * the rest of the page never re-renders while recording — re-rendering the
+ * whole screen 60×/s is what made the camera preview and encoder drop frames.
+ *
+ * The readout is rendered as a real (vdom-owned) text child and the rAF loop
+ * mutates that same node's data. Rendering the span EMPTY and relying on
+ * textContent alone looks equivalent, but the reconciler bulk-clears the
+ * children of any element whose vnode has none — so every mid-take re-render
+ * (zoom sync, mic-silent warning) blanked the readout for up to 100ms and
+ * the pill visibly collapsed/re-expanded: the "recording counter jitter".
  */
 export function RecordTimer(handle: Handle<RecordTimerProps>) {
+  const elapsedText = () =>
+    formatDuration(Math.max(0, performance.now() - handle.props.startedAt))
+
   return () => (
     <span
       className={handle.props.className}
@@ -21,19 +31,26 @@ export function RecordTimer(handle: Handle<RecordTimerProps>) {
         let raf = 0
         let lastText = ''
         const tick = () => {
-          const text = formatDuration(Math.max(0, performance.now() - handle.props.startedAt))
+          const text = elapsedText()
           // The readout has 0.1s resolution, so ~5 of 6 frames would write
-          // the same string — and every textContent write dirties layout.
+          // the same string — and every text write dirties layout.
           // Skipping no-ops keeps recording free of per-frame layout work.
           if (text !== lastText) {
             lastText = text
-            node.textContent = text
+            // Mutate the existing text node (never replace it): the vdom
+            // holds a reference to this node, and re-renders must keep
+            // patching the node that is actually on screen.
+            const textNode = node.firstChild
+            if (textNode) textNode.nodeValue = text
+            else node.textContent = text
           }
           raf = requestAnimationFrame(tick)
         }
         tick()
         signal.addEventListener('abort', () => cancelAnimationFrame(raf))
       })}
-    />
+    >
+      {elapsedText()}
+    </span>
   )
 }

--- a/src/lib/camera.ts
+++ b/src/lib/camera.ts
@@ -143,7 +143,10 @@ export interface Camera {
   start: () => Promise<void>
   flip: () => Promise<void>
   stop: () => void
-  setZoom: (value: number) => void
+  /** `silent` skips the owning component's re-render sync — for zoom driven
+   * from inside an active take, where nothing that reads `camera.zoom` is on
+   * screen and any re-render competes with the preview and encoder. */
+  setZoom: (value: number, options?: { silent?: boolean }) => void
   setTorch: (on: boolean) => Promise<void>
   enableMic: () => Promise<void>
   /** `keepWarm` defers the actual stop by MIC_KEEP_WARM_MS (take-end
@@ -503,7 +506,7 @@ export function createCamera(notify: () => void): Camera {
     }
   }
 
-  function setZoom(value: number): void {
+  function setZoom(value: number, options?: { silent?: boolean }): void {
     const track = camera.stream?.getVideoTracks()[0]
     const range = camera.zoom
     if (!track || !range) return
@@ -512,8 +515,12 @@ export function createCamera(notify: () => void): Camera {
     void track
       .applyConstraints({ advanced: [{ zoom: clamped } as MediaTrackConstraintSet] })
       .catch(() => undefined)
+    // Mid-take drag-to-zoom passes silent: the zoom chips it would sync are
+    // hidden while recording, and `camera.zoom` is already current for
+    // whatever re-render comes next (take end, snap-back).
+    if (options?.silent) return
     // Constraints apply immediately; the owning component syncs on a trailing
-    // timer so drag-to-zoom during a recording doesn't rerender per move.
+    // timer so a zoom ramp doesn't rerender per step.
     if (!zoomNotifyTimer) {
       zoomNotifyTimer = window.setTimeout(() => {
         zoomNotifyTimer = 0

--- a/src/styles/record.css
+++ b/src/styles/record.css
@@ -321,6 +321,10 @@
   left: 50%;
   transform: translateX(-50%);
   z-index: 3;
+  /* Center-anchored pill: labels flip between widths ("1×" / "1.1×"), so
+     without a floor both edges breathe on every 0.1× step of a drag. */
+  min-width: calc(4.5ch + 28px);
+  text-align: center;
   padding: 6px 14px;
   border-radius: 999px;
   background: rgba(0, 0, 0, 0.55);

--- a/tests/e2e/record.spec.ts
+++ b/tests/e2e/record.spec.ts
@@ -84,6 +84,73 @@ test.describe('camera & hold-to-record', () => {
     await expect(pill).toBeHidden()
   })
 
+  test('mid-take re-renders never blank the REC timer or zoom HUD', async ({ page }) => {
+    // The fake camera exposes no zoom range — shim one in so drag-to-zoom
+    // (and its HUD) engages like on a real phone.
+    await page.addInitScript(() => {
+      const original = MediaStreamTrack.prototype.getCapabilities
+      MediaStreamTrack.prototype.getCapabilities = function () {
+        const caps = (original ? original.call(this) : {}) as MediaTrackCapabilities &
+          Record<string, unknown>
+        if (this.kind === 'video') {
+          caps.zoom = { min: 1, max: 8, step: 0.1 }
+        }
+        return caps
+      }
+    })
+    await openNewProject(page)
+    await pressStageUntilRecording(page)
+
+    // Regression guard: both readouts update their text imperatively. A
+    // re-render while recording used to bulk-clear them (the reconciler
+    // wipes children of childless vnodes), collapsing the pills — visible
+    // jitter. Record every mutation that leaves either readout empty.
+    await page.evaluate(() => {
+      const empties: string[] = []
+      const watch = (selector: string) => {
+        const el = document.querySelector(selector)
+        if (!el) {
+          empties.push(`${selector} missing`)
+          return
+        }
+        const observer = new MutationObserver(() => {
+          if ((el.textContent ?? '').trim() === '') empties.push(selector)
+        })
+        observer.observe(el, { childList: true, characterData: true, subtree: true })
+      }
+      watch('.record-pill .record-elapsed')
+      watch('.zoom-hud')
+      ;(window as Window & { __emptyTextEvents?: string[] }).__emptyTextEvents = empties
+    })
+
+    // Drift past the drag-zoom dead zone, then jiggle like a real thumb.
+    const box = await page.locator('.record-stage').boundingBox()
+    if (!box) throw new Error('no stage')
+    const centerX = box.x + box.width / 2
+    const centerY = box.y + box.height / 2
+    await page.mouse.move(centerX, centerY - 40, { steps: 8 })
+    const hud = page.locator('.zoom-hud')
+    await expect(hud).toHaveClass(/is-visible/)
+    await expect(hud).toHaveText(/\d(\.\d)?×/)
+    for (let i = 0; i < 14; i += 1) {
+      await page.mouse.move(centerX + (i % 2 ? 2 : -2), centerY - 40 - (i % 3), { steps: 2 })
+      await page.waitForTimeout(250)
+    }
+
+    // The fake mic is silent, so the warning re-renders the screen mid-take —
+    // proof the take actually survived at least one re-render.
+    await expect(page.locator('.record-screen')).toContainText(/mic isn/i, {
+      timeout: 10_000,
+    })
+    await expect(page.locator('.record-pill .record-elapsed')).toHaveText(/\d+\.\ds/)
+    await expect(hud).toHaveText(/\d(\.\d)?×/)
+    const emptyEvents = await page.evaluate(
+      () => (window as Window & { __emptyTextEvents?: string[] }).__emptyTextEvents,
+    )
+    expect(emptyEvents).toEqual([])
+    await page.mouse.up()
+  })
+
   test('a very short tap does not create an empty clip', async ({ page }) => {
     await openNewProject(page)
     const stage = page.locator('.record-stage')


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

While recording, the zoom pill and the REC counter visibly jittered — even without deliberate zooming (slight finger drift during the hold was enough).

## Root cause

Both readouts update their text imperatively (`textContent`) into elements whose vnodes render **no children** — and the remix/ui reconciler bulk-clears the children of any childless vnode on every diff (`domParent.textContent = ''` in `diffChildren`). So every re-render while recording wiped both readouts, collapsing the pills until the next imperative write refilled them.

The re-render cadence came from drag-to-zoom itself: once finger drift crossed the 14px dead zone, every `pointermove` called `camera.setZoom`, which schedules a trailing `notify()` re-render every 150ms. Result: both pills rhythmically blanked/collapsed/re-expanded for the whole drag — the jitter. (The mic-silent warning transition also triggers the same wipe once per take.)

## Fix

- `record-timer.tsx` / `record-screen.tsx`: render both readouts as real vdom text children and have the imperative paths mutate that same text node's data. Re-renders now patch the on-screen node instead of wiping it.
- `camera.ts` + drag path: `setZoom(value, { silent: true })` for mid-take drag-zoom — the zoom chips it would sync are hidden while recording, and `camera.zoom` stays current for whatever re-render comes next. This removes the 150ms re-render churn during capture entirely (matching the codebase's "nothing re-renders during capture" design).
- `record.css`: give `.zoom-hud` a `min-width` + centered text so 0.1× label width flips ("1×" ↔ "1.1×") stop breathing the center-anchored pill's edges.

## Testing

- New e2e regression test: shims a zoom range onto the fake camera, holds to record, drifts past the dead zone, jiggles for ~3.5s, and uses a MutationObserver to assert neither readout's text ever goes empty across a mid-take re-render (the fake-mic silent warning guarantees one). Verified the test **fails against the previous code** (`.zoom-hud is-visible` resolved with empty text) and passes with the fix.
- Full suites green: `npm run lint`, `npm test` (201 unit tests), `npx playwright test` (63 e2e tests).
- Manual before/after demo in headed Chromium with fake media and a shimmed zoom range, reproducing the hold + finger-drift gesture:

**Before** — zoom HUD and REC counter text repeatedly blank; the pills collapse and re-expand throughout the drag:

<a href="https://cursor.com/agents/bc-27d71707-5bf2-4d70-b58a-80fa6e6aeffd/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fjitter_before_fix_zoom_pill_and_rec_counter_flicker.mp4"><img src="https://cursor.com/artifacts/c/art-1ccb5365-bd5d-4ca4-98bd-219cbe44f925" alt="jitter_before_fix_zoom_pill_and_rec_counter_flicker.mp4" /></a>

**After** — both pills stay steady for the whole take while the timer counts up and the zoom label tracks the drag:

<a href="https://cursor.com/agents/bc-27d71707-5bf2-4d70-b58a-80fa6e6aeffd/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fstable_after_fix_zoom_pill_and_rec_counter_steady.mp4"><img src="https://cursor.com/artifacts/c/art-8afc0306-cc1b-4900-8e6c-2c8661d4385f" alt="stable_after_fix_zoom_pill_and_rec_counter_steady.mp4" /></a>

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-27d71707-5bf2-4d70-b58a-80fa6e6aeffd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-27d71707-5bf2-4d70-b58a-80fa6e6aeffd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

