### PR TITLE
Fix light-mode contrast on editor chrome and Go button

### DIFF
--- a/src/styles/editor.css
+++ b/src/styles/editor.css
@@ -808,6 +808,41 @@
   color: var(--danger-ink);
 }
 
+/* Light mode: small labels and accent-on-mint chips need darker ink than the
+   shared tokens provide (~3.8:1 for accent text; disabled@0.38 disappears).
+   Key-hints also need dark ink here — the global style assumes a dark stage. */
+@media (prefers-color-scheme: light) {
+  .editor-action-label {
+    color: var(--ink);
+  }
+
+  .editor-action.prominent {
+    color: var(--ink-strong);
+  }
+
+  .editor-action.prominent .editor-action-label {
+    color: var(--ink-strong);
+  }
+
+  .editor-action:disabled {
+    opacity: 0.55;
+  }
+
+  .editor-screen .key-hints {
+    color: var(--ink-muted);
+  }
+
+  .editor-screen .key-hints kbd {
+    color: var(--ink);
+    border-color: var(--line);
+    background: color-mix(in srgb, var(--ink) 8%, transparent);
+  }
+
+  .editor-toolbar .btn-ghost:disabled {
+    opacity: 0.62;
+  }
+}
+
 .editor-toolbar .btn-ghost {
   display: inline-flex;
   align-items: center;

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -243,7 +243,8 @@ a {
 /* Light-mode accent (#1f8a68) + --ink-strong (#102019) is ~3.9:1. Pure
    black on that green clears WCAG AA (4.5:1) without shifting the brand. */
 @media (prefers-color-scheme: light) {
-  .btn-primary {
+  .btn-primary,
+  .go-button {
     color: #000000;
   }
 }
@@ -761,12 +762,14 @@ a {
   margin: 0 0 14px;
 }
 
-/* Keyboard hints only make sense where a keyboard is likely present. */
+/* Keyboard hints only make sense where a keyboard is likely present.
+   Default ink is light — the record screen paints these over the dark stage.
+   Light-mode editor overrides live in editor.css (pale panel chrome). */
 .key-hints {
   display: none;
   padding: 4px 16px 10px;
   font-size: 11px;
-  color: var(--ink-soft, rgba(255, 255, 255, 0.55));
+  color: rgba(255, 255, 255, 0.72);
   text-align: center;
   user-select: none;
 }
@@ -774,11 +777,12 @@ a {
 .key-hints kbd {
   display: inline-block;
   padding: 1px 5px;
-  border: 1px solid var(--line);
+  border: 1px solid rgba(255, 255, 255, 0.28);
   border-radius: 5px;
   font-family: inherit;
   font-size: 10px;
-  background: rgba(127, 127, 127, 0.12);
+  color: rgba(255, 255, 255, 0.88);
+  background: rgba(255, 255, 255, 0.1);
 }
 
 @media (hover: hover) and (pointer: fine) {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -243,8 +243,7 @@ a {
 /* Light-mode accent (#1f8a68) + --ink-strong (#102019) is ~3.9:1. Pure
    black on that green clears WCAG AA (4.5:1) without shifting the brand. */
 @media (prefers-color-scheme: light) {
-  .btn-primary,
-  .go-button {
+  .btn-primary {
     color: #000000;
   }
 }
@@ -331,6 +330,13 @@ a {
 .go-button:disabled {
   opacity: 0.42;
   cursor: not-allowed;
+}
+
+/* Must follow the base .go-button rule so black wins over --ink-strong. */
+@media (prefers-color-scheme: light) {
+  .go-button {
+    color: #000000;
+  }
 }
 
 .sheet-backdrop {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Light-mode editor chrome failed basic readability: clip actions, the Trim chip, disabled toolbar controls, keyboard hints, and the Go label were too low-contrast against the pale panel.

## Changes
- Use black text on the Go button in light mode (same AA fix already applied to `.btn-primary`), placed **after** the base `.go-button` rule so the cascade wins.
- Darken editor action labels and the Trim chip ink; raise disabled opacity so inactive controls stay legible.
- Keep record-screen key-hints light over the dark stage; override editor key-hints to dark ink/kbd chrome in light mode.

## Test plan
- [x] Open editor in light mode with a selected clip — action labels readable
- [x] Trim chip dark ink on mint background
- [x] Go label black on green (cascade fix verified against Bugbot/CodeRabbit)
- [ ] Keyboard hint row readable on editor panel (desktop hover/fine pointer)
- [ ] Record-screen keyboard hints remain readable over camera stage
- [ ] Spot-check dark mode unchanged
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1c2a6e10-a7ae-47a4-a4aa-8ab0d04abe98?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1c2a6e10-a7ae-47a4-a4aa-8ab0d04abe98&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved light-mode contrast for editor action labels, buttons, disabled controls, and keyboard hints.
  * Updated light-mode button and keyboard key colors for clearer readability.
  * Enhanced visibility of disabled toolbar controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->