### PR TITLE
Move unit tests from Vitest in Node to Vitest browser mode

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,11 +29,13 @@ jobs:
       - name: Lint / typecheck
         run: npm run lint
 
-      - name: Unit tests
-        run: npm test
-
+      # Vitest runs in browser mode (real Chromium), so the browser must be
+      # installed before the unit tests too, not just the e2e suite.
       - name: Install Playwright Chromium
         run: npx playwright install --with-deps chromium
+
+      - name: Unit tests
+        run: npm test
 
       # The preview-audio e2e tests need a running audio server: without an
       # output device Chromium keeps realtime AudioContexts suspended and the

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Open the printed localhost URL in Chrome (desktop or Android). Camera/microphone
 ```bash
 npm run build      # production build + service worker
 npm run preview    # serve dist (PWA cache active)
-npm test           # storage/export-planner unit tests
+npm test           # storage/export-planner unit tests (Vitest browser mode, real Chromium)
 npm run test:e2e   # Playwright e2e suite (fake camera/mic; recording, editor, playback, export, plans)
 npm run test:smoke # Playwright UX smoke (fake camera, records + exports)
 ```
@@ -273,7 +273,7 @@ under `/api/` so no service worker or cached shell can interfere:
 | `npm run dev`                        | Vite dev server                            |
 | `npm run build`                      | Typecheck + production bundle              |
 | `npm run preview`                    | Preview production build                   |
-| `npm test`                           | Vitest storage/export-planner tests        |
+| `npm test`                           | Vitest storage/export-planner tests (browser mode, Chromium) |
 | `npm run test:e2e`                   | Playwright e2e suite (`tests/e2e/`): recording, editor, playback, export, plans, keyboard |
 | `npm run test:smoke`                 | Playwright smoke: record → edit → export   |
 | `node scripts/probe-export-chrome.mjs` | Export validation in Chrome stable (real codecs) |

--- a/docs/contribute/running-and-testing.md
+++ b/docs/contribute/running-and-testing.md
@@ -12,12 +12,26 @@ own dev server on port `4189`, so `npm run test:e2e` can run alongside a
 ## Lint / unit tests
 
 - Lint & typecheck: `npm run lint` (`tsc -b`).
-- Unit tests: `npm test` (Vitest).
+- Unit tests: `npm test` (Vitest browser mode — tests run in headless
+  Chromium against real browser APIs: IndexedDB, localStorage, AudioContext).
+
+Vitest browser-mode notes:
+
+- The suite needs Playwright's Chromium installed (same install as e2e, see
+  below).
+- Test-side code runs in the browser, so Node APIs are unavailable in test
+  files. Anything that genuinely needs Node (e.g. running ffmpeg for the MP4
+  metadata test) lives in a [custom command](https://vitest.dev/api/browser/commands)
+  (`src/test/ffmpeg-command.ts`) that executes on the Vitest server.
+- `vi.resetModules()` does not invalidate the browser module graph. Modules
+  with test-relevant module-level state export explicit reset helpers instead
+  (`resetRecordingMimeTypeForTests`, `resetMicMonitorForTests`,
+  `resetAppUpdateForTests`, `__resetDbForTests`).
 
 ## End-to-end / smoke tests
 
-`npm run test:e2e` (Playwright) and `npm run test:smoke` need Playwright's
-Chromium browser installed:
+`npm test` (browser mode), `npm run test:e2e` (Playwright), and
+`npm run test:smoke` need Playwright's Chromium browser installed:
 
 ```bash
 npx playwright install chromium

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "kody-video",
       "version": "0.1.0",
+      "license": "FSL-1.1-ALv2",
       "dependencies": {
         "@sentry/browser": "^10.69.0",
         "client-zip": "^2.5.0",
@@ -18,12 +19,12 @@
         "@playwright/test": "^1.62.0",
         "@sentry/vite-plugin": "^5.4.0",
         "@types/node": "^26.1.1",
-        "fake-indexeddb": "^6.0.1",
+        "@vitest/browser-playwright": "^4.1.10",
         "playwright": "^1.62.0",
         "typescript": "~5.8.3",
         "vite": "^7.0.4",
         "vite-plugin-pwa": "^1.0.1",
-        "vitest": "^3.2.4"
+        "vitest": "^4.1.10"
       }
     },
     "node_modules/@apideck/better-ajv-errors": {
@@ -1584,6 +1585,13 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@blazediff/core": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@blazediff/core/-/core-1.9.1.tgz",
+      "integrity": "sha512-ehg3jIkYKulZh+8om/O25vkvSsXXwC+skXmyA87FFx6A/45eqOkZsBltMw/TVteb0mloiGT8oGRTcjRAz66zaA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@emnapi/core": {
       "version": "1.11.3",
@@ -3427,6 +3435,13 @@
         "node": ">=20"
       }
     },
+    "node_modules/@polka/url": {
+      "version": "1.0.0-next.29",
+      "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.29.tgz",
+      "integrity": "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@remix-run/assert": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/@remix-run/assert/-/assert-0.3.0.tgz",
@@ -3456,12 +3471,6 @@
         "picomatch": "^4.0.4",
         "source-map-js": "^1.2.1"
       }
-    },
-    "node_modules/@remix-run/assets/node_modules/es-module-lexer": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
-      "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
-      "license": "MIT"
     },
     "node_modules/@remix-run/async-context-middleware": {
       "version": "0.3.4",
@@ -4309,12 +4318,6 @@
       "engines": {
         "node": ">=18"
       }
-    },
-    "node_modules/@remix-run/test/node_modules/es-module-lexer": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
-      "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
-      "license": "MIT"
     },
     "node_modules/@remix-run/test/node_modules/esbuild": {
       "version": "0.27.7",
@@ -5261,59 +5264,6 @@
         "tslib": "^2.4.0"
       }
     },
-    "node_modules/@types/babel__core": {
-      "version": "7.20.5",
-      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
-      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@babel/parser": "^7.20.7",
-        "@babel/types": "^7.20.7",
-        "@types/babel__generator": "*",
-        "@types/babel__template": "*",
-        "@types/babel__traverse": "*"
-      }
-    },
-    "node_modules/@types/babel__generator": {
-      "version": "7.27.0",
-      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
-      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@babel/types": "^7.0.0"
-      }
-    },
-    "node_modules/@types/babel__template": {
-      "version": "7.4.4",
-      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
-      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@babel/parser": "^7.1.0",
-        "@babel/types": "^7.0.0"
-      }
-    },
-    "node_modules/@types/babel__traverse": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
-      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@babel/types": "^7.28.2"
-      }
-    },
     "node_modules/@types/chai": {
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
@@ -5390,40 +5340,88 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@vitest/expect": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.7.tgz",
-      "integrity": "sha512-E8eBXaKibuvH2pSZErOjdVb5vF4PbKYcrnluBTYxEk1l/VhhwZg1kZQsdtjq+CsF5CFydf2Rdkz7jDHKSisi3w==",
+    "node_modules/@vitest/browser": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/browser/-/browser-4.1.10.tgz",
+      "integrity": "sha512-UDwuWGwXj646CBx/bQHOaJSX7np0I8JL/UKQYa1e4QrVHH8VdWtx8eaOuf8sy0ShwDgR6NjJAsp5eF6vjF6qng==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
+        "@blazediff/core": "1.9.1",
+        "@vitest/mocker": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "magic-string": "^0.30.21",
+        "pngjs": "^7.0.0",
+        "sirv": "^3.0.2",
+        "tinyrainbow": "^3.1.0",
+        "ws": "^8.19.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "vitest": "4.1.10"
+      }
+    },
+    "node_modules/@vitest/browser-playwright": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/browser-playwright/-/browser-playwright-4.1.10.tgz",
+      "integrity": "sha512-nMoXGEiRpT7m3W7NsbvrM2aKNwiNHZf+zEpUCvMteGjZFvfT96Q9fh7QyB98dvDWXiKvrLxA7bJ1mCOOv+JQPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/browser": "4.1.10",
+        "@vitest/mocker": "4.1.10",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "playwright": "*",
+        "vitest": "4.1.10"
+      },
+      "peerDependenciesMeta": {
+        "playwright": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "3.2.7",
-        "@vitest/utils": "3.2.7",
-        "chai": "^5.2.0",
-        "tinyrainbow": "^2.0.0"
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.7.tgz",
-      "integrity": "sha512-Trr0hYO9CM3Wj6ksWHRhK9IZpIY6wTMO5u/MqXurMxT57sWBaOPEtP3Oq60ihZuh5JsiagKfz95OcxdEP6dBrA==",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "3.2.7",
+        "@vitest/spy": "4.1.10",
         "estree-walker": "^3.0.3",
-        "magic-string": "^0.30.17"
+        "magic-string": "^0.30.21"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
         "msw": "^2.4.9",
-        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
       },
       "peerDependenciesMeta": {
         "msw": {
@@ -5435,42 +5433,42 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.7.tgz",
-      "integrity": "sha512-KUHlwqVu0sRlhCdyPdQ/wBoTfRahjUky1MubOmYw9fWfIZy1gNoHpuaaQBPAaMaVYdQYHJLurzj8ECCj5OwTqA==",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "tinyrainbow": "^2.0.0"
+        "tinyrainbow": "^3.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.7.tgz",
-      "integrity": "sha512-sB9y4ovltoQP+WaUPwmSxO9WIg9Ig694Di5PalVPsYHklAdE027mehpWF2SQSVq+k6sFgaivbTjTJwZLSHbedA==",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "3.2.7",
-        "pathe": "^2.0.3",
-        "strip-literal": "^3.0.0"
+        "@vitest/utils": "4.1.10",
+        "pathe": "^2.0.3"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.7.tgz",
-      "integrity": "sha512-7C+MwShwtBSI5Buwoyg3s/iY1eHL9PKAf+O1wVh/TdnjXUtkoL/9YQtre90i4MtNXM6edP1wJ2zOBpfCyhIS7g==",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "3.2.7",
-        "magic-string": "^0.30.17",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "magic-string": "^0.30.21",
         "pathe": "^2.0.3"
       },
       "funding": {
@@ -5478,28 +5476,25 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.7.tgz",
-      "integrity": "sha512-Q2eQGI6d2L/hBtZ0qNuKcAGid68XK6cv1xsoaIma6PaJhHPoqcEJhYpXZ/5myCMqkNgtP6UKuBhbc0nHKnrkuQ==",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "tinyspy": "^4.0.3"
-      },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.7.tgz",
-      "integrity": "sha512-x6BDOd7dyo3PFLY3I9/HJ25X/6OurhGXk2/B9gOZNPF7XDVjeBK4k01lQE5uvDpbuheErh91qYuE1E2OEjK3Rw==",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "3.2.7",
-        "loupe": "^3.1.4",
-        "tinyrainbow": "^2.0.0"
+        "@vitest/pretty-format": "4.1.10",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
@@ -5765,16 +5760,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/cac": {
-      "version": "6.7.14",
-      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
-      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/call-bind": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
@@ -5847,30 +5832,13 @@
       "license": "CC-BY-4.0"
     },
     "node_modules/chai": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
-      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "assertion-error": "^2.0.1",
-        "check-error": "^2.1.1",
-        "deep-eql": "^5.0.1",
-        "loupe": "^3.1.0",
-        "pathval": "^2.0.0"
-      },
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/check-error": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
-      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 16"
       }
     },
     "node_modules/chokidar": {
@@ -6026,16 +5994,6 @@
         "supports-color": {
           "optional": true
         }
-      }
-    },
-    "node_modules/deep-eql": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
-      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/deepmerge": {
@@ -6253,10 +6211,9 @@
       }
     },
     "node_modules/es-module-lexer": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
-      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
-      "dev": true,
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+      "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
       "license": "MIT"
     },
     "node_modules/es-object-atoms": {
@@ -6402,16 +6359,6 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=12.0.0"
-      }
-    },
-    "node_modules/fake-indexeddb": {
-      "version": "6.2.5",
-      "resolved": "https://registry.npmjs.org/fake-indexeddb/-/fake-indexeddb-6.2.5.tgz",
-      "integrity": "sha512-CGnyrvbhPlWYMngksqrSSUT1BAVP49dZocrHuK0SvtR0D5TMs5wP0o3j7jexDJW01KSadjBp1M/71o/KR3nD1w==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -7764,13 +7711,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/loupe": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
-      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -7877,6 +7817,16 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
+    "node_modules/mrmime": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.1.tgz",
+      "integrity": "sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -7976,6 +7926,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/obug": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+      "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
       }
     },
     "node_modules/own-keys": {
@@ -8232,16 +8196,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/pathval": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
-      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 14.16"
-      }
-    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -8297,7 +8251,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -8306,6 +8259,16 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/pngjs": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-7.0.0.tgz",
+      "integrity": "sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.19.0"
       }
     },
     "node_modules/possible-typed-array-names": {
@@ -8899,6 +8862,21 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/sirv": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/sirv/-/sirv-3.0.2.tgz",
+      "integrity": "sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@polka/url": "^1.0.0-next.24",
+        "mrmime": "^2.0.0",
+        "totalist": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/smob": {
       "version": "1.6.2",
       "resolved": "https://registry.npmjs.org/smob/-/smob-1.6.2.tgz",
@@ -8957,9 +8935,9 @@
       "license": "MIT"
     },
     "node_modules/std-env": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
-      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
       "dev": true,
       "license": "MIT"
     },
@@ -9090,26 +9068,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/strip-literal": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
-      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "js-tokens": "^9.0.1"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/antfu"
-      }
-    },
-    "node_modules/strip-literal/node_modules/js-tokens": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
-      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -9191,11 +9149,14 @@
       "license": "MIT"
     },
     "node_modules/tinyexec": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
-      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.3.0.tgz",
+      "integrity": "sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/tinyglobby": {
       "version": "0.2.17",
@@ -9214,34 +9175,24 @@
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
-    "node_modules/tinypool": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
-      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^18.0.0 || >=20.0.0"
-      }
-    },
     "node_modules/tinyrainbow": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
-      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.1.tgz",
+      "integrity": "sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
       }
     },
-    "node_modules/tinyspy": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
-      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+    "node_modules/totalist": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/totalist/-/totalist-3.0.1.tgz",
+      "integrity": "sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=6"
       }
     },
     "node_modules/tr46": {
@@ -9587,29 +9538,6 @@
         }
       }
     },
-    "node_modules/vite-node": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
-      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cac": "^6.7.14",
-        "debug": "^4.4.1",
-        "es-module-lexer": "^1.7.0",
-        "pathe": "^2.0.3",
-        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
-      },
-      "bin": {
-        "vite-node": "vite-node.mjs"
-      },
-      "engines": {
-        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
     "node_modules/vite-plugin-pwa": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/vite-plugin-pwa/-/vite-plugin-pwa-1.3.0.tgz",
@@ -9642,65 +9570,79 @@
       }
     },
     "node_modules/vitest": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.7.tgz",
-      "integrity": "sha512-KrxIJ62Fd89gfysR4WotlgZABiz2dqFPgqGzX7s+CwsqLFomRH7777ZcrOD6+WVAh7khPQP41A+BKbpcJFrdEg==",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@types/chai": "^5.2.2",
-        "@vitest/expect": "3.2.7",
-        "@vitest/mocker": "3.2.7",
-        "@vitest/pretty-format": "^3.2.7",
-        "@vitest/runner": "3.2.7",
-        "@vitest/snapshot": "3.2.7",
-        "@vitest/spy": "3.2.7",
-        "@vitest/utils": "3.2.7",
-        "chai": "^5.2.0",
-        "debug": "^4.4.1",
-        "expect-type": "^1.2.1",
-        "magic-string": "^0.30.17",
+        "@vitest/expect": "4.1.10",
+        "@vitest/mocker": "4.1.10",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/runner": "4.1.10",
+        "@vitest/snapshot": "4.1.10",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
         "pathe": "^2.0.3",
-        "picomatch": "^4.0.2",
-        "std-env": "^3.9.0",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
         "tinybench": "^2.9.0",
-        "tinyexec": "^0.3.2",
-        "tinyglobby": "^0.2.14",
-        "tinypool": "^1.1.1",
-        "tinyrainbow": "^2.0.0",
-        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
-        "vite-node": "3.2.4",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
         "why-is-node-running": "^2.3.0"
       },
       "bin": {
         "vitest": "vitest.mjs"
       },
       "engines": {
-        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
         "@edge-runtime/vm": "*",
-        "@types/debug": "^4.1.12",
-        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
-        "@vitest/browser": "3.2.7",
-        "@vitest/ui": "3.2.7",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.10",
+        "@vitest/browser-preview": "4.1.10",
+        "@vitest/browser-webdriverio": "4.1.10",
+        "@vitest/coverage-istanbul": "4.1.10",
+        "@vitest/coverage-v8": "4.1.10",
+        "@vitest/ui": "4.1.10",
         "happy-dom": "*",
-        "jsdom": "*"
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
       },
       "peerDependenciesMeta": {
         "@edge-runtime/vm": {
           "optional": true
         },
-        "@types/debug": {
+        "@opentelemetry/api": {
           "optional": true
         },
         "@types/node": {
           "optional": true
         },
-        "@vitest/browser": {
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
           "optional": true
         },
         "@vitest/ui": {
@@ -9711,6 +9653,9 @@
         },
         "jsdom": {
           "optional": true
+        },
+        "vite": {
+          "optional": false
         }
       }
     },
@@ -10086,6 +10031,28 @@
       "dependencies": {
         "@types/trusted-types": "^2.0.2",
         "workbox-core": "7.4.1"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.2",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.2.tgz",
+      "integrity": "sha512-54dMVAo4WIe6SKy3vBgN+9bJZqqQ8IMRevAkOLQALhi49qkkQDQfWdAZ8KQlXiEabw88ARXXdUrlvtbKQX+aKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/yallist": {

--- a/package.json
+++ b/package.json
@@ -25,11 +25,11 @@
     "@playwright/test": "^1.62.0",
     "@sentry/vite-plugin": "^5.4.0",
     "@types/node": "^26.1.1",
-    "fake-indexeddb": "^6.0.1",
+    "@vitest/browser-playwright": "^4.1.10",
     "playwright": "^1.62.0",
     "typescript": "~5.8.3",
     "vite": "^7.0.4",
     "vite-plugin-pwa": "^1.0.1",
-    "vitest": "^3.2.4"
+    "vitest": "^4.1.10"
   }
 }

--- a/src/lib/app-update.test.ts
+++ b/src/lib/app-update.test.ts
@@ -20,43 +20,28 @@ function mockRegistration(
   } as unknown as ServiceWorkerRegistration
 }
 
-type Listener = EventListenerOrEventListenerObject
-
+// Browser mode: app-update listens on the real document/window, so tests
+// dispatch real events. `document` itself cannot be replaced in Chromium,
+// but its visibilityState getter can be shadowed on the instance.
 function createDomStub(initialVisibility: DocumentVisibilityState = 'visible') {
-  const listeners = new Map<string, Set<Listener>>()
   let visibilityState = initialVisibility
-
-  const dispatch = (type: string) => {
-    const event = { type } as Event
-    for (const listener of listeners.get(type) ?? []) {
-      if (typeof listener === 'function') listener(event)
-      else listener.handleEvent(event)
-    }
-  }
-
-  const target = {
-    addEventListener(type: string, listener: Listener) {
-      if (!listeners.has(type)) listeners.set(type, new Set())
-      listeners.get(type)!.add(listener)
-    },
-    removeEventListener(type: string, listener: Listener) {
-      listeners.get(type)?.delete(listener)
-    },
-    dispatchEvent(event: Event) {
-      dispatch(event.type)
-      return true
-    },
-    get visibilityState() {
-      return visibilityState
-    },
+  Object.defineProperty(document, 'visibilityState', {
+    configurable: true,
+    get: () => visibilityState,
+  })
+  return {
     setVisibility(next: DocumentVisibilityState) {
       visibilityState = next
     },
+    dispatch(type: 'visibilitychange' | 'focus' | 'pageshow') {
+      const target = type === 'visibilitychange' ? document : window
+      target.dispatchEvent(new Event(type))
+    },
   }
+}
 
-  vi.stubGlobal('document', target)
-  vi.stubGlobal('window', target)
-  return { ...target, dispatch }
+function restoreVisibilityState() {
+  Reflect.deleteProperty(document, 'visibilityState')
 }
 
 describe('app-update resume checks', () => {
@@ -66,7 +51,7 @@ describe('app-update resume checks', () => {
 
   afterEach(() => {
     resetAppUpdateForTests()
-    vi.unstubAllGlobals()
+    restoreVisibilityState()
     vi.restoreAllMocks()
   })
 
@@ -147,7 +132,7 @@ describe('checkForUpdates (manual)', () => {
 
   afterEach(() => {
     resetAppUpdateForTests()
-    vi.unstubAllGlobals()
+    restoreVisibilityState()
     vi.restoreAllMocks()
   })
 

--- a/src/lib/export/mp4-metadata.test.ts
+++ b/src/lib/export/mp4-metadata.test.ts
@@ -1,7 +1,3 @@
-import { execFileSync } from 'node:child_process'
-import { existsSync, mkdtempSync, writeFileSync } from 'node:fs'
-import { tmpdir } from 'node:os'
-import { join } from 'node:path'
 import {
   BufferTarget,
   EncodedPacket,
@@ -10,9 +6,8 @@ import {
   Output,
 } from 'mediabunny'
 import { describe, expect, it } from 'vitest'
+import { commands } from 'vitest/browser'
 import { formatIso6709, injectMp4Metadata, type Mp4Chapter } from './mp4-metadata'
-
-const PLAYWRIGHT_FFMPEG = '/home/ubuntu/.cache/ms-playwright/ffmpeg-1011/ffmpeg-linux'
 
 const AVC_DESC = new Uint8Array([
   0x01, 0x42, 0x00, 0x1e, 0xff, 0xe1, 0x00, 0x08, 0x67, 0x42, 0x00, 0x1e, 0xda, 0x02, 0xd0,
@@ -104,28 +99,14 @@ function findBox(bytes: Uint8Array, type: number, start = 0, end = bytes.byteLen
   return listBoxes(bytes, start, end).find((b) => b.type === type) ?? null
 }
 
-function resolveFfmpeg(): string | null {
-  const candidates = [
-    PLAYWRIGHT_FFMPEG,
-    'ffmpeg',
-    '/usr/bin/ffmpeg',
-  ]
-  for (const bin of candidates) {
-    if (bin !== 'ffmpeg' && !existsSync(bin)) continue
-    try {
-      // Playwright's ffmpeg build is VP8/WebM-only; probe MP4 demux support.
-      const help = execFileSync(bin, ['-hide_banner', '-demuxers'], {
-        encoding: 'utf8',
-        stdio: ['ignore', 'pipe', 'pipe'],
-      })
-      if (/\bmov\b|\bmp4\b/i.test(help)) return bin
-    } catch {
-      // try next
-    }
+function toBase64(buffer: ArrayBuffer): string {
+  const bytes = new Uint8Array(buffer)
+  let binary = ''
+  const chunk = 0x8000
+  for (let i = 0; i < bytes.length; i += chunk) {
+    binary += String.fromCharCode(...bytes.subarray(i, i + chunk))
   }
-  // Spec asks us to skip when the playwright binary is missing; if it exists
-  // but cannot demux MP4, also skip rather than fail the suite.
-  return null
+  return btoa(binary)
 }
 
 describe('injectMp4Metadata', () => {
@@ -197,12 +178,6 @@ describe('injectMp4Metadata', () => {
   })
 
   it('is validated by ffmpeg when an MP4-capable binary is available', async () => {
-    const ffmpeg = resolveFfmpeg()
-    if (!ffmpeg) {
-      // Playwright build ships without an MP4 demuxer; skip rather than fail.
-      return
-    }
-
     const title = 'Morning Walk'
     const location = { lat: 37.7749, lng: -122.4194 }
     const injected = injectMp4Metadata(await buildTinyMp4(), {
@@ -213,19 +188,12 @@ describe('injectMp4Metadata', () => {
       location,
     })
 
-    const dir = mkdtempSync(join(tmpdir(), 'kody-mp4-meta-'))
-    const file = join(dir, 'export.mp4')
-    writeFileSync(file, Buffer.from(injected))
-
-    let stderr = ''
-    try {
-      execFileSync(ffmpeg, ['-hide_banner', '-i', file], {
-        encoding: 'utf8',
-        stdio: ['ignore', 'pipe', 'pipe'],
-      })
-    } catch (err) {
-      // ffmpeg -i exits non-zero without an output file; stderr still has the probe.
-      stderr = err && typeof err === 'object' && 'stderr' in err ? String((err as { stderr: unknown }).stderr) : ''
+    // ffmpeg runs on the Vitest server (Node), not in the browser — see
+    // src/test/ffmpeg-command.ts.
+    const stderr = await commands.probeMp4WithFfmpeg(toBase64(injected))
+    if (stderr === null) {
+      // No MP4-capable ffmpeg on the server; skip rather than fail.
+      return
     }
     expect(stderr).toMatch(/Chapters/i)
     expect(stderr).toContain(title)

--- a/src/lib/media.test.ts
+++ b/src/lib/media.test.ts
@@ -1,9 +1,10 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
+import { pickRecordingMimeType, resetRecordingMimeTypeForTests } from './media'
 
 // The recording mime preference is cached at module scope (it runs inside
-// the pointerdown that starts every take), so each test re-imports a fresh
-// module instance via vi.resetModules — a top-level import would share one
-// cache across tests.
+// the pointerdown that starts every take); resetRecordingMimeTypeForTests
+// clears the cache between tests — the browser module graph cannot be
+// re-imported per test the way vi.resetModules allowed in Node.
 
 class FakeMediaRecorder {
   static probes: string[] = []
@@ -14,41 +15,36 @@ class FakeMediaRecorder {
   }
 }
 
-async function freshPickRecordingMimeType() {
-  vi.resetModules()
-  const media = await import('./media')
-  return media.pickRecordingMimeType
-}
-
 afterEach(() => {
   vi.unstubAllGlobals()
+  resetRecordingMimeTypeForTests()
   FakeMediaRecorder.probes = []
   FakeMediaRecorder.supported = new Set()
 })
 
 describe('pickRecordingMimeType', () => {
-  it('probes the platform once and serves later takes from the cache', async () => {
+  it('probes the platform once and serves later takes from the cache', () => {
     FakeMediaRecorder.supported = new Set(['video/webm;codecs=vp9,opus'])
     vi.stubGlobal('MediaRecorder', FakeMediaRecorder)
-    const pick = await freshPickRecordingMimeType()
+    resetRecordingMimeTypeForTests()
 
-    const first = pick()
+    const first = pickRecordingMimeType()
     const probesAfterFirst = FakeMediaRecorder.probes.length
     expect(first).toBe('video/webm;codecs=vp9,opus')
     expect(probesAfterFirst).toBeGreaterThan(0)
 
-    expect(pick()).toBe(first)
-    expect(pick()).toBe(first)
+    expect(pickRecordingMimeType()).toBe(first)
+    expect(pickRecordingMimeType()).toBe(first)
     expect(FakeMediaRecorder.probes.length).toBe(probesAfterFirst)
   })
 
-  it('caches the empty result when nothing is supported', async () => {
+  it('caches the empty result when nothing is supported', () => {
     vi.stubGlobal('MediaRecorder', FakeMediaRecorder)
-    const pick = await freshPickRecordingMimeType()
+    resetRecordingMimeTypeForTests()
 
-    expect(pick()).toBe('')
+    expect(pickRecordingMimeType()).toBe('')
     const probesAfterFirst = FakeMediaRecorder.probes.length
-    expect(pick()).toBe('')
+    expect(pickRecordingMimeType()).toBe('')
     expect(FakeMediaRecorder.probes.length).toBe(probesAfterFirst)
   })
 })

--- a/src/lib/media.ts
+++ b/src/lib/media.ts
@@ -313,6 +313,11 @@ export function pickRecordingMimeType(): string {
   return cachedRecordingMimeType
 }
 
+/** Test-only: clear the cached probe so each Vitest case re-probes. */
+export function resetRecordingMimeTypeForTests(): void {
+  cachedRecordingMimeType = null
+}
+
 function probeRecordingMimeType(): string {
   if (typeof MediaRecorder === 'undefined') return ''
   const mobile = [

--- a/src/lib/mic-monitor.test.ts
+++ b/src/lib/mic-monitor.test.ts
@@ -1,8 +1,13 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  resetMicMonitorForTests,
+  startMicLevelMonitor,
+  warmMicMonitorContext,
+} from './mic-monitor'
 
-// The monitor shares one AudioContext at module scope, so each test
-// re-imports a fresh module instance via vi.resetModules — a top-level
-// import would leak the shared context between tests.
+// The monitor shares one AudioContext at module scope;
+// resetMicMonitorForTests drops it between tests — the browser module graph
+// cannot be re-imported per test the way vi.resetModules allowed in Node.
 
 class FakeAnalyser {
   fftSize = 0
@@ -53,31 +58,25 @@ const liveTrack = () => ({
   addEventListener: () => undefined,
 })
 
-async function freshMicMonitor() {
-  vi.resetModules()
-  return import('./mic-monitor')
-}
-
 afterEach(() => {
   vi.unstubAllGlobals()
+  resetMicMonitorForTests()
   FakeAudioContext.constructed = 0
 })
 
 describe('warmMicMonitorContext', () => {
-  it('creates the shared context once, suspended, and takes reuse it', async () => {
+  it('creates the shared context once, suspended, and takes reuse it', () => {
     vi.stubGlobal('AudioContext', FakeAudioContext)
     vi.stubGlobal('MediaStream', FakeMediaStream)
-    vi.stubGlobal('window', globalThis)
-    const monitor = await freshMicMonitor()
 
-    monitor.warmMicMonitorContext()
-    monitor.warmMicMonitorContext()
+    warmMicMonitorContext()
+    warmMicMonitorContext()
     expect(FakeAudioContext.constructed).toBe(1)
 
     // A take starting later must reuse the pre-warmed context instead of
     // constructing a second one on the record-start critical path.
     const stream = new FakeMediaStream([liveTrack()]) as unknown as MediaStream
-    const handle = monitor.startMicLevelMonitor(stream, {
+    const handle = startMicLevelMonitor(stream, {
       onSilent: () => undefined,
       onSound: () => undefined,
     })
@@ -85,8 +84,9 @@ describe('warmMicMonitorContext', () => {
     handle.stop()
   })
 
-  it('is a no-op when AudioContext is unavailable', async () => {
-    const monitor = await freshMicMonitor()
-    expect(() => monitor.warmMicMonitorContext()).not.toThrow()
+  it('is a no-op when AudioContext is unavailable', () => {
+    // The browser has a real AudioContext — hide it for this test.
+    vi.stubGlobal('AudioContext', undefined)
+    expect(() => warmMicMonitorContext()).not.toThrow()
   })
 })

--- a/src/lib/mic-monitor.ts
+++ b/src/lib/mic-monitor.ts
@@ -22,6 +22,11 @@ export interface MicLevelMonitor {
  */
 let sharedContext: AudioContext | null = null
 
+/** Test-only: drop the shared context so each Vitest case starts fresh. */
+export function resetMicMonitorForTests(): void {
+  sharedContext = null
+}
+
 function acquireContext(): AudioContext | null {
   if (typeof AudioContext === 'undefined') return null
   try {

--- a/src/lib/showcase.test.ts
+++ b/src/lib/showcase.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it } from 'vitest'
 import {
   dismissShowcaseBanner,
   isShowcaseBannerDismissed,
@@ -27,22 +27,9 @@ describe('showcaseForHostname', () => {
 })
 
 describe('showcase banner dismissal', () => {
-  // Node test environment has no localStorage; back it with a Map.
-  const backing = new Map<string, string>()
-
+  // Browser mode has the real localStorage; just start each test clean.
   beforeEach(() => {
-    backing.clear()
-    Object.defineProperty(globalThis, 'localStorage', {
-      configurable: true,
-      value: {
-        getItem: (key: string) => backing.get(key) ?? null,
-        setItem: (key: string, value: string) => void backing.set(key, value),
-      },
-    })
-  })
-
-  afterEach(() => {
-    delete (globalThis as { localStorage?: unknown }).localStorage
+    localStorage.clear()
   })
 
   it('starts visible and stays dismissed after dismissal', () => {

--- a/src/lib/storage.test.ts
+++ b/src/lib/storage.test.ts
@@ -504,10 +504,11 @@ describe('storage layer', () => {
   it('does not leak AbortError unhandled rejections when a clip put fails', async () => {
     const project = await createProject('Fail put')
     const unhandled: unknown[] = []
-    const onUnhandled = (reason: unknown) => {
-      unhandled.push(reason)
+    const onUnhandled = (event: PromiseRejectionEvent) => {
+      unhandled.push(event.reason)
+      event.preventDefault()
     }
-    process.on('unhandledRejection', onUnhandled)
+    window.addEventListener('unhandledrejection', onUnhandled)
     try {
       // Functions are not structured-cloneable, so IndexedDB rejects the put.
       await expect(
@@ -520,6 +521,9 @@ describe('storage layer', () => {
         }),
       ).rejects.toBeTruthy()
       // Let any orphaned tx.done rejection surface if the leak regresses.
+      // Chromium fires unhandledrejection a task after the rejection, so
+      // yield through two macrotasks before judging.
+      await new Promise<void>((resolve) => setTimeout(resolve, 0))
       await new Promise<void>((resolve) => setTimeout(resolve, 0))
       const abortLeaks = unhandled.filter(
         (err) =>
@@ -527,7 +531,7 @@ describe('storage layer', () => {
       )
       expect(abortLeaks).toHaveLength(0)
     } finally {
-      process.off('unhandledRejection', onUnhandled)
+      window.removeEventListener('unhandledrejection', onUnhandled)
     }
   })
 })

--- a/src/test/ffmpeg-command.ts
+++ b/src/test/ffmpeg-command.ts
@@ -1,0 +1,70 @@
+import { execFileSync } from 'node:child_process'
+import { existsSync, mkdtempSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { Buffer } from 'node:buffer'
+import type { BrowserCommand } from 'vitest/node'
+
+/**
+ * Vitest browser-mode command: tests run inside Chromium, but ffmpeg
+ * validation needs a real binary and filesystem, so this half executes on
+ * the Vitest server (Node) and the test calls it via `commands`.
+ */
+
+const PLAYWRIGHT_FFMPEG = '/home/ubuntu/.cache/ms-playwright/ffmpeg-1011/ffmpeg-linux'
+
+function resolveFfmpeg(): string | null {
+  const candidates = [PLAYWRIGHT_FFMPEG, 'ffmpeg', '/usr/bin/ffmpeg']
+  for (const bin of candidates) {
+    if (bin !== 'ffmpeg' && !existsSync(bin)) continue
+    try {
+      // Playwright's ffmpeg build is VP8/WebM-only; probe MP4 demux support.
+      const help = execFileSync(bin, ['-hide_banner', '-demuxers'], {
+        encoding: 'utf8',
+        stdio: ['ignore', 'pipe', 'pipe'],
+      })
+      if (/\bmov\b|\bmp4\b/i.test(help)) return bin
+    } catch {
+      // try next
+    }
+  }
+  // Spec asks us to skip when the playwright binary is missing; if it exists
+  // but cannot demux MP4, also skip rather than fail the suite.
+  return null
+}
+
+/**
+ * Writes the MP4 (base64) to a temp file and runs `ffmpeg -i` on it.
+ * Returns ffmpeg's stderr probe output, or null when no MP4-capable
+ * binary is available (callers skip rather than fail).
+ */
+export const probeMp4WithFfmpeg: BrowserCommand<[base64Mp4: string]> = (
+  _ctx,
+  base64Mp4,
+): string | null => {
+  const ffmpeg = resolveFfmpeg()
+  if (!ffmpeg) return null
+
+  const dir = mkdtempSync(join(tmpdir(), 'kody-mp4-meta-'))
+  const file = join(dir, 'export.mp4')
+  writeFileSync(file, Buffer.from(base64Mp4, 'base64'))
+
+  try {
+    execFileSync(ffmpeg, ['-hide_banner', '-i', file], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    })
+    return ''
+  } catch (err) {
+    // ffmpeg -i exits non-zero without an output file; stderr still has the probe.
+    return err && typeof err === 'object' && 'stderr' in err
+      ? String((err as { stderr: unknown }).stderr)
+      : ''
+  }
+}
+
+declare module 'vitest/browser' {
+  interface BrowserCommands {
+    probeMp4WithFfmpeg: (base64Mp4: string) => Promise<string | null>
+  }
+}

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,7 +1,0 @@
-import 'fake-indexeddb/auto'
-import { IDBKeyRange } from 'fake-indexeddb'
-
-// Ensure IDBKeyRange is available for idb index queries in Node.
-if (typeof globalThis.IDBKeyRange === 'undefined') {
-  globalThis.IDBKeyRange = IDBKeyRange
-}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,10 +1,24 @@
+import { playwright } from '@vitest/browser-playwright'
 import { defineConfig } from 'vitest/config'
+import { probeMp4WithFfmpeg } from './src/test/ffmpeg-command'
 
 export default defineConfig({
+  // Pre-bundle everything the component tests pull in — a dependency
+  // discovered mid-run makes Vite reload the page and re-run tests.
+  optimizeDeps: {
+    include: ['remix/ui/jsx-dev-runtime'],
+  },
   test: {
-    environment: 'node',
     // Unit tests only — tests/e2e belongs to Playwright.
     include: ['src/**/*.test.ts', 'functions/**/*.test.ts'],
-    setupFiles: ['./src/test/setup.ts'],
+    browser: {
+      enabled: true,
+      headless: true,
+      provider: playwright(),
+      instances: [{ browser: 'chromium' }],
+      // Unit-style assertions — a page screenshot of a failure adds noise.
+      screenshotFailures: false,
+      commands: { probeMp4WithFfmpeg },
+    },
   },
 })


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`npm test` now runs the unit suite in real headless Chromium via Vitest 4 browser mode (`@vitest/browser-playwright`), instead of Node with fakes.

- **Real browser APIs replace fakes**: `fake-indexeddb` is removed (real IndexedDB, reset per test by the existing `__resetDbForTests`), the showcase test uses real `localStorage`, and the storage AbortError-leak test listens for `window` `unhandledrejection` events instead of `process.on('unhandledRejection')`.
- **Node-only work moved server-side**: the ffmpeg MP4-metadata validation runs on the Vitest server through a custom [browser command](https://vitest.dev/api/browser/commands) (`src/test/ffmpeg-command.ts`); the test ships the muxed MP4 to it as base64.
- **`vi.resetModules()` fallout**: it cannot invalidate the browser module graph, so `media.ts` and `mic-monitor.ts` gained explicit test-reset helpers (`resetRecordingMimeTypeForTests`, `resetMicMonitorForTests`), matching the existing `resetAppUpdateForTests` pattern.
- **`document` cannot be redefined in Chromium**: the app-update tests now drive the real `document`/`window` with dispatched events and a shadowed `visibilityState` getter.
- **CI**: Playwright Chromium install now happens before the unit-test step, since the unit suite needs the browser too. Docs updated (`README.md`, `docs/contribute/running-and-testing.md`).

## Verification

- `npx vitest run`: 25 files, 201 tests passed in Chromium.
- Verified the ffmpeg browser command resolves a real MP4-capable binary and that the `unhandledrejection` listener catches a deliberately leaked AbortError (temporary scratch test, removed).
- `npm run lint` (tsc -b) clean.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dc12cca5-62aa-48f4-8482-1dd8fd66bbd5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dc12cca5-62aa-48f4-8482-1dd8fd66bbd5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

