### PR TITLE
Independent per-clip volume sliders + persisted audio normalization

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,25 +32,31 @@ For a phone on the same network, use your machine’s LAN URL over HTTPS, or tun
 - Self-timer for hands-free takes (tap to stop)
 - Recording feedback (REC pill + elapsed) with a page that does **not** re-render per frame — capture stays smooth
 - Editor: filmstrip timeline (thumbnails, width ∝ duration), drag to reorder, duplicate, delete w/ undo, **in-timeline trim with drag handles**, **add clips from your device/gallery**
+- **Per-clip audio levels**: every clip's audio is **peak-normalized** as a
+  post-recording step (measured once, persisted on the clip, backfilled
+  automatically when an older project loads), so takes recorded at
+  different distances play back at consistent loudness — in the previews
+  and in the export. Selecting a clip in the timeline shows a **Clip
+  sound** slider: the clip's own volume, 0–100% (default 100%), applied
+  with or without music
 - **Background music** (Plus): build a playlist of audio tracks that play one
   after the other under the film (nothing loops — a hint suggests adding
-  another track when the music ends before the film does). The mix is
-  **relative**: one balance slider per clip splits the audio between the
-  clip's own   sound (left) and the music (right) — 80% music means 20% clip
-  sound — so the blend can never clip, and both sources are
-  **peak-normalized** so the split means the same thing however hot either
-  recording is. Defaults to 25% music under every clip; tap a clip to set
-  its own balance (duck the music under speech, swell it for b-roll). Mix
-  changes glide across clip boundaries. Tapping a track row opens its
-  **detail view** (the audio counterpart of the clip trim view): trim the
-  track to a kept window over its waveform, set the track's level, and
-  toggle its fade in/out (on by default — each track eases in where it
-  starts and out where it ends, including the film's edges). All of it —
-  levels, normalization, fades, trims, track hand-offs — plays the same in
-  the previews as in the exported file: the project preview runs the whole
-  film's bed, and the editor's clip stage plays the music under the
-  selected clip from its exact spot on the film's timeline (normalization
-  boosts cap at the browser's volume ceiling in previews)
+  another track when the music ends before the film does). Each track
+  carries its own **volume** (default 25% — normalized music sits under
+  speech), set in the track's **detail view** (the audio counterpart of
+  the clip trim view: trim the track to a kept window over its waveform,
+  set its volume, and toggle its fade in/out — on by default; each track
+  eases in where it starts and out where it ends, including the film's
+  edges). The selected clip additionally gets a **Music** slider that
+  ducks the playing track's volume during that clip (0–100%, default
+  100%) — the clip's own sound and the music are independent dials, and
+  the blend hard-clamps rather than coupling them. Volume changes glide
+  across clip boundaries. All of it — volumes, normalization, fades,
+  trims, track hand-offs — plays the same in the previews as in the
+  exported file: the project preview runs the whole film's bed, and the
+  editor's clip stage plays the music under the selected clip from its
+  exact spot on the film's timeline (normalization boosts cap at the
+  browser's volume ceiling in previews)
 - Project preview playback: tap edges to skip clips, tap middle to stop
 - Up to **6** stable project slots (create / open / rename / delete, poster art from your clips)
 - Big Go CTA: on-device export to **one video file**, then Share (system sheet) or Save
@@ -137,7 +143,7 @@ before this feature simply lack the data and degrade gracefully.
 | clips    | Clip metadata, `Blob` media, filmstrip thumbnails     |
 | undo     | Last deleted clip per project (for Undo)              |
 | meta     | Settings (`maxProjects`, last opened id, onboarding)  |
-| audio    | Background-music playlist per project (blobs, volumes, per-track trims/levels/fades) |
+| audio    | Background-music playlist per project (blobs, per-track trims/volumes/fades) |
 
 Database name: `kody-video`. Blobs never leave the device unless the user explicitly shares/downloads.
 

--- a/src/components/audio-detail-strip.tsx
+++ b/src/components/audio-detail-strip.tsx
@@ -36,10 +36,12 @@ interface AudioDetailStripProps {
 /**
  * Detail view for ONE background-music track, opened from its playlist row
  * — the audio counterpart of the clip TrimStrip. Trim handles bound the
- * kept window over a waveform, the level slider scales the track's side of
- * the mix, and the fade toggles ease the track in/out where it starts and
- * ends. Everything is a local draft until Done persists it (Cancel or
- * Escape discards); the preview button auditions the kept window live.
+ * kept window over a waveform, the volume slider sets the music's level
+ * under the clips while this track plays (clips can duck it further with
+ * their own music slider), and the fade toggles ease the track in/out
+ * where it starts and ends. Everything is a local draft until Done
+ * persists it (Cancel or Escape discards); the preview button auditions
+ * the kept window live.
  */
 export function AudioDetailStrip(handle: Handle<AudioDetailStripProps>) {
   const { props } = handle
@@ -322,15 +324,15 @@ export function AudioDetailStrip(handle: Handle<AudioDetailStripProps>) {
             Preview
           </button>
           <div className="audio-detail-level">
-            <span className="audio-volume-label">Level</span>
+            <span className="audio-volume-label">Volume</span>
             <input
               type="range"
               min={0}
               max={100}
               step={5}
               value={levelPct}
-              aria-label="Track level"
-              aria-valuetext={`${levelPct}% level`}
+              aria-label="Track volume"
+              aria-valuetext={`${levelPct}% volume`}
               mix={[
                 on('input', (event) => {
                   volume = Number((event.currentTarget as HTMLInputElement).value) / 100

--- a/src/components/audio-strip.tsx
+++ b/src/components/audio-strip.tsx
@@ -5,13 +5,13 @@ import { reportError } from '../lib/error-reporting'
 import {
   addProjectAudioFromFile,
   removeAudioTrack,
-  setClipAudioVolume,
-  setProjectAudioSettings,
+  setClipVolumes,
 } from '../lib/project-actions'
 import {
   audioTrackKeptMs,
   audioTrackLevel,
-  clipAudioVolume,
+  clipMusicVolume,
+  clipSoundVolume,
   formatDuration,
   projectAudioTotalDurationMs,
   type ClipId,
@@ -35,20 +35,30 @@ interface AudioStripProps {
   plus: boolean
   /** Open the Plus upsell sheet (owned by the page, like restore). */
   onUpsell: () => void
-  /** Open a track's detail view (trim, level, fades) — owned by the editor
+  /** Open a track's detail view (trim, volume, fades) — owned by the editor
    * screen, like the clip trim view. */
   onEditTrack: (trackId: string) => void
   showToast: (message: string) => void
   refresh: () => void
 }
 
+/** A pending slider value for one clip, mid-edit / awaiting the post-write
+ * refresh. */
+interface PendingClipVolume {
+  clipId: ClipId
+  volume: number
+}
+
 /**
- * Background-music panel under the timeline: build a playlist of tracks
- * (played one after the other until the film ends), set the default mix,
- * and dial the music volume for the selected clip. Tapping a track row
- * opens its detail view (trim, level, fades — the audio counterpart of the
- * clip trim view). Volume writes persist on slider release; the label
- * tracks the thumb live.
+ * Audio panel under the timeline: build a background-music playlist of
+ * tracks (played one after the other until the film ends) and dial the
+ * selected clip's levels — its own sound and the music under it, each an
+ * independent 0–100% volume (100% is the default; the music slider ducks
+ * the playing track's own volume). Tapping a track row opens its detail
+ * view (trim, volume, fades — the audio counterpart of the clip trim
+ * view), whose volume slider is where the music's base level lives.
+ * Volume writes persist on slider release; the label tracks the thumb
+ * live.
  */
 export function AudioStrip(handle: Handle<AudioStripProps>) {
   const { props } = handle
@@ -56,8 +66,8 @@ export function AudioStrip(handle: Handle<AudioStripProps>) {
   const fileInputRef: { current: HTMLInputElement | null } = { current: null }
   /** Slider values mid-edit / awaiting the post-write refresh — they keep
    * the controls steady until props catch up with what was persisted. */
-  let pendingDefault: number | null = null
-  let pendingClip: { clipId: ClipId; volume: number } | null = null
+  let pendingClipSound: PendingClipVolume | null = null
+  let pendingClipMusic: PendingClipVolume | null = null
 
   const setBusy = (next: boolean) => {
     busy = next
@@ -92,8 +102,8 @@ export function AudioStrip(handle: Handle<AudioStripProps>) {
       .then(() => props.refresh())
       .catch((err) => {
         reportError(err, 'project-audio')
-        pendingDefault = null
-        pendingClip = null
+        pendingClipSound = null
+        pendingClipMusic = null
         props.showToast('Could not save that change — try again')
         props.refresh()
         void handle.update()
@@ -118,22 +128,14 @@ export function AudioStrip(handle: Handle<AudioStripProps>) {
     })()
   }
 
-  const commitDefaultVolume = (volume: number) => {
-    const audio = props.audio
-    if (!audio) return
-    pendingDefault = volume
-    persist(setProjectAudioSettings(audio.projectId, { defaultVolume: volume }))
+  const commitClipSound = (clipId: ClipId, volume: number) => {
+    pendingClipSound = { clipId, volume }
+    persist(setClipVolumes(clipId, { clipVolume: volume }))
   }
 
-  const commitClipVolume = (clipId: ClipId, volume: number) => {
-    pendingClip = { clipId, volume }
-    persist(setClipAudioVolume(clipId, volume))
-  }
-
-  const resetClipVolume = (clipId: ClipId) => {
-    pendingClip = null
-    persist(setClipAudioVolume(clipId, null))
-    void handle.update()
+  const commitClipMusic = (clipId: ClipId, volume: number) => {
+    pendingClipMusic = { clipId, volume }
+    persist(setClipVolumes(clipId, { musicVolume: volume }))
   }
 
   return () => {
@@ -163,6 +165,46 @@ export function AudioStrip(handle: Handle<AudioStripProps>) {
       />
     )
 
+    // Drop the held control values once a refresh delivered them back (or
+    // the selection moved on).
+    if (
+      pendingClipSound !== null &&
+      (selectedClip?.id !== pendingClipSound.clipId ||
+        Math.abs(clipSoundVolume(selectedClip) - pendingClipSound.volume) < 0.005)
+    ) {
+      pendingClipSound = null
+    }
+    if (
+      pendingClipMusic !== null &&
+      (selectedClip?.id !== pendingClipMusic.clipId ||
+        Math.abs(clipMusicVolume(selectedClip) - pendingClipMusic.volume) < 0.005)
+    ) {
+      pendingClipMusic = null
+    }
+
+    const clipSound = selectedClip
+      ? (pendingClipSound?.volume ?? clipSoundVolume(selectedClip))
+      : 1
+    const clipMusic = selectedClip
+      ? (pendingClipMusic?.volume ?? clipMusicVolume(selectedClip))
+      : 1
+
+    // The clip's own sound volume applies with or without music (and on
+    // the free plan) — it is about the clip, not the playlist.
+    const clipSoundRow = selectedClip ? (
+      <VolumeRow
+        label={`Clip ${selectedIndex + 1} sound`}
+        ariaLabel={`Clip ${selectedIndex + 1} sound volume`}
+        volume={clipSound}
+        disabled={disabled || busy}
+        onPreview={(volume) => {
+          pendingClipSound = { clipId: selectedClip.id, volume }
+          void handle.update()
+        }}
+        onCommit={(volume) => commitClipSound(selectedClip.id, volume)}
+      />
+    ) : null
+
     if (!audio) {
       // Free plan: the button stays visible (discoverable) but opens the
       // Plus upsell instead of the file picker.
@@ -182,6 +224,7 @@ export function AudioStrip(handle: Handle<AudioStripProps>) {
                 <IconLock size={13} />
               </span>
             </button>
+            {clipSoundRow}
           </div>
         )
       }
@@ -198,33 +241,10 @@ export function AudioStrip(handle: Handle<AudioStripProps>) {
             <IconMusic size={18} />
             {busy ? 'Adding music…' : 'Add music'}
           </button>
+          {clipSoundRow}
         </div>
       )
     }
-
-    // Drop the held control values once a refresh delivered them back.
-    if (pendingDefault !== null && Math.abs(audio.defaultVolume - pendingDefault) < 0.005) {
-      pendingDefault = null
-    }
-    if (
-      pendingClip !== null &&
-      (selectedClip?.id !== pendingClip.clipId ||
-        (selectedClip.audioVolume !== undefined &&
-          Math.abs(selectedClip.audioVolume - pendingClip.volume) < 0.005))
-    ) {
-      pendingClip = null
-    }
-
-    const defaultVolume = pendingDefault ?? audio.defaultVolume
-    const clipOverridden = selectedClip
-      ? pendingClip?.clipId === selectedClip.id || selectedClip.audioVolume !== undefined
-      : false
-    // Follows the pending default too, so both rows agree mid-drag.
-    const clipVolume = selectedClip
-      ? pendingClip?.clipId === selectedClip.id
-        ? pendingClip.volume
-        : clipAudioVolume(selectedClip, defaultVolume)
-      : defaultVolume
 
     const musicMs = projectAudioTotalDurationMs(audio)
     const musicEndsEarly = props.projectDurationMs > 0 && musicMs < props.projectDurationMs
@@ -235,7 +255,7 @@ export function AudioStrip(handle: Handle<AudioStripProps>) {
         {audio.tracks.map((track, trackIndex) => {
           const keptMs = audioTrackKeptMs(track)
           const trimmed = keptMs < track.durationMs
-          const levelPct = Math.round(audioTrackLevel(track) * 100)
+          const volumePct = Math.round(audioTrackLevel(track) * 100)
           return (
             <div key={track.id} className="audio-track-row">
               <button
@@ -243,7 +263,7 @@ export function AudioStrip(handle: Handle<AudioStripProps>) {
                 className="audio-track-open"
                 disabled={disabled || busy}
                 aria-label={`Edit music track ${trackIndex + 1} (${track.name})`}
-                title="Trim, level, and fades"
+                title="Trim, volume, and fades"
                 mix={on('click', () => props.onEditTrack(track.id))}
               >
                 <span className="audio-track-icon" aria-hidden="true">
@@ -260,7 +280,7 @@ export function AudioStrip(handle: Handle<AudioStripProps>) {
                 <span className="audio-track-duration muted">
                   {formatDuration(keptMs)}
                   {trimmed ? ' kept' : ''}
-                  {levelPct < 100 ? ` · ${levelPct}%` : ''}
+                  {` · ${volumePct}%`}
                 </span>
               </button>
               <button
@@ -294,73 +314,55 @@ export function AudioStrip(handle: Handle<AudioStripProps>) {
           ) : null}
         </div>
 
+        {clipSoundRow}
         {selectedClip ? (
-          <MixRow
-            label={`Clip ${selectedIndex + 1}${clipOverridden ? '' : ' · default'}`}
-            ariaLabel={`Audio mix during clip ${selectedIndex + 1}`}
-            share={clipVolume}
+          <VolumeRow
+            label={`Clip ${selectedIndex + 1} music`}
+            ariaLabel={`Music volume during clip ${selectedIndex + 1}`}
+            volume={clipMusic}
             disabled={disabled || busy}
-            onPreview={(share) => {
-              pendingClip = { clipId: selectedClip.id, volume: share }
+            onPreview={(volume) => {
+              pendingClipMusic = { clipId: selectedClip.id, volume }
               void handle.update()
             }}
-            onCommit={(share) => commitClipVolume(selectedClip.id, share)}
-            onReset={clipOverridden ? () => resetClipVolume(selectedClip.id) : undefined}
+            onCommit={(volume) => commitClipMusic(selectedClip.id, volume)}
           />
         ) : null}
-
-        <MixRow
-          label="All clips"
-          ariaLabel="Default audio mix"
-          share={defaultVolume}
-          disabled={disabled || busy}
-          onPreview={(share) => {
-            pendingDefault = share
-            void handle.update()
-          }}
-          onCommit={(share) => commitDefaultVolume(share)}
-        />
       </div>
     )
   }
 }
 
-interface MixRowProps {
+interface VolumeRowProps {
   label: string
   ariaLabel: string
-  /** Music's share of the mix (0–1); the clip's own sound gets the rest. */
-  share: number
+  /** The level (0–1); 1 (100%) is the default and stores no override. */
+  volume: number
   disabled: boolean
   /** Live thumb move (label preview only — nothing persisted yet). */
-  onPreview: (share: number) => void
+  onPreview: (volume: number) => void
   /** Slider released — persist. */
-  onCommit: (share: number) => void
-  /** Present only when the row is overridable and currently overridden. */
-  onReset?: () => void
+  onCommit: (volume: number) => void
 }
 
-/** One balance slider: clip sound on the left, music on the right — drag
- * toward the side that should carry more of the mix. */
-function MixRow(handle: Handle<MixRowProps>) {
+/** One volume slider: 0% silences that side for this clip, 100% (default)
+ * plays it at its full mixed level. */
+function VolumeRow(handle: Handle<VolumeRowProps>) {
   return () => {
-    const { label, ariaLabel, share, disabled, onReset } = handle.props
-    const musicPct = Math.round(share * 100)
-    const clipPct = 100 - musicPct
+    const { label, ariaLabel, volume, disabled } = handle.props
+    const pct = Math.round(volume * 100)
     return (
-      <div className="audio-mix-row">
+      <div className="audio-volume-row">
         <span className="audio-volume-label">{label}</span>
-        <span className="audio-mix-side" aria-hidden="true">
-          Clip <strong>{clipPct}%</strong>
-        </span>
         <input
           type="range"
           min={0}
           max={100}
           step={5}
-          value={musicPct}
+          value={pct}
           disabled={disabled}
           aria-label={ariaLabel}
-          aria-valuetext={`${clipPct}% clip sound, ${musicPct}% music`}
+          aria-valuetext={`${pct}% volume`}
           mix={[
             on('input', (event) => {
               handle.props.onPreview(
@@ -374,20 +376,7 @@ function MixRow(handle: Handle<MixRowProps>) {
             }),
           ]}
         />
-        <span className="audio-mix-side" aria-hidden="true">
-          <strong>{musicPct}%</strong> Music
-        </span>
-        {onReset ? (
-          <button
-            type="button"
-            className="audio-volume-reset"
-            disabled={disabled}
-            aria-label="Reset this clip to the default audio mix"
-            mix={on('click', () => handle.props.onReset?.())}
-          >
-            Reset
-          </button>
-        ) : null}
+        <strong className="audio-volume-value">{pct}%</strong>
       </div>
     )
   }

--- a/src/components/editor-clip-preview.tsx
+++ b/src/components/editor-clip-preview.tsx
@@ -176,10 +176,12 @@ export function EditorClipPreview(handle: Handle<EditorClipPreviewProps>) {
     normalizedElementVolume(clipSoundVolume(props.clip), clipAudioScale(props.clip))
 
   /** Without music there is no per-frame tick — apply the clip's own
-   * level (and normalization) directly whenever it may have changed. */
+   * level (and normalization) directly whenever it may have changed. The
+   * gate matches the music element's mount condition (tracks present):
+   * only a MOUNTED bed runs the tick that owns the volume instead. */
   const applyClipVolume = () => {
     const video = media
-    if (!video || props.audio) return
+    if (!video || (props.audio?.tracks.length ?? 0) > 0) return
     video.volume = clipElementVolumeNow()
   }
 

--- a/src/components/editor-clip-preview.tsx
+++ b/src/components/editor-clip-preview.tsx
@@ -2,9 +2,9 @@ import type { Handle } from 'remix/ui'
 import { on, ref } from 'remix/ui'
 import { planExport } from '../lib/export'
 import {
-  clipElementVolume,
+  clipAudioScale,
   measureAudioNormalization,
-  musicElementVolume,
+  normalizedElementVolume,
   peekAudioNormalization,
 } from '../lib/preview-audio-normalization'
 import {
@@ -17,7 +17,12 @@ import {
 } from '../lib/preview-music-bed'
 import { BlobVideo } from './blob-video'
 import { IconPause, IconPlay } from './icons'
-import { clipAudioVolume, type ClipRecord, type ProjectAudioRecord } from '../lib/types'
+import {
+  clipMusicVolume,
+  clipSoundVolume,
+  type ClipRecord,
+  type ProjectAudioRecord,
+} from '../lib/types'
 
 /** Smoothing time constant for level moves (~settles in 3×) — matches the
  * project preview's glide feel. */
@@ -70,7 +75,8 @@ export function EditorClipPreview(handle: Handle<EditorClipPreviewProps>) {
 
   // Music bed under the clip. Plain element volumes carry the export's
   // normalization scales (see preview-audio-normalization.ts) — the music
-  // at share × scale, the clip's own sound at (1 − share) × its scale.
+  // at its clip-scaled volume × scale, the clip's own sound at its own
+  // volume × its scale (the two are independent).
   let musicEl: HTMLAudioElement | null = null
   /** Object URLs keyed by track BLOB — the stage outlives playlist edits
    * (it is keyed by clip id), so index-keyed URLs would go stale when a
@@ -162,9 +168,20 @@ export function EditorClipPreview(handle: Handle<EditorClipPreviewProps>) {
     if (wasAudible) playMusic()
   }
 
-  /** This clip's music share of the mix (its override or the default). */
-  const musicShare = (): number =>
-    props.audio ? clipAudioVolume(props.clip, props.audio.defaultVolume) : 0
+  /** The music's level while this clip plays (its duck, if any). */
+  const musicLevel = (): number => (props.audio ? clipMusicVolume(props.clip) : 0)
+
+  /** The clip's own element volume: its sound level × normalization. */
+  const clipElementVolumeNow = (): number =>
+    normalizedElementVolume(clipSoundVolume(props.clip), clipAudioScale(props.clip))
+
+  /** Without music there is no per-frame tick — apply the clip's own
+   * level (and normalization) directly whenever it may have changed. */
+  const applyClipVolume = () => {
+    const video = media
+    if (!video || props.audio) return
+    video.volume = clipElementVolumeNow()
+  }
 
   /** Put the bed at the export-true position for the current video time and
    * start it (no-op when there is no music to play there). */
@@ -320,28 +337,25 @@ export function EditorClipPreview(handle: Handle<EditorClipPreviewProps>) {
       // live playlist coverage (the playhead can pass the last decoded
       // sample before the `ended` handler runs — no bed past the playlist,
       // like the export) AND a playing element (a rejected music play()
-      // must not leave the clip ducked under silence).
+      // must not leave a stale level standing).
       const musicHere =
         !musicExhausted && position !== null && trackAtMs(position) !== null && !el.paused
-      const mix = musicHere ? musicShare() * fadeScaleAt(position) : 0
+      const mix = musicHere ? musicLevel() * fadeScaleAt(position) : 0
       // The element's volume is the export's music-side gain: envelope ×
-      // normalization boost × the track's level and interior fades.
+      // normalization boost × the track's volume and interior fades.
       const trackBlob = props.audio?.tracks[musicTrackIndex]?.blob
       const musicScale = trackBlob ? (peekAudioNormalization(trackBlob)?.scale ?? 1) : 1
       const musicGain =
         props.audio && musicTrackIndex >= 0
           ? trackMusicGain(props.audio, musicTrackIndex, el.currentTime, filmTotalMs())
           : 1
-      musicVol = glide(musicVol, musicElementVolume(mix, musicScale * musicGain))
+      musicVol = glide(musicVol, normalizedElementVolume(mix, musicScale * musicGain))
       el.volume = musicVol
       const video = media
       if (video) {
-        const clipScale = peekAudioNormalization(props.clip.blob)?.scale ?? 1
-        // The clip's own sound stays coupled to the SAME gliding mix, like
-        // the project preview and the export's playlist-end ease: it
-        // carries the normalized complement under a sounding bed and
-        // returns to its normalized full level exactly as the mix falls.
-        clipVol = glide(clipVol, clipElementVolume(mix, clipScale))
+        // The clip's own sound holds ITS OWN level — independent of the
+        // music (no ducking, no complement), exactly like the export.
+        clipVol = glide(clipVol, clipElementVolumeNow())
         video.volume = clipVol
       }
       raf = requestAnimationFrame(tick)
@@ -384,6 +398,7 @@ export function EditorClipPreview(handle: Handle<EditorClipPreviewProps>) {
     media = video
     explicitSeek = false
     pendingSeekSec = null
+    applyClipVolume()
     const apiRef = props.apiRef
     if (!apiRef) return
     apiRef.current = {
@@ -449,6 +464,8 @@ export function EditorClipPreview(handle: Handle<EditorClipPreviewProps>) {
     const endSec = clip.trimEndMs / 1000
     const remountKey = `${clip.id}:${clip.blob.size}:${clip.blob.type}:${clip.trimStartMs}:${clip.trimEndMs}`
     const hasMusic = (props.audio?.tracks.length ?? 0) > 0
+    // A volume edit re-renders the stage without remounting — follow it.
+    applyClipVolume()
 
     return (
       <div className="editor-clip-preview-wrap">

--- a/src/components/playback-overlay.tsx
+++ b/src/components/playback-overlay.tsx
@@ -2,9 +2,9 @@ import type { Handle } from 'remix/ui'
 import { on, ref } from 'remix/ui'
 import { planExport } from '../lib/export'
 import {
-  clipElementVolume,
+  clipAudioScale,
   measureAudioNormalization,
-  musicElementVolume,
+  normalizedElementVolume,
   peekAudioNormalization,
 } from '../lib/preview-audio-normalization'
 import {
@@ -16,7 +16,12 @@ import {
   trackMusicGain,
   trackPlayback,
 } from '../lib/preview-music-bed'
-import { clipAudioVolume, type ClipRecord, type ProjectAudioRecord } from '../lib/types'
+import {
+  clipMusicVolume,
+  clipSoundVolume,
+  type ClipRecord,
+  type ProjectAudioRecord,
+} from '../lib/types'
 import { IconPlay } from './icons'
 import { isInteractiveTarget } from '../lib/keyboard'
 
@@ -77,19 +82,27 @@ export function PlaybackOverlay(handle: Handle<PlaybackOverlayProps>) {
    * metadata window says so. Cleared when a skip seeks music again. */
   let playlistDone = false
 
-  // Export-fidelity levels: the export peak-normalizes BOTH sources toward
-  // the same peak before blending by the mix share (a quietly mastered song
-  // is boosted up to 4×). The previews carry those measured scales through
+  // Export-fidelity levels: the export peak-normalizes EVERY source toward
+  // the same peak before applying its volume (a quietly mastered song is
+  // boosted up to 4×). The previews carry those measured scales through
   // plain element volumes, clamped to the ceiling of 1 — deliberately NOT
   // through a Web Audio media-element graph, whose captured elements go
   // permanently silent on WebKit/iOS whenever the context is not running.
   // See preview-audio-normalization.ts for the trade-off. Playlist
-  // geometry (trims, levels, interior fades) lives in preview-music-bed.ts,
-  // shared with the editor's clip stage.
+  // geometry (trims, volumes, interior fades) lives in
+  // preview-music-bed.ts, shared with the editor's clip stage.
 
-  /** Normalization gain the export applies to this source (1 until the
-   * background measurement lands). */
-  const scaleFor = (blob: Blob): number => peekAudioNormalization(blob)?.scale ?? 1
+  /** Normalization gain the export applies to a playlist track (1 until
+   * the background measurement lands). */
+  const trackScaleFor = (blob: Blob): number => peekAudioNormalization(blob)?.scale ?? 1
+
+  /** The current clip's element volume: its own sound level times its
+   * normalization gain (persisted measurement — export-exact). */
+  const clipElementVolumeNow = (): number => {
+    const segment = currentSegment()
+    if (!segment) return 1
+    return normalizedElementVolume(clipSoundVolume(segment.clip), clipAudioScale(segment.clip))
+  }
 
   /** A rejected play() surfaces the tap-to-play affordance only for
    * autoplay-policy rejections. AbortError means the attempt was merely
@@ -115,9 +128,8 @@ export function PlaybackOverlay(handle: Handle<PlaybackOverlayProps>) {
 
   const segmentMusicVolume = () => {
     const segment = currentSegment()
-    const track = props.audio
-    if (!segment || !track) return 0
-    return clipAudioVolume(segment.clip, track.defaultVolume) * fadeOutScale()
+    if (!segment || !props.audio) return 0
+    return clipMusicVolume(segment.clip) * fadeOutScale()
   }
 
   const filmTotalMs = () => {
@@ -244,14 +256,15 @@ export function PlaybackOverlay(handle: Handle<PlaybackOverlayProps>) {
     if (!track) return
     audioEl = el
     // No fade-in on the opening track means the music starts at the clip's
-    // mix level; otherwise the per-frame glide below fades it in from
-    // silence. `mix` is the export envelope's value (share × film-edge
-    // fades), tracked apart from the element volume so the normalization
-    // scales can multiply on top without distorting the glide.
+    // music level; otherwise the per-frame glide below fades it in from
+    // silence. `musicMix` is the export envelope's value (music volume ×
+    // film-edge fades), tracked apart from the element volume so the
+    // normalization scales can multiply on top without distorting the
+    // glide.
     const firstTrack = track.tracks[0]
     const opensWithFade = firstTrack ? trackPlayback(track, firstTrack).fadeIn : track.fadeIn
-    let mix = opensWithFade ? 0 : segmentMusicVolume()
-    el.volume = mix
+    let musicMix = opensWithFade ? 0 : segmentMusicVolume()
+    el.volume = musicMix
 
     // Measure every source up front, one decode at a time: the scales and
     // decoded track lengths should be ready by the time the playhead needs
@@ -274,14 +287,16 @@ export function PlaybackOverlay(handle: Handle<PlaybackOverlayProps>) {
       }
     })()
 
-    // Per-frame glide of BOTH sides of the mix: the export envelope value
-    // glides toward the current clip's share (0 where the playlist has run
-    // out), and each element's volume is its side of the blend times its
+    // Per-frame glide of BOTH sides of the mix: each envelope value glides
+    // toward the current clip's level (music: 0 where the playlist has run
+    // out), and each element's volume is its gliding level times its
     // source's normalization scale, clamped to the element ceiling.
     let last = performance.now()
     let raf = 0
     let reportedClipScale = ''
     let reportedMusicScale = ''
+    /** Gliding clip-sound level (null = snap to the first target). */
+    let clipMix: number | null = null
     const tick = (now: number) => {
       const dt = Math.min(100, now - last)
       last = now
@@ -307,29 +322,36 @@ export function PlaybackOverlay(handle: Handle<PlaybackOverlayProps>) {
       }
       const musicHere =
         !playlistDone && trackAtMs(timelinePositionMs()) !== null
-      const target = musicHere ? segmentMusicVolume() : 0
       const alpha = 1 - Math.exp(-dt / MUSIC_VOLUME_TAU_MS)
-      const next = mix + (target - mix) * alpha
-      mix = Math.abs(next - target) < 0.005 ? target : next
+      const glide = (current: number, target: number): number => {
+        const next = current + (target - current) * alpha
+        return Math.abs(next - target) < 0.005 ? target : next
+      }
+      musicMix = glide(musicMix, musicHere ? segmentMusicVolume() : 0)
       // The element's volume is the export's music-side gain: the gliding
-      // envelope × the track's normalization boost × the track's level and
-      // interior fades, clamped to the element ceiling.
+      // envelope × the track's normalization boost × the track's volume
+      // and interior fades, clamped to the element ceiling.
       const trackBlob = props.audio?.tracks[musicTrackIndex]?.blob
-      const musicScale = trackBlob ? scaleFor(trackBlob) : 1
+      const musicScale = trackBlob ? trackScaleFor(trackBlob) : 1
       const musicGain =
         props.audio && musicTrackIndex >= 0
           ? trackMusicGain(props.audio, musicTrackIndex, el.currentTime, filmTotalMs())
           : 1
-      el.volume = musicElementVolume(mix, musicScale * musicGain)
+      el.volume = normalizedElementVolume(musicMix, musicScale * musicGain)
       const video = videoEl
       const segment = currentSegment()
-      const clipScale = segment ? scaleFor(segment.clip.blob) : 1
+      const clipScale = segment ? clipAudioScale(segment.clip) : 1
       if (video) {
-        // The clip's own sound carries the complement of the CURRENT
-        // (gliding) mix — during the fade-in it starts at full and only
-        // comes down as the bed actually rises. After the playlist ends it
-        // keeps its normalization, exactly like the export's foreground.
-        video.volume = clipElementVolume(mix, clipScale)
+        // The clip's own sound glides toward ITS OWN level — independent
+        // of the music (no ducking, no complement), exactly like the
+        // export's clip envelope.
+        clipMix =
+          clipMix === null
+            ? segment
+              ? clipSoundVolume(segment.clip)
+              : 1
+            : glide(clipMix, segment ? clipSoundVolume(segment.clip) : 1)
+        video.volume = normalizedElementVolume(clipMix, clipScale)
       }
       // Test observability for the applied normalization scales.
       const clipScaleText = String(clipScale)
@@ -380,6 +402,9 @@ export function PlaybackOverlay(handle: Handle<PlaybackOverlayProps>) {
     if (nextIndex === index) {
       const video = videoEl
       if (video) {
+        // Without music there is no per-frame tick — apply the clip's own
+        // level (and normalization) at each start.
+        if (!props.audio) video.volume = clipElementVolumeNow()
         video.currentTime = startSec()
         void video
           .play()
@@ -416,6 +441,9 @@ export function PlaybackOverlay(handle: Handle<PlaybackOverlayProps>) {
   }
 
   const startPlayback = (video: HTMLVideoElement) => {
+    // Without music there is no per-frame tick — apply the clip's own
+    // level (and normalization) at each segment start.
+    if (!props.audio) video.volume = clipElementVolumeNow()
     video.currentTime = startSec()
     void video
       .play()

--- a/src/components/playback-overlay.tsx
+++ b/src/components/playback-overlay.tsx
@@ -345,12 +345,8 @@ export function PlaybackOverlay(handle: Handle<PlaybackOverlayProps>) {
         // The clip's own sound glides toward ITS OWN level — independent
         // of the music (no ducking, no complement), exactly like the
         // export's clip envelope.
-        clipMix =
-          clipMix === null
-            ? segment
-              ? clipSoundVolume(segment.clip)
-              : 1
-            : glide(clipMix, segment ? clipSoundVolume(segment.clip) : 1)
+        const clipTarget = segment ? clipSoundVolume(segment.clip) : 1
+        clipMix = clipMix === null ? clipTarget : glide(clipMix, clipTarget)
         video.volume = normalizedElementVolume(clipMix, clipScale)
       }
       // Test observability for the applied normalization scales.

--- a/src/components/timeline.tsx
+++ b/src/components/timeline.tsx
@@ -2,6 +2,8 @@ import type { Handle } from 'remix/ui'
 import { on, ref } from 'remix/ui'
 import { reorderClips } from '../lib/storage'
 import {
+  clipMusicVolume,
+  clipSoundVolume,
   effectiveDurationMs,
   formatDuration,
   type ClipId,
@@ -336,12 +338,15 @@ export function Timeline(handle: Handle<TimelineProps>) {
                 role="option"
                 aria-selected={selected}
                 aria-label={`Clip ${index + 1}, ${formatDuration(effectiveDurationMs(clip))}${
+                  // Presence checks stay on the raw fields (override vs
+                  // default); displayed values go through the clamped
+                  // accessors playback uses.
                   clip.clipVolume !== undefined
-                    ? `, clip sound ${Math.round(clip.clipVolume * 100)}%`
+                    ? `, clip sound ${Math.round(clipSoundVolume(clip) * 100)}%`
                     : ''
                 }${
                   props.showAudioBadges && clip.musicVolume !== undefined
-                    ? `, music ${Math.round(clip.musicVolume * 100)}%`
+                    ? `, music ${Math.round(clipMusicVolume(clip) * 100)}%`
                     : ''
                 }`}
                 data-clip-id={clip.id}
@@ -384,12 +389,12 @@ export function Timeline(handle: Handle<TimelineProps>) {
                 <span className="clip-dur">{formatDuration(effectiveDurationMs(clip))}</span>
                 {props.showAudioBadges && clip.musicVolume !== undefined ? (
                   <span className="clip-audio-badge" aria-hidden="true">
-                    ♪ {Math.round(clip.musicVolume * 100)}%
+                    ♪ {Math.round(clipMusicVolume(clip) * 100)}%
                   </span>
                 ) : null}
                 {clip.clipVolume !== undefined ? (
                   <span className="clip-volume-badge" aria-hidden="true">
-                    clip {Math.round(clip.clipVolume * 100)}%
+                    clip {Math.round(clipSoundVolume(clip) * 100)}%
                   </span>
                 ) : null}
               </button>

--- a/src/components/timeline.tsx
+++ b/src/components/timeline.tsx
@@ -336,8 +336,12 @@ export function Timeline(handle: Handle<TimelineProps>) {
                 role="option"
                 aria-selected={selected}
                 aria-label={`Clip ${index + 1}, ${formatDuration(effectiveDurationMs(clip))}${
-                  props.showAudioBadges && clip.audioVolume !== undefined
-                    ? `, music ${Math.round(clip.audioVolume * 100)}%`
+                  clip.clipVolume !== undefined
+                    ? `, clip sound ${Math.round(clip.clipVolume * 100)}%`
+                    : ''
+                }${
+                  props.showAudioBadges && clip.musicVolume !== undefined
+                    ? `, music ${Math.round(clip.musicVolume * 100)}%`
                     : ''
                 }`}
                 data-clip-id={clip.id}
@@ -378,9 +382,14 @@ export function Timeline(handle: Handle<TimelineProps>) {
                   )}
                 </div>
                 <span className="clip-dur">{formatDuration(effectiveDurationMs(clip))}</span>
-                {props.showAudioBadges && clip.audioVolume !== undefined ? (
+                {props.showAudioBadges && clip.musicVolume !== undefined ? (
                   <span className="clip-audio-badge" aria-hidden="true">
-                    ♪ {Math.round(clip.audioVolume * 100)}%
+                    ♪ {Math.round(clip.musicVolume * 100)}%
+                  </span>
+                ) : null}
+                {clip.clipVolume !== undefined ? (
+                  <span className="clip-volume-badge" aria-hidden="true">
+                    clip {Math.round(clip.clipVolume * 100)}%
                   </span>
                 ) : null}
               </button>

--- a/src/lib/clip-audio-peak.test.ts
+++ b/src/lib/clip-audio-peak.test.ts
@@ -1,0 +1,70 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import { ensureClipAudioPeak, measureClipAudioPeak } from './clip-audio-peak'
+import { __resetDbForTests, addClip, createProject, getClip } from './storage'
+
+/** Tiny mono 16-bit PCM WAV with a known amplitude. */
+function makeWavBlob(amplitude: number, durationSec = 0.5, freq = 440): Blob {
+  const rate = 8000
+  const samples = Math.round(durationSec * rate)
+  const bytes = new DataView(new ArrayBuffer(44 + samples * 2))
+  const writeAscii = (offset: number, text: string) => {
+    for (let i = 0; i < text.length; i += 1) bytes.setUint8(offset + i, text.charCodeAt(i))
+  }
+  writeAscii(0, 'RIFF')
+  bytes.setUint32(4, 36 + samples * 2, true)
+  writeAscii(8, 'WAVE')
+  writeAscii(12, 'fmt ')
+  bytes.setUint32(16, 16, true)
+  bytes.setUint16(20, 1, true)
+  bytes.setUint16(22, 1, true)
+  bytes.setUint32(24, rate, true)
+  bytes.setUint32(28, rate * 2, true)
+  bytes.setUint16(32, 2, true)
+  bytes.setUint16(34, 16, true)
+  writeAscii(36, 'data')
+  bytes.setUint32(40, samples * 2, true)
+  for (let i = 0; i < samples; i += 1) {
+    bytes.setInt16(
+      44 + i * 2,
+      Math.round(Math.sin((2 * Math.PI * freq * i) / rate) * amplitude * 32767),
+      true,
+    )
+  }
+  return new Blob([bytes.buffer], { type: 'audio/wav' })
+}
+
+describe('clip audio peak measurement', () => {
+  beforeEach(async () => {
+    await __resetDbForTests()
+  })
+
+  it('measures the whole-file peak of decodable audio', async () => {
+    const peak = await measureClipAudioPeak(makeWavBlob(0.5))
+    // Resampling to the export rate can nudge the peak slightly.
+    expect(peak).toBeGreaterThan(0.4)
+    expect(peak).toBeLessThan(0.6)
+  })
+
+  it('reports 0 for undecodable blobs (mixed unscaled, like the export)', async () => {
+    expect(await measureClipAudioPeak(new Blob(['not media'], { type: 'video/webm' }))).toBe(0)
+  })
+
+  it('backfills and persists the measurement once', async () => {
+    const project = await createProject('Peaks')
+    const clip = await addClip({
+      projectId: project.id,
+      blob: makeWavBlob(0.5),
+      mimeType: 'video/webm',
+      durationMs: 500,
+    })
+    expect(clip.audioPeak).toBeUndefined()
+
+    const measured = await ensureClipAudioPeak(clip)
+    expect(measured.audioPeak).toBeGreaterThan(0.4)
+    expect((await getClip(clip.id))?.audioPeak).toBe(measured.audioPeak)
+
+    // Already-measured clips are returned as-is (no re-decode, no write).
+    const again = await ensureClipAudioPeak({ ...measured, blob: new Blob(['junk']) })
+    expect(again.audioPeak).toBe(measured.audioPeak)
+  })
+})

--- a/src/lib/clip-audio-peak.ts
+++ b/src/lib/clip-audio-peak.ts
@@ -1,0 +1,41 @@
+import { channelPeak } from './export/background-audio'
+import { decodeBlobAudio } from './export/shared'
+import { updateClipAudioPeak } from './storage'
+import type { ClipRecord } from './types'
+
+/**
+ * Post-recording audio normalization measurement: every clip's whole-file
+ * audio peak is measured once and persisted on the clip record, so the
+ * previews can apply the export's exact normalization gain synchronously
+ * (no per-session decode wait) and every surface hears the same levels.
+ * Runs automatically when a project loads with unmeasured clips — the
+ * loader backfill, like thumbnails.
+ */
+
+/** Must match the export engines' mixing rate: peaks are measured AFTER
+ * resampling, and resampling can nudge a waveform's peak. */
+const PEAK_SAMPLE_RATE = 48000
+
+/** The blob's exact whole-file audio peak; 0 = silent or undecodable
+ * (normalizationScale treats both as "mix unscaled"). */
+export async function measureClipAudioPeak(blob: Blob): Promise<number> {
+  try {
+    const buffer = await decodeBlobAudio(blob, PEAK_SAMPLE_RATE)
+    if (!buffer) return 0
+    const channels = Array.from({ length: buffer.numberOfChannels }, (_, ch) =>
+      buffer.getChannelData(ch),
+    )
+    return channelPeak(channels)
+  } catch {
+    return 0
+  }
+}
+
+/** Measure and persist the clip's audio peak when it is still unmeasured.
+ * Returns the (possibly updated) record for immediate use. */
+export async function ensureClipAudioPeak(clip: ClipRecord): Promise<ClipRecord> {
+  if (clip.audioPeak !== undefined) return clip
+  const audioPeak = await measureClipAudioPeak(clip.blob)
+  await updateClipAudioPeak(clip.id, audioPeak)
+  return { ...clip, audioPeak }
+}

--- a/src/lib/clip-audio-peak.ts
+++ b/src/lib/clip-audio-peak.ts
@@ -32,10 +32,13 @@ export async function measureClipAudioPeak(blob: Blob): Promise<number> {
 }
 
 /** Measure and persist the clip's audio peak when it is still unmeasured.
- * Returns the (possibly updated) record for immediate use. */
+ * Returns the (possibly updated) record for immediate use. Persistence is
+ * best-effort: a write failure (quota, transient) must not fail the
+ * project load — the measured value still serves this session, and the
+ * next load retries the write. */
 export async function ensureClipAudioPeak(clip: ClipRecord): Promise<ClipRecord> {
   if (clip.audioPeak !== undefined) return clip
   const audioPeak = await measureClipAudioPeak(clip.blob)
-  await updateClipAudioPeak(clip.id, audioPeak)
+  await updateClipAudioPeak(clip.id, audioPeak).catch(() => undefined)
   return { ...clip, audioPeak }
 }

--- a/src/lib/export/background-audio.test.ts
+++ b/src/lib/export/background-audio.test.ts
@@ -6,6 +6,7 @@ import {
   MAX_NORMALIZATION_BOOST,
   NORMALIZED_PEAK,
   VOLUME_RAMP_MS,
+  applyGainEnvelope,
   boundaryRampHalfMs,
   channelPeak,
   createBackgroundMixer,
@@ -13,7 +14,6 @@ import {
   gainAtMs,
   normalizationScale,
   planSegmentGain,
-  segmentVolume,
   type GainPoint,
   type SequentialBackgroundSource,
 } from './background-audio'
@@ -45,6 +45,28 @@ describe('planSegmentGain', () => {
     expect(gainAtMs(points, 100)).toBeCloseTo(0.25)
     expect(gainAtMs(points, 7900)).toBeCloseTo(0.25)
     expect(gainAtMs(points, 8000)).toBe(0)
+  })
+
+  it('holds the level flat at film edges for the clip envelope', () => {
+    // 'hold' is the clip-sound edge behavior: no fade to silence at the
+    // film's edges (segment slicing already click-kills hard edges).
+    const points = planSegmentGain({ volume: 0.7, durationMs: 8000, fades: 'hold' })
+    expect(gainAtMs(points, 0)).toBeCloseTo(0.7)
+    expect(gainAtMs(points, 4000)).toBeCloseTo(0.7)
+    expect(gainAtMs(points, 8000)).toBeCloseTo(0.7)
+  })
+
+  it('still ramps between neighbors under hold edges', () => {
+    const half = boundaryRampHalfMs(4000, 4000)
+    const incoming = planSegmentGain({
+      volume: 0.2,
+      durationMs: 4000,
+      entry: { fromVolume: 1, halfMs: half },
+      fades: 'hold',
+    })
+    expect(gainAtMs(incoming, 0)).toBeCloseTo(0.6)
+    expect(gainAtMs(incoming, half)).toBeCloseTo(0.2)
+    expect(gainAtMs(incoming, 4000)).toBeCloseTo(0.2)
   })
 
   it('honors the fade toggles independently', () => {
@@ -133,16 +155,11 @@ describe('planSegmentGain', () => {
     expect(boundaryRampHalfMs(400, 4000)).toBe(200)
     expect(boundaryRampHalfMs(4000, 100)).toBe(50)
   })
-
-  it('reads the clip override through segmentVolume', () => {
-    expect(segmentVolume({ clip: { audioVolume: 0.7 } } as never, 0.25)).toBe(0.7)
-    expect(segmentVolume({ clip: {} } as never, 0.25)).toBe(0.25)
-  })
 })
 
 describe('filmEdgeFades', () => {
   const blob = new Blob(['x'])
-  const playlist = { defaultVolume: 0.25, fadeIn: true, fadeOut: true }
+  const playlist = { fadeIn: true, fadeOut: true }
 
   it('reads the film edges from the tracks that play there', () => {
     const fades = filmEdgeFades(
@@ -225,11 +242,56 @@ describe('normalization', () => {
   })
 })
 
+describe('applyGainEnvelope', () => {
+  const flat = (volume: number): GainPoint[] => [
+    { tMs: 0, volume },
+    { tMs: 1_000_000, volume },
+  ]
+
+  it('scales the slice by scale × envelope', () => {
+    const channels = [new Float32Array([0.4, 0.4])]
+    applyGainEnvelope(channels, flat(0.5), 48000, 1.5)
+    for (const sample of channels[0]) {
+      expect(sample).toBeCloseTo(0.4 * 0.5 * 1.5)
+    }
+  })
+
+  it('follows the envelope over time and hard-clamps', () => {
+    // 1 frame = 1ms at sampleRate 1000 for readable positions.
+    const channels = [new Float32Array([0.5, 0.5, 0.5])]
+    applyGainEnvelope(
+      channels,
+      [
+        { tMs: 0, volume: 0 },
+        { tMs: 2, volume: 1 },
+      ],
+      1000,
+      4,
+    )
+    expect(channels[0][0]).toBeCloseTo(0)
+    expect(channels[0][1]).toBeCloseTo(1) // 0.5·0.5·4 = 1 exactly
+    expect(channels[0][2]).toBe(1) // 0.5·1·4 = 2 → clamped
+  })
+
+  it('is a no-op at unity gain', () => {
+    const channels = [new Float32Array([0.3, -0.3])]
+    const before = Array.from(channels[0])
+    applyGainEnvelope(channels, flat(1), 48000)
+    expect(Array.from(channels[0])).toEqual(before)
+  })
+})
+
 describe('createBackgroundMixer', () => {
   const flatEnvelope = (volume: number): GainPoint[] => [
     { tMs: 0, volume },
     { tMs: 1_000_000, volume },
   ]
+
+  /** Flat music + clip envelopes (clip defaults to full volume). */
+  const envelopes = (music: number, clip = 1) => ({
+    music: flatEnvelope(music),
+    clip: flatEnvelope(clip),
+  })
 
   function sourceOf(tracks: Array<Float32Array[] | null>): SequentialBackgroundSource {
     return {
@@ -238,16 +300,29 @@ describe('createBackgroundMixer', () => {
     }
   }
 
-  it('blends complementary shares: music at g, clip at 1 − g', async () => {
+  it('blends the two independent levels: clip at its volume, music at its own', async () => {
     const slice = [new Float32Array([0.6, 0.6, 0.6, 0.6])]
     const mixer = createBackgroundMixer(
       sourceOf([[new Float32Array([0.4, 0.4, 0.4, 0.4])]]),
       48000,
     )
-    // 30% music: out = 0.6·0.7 + 0.4·0.3 = 0.54.
-    await mixer.mixInto(slice, 0, flatEnvelope(0.3))
+    // Clip 70%, music 30%: out = 0.6·0.7 + 0.4·0.3 = 0.54.
+    await mixer.mixInto(slice, 0, envelopes(0.3, 0.7))
     for (const sample of slice[0]) {
       expect(sample).toBeCloseTo(0.6 * 0.7 + 0.4 * 0.3)
+    }
+  })
+
+  it('a quiet music level never ducks the clip side', async () => {
+    const slice = [new Float32Array([0.6, 0.6])]
+    const mixer = createBackgroundMixer(
+      sourceOf([[new Float32Array([0.4, 0.4])]]),
+      48000,
+    )
+    // Music ducked to 10%, clip at full: out = 0.6 + 0.4·0.1 = 0.64.
+    await mixer.mixInto(slice, 0, envelopes(0.1))
+    for (const sample of slice[0]) {
+      expect(sample).toBeCloseTo(0.64)
     }
   })
 
@@ -257,26 +332,24 @@ describe('createBackgroundMixer', () => {
       sourceOf([[new Float32Array([0.4, 0.4])]]),
       48000,
     )
-    // Clip normalized 2×: out = 0.2·2·0.5 + 0.4·0.5 = 0.4.
-    await mixer.mixInto(slice, 0, flatEnvelope(0.5), 2)
+    // Clip normalized 2× at half volume: out = 0.2·2·0.5 + 0.4·0.5 = 0.4.
+    await mixer.mixInto(slice, 0, envelopes(0.5, 0.5), 2)
     for (const sample of slice[0]) {
       expect(sample).toBeCloseTo(0.4)
     }
   })
 
-  it('eases the clip back to full volume when the playlist runs out', async () => {
-    // 1 frame = 30ms (sampleRate ~33.33) would be awkward; use sampleRate 10
-    // so the 300ms end ramp spans exactly 3 frames.
+  it('keeps the clip at its own level when the playlist runs out', async () => {
     const mixer = createBackgroundMixer(
       sourceOf([[new Float32Array([0, 0])]]), // 2 frames of silent music
       10,
     )
     const slice = [new Float32Array(6).fill(0.6)]
-    await mixer.mixInto(slice, 0, flatEnvelope(0.8))
-    // Frames 0–1: clip at 1 − 0.8 = 0.2 share. From frame 2 the playlist is
-    // over and the clip ramps 0.2 → 1 over 3 frames.
+    await mixer.mixInto(slice, 0, envelopes(0.8, 0.5))
+    // The clip side holds 0.5 throughout — music ending changes nothing on
+    // the clip's side (the levels are independent).
     expect(Array.from(slice[0]).map((v) => Number(v.toFixed(2)))).toEqual([
-      0.12, 0.12, 0.12, 0.28, 0.44, 0.6,
+      0.3, 0.3, 0.3, 0.3, 0.3, 0.3,
     ])
   })
 
@@ -287,7 +360,7 @@ describe('createBackgroundMixer', () => {
       48000,
     )
     const slice = [new Float32Array(6)]
-    await mixer.mixInto(slice, 0, flatEnvelope(1))
+    await mixer.mixInto(slice, 0, envelopes(1))
     expect(Array.from(slice[0]).map((v) => Number(v.toFixed(2)))).toEqual([
       0.2, 0.2, 0.6, 0.6, 0, 0,
     ])
@@ -300,8 +373,8 @@ describe('createBackgroundMixer', () => {
     )
     const first = [new Float32Array(2)]
     const second = [new Float32Array(4)]
-    await mixer.mixInto(first, 0, flatEnvelope(1))
-    await mixer.mixInto(second, 2, flatEnvelope(1))
+    await mixer.mixInto(first, 0, envelopes(1))
+    await mixer.mixInto(second, 2, envelopes(1))
     expect(Array.from(first[0]).map((v) => Number(v.toFixed(2)))).toEqual([0.2, 0.2])
     // Second slice spans the A→B hand-off (frame 3) and B's end (frame 6).
     expect(Array.from(second[0]).map((v) => Number(v.toFixed(2)))).toEqual([0.2, 0.6, 0.6, 0.6])
@@ -316,11 +389,14 @@ describe('createBackgroundMixer', () => {
     )
     const first = [new Float32Array(2)]
     const second = [new Float32Array(2)]
-    await mixer.mixInto(first, 0, flatEnvelope(1))
-    await mixer.mixInto(second, 2, [
-      { tMs: 0, volume: 0.5 },
-      { tMs: 2, volume: 0.5 },
-    ])
+    await mixer.mixInto(first, 0, envelopes(1))
+    await mixer.mixInto(second, 2, {
+      music: [
+        { tMs: 0, volume: 0.5 },
+        { tMs: 2, volume: 0.5 },
+      ],
+      clip: flatEnvelope(1),
+    })
     expect(first[0][0]).toBeCloseTo(0.4)
     expect(second[0][0]).toBeCloseTo(0.2)
   })
@@ -331,29 +407,28 @@ describe('createBackgroundMixer', () => {
       48000,
     )
     const slice = [new Float32Array(3)]
-    await mixer.mixInto(slice, 0, flatEnvelope(0.5))
+    await mixer.mixInto(slice, 0, envelopes(0.5))
     expect(Array.from(slice[0]).map((v) => Number(v.toFixed(2)))).toEqual([0.2, 0.2, 0])
   })
 
   it('spreads a mono track across stereo slices and hard-clamps the blend', async () => {
     const slice = [new Float32Array([0.9]), new Float32Array([-0.9])]
     const mixer = createBackgroundMixer(sourceOf([[new Float32Array([1])]]), 48000)
-    // An extreme normalization boost is the only way past 1 now that the
-    // shares themselves are complementary: 0.9·4·0.5 + 1·0.5 = 2.3 → 1.
-    await mixer.mixInto(slice, 0, flatEnvelope(0.5), 4)
+    // Independent levels can sum past 1: 0.9·4·0.5 + 1·0.5 = 2.3 → 1.
+    await mixer.mixInto(slice, 0, envelopes(0.5, 0.5), 4)
     expect(slice[0][0]).toBe(1)
     expect(slice[1][0]).toBe(-1)
   })
 
-  it('leaves slices untouched when the music share is zero', async () => {
+  it('leaves slices untouched when both levels are unity and zero', async () => {
     const slice = [new Float32Array([0.3, 0.3])]
     const before = Array.from(slice[0])
     const mixer = createBackgroundMixer(sourceOf([[new Float32Array([0.5, 0.5])]]), 48000)
-    await mixer.mixInto(slice, 0, flatEnvelope(0))
+    await mixer.mixInto(slice, 0, envelopes(0))
     expect(Array.from(slice[0])).toEqual(before)
   })
 
-  it('scales the music side by the track level, leaving the clip side alone', async () => {
+  it('scales the music side by the track volume, leaving the clip side alone', async () => {
     const slice = [new Float32Array([0.6, 0.6])]
     const mixer = createBackgroundMixer(
       {
@@ -362,8 +437,9 @@ describe('createBackgroundMixer', () => {
       },
       48000,
     )
-    // out = clip·(1 − g) + music·g·level = 0.6·0.5 + 0.4·0.5·0.5 = 0.4.
-    await mixer.mixInto(slice, 0, flatEnvelope(0.5))
+    // out = clip·clipEnv + music·musicEnv·trackVolume
+    //     = 0.6·0.5 + 0.4·0.5·0.5 = 0.4.
+    await mixer.mixInto(slice, 0, envelopes(0.5, 0.5))
     for (const sample of slice[0]) {
       expect(sample).toBeCloseTo(0.4)
     }
@@ -384,9 +460,9 @@ describe('createBackgroundMixer', () => {
       10,
     )
     const slice = [new Float32Array(8)]
-    await mixer.mixInto(slice, 0, flatEnvelope(1))
+    await mixer.mixInto(slice, 0, envelopes(1))
     const samples = Array.from(slice[0]).map((v) => Number(v.toFixed(2)))
-    // Track 0 starts the film — its fade-in belongs to the share envelope,
+    // Track 0 starts the film — its fade-in belongs to the music envelope,
     // so it opens at full level; its end (before the film's) fades out.
     expect(samples.slice(0, 2)).toEqual([0.4, 0.4])
     expect(samples[2]).toBeCloseTo(0.4 * (2 / 2), 2)
@@ -404,14 +480,14 @@ describe('createBackgroundMixer', () => {
       {
         ...sourceOf([[new Float32Array(4).fill(0.4)]]),
         getTrackPlayback: () => ({ volume: 1, fadeIn: true, fadeOut: true }),
-        // The film ends where (or before) the track does — the share
+        // The film ends where (or before) the track does — the music
         // envelope's film-edge fade covers that cut instead.
         totalFrames: 4,
       },
       10,
     )
     const slice = [new Float32Array(4)]
-    await mixer.mixInto(slice, 0, flatEnvelope(1))
+    await mixer.mixInto(slice, 0, envelopes(1))
     expect(Array.from(slice[0]).map((v) => Number(v.toFixed(2)))).toEqual([
       0.4, 0.4, 0.4, 0.4,
     ])
@@ -430,9 +506,9 @@ describe('createBackgroundMixer', () => {
       48000,
     )
     // The film only reaches into track 2's range (frames 0..5).
-    await mixer.mixInto([new Float32Array(3)], 0, flatEnvelope(0.5))
+    await mixer.mixInto([new Float32Array(3)], 0, envelopes(0.5))
     expect(decoded).toEqual([0, 1])
-    await mixer.mixInto([new Float32Array(3)], 3, flatEnvelope(0.5))
+    await mixer.mixInto([new Float32Array(3)], 3, envelopes(0.5))
     expect(decoded).toEqual([0, 1, 2])
   })
 })

--- a/src/lib/export/background-audio.test.ts
+++ b/src/lib/export/background-audio.test.ts
@@ -341,15 +341,16 @@ describe('createBackgroundMixer', () => {
 
   it('keeps the clip at its own level when the playlist runs out', async () => {
     const mixer = createBackgroundMixer(
-      sourceOf([[new Float32Array([0, 0])]]), // 2 frames of silent music
+      sourceOf([[new Float32Array([0.4, 0.4])]]), // 2 frames of music
       10,
     )
     const slice = [new Float32Array(6).fill(0.6)]
     await mixer.mixInto(slice, 0, envelopes(0.8, 0.5))
-    // The clip side holds 0.5 throughout — music ending changes nothing on
-    // the clip's side (the levels are independent).
+    // While the track plays: clip 0.6·0.5 + music 0.4·0.8 = 0.62. After the
+    // playlist runs out only the clip envelope applies — music ending
+    // changes nothing on the clip's side (the levels are independent).
     expect(Array.from(slice[0]).map((v) => Number(v.toFixed(2)))).toEqual([
-      0.3, 0.3, 0.3, 0.3, 0.3, 0.3,
+      0.62, 0.62, 0.3, 0.3, 0.3, 0.3,
     ])
   })
 

--- a/src/lib/export/background-audio.ts
+++ b/src/lib/export/background-audio.ts
@@ -1,21 +1,18 @@
-import {
-  clipAudioVolume,
-  resolveAudioTrackPlayback,
-  type AudioTrackPlaybackFields,
-} from '../types'
-import type { PlannedSegment } from './plan'
+import { resolveAudioTrackPlayback, type AudioTrackPlaybackFields } from '../types'
 
 /**
- * Background-music mix planning shared by both export engines and unit
- * tests. The per-clip value is the music's SHARE of the audio mix: gain g
- * for the music means gain (1 − g) for the clip's own sound, so the two
- * always sum to one — no clipping, no shouting match between mic and
- * music. Per-clip shares become piecewise-linear envelopes (mix changes
- * glide across clip boundaries), and the playlist's tracks are mixed in
- * one after the other — the film's end cuts the music off, nothing loops.
+ * Audio gain planning shared by both export engines and unit tests. Each
+ * clip carries two independent levels: its own (foreground) sound volume
+ * and the music's volume while it plays (which scales the playing track's
+ * own volume). Both are peak-normalized first so the dials mean the same
+ * thing however hot either recording is, and both become piecewise-linear
+ * envelopes (level changes glide across clip boundaries). The playlist's
+ * tracks are mixed in one after the other — the film's end cuts the music
+ * off, nothing loops. The blend hard-clamps to [-1, 1]: the sides no
+ * longer sum to one, so a hot clip under loud music can touch the rail.
  */
 
-/** Length of the glide between two clips with different music shares. */
+/** Length of the glide between two clips with different levels. */
 export const VOLUME_RAMP_MS = 600
 /** Musical ease-in at the start of the film (the "Fade in" toggle). */
 export const FADE_IN_MS = 800
@@ -23,9 +20,6 @@ export const FADE_IN_MS = 800
 export const FADE_OUT_MS = 1200
 /** With fades off, a click-kill ramp too short to hear as a fade. */
 export const EDGE_RAMP_MS = 15
-/** When the playlist runs out mid-film, the clip sound eases back to full
- * volume over this window instead of jumping. */
-export const PLAYLIST_END_RAMP_MS = 300
 
 /** Peak both sources are normalized toward before blending. */
 export const NORMALIZED_PEAK = 0.9
@@ -62,19 +56,17 @@ export interface BackgroundAudioTrack extends AudioTrackPlaybackFields {
 
 export interface BackgroundAudio {
   tracks: BackgroundAudioTrack[]
-  defaultVolume: number
   /** Playlist-level fade defaults for tracks without their own flags. */
   fadeIn: boolean
   fadeOut: boolean
 }
 
 /**
- * Film-edge fades for the share envelope, read from the tracks that
+ * Film-edge fades for the music envelope, read from the tracks that
  * actually play at the film's edges: the first track's fade-in opens the
  * film, and the fade-out belongs to whichever track the film's end cuts
  * off. When the playlist runs out before the film ends there is no music
- * at the film's end to fade (the playlist-end ramp already eased the clip
- * sound back), so fadeOut is false.
+ * at the film's end to fade, so fadeOut is false.
  */
 export function filmEdgeFades(
   background: BackgroundAudio,
@@ -106,7 +98,7 @@ export interface BackgroundFades {
 }
 
 export interface SegmentGainArgs {
-  /** This clip's music volume. */
+  /** This clip's level (music volume or the clip's own sound volume). */
   volume: number
   /** The segment's REAL duration (after media clamping), in ms. */
   durationMs: number
@@ -114,7 +106,11 @@ export interface SegmentGainArgs {
   entry?: { fromVolume: number; halfMs: number }
   /** Ramp out toward the next clip's volume (omit at the film end). */
   exit?: { toVolume: number; halfMs: number }
-  fades: BackgroundFades
+  /** Film-edge behavior where there is no neighbor: the music envelope
+   * fades in/out (or click-kill ramps); the clip's own envelope passes
+   * 'hold' to keep its level — segment slicing already click-kills the
+   * clip sound's hard edges. */
+  fades: BackgroundFades | 'hold'
 }
 
 /**
@@ -139,6 +135,8 @@ export function planSegmentGain({
   if (entry) {
     points.push({ tMs: 0, volume: (entry.fromVolume + volume) / 2 })
     points.push({ tMs: Math.min(entry.halfMs, durationMs / 2), volume })
+  } else if (fades === 'hold') {
+    points.push({ tMs: 0, volume })
   } else {
     const fadeIn = Math.min(fades.fadeIn ? FADE_IN_MS : EDGE_RAMP_MS, durationMs / 2)
     points.push({ tMs: 0, volume: 0 })
@@ -147,6 +145,8 @@ export function planSegmentGain({
   if (exit) {
     points.push({ tMs: durationMs - Math.min(exit.halfMs, durationMs / 2), volume })
     points.push({ tMs: durationMs, volume: (volume + exit.toVolume) / 2 })
+  } else if (fades === 'hold') {
+    points.push({ tMs: durationMs, volume })
   } else {
     const fadeOut = Math.min(fades.fadeOut ? FADE_OUT_MS : EDGE_RAMP_MS, durationMs / 2)
     points.push({ tMs: durationMs - fadeOut, volume })
@@ -165,14 +165,6 @@ export function boundaryRampHalfMs(aDurationMs: number, bDurationMs: number): nu
   return Math.min(VOLUME_RAMP_MS / 2, aDurationMs / 2, bDurationMs / 2)
 }
 
-/** Music volume for one planned segment (override or default). */
-export function segmentVolume(
-  segment: Pick<PlannedSegment, 'clip'>,
-  defaultVolume: number,
-): number {
-  return clipAudioVolume(segment.clip, defaultVolume)
-}
-
 /** Envelope gain at an output-timeline position (linear between points). */
 export function gainAtMs(points: GainPoint[], tMs: number): number {
   if (points.length === 0) return 0
@@ -189,16 +181,58 @@ export function gainAtMs(points: GainPoint[], tMs: number): number {
   return points[points.length - 1].volume
 }
 
+/** Stateful piecewise-linear evaluator for one envelope. Positions must be
+ * requested in nondecreasing order (the mixers' sample loops are). */
+function createEnvelopeCursor(points: GainPoint[], emptyValue: number) {
+  let cursor = 0
+  return (tMs: number): number => {
+    if (points.length === 0) return emptyValue
+    while (cursor < points.length && points[cursor].tMs < tMs) cursor += 1
+    if (cursor === 0) return points[0].volume
+    if (cursor >= points.length) return points[points.length - 1].volume
+    const prev = points[cursor - 1]
+    const next = points[cursor]
+    const span = next.tMs - prev.tMs
+    if (span <= 0) return next.volume
+    return prev.volume + ((next.volume - prev.volume) * (tMs - prev.tMs)) / span
+  }
+}
+
+/**
+ * Scale a segment slice's channels in place by `scale × envelope(t)` — the
+ * music-free counterpart of BackgroundMixer.mixInto, so per-clip volume
+ * and normalization apply with or without a playlist. `points` live on
+ * the slice's local timeline (its time 0 is the slice's first sample).
+ */
+export function applyGainEnvelope(
+  channels: Float32Array[],
+  points: GainPoint[],
+  sampleRate: number,
+  scale = 1,
+): void {
+  if (channels.length === 0) return
+  if (scale === 1 && points.every((point) => point.volume === 1)) return
+  const clamp = (value: number): number => (value > 1 ? 1 : value < -1 ? -1 : value)
+  const envelope = createEnvelopeCursor(points, 1)
+  const length = channels[0].length
+  for (let i = 0; i < length; i += 1) {
+    const gain = scale * envelope((i / sampleRate) * 1000)
+    for (let ch = 0; ch < channels.length; ch += 1) {
+      channels[ch][i] = clamp(channels[ch][i] * gain)
+    }
+  }
+}
+
 /** How one playlist track sits in the music side of the mix. */
 export interface TrackMixPlayback {
-  /** Track level (0–1) — scales the music's contribution only; the clip
-   * side keeps its complement of the share. */
+  /** Track volume (0–1) — scales the music's contribution only; the
+   * clip's own sound rides its own envelope. */
   volume: number
   /** Ease this track in where it starts mid-film (the film-start fade
-   * lives in the share envelope instead). */
+   * lives in the music envelope instead). */
   fadeIn: boolean
   /** Ease this track out where it ends before the film does (a film-end
-   * cut fades via the share envelope instead). */
+   * cut fades via the music envelope instead). */
   fadeOut: boolean
 }
 
@@ -208,26 +242,35 @@ export interface SequentialBackgroundSource {
    * kept window); null = undecodable (the track is skipped and the next
    * one starts in its place). */
   getTrack: (index: number) => Promise<Float32Array[] | null>
-  /** Per-track level + interior fades; absent = unity, no fades. */
+  /** Per-track volume + interior fades; absent = unity, no fades. */
   getTrackPlayback?: (index: number) => TrackMixPlayback
   /** Film length in output frames — a track whose end lands at or past it
-   * is cut by the film (its own fade-out is skipped; the share envelope's
+   * is cut by the film (its own fade-out is skipped; the music envelope's
    * film-edge fade covers that cut). */
   totalFrames?: number
 }
 
+/** The two per-segment gain envelopes, both on the slice's local timeline
+ * (time 0 is the slice's first sample). */
+export interface SegmentEnvelopes {
+  /** Music level (the clip's music volume, with film-edge fades). */
+  music: GainPoint[]
+  /** The clip's own (foreground) sound level. */
+  clip: GainPoint[]
+}
+
 export interface BackgroundMixer {
   /** Blend the playlist into a segment slice's channels (which carry the
-   * clip's own sound), in place: `out = clip·fgScale·(1−g) + music·g`,
-   * where g follows `points` — the slice's own local envelope (its time 0
-   * is the slice's first sample) — and `foregroundScale` is the clip's
-   * normalization gain. Slices must be requested in output order (tracks
-   * are decoded lazily, one at a time, and released once the timeline
-   * passes them). */
+   * clip's own sound), in place:
+   * `out = clip·fgScale·clipEnv(t) + music·trackVolume·musicEnv(t)`,
+   * where `foregroundScale` is the clip's normalization gain and the
+   * track's own volume/normalization/fades ride the music side. Slices
+   * must be requested in output order (tracks are decoded lazily, one at
+   * a time, and released once the timeline passes them). */
   mixInto: (
     channels: Float32Array[],
     sliceStartFrame: number,
-    points: GainPoint[],
+    envelopes: SegmentEnvelopes,
     foregroundScale?: number,
   ) => Promise<void>
 }
@@ -235,9 +278,9 @@ export interface BackgroundMixer {
 /**
  * Sequential playlist mixer: track 0 starts at output frame 0, each next
  * track starts where the previous one's decoded samples end, and when the
- * playlist runs out the clip sound eases back to full volume (over
- * PLAYLIST_END_RAMP_MS) and the rest of the film simply has no music.
- * Everything hard-clamps to [-1, 1].
+ * playlist runs out the rest of the film simply has no music — the clip
+ * sound keeps following its own envelope, unaffected. Everything
+ * hard-clamps to [-1, 1].
  */
 export function createBackgroundMixer(
   source: SequentialBackgroundSource,
@@ -248,11 +291,7 @@ export function createBackgroundMixer(
   let trackStartFrame = 0
   let current: Float32Array[] | null = null
   let exhausted = source.trackCount === 0
-  /** Frame where the playlist ran out, and the music share right before —
-   * the foreground ramps from (1 − that share) back to full from here. */
-  let exhaustedAtFrame: number | null = null
-  let shareAtExhaustion = 0
-  /** The current track's level and precomputed fade windows (in frames of
+  /** The current track's volume and precomputed fade windows (in frames of
    * the track's own timeline; 0 = that fade is off). */
   let trackVolume = 1
   let fadeInFrames = 0
@@ -264,7 +303,7 @@ export function createBackgroundMixer(
     const playback = source.getTrackPlayback?.(trackIndex)
     const trackFrames = current![0].length
     trackVolume = playback?.volume ?? 1
-    // The film-start fade lives in the share envelope — a track fade-in on
+    // The film-start fade lives in the music envelope — a track fade-in on
     // top of it would fade twice — so it only applies to tracks that start
     // mid-film. Same for a film-end cut and the track fade-out.
     const endsBeforeFilm =
@@ -306,26 +345,22 @@ export function createBackgroundMixer(
   const mixInto = async (
     channels: Float32Array[],
     sliceStartFrame: number,
-    points: GainPoint[],
+    envelopes: SegmentEnvelopes,
     foregroundScale = 1,
   ): Promise<void> => {
-    if (channels.length === 0 || points.length === 0) return
+    if (channels.length === 0) return
     const sliceLength = channels[0].length
-    const endRampFrames = Math.max(1, Math.round((PLAYLIST_END_RAMP_MS / 1000) * sampleRate))
+    const musicEnvelope = createEnvelopeCursor(envelopes.music, 0)
+    const clipEnvelope = createEnvelopeCursor(envelopes.clip, 1)
     let i = 0
-    let cursor = 0
     while (i < sliceLength) {
       const frame = sliceStartFrame + i
       if (!(await ensureTrackFor(frame))) {
-        // Playlist over: no music, but the clip keeps its normalization
-        // (consistent loudness across the whole film) and its share eases
-        // from (1 − last music share) back to full instead of jumping.
-        exhaustedAtFrame ??= frame
+        // Playlist over: no music for the rest of the film. The clip keeps
+        // its own envelope and normalization (consistent loudness across
+        // the whole film) — the sides are independent, nothing to ease.
         for (; i < sliceLength; i += 1) {
-          const outFrame = sliceStartFrame + i
-          const ramp = Math.min(1, (outFrame - exhaustedAtFrame) / endRampFrames)
-          const foreground =
-            foregroundScale * (1 - shareAtExhaustion + shareAtExhaustion * ramp)
+          const foreground = foregroundScale * clipEnvelope((i / sampleRate) * 1000)
           for (let ch = 0; ch < channels.length; ch += 1) {
             channels[ch][i] = clamp(channels[ch][i] * foreground)
           }
@@ -339,26 +374,12 @@ export function createBackgroundMixer(
       for (; i < runEnd; i += 1) {
         const outFrame = sliceStartFrame + i
         const tMs = (i / sampleRate) * 1000
-        while (cursor < points.length && points[cursor].tMs < tMs) cursor += 1
-        let share: number
-        if (cursor === 0) {
-          share = points[0].volume
-        } else if (cursor >= points.length) {
-          share = points[points.length - 1].volume
-        } else {
-          const prev = points[cursor - 1]
-          const next = points[cursor]
-          const span = next.tMs - prev.tMs
-          share =
-            span <= 0
-              ? next.volume
-              : prev.volume + ((next.volume - prev.volume) * (tMs - prev.tMs)) / span
-        }
-        shareAtExhaustion = share
+        const musicLevel = musicEnvelope(tMs)
+        const clipLevel = clipEnvelope(tMs)
         const sourceIndex = outFrame - trackStartFrame
-        // The music side alone carries the track's level and fades — the
-        // clip keeps the complement of the SHARE, so a quiet track never
-        // makes the clip louder or softer.
+        // The music side carries the track's own volume and fades under
+        // the clip's music envelope; the clip's sound rides its own
+        // envelope — a quiet track never makes the clip louder or softer.
         let musicGain = trackVolume
         if (fadeInFrames > 0 && sourceIndex < fadeInFrames) {
           musicGain *= sourceIndex / fadeInFrames
@@ -369,8 +390,8 @@ export function createBackgroundMixer(
         }
         for (let ch = 0; ch < channels.length; ch += 1) {
           channels[ch][i] = clamp(
-            channels[ch][i] * foregroundScale * (1 - share) +
-              sources[ch][sourceIndex] * share * musicGain,
+            channels[ch][i] * foregroundScale * clipLevel +
+              sources[ch][sourceIndex] * musicLevel * musicGain,
           )
         }
       }

--- a/src/lib/export/encode-realtime.ts
+++ b/src/lib/export/encode-realtime.ts
@@ -1,5 +1,5 @@
 import { pickRecorderMimeType } from '../media'
-import { clipAudioVolume, resolveAudioTrackPlayback } from '../types'
+import { clipMusicVolume, clipSoundVolume, resolveAudioTrackPlayback } from '../types'
 import {
   FADE_IN_MS,
   FADE_OUT_MS,
@@ -104,18 +104,31 @@ export async function exportRealtime(
     dest = null
   }
 
+  // Clip audio flows through one gain node that glides toward each clip's
+  // own sound volume as the export reaches it — this engine paints in
+  // realtime, so Web Audio's own ramping does the work. Every clip is
+  // peak-normalized on the way in (per-segment gain), music or not.
+  /** Gain the clips' own audio plays through (each clip's sound volume). */
+  let clipMixGain: GainNode | null = null
+  if (audioContext && dest) {
+    try {
+      const clipGain = audioContext.createGain()
+      clipGain.gain.value = 1
+      clipGain.connect(dest)
+      clipMixGain = clipGain
+    } catch {
+      clipMixGain = null
+    }
+  }
+
   // Background music rides sequentially chained buffer sources behind a
   // gain node: each track starts when the previous one ends (nothing
-  // loops), and the gain glides toward each clip's music SHARE as the
-  // export reaches it — this engine paints in realtime, so Web Audio's own
-  // ramping does the work. Clip audio flows through a mirror gain node
-  // held at the complement (1 − share), so the two sides of the mix always
-  // sum to one. Tracks are peak-normalized via a per-source gain.
+  // loops), and the gain glides toward each clip's music volume as the
+  // export reaches it. Tracks are peak-normalized and carry their own
+  // volume via a per-source gain.
   let backgroundGain: GainNode | null = null
-  /** Complement gain the clips' own audio plays through (1 − music share). */
-  let clipMixGain: GainNode | null = null
   /** Set once the playlist has truly run out — later segments must stop
-   * scheduling the duck (the film's remainder is music-free). */
+   * scheduling music moves (the film's remainder is music-free). */
   const playlistState = { done: false }
   let startBackground: (() => void) | null = null
   let stopBackground: (() => void) | null = null
@@ -129,9 +142,6 @@ export async function exportRealtime(
       const gain = audioContext.createGain()
       gain.gain.value = 0
       gain.connect(dest)
-      const clipGain = audioContext.createGain()
-      clipGain.gain.value = 1
-      clipGain.connect(dest)
       let stopped = false
       /** Output position where the next track starts (the kept windows
        * played so far) — the realtime mirror of the mixer's
@@ -141,17 +151,16 @@ export async function exportRealtime(
       const playFrom = async (index: number): Promise<void> => {
         if (stopped || !audioContext) return
         if (index >= backgroundTracks.length) {
-          // Playlist over mid-film: the clip sound eases back to full and
-          // stays there for the rest of the film.
+          // Playlist over mid-film: the rest of the film is music-free
+          // (the clip sound rides its own gain, unaffected).
           playlistState.done = true
-          clipGain.gain.setTargetAtTime(1, audioContext.currentTime, 0.1)
           return
         }
         // Undecodable tracks are skipped; the next one starts in their place.
         const buffer = await decodeBackgroundAudio(backgroundTracks[index].blob)
         if (stopped) return
         if (!buffer) return playFrom(index + 1)
-        // Only the kept (trimmed) window plays, at the track's own level.
+        // Only the kept (trimmed) window plays, at the track's own volume.
         const playback = resolveAudioTrackPlayback(backgroundTracks[index], options.background!)
         const trimStartSec = Math.min(playback.trimStartMs / 1000, buffer.duration)
         const trimEndSec = Math.min(playback.trimEndMs / 1000, buffer.duration)
@@ -159,10 +168,10 @@ export async function exportRealtime(
         if (keptSec < 0.05) return playFrom(index + 1)
         const source = audioContext.createBufferSource()
         source.buffer = buffer
-        // Peak-normalize the track so the mix shares mean the same thing
+        // Peak-normalize the track so the volume dials mean the same thing
         // regardless of how hot the file is mastered (whole-file peak, so
         // loudness doesn't change with where the track is trimmed), then
-        // apply the track's level on top.
+        // apply the track's own volume on top.
         const channels = Array.from({ length: buffer.numberOfChannels }, (_, ch) =>
           buffer.getChannelData(ch),
         )
@@ -209,10 +218,8 @@ export async function exportRealtime(
         }
       }
       backgroundGain = gain
-      clipMixGain = clipGain
     } catch {
       backgroundGain = null
-      clipMixGain = null
       startBackground = null
       stopBackground = null
     }
@@ -264,34 +271,39 @@ export async function exportRealtime(
       try {
         const clamped = clampSegmentToMedia(segment, loaded.mediaDurationMs)
         if (!clamped) continue
-        if (backgroundGain && clipMixGain && audioContext && options.background) {
-          startBackground?.()
-          // A finished playlist means the rest of the film is music-free —
-          // re-scheduling the duck would leave clip audio quiet for nothing.
-          const share = playlistState.done
-            ? 0
-            : clipAudioVolume(segment.clip, options.background.defaultVolume)
+        if (audioContext && clipMixGain) {
           const now = audioContext.currentTime
-          if (segmentIndex === 0 && !backgroundEdgeFades?.fadeIn) {
-            // No fade-in: the mix opens at the clip's shares directly.
-            backgroundGain.gain.setValueAtTime(share, now)
-            clipMixGain.gain.setValueAtTime(1 - share, now)
+          // The clip's own sound glides toward this clip's volume (a step
+          // at the very first segment — nothing is sounding before it).
+          const clipLevel = clipSoundVolume(segment.clip)
+          if (segmentIndex === 0) {
+            clipMixGain.gain.setValueAtTime(clipLevel, now)
           } else {
-            backgroundGain.gain.setTargetAtTime(share, now, 0.2)
-            clipMixGain.gain.setTargetAtTime(1 - share, now, 0.2)
+            clipMixGain.gain.setTargetAtTime(clipLevel, now, 0.2)
           }
-          // This engine paints in realtime, so the last segment's end lands
-          // roughly `segment length` from now — schedule the musical
-          // fade-out to finish there (clip sound rising back to full),
-          // shrinking it on short final clips (like the WebCodecs
-          // envelope) instead of dropping it.
-          const isLast = segmentIndex === plan.segments.length - 1
-          const segmentSec = (clamped.endMs - clamped.startMs) / 1000
-          if (isLast && backgroundEdgeFades?.fadeOut) {
-            const fadeSec = Math.min(1.2, segmentSec / 2)
-            if (fadeSec > 0.05) {
-              backgroundGain.gain.setTargetAtTime(0, now + segmentSec - fadeSec, fadeSec / 3)
-              clipMixGain.gain.setTargetAtTime(1, now + segmentSec - fadeSec, fadeSec / 3)
+          if (backgroundGain && options.background) {
+            startBackground?.()
+            // A finished playlist means the rest of the film is music-free —
+            // re-scheduling a music level would move a silent bus for nothing.
+            const musicLevel = playlistState.done ? 0 : clipMusicVolume(segment.clip)
+            if (segmentIndex === 0 && !backgroundEdgeFades?.fadeIn) {
+              // No fade-in: the music opens at the clip's level directly.
+              backgroundGain.gain.setValueAtTime(musicLevel, now)
+            } else {
+              backgroundGain.gain.setTargetAtTime(musicLevel, now, 0.2)
+            }
+            // This engine paints in realtime, so the last segment's end
+            // lands roughly `segment length` from now — schedule the
+            // musical fade-out to finish there, shrinking it on short
+            // final clips (like the WebCodecs envelope) instead of
+            // dropping it.
+            const isLast = segmentIndex === plan.segments.length - 1
+            const segmentSec = (clamped.endMs - clamped.startMs) / 1000
+            if (isLast && backgroundEdgeFades?.fadeOut) {
+              const fadeSec = Math.min(1.2, segmentSec / 2)
+              if (fadeSec > 0.05) {
+                backgroundGain.gain.setTargetAtTime(0, now + segmentSec - fadeSec, fadeSec / 3)
+              }
             }
           }
         }
@@ -303,8 +315,8 @@ export async function exportRealtime(
           canvas,
           ctx,
           audioContext,
-          // With music, clip audio joins the mix through the complement
-          // gain (and gets peak-normalized); without, straight to the mux.
+          // Clip audio joins the graph through the clip-volume gain and
+          // gets peak-normalized on the way in (music or not).
           clipDestination: clipMixGain ?? dest,
           normalizeClip: clipMixGain !== null,
           frameCounter,
@@ -330,12 +342,11 @@ export async function exportRealtime(
 
     // End-of-film safety ramp: with Fade out on it just finishes what the
     // scheduled fade started; with it off, a click-kill too short to hear
-    // as a fade (mirrors the WebCodecs edge ramp). The clip side rises to
-    // full in mirror, like the WebCodecs envelope's complement.
+    // as a fade (mirrors the WebCodecs edge ramp). The clip side keeps its
+    // own level — the sides are independent now.
     if (backgroundGain && audioContext) {
       const tau = backgroundEdgeFades?.fadeOut ? 0.06 : 0.008
       backgroundGain.gain.setTargetAtTime(0, audioContext.currentTime, tau)
-      clipMixGain?.gain.setTargetAtTime(1, audioContext.currentTime, tau)
     }
     // Hold the last frame briefly so the final GOP isn't truncated.
     await wait(180)
@@ -369,10 +380,10 @@ interface PaintSegmentArgs {
   canvas: HTMLCanvasElement
   ctx: CanvasRenderingContext2D
   audioContext: AudioContext | null
-  /** Where the clip's own audio joins the recording graph (the clip-mix
-   * complement gain when music is present, else the mux destination). */
+  /** Where the clip's own audio joins the recording graph (the clip-volume
+   * gain when the graph exists, else the mux destination). */
   clipDestination: AudioNode | null
-  /** Peak-normalize the clip audio (on whenever the project has music). */
+  /** Peak-normalize the clip audio (on whenever the graph exists). */
   normalizeClip: boolean
   frameCounter: { count: number }
   getPreviewCanvas?: () => HTMLCanvasElement | null
@@ -429,7 +440,7 @@ async function paintSegment({
           bufferSource.buffer = audioBuffer
           let clipOutput: AudioNode = bufferSource
           if (normalizeClip) {
-            // Peak-normalize so the mix shares mean the same thing however
+            // Peak-normalize so the volume dials mean the same thing however
             // hot (or quiet) the mic recording is.
             const channels = Array.from(
               { length: audioBuffer.numberOfChannels },

--- a/src/lib/export/encode-realtime.ts
+++ b/src/lib/export/encode-realtime.ts
@@ -271,15 +271,19 @@ export async function exportRealtime(
       try {
         const clamped = clampSegmentToMedia(segment, loaded.mediaDurationMs)
         if (!clamped) continue
-        if (audioContext && clipMixGain) {
+        if (audioContext) {
           const now = audioContext.currentTime
           // The clip's own sound glides toward this clip's volume (a step
           // at the very first segment — nothing is sounding before it).
-          const clipLevel = clipSoundVolume(segment.clip)
-          if (segmentIndex === 0) {
-            clipMixGain.gain.setValueAtTime(clipLevel, now)
-          } else {
-            clipMixGain.gain.setTargetAtTime(clipLevel, now, 0.2)
+          // Each bus is guarded on its own — a failed clip gain node must
+          // not leave the music bus unscheduled (parked at 0) too.
+          if (clipMixGain) {
+            const clipLevel = clipSoundVolume(segment.clip)
+            if (segmentIndex === 0) {
+              clipMixGain.gain.setValueAtTime(clipLevel, now)
+            } else {
+              clipMixGain.gain.setTargetAtTime(clipLevel, now, 0.2)
+            }
           }
           if (backgroundGain && options.background) {
             startBackground?.()

--- a/src/lib/export/encode-webcodecs.ts
+++ b/src/lib/export/encode-webcodecs.ts
@@ -355,15 +355,21 @@ export async function exportWithWebCodecs(
         const musicVolume = clipMusicVolume(segment.clip)
         const clipVolume = clipSoundVolume(segment.clip)
         // Whole-clip peak (not just this trim window) so a clip's
-        // loudness doesn't change with where it is trimmed.
+        // loudness doesn't change with where it is trimmed. The persisted
+        // measurement (same decode + scan at the same rate) is preferred —
+        // it skips a per-segment full scan and keeps the export's gain
+        // identical to what the previews played.
         const foregroundScale = normalizationScale(
-          sourceChannels ? channelPeak(sourceChannels) : 0,
+          segment.clip.audioPeak ?? (sourceChannels ? channelPeak(sourceChannels) : 0),
         )
         // The slice's real span (joints shift it by half a crossfade).
         const sliceDurationMs = (sliceChannels[0]!.length / AUDIO_SAMPLE_RATE) * 1000
         const nextPlanned = plan.segments[segmentIndex + 1]
+        // Ramp halves clamp to the REAL clamped durations on both known
+        // sides; only the exit peeks at the next clip's PLANNED duration
+        // (its real one isn't measured yet).
         const entryHalfMs = previousSegment
-          ? boundaryRampHalfMs(previousSegment.durationMs, plannedDurationsMs[segmentIndex])
+          ? boundaryRampHalfMs(previousSegment.durationMs, segmentMs)
           : 0
         const exitHalfMs = nextPlanned
           ? boundaryRampHalfMs(segmentMs, plannedDurationsMs[segmentIndex + 1])

--- a/src/lib/export/encode-webcodecs.ts
+++ b/src/lib/export/encode-webcodecs.ts
@@ -18,15 +18,20 @@ import {
 } from 'mediabunny'
 import { deriveProjectLocation } from '../geo'
 import { isIosBrowser } from '../platform'
-import { resolveAudioTrackPlayback, type ClipRecord } from '../types'
 import {
+  clipMusicVolume,
+  clipSoundVolume,
+  resolveAudioTrackPlayback,
+  type ClipRecord,
+} from '../types'
+import {
+  applyGainEnvelope,
   boundaryRampHalfMs,
   channelPeak,
   createBackgroundMixer,
   filmEdgeFades,
   normalizationScale,
   planSegmentGain,
-  segmentVolume,
   type BackgroundAudio,
 } from './background-audio'
 import { injectMp4Metadata, type Mp4Chapter } from './mp4-metadata'
@@ -194,14 +199,14 @@ export async function exportWithWebCodecs(
 
   // Background music: playlist tracks are decoded lazily (one at a time,
   // released as the timeline passes them) and BLENDED with each segment's
-  // audio slice under a per-segment mix envelope — the per-clip value is
-  // the music's share of the mix, the clip's own sound gets the
-  // complement, and both sources are peak-normalized first so the shares
-  // mean the same thing regardless of how hot either recording is.
-  // Envelopes are built from each segment's REAL (clamped) duration as it
-  // is mixed, so ramps and fades stay on their clips even when clamping
-  // shifts the timeline; only ramp-length clamping peeks at the next
-  // clip's planned duration.
+  // audio slice under two per-segment envelopes — the clip's own sound
+  // rides its clip-volume envelope and the music rides its music-volume
+  // envelope (scaling the playing track's own volume). Both sources are
+  // peak-normalized first so the dials mean the same thing regardless of
+  // how hot either recording is. Envelopes are built from each segment's
+  // REAL (clamped) duration as it is mixed, so ramps and fades stay on
+  // their clips even when clamping shifts the timeline; only ramp-length
+  // clamping peeks at the next clip's planned duration.
   const backgroundMixer =
     background && background.tracks.length > 0
       ? createBackgroundMixer(
@@ -259,9 +264,13 @@ export async function exportWithWebCodecs(
   /** Film-edge fades come from the tracks at the film's edges. */
   const backgroundEdgeFades = background ? filmEdgeFades(background, plan.totalMs) : null
   const plannedDurationsMs = plan.segments.map((s) => s.endMs - s.startMs)
-  /** Volume + real duration of the previous MIXED segment (dropped
+  /** Volumes + real duration of the previous EMITTED segment (dropped
    * segments must not become ramp anchors). */
-  let previousMixed: { volume: number; durationMs: number } | null = null
+  let previousSegment: {
+    musicVolume: number
+    clipVolume: number
+    durationMs: number
+  } | null = null
   /** Tail withheld from the previous EMITTED segment for the joint
    * crossfade (see segment-audio.ts); null until a segment emits. */
   let crossfadeCarry: Float32Array[] | null = null
@@ -327,12 +336,13 @@ export async function exportWithWebCodecs(
         // CROSSFADE at the joint: the previous slice withheld its tail, and
         // this slice mixes it into its own head (see segment-audio.ts).
         const buffer = await decodeClipAudio(segment.clip.blob, AUDIO_SAMPLE_RATE)
+        const sourceChannels = buffer
+          ? Array.from({ length: buffer.numberOfChannels }, (_, ch) =>
+              buffer.getChannelData(ch),
+            )
+          : null
         const { channels: sliceChannels, carryOut } = sliceSegmentAudio({
-          source: buffer
-            ? Array.from({ length: buffer.numberOfChannels }, (_, ch) =>
-                buffer.getChannelData(ch),
-              )
-            : null,
+          source: sourceChannels,
           startMs: clamped.startMs,
           segmentMs,
           sampleRate: AUDIO_SAMPLE_RATE,
@@ -341,52 +351,60 @@ export async function exportWithWebCodecs(
           hasNext,
         })
         crossfadeCarry = carryOut
+        // Per-clip levels + normalization apply with or without music.
+        const musicVolume = clipMusicVolume(segment.clip)
+        const clipVolume = clipSoundVolume(segment.clip)
+        // Whole-clip peak (not just this trim window) so a clip's
+        // loudness doesn't change with where it is trimmed.
+        const foregroundScale = normalizationScale(
+          sourceChannels ? channelPeak(sourceChannels) : 0,
+        )
+        // The slice's real span (joints shift it by half a crossfade).
+        const sliceDurationMs = (sliceChannels[0]!.length / AUDIO_SAMPLE_RATE) * 1000
+        const nextPlanned = plan.segments[segmentIndex + 1]
+        const entryHalfMs = previousSegment
+          ? boundaryRampHalfMs(previousSegment.durationMs, plannedDurationsMs[segmentIndex])
+          : 0
+        const exitHalfMs = nextPlanned
+          ? boundaryRampHalfMs(segmentMs, plannedDurationsMs[segmentIndex + 1])
+          : 0
+        const clipEnvelope = planSegmentGain({
+          volume: clipVolume,
+          durationMs: sliceDurationMs,
+          entry: previousSegment
+            ? { fromVolume: previousSegment.clipVolume, halfMs: entryHalfMs }
+            : undefined,
+          exit: nextPlanned
+            ? { toVolume: clipSoundVolume(nextPlanned.clip), halfMs: exitHalfMs }
+            : undefined,
+          fades: 'hold',
+        })
         if (backgroundMixer && background) {
-          const volume = segmentVolume(segment, background.defaultVolume)
-          const nextPlanned = plan.segments[segmentIndex + 1]
           await backgroundMixer.mixInto(
             sliceChannels,
             // Frames already written = the real position of this slice, even
             // when clamping shortened an earlier segment.
             audioFramesWritten,
-            planSegmentGain({
-              volume,
-              // The slice's real span (joints shift it by half a crossfade).
-              durationMs: (sliceChannels[0]!.length / AUDIO_SAMPLE_RATE) * 1000,
-              entry: previousMixed
-                ? {
-                    fromVolume: previousMixed.volume,
-                    halfMs: boundaryRampHalfMs(
-                      previousMixed.durationMs,
-                      plannedDurationsMs[segmentIndex],
-                    ),
-                  }
-                : undefined,
-              exit: nextPlanned
-                ? {
-                    toVolume: segmentVolume(nextPlanned, background.defaultVolume),
-                    halfMs: boundaryRampHalfMs(
-                      segmentMs,
-                      plannedDurationsMs[segmentIndex + 1],
-                    ),
-                  }
-                : undefined,
-              fades: backgroundEdgeFades ?? background,
-            }),
-            // Whole-clip peak (not just this trim window) so a clip's
-            // loudness doesn't change with where it is trimmed.
-            normalizationScale(
-              buffer
-                ? channelPeak(
-                    Array.from({ length: buffer.numberOfChannels }, (_, ch) =>
-                      buffer.getChannelData(ch),
-                    ),
-                  )
-                : 0,
-            ),
+            {
+              music: planSegmentGain({
+                volume: musicVolume,
+                durationMs: sliceDurationMs,
+                entry: previousSegment
+                  ? { fromVolume: previousSegment.musicVolume, halfMs: entryHalfMs }
+                  : undefined,
+                exit: nextPlanned
+                  ? { toVolume: clipMusicVolume(nextPlanned.clip), halfMs: exitHalfMs }
+                  : undefined,
+                fades: backgroundEdgeFades ?? background,
+              }),
+              clip: clipEnvelope,
+            },
+            foregroundScale,
           )
-          previousMixed = { volume, durationMs: segmentMs }
+        } else {
+          applyGainEnvelope(sliceChannels, clipEnvelope, AUDIO_SAMPLE_RATE, foregroundScale)
         }
+        previousSegment = { musicVolume, clipVolume, durationMs: segmentMs }
         await audioSource.add(toAudioBuffer(sliceChannels))
         audioFramesWritten += sliceChannels[0]!.length
 

--- a/src/lib/export/last-export.ts
+++ b/src/lib/export/last-export.ts
@@ -7,7 +7,14 @@
  */
 
 import { getDb, getSettings } from '../storage'
-import type { ClipRecord, ProjectAudioRecord, ProjectId } from '../types'
+import {
+  audioTrackLevel,
+  clipMusicVolume,
+  clipSoundVolume,
+  type ClipRecord,
+  type ProjectAudioRecord,
+  type ProjectId,
+} from '../types'
 import { withExportCacheReserved } from './export-cache'
 import { readOpfsFile, removeExportEntry, streamToOpfsFile } from './opfs'
 import type { ExportResult } from './shared'
@@ -18,7 +25,7 @@ const LAST_EXPORT_PREFIX = 'last-export'
 export function exportSignature(
   clips: ClipRecord[],
   watermarked: boolean,
-  audio?: Pick<ProjectAudioRecord, 'tracks' | 'defaultVolume' | 'fadeIn' | 'fadeOut'> | null,
+  audio?: Pick<ProjectAudioRecord, 'tracks' | 'fadeIn' | 'fadeOut'> | null,
 ): string {
   return JSON.stringify({
     watermarked,
@@ -26,7 +33,10 @@ export function exportSignature(
       clip.id,
       clip.trimStartMs,
       clip.trimEndMs,
-      clip.audioVolume ?? null,
+      // Per-clip levels, resolved so an explicit value equal to the
+      // default signs identically to no value.
+      clipSoundVolume(clip),
+      clipMusicVolume(clip),
     ]),
     audio: audio
       ? {
@@ -37,11 +47,10 @@ export function exportSignature(
             // equal to the default signs identically to no value.
             track.trimStartMs ?? 0,
             track.trimEndMs ?? track.durationMs,
-            track.volume ?? 1,
+            audioTrackLevel(track),
             track.fadeIn ?? audio.fadeIn,
             track.fadeOut ?? audio.fadeOut,
           ]),
-          defaultVolume: audio.defaultVolume,
           fadeIn: audio.fadeIn,
           fadeOut: audio.fadeOut,
         }

--- a/src/lib/preview-audio-normalization.ts
+++ b/src/lib/preview-audio-normalization.ts
@@ -1,22 +1,24 @@
 import { channelPeak, normalizationScale } from './export/background-audio'
 import { decodeBlobAudio } from './export/shared'
+import type { ClipMeta } from './types'
 
 /**
- * The export peak-normalizes both sides of the background-music mix (the
- * clip's own sound and each playlist track) before blending them by the
- * mix share — a quietly mastered song is boosted up to 4×. For the live
- * previews to play the music at the level (and hand tracks off at the
- * position) the export will render, they need the same measurements: this
- * module runs the export's own decode + exact peak scan per source blob,
- * cached so a preview reopen or playlist revisit never re-decodes.
+ * The export peak-normalizes every audio source (the clip's own sound and
+ * each playlist track) before applying its volume — a quietly mastered
+ * song or a soft mic take is boosted up to 4×. For the live previews to
+ * play at the levels (and hand tracks off at the positions) the export
+ * will render, they need the same measurements. Clips carry theirs
+ * persisted (`ClipMeta.audioPeak`, backfilled on project load); playlist
+ * tracks are measured here with the export's own decode + exact peak
+ * scan, cached per blob so a preview reopen never re-decodes.
  *
  * Levels are applied through plain element volumes, NOT a Web Audio
  * media-element graph: `createMediaElementSource` permanently captures an
  * element's output, and on WebKit/iOS a context that is not (yet) running
  * turns that into total silence with no way back. Element volume caps at
  * 1, so normalization boosts are clamped into the ceiling — the default
- * 25% music share times the maximum 4× boost lands exactly at 1.0, and
- * louder shares play at the ceiling (slightly under the export's level,
+ * 25% track volume times the maximum 4× boost lands exactly at 1.0, and
+ * louder settings play at the ceiling (slightly under the export's level,
  * but always audible everywhere).
  */
 
@@ -74,14 +76,16 @@ async function measure(blob: Blob): Promise<AudioNormalizationInfo> {
   }
 }
 
-/** Element volume for the music bed at one moment: the export's normalized
- * level (mix share × normalization boost), clamped to the volume ceiling. */
-export function musicElementVolume(mix: number, scale: number): number {
-  return Math.max(0, Math.min(1, mix * scale))
+/** Element volume for one source at one moment: the export's normalized
+ * level (gain × normalization boost), clamped to the volume ceiling. */
+export function normalizedElementVolume(gain: number, scale: number): number {
+  return Math.max(0, Math.min(1, gain * scale))
 }
 
-/** Element volume for the clip's own sound under the bed: the export's
- * normalized complement, clamped to the volume ceiling. */
-export function clipElementVolume(mix: number, scale: number): number {
-  return Math.max(0, Math.min(1, (1 - mix) * scale))
+/** The clip's normalization gain: derived from the persisted measurement
+ * when present (synchronous, export-exact), else from the in-memory
+ * measurement while it lands (1 until then). */
+export function clipAudioScale(clip: Pick<ClipMeta, 'audioPeak'> & { blob: Blob }): number {
+  if (clip.audioPeak !== undefined) return normalizationScale(clip.audioPeak)
+  return peekAudioNormalization(clip.blob)?.scale ?? 1
 }

--- a/src/lib/project-actions.ts
+++ b/src/lib/project-actions.ts
@@ -15,12 +15,11 @@ import {
   removeProjectAudioTrack,
   setLastOpenedProjectId,
   undoDeleteLastClip,
-  updateClipAudioVolume,
   updateClipThumbs,
   updateClipTrim,
-  updateProjectAudioSettings,
+  updateClipVolumes,
   updateProjectAudioTrack,
-  type ProjectAudioSettings,
+  type ClipVolumeSettings,
   type ProjectAudioTrackSettings,
 } from './storage'
 import { probeAudioFile } from './audio-import'
@@ -168,14 +167,17 @@ export async function loadProjectPage(projectId: ProjectId): Promise<ProjectLoad
       }
     }
     await setLastOpenedProjectId(projectId)
-    // Backfill filmstrip thumbnails for clips that lack them. Serially —
-    // Android caps concurrent video decoders hard, and this normally touches
-    // at most the clip that was just recorded.
-    // Lazy: thumbs → export/shared → mediabunny. Home never hits this path.
+    // Backfill filmstrip thumbnails and the persisted audio-normalization
+    // measurement for clips that lack them. Serially — Android caps
+    // concurrent video decoders hard, and this normally touches at most
+    // the clip that was just recorded.
+    // Lazy: thumbs / clip-audio-peak → export/shared → mediabunny. Home
+    // never hits this path.
     const { ensureClipThumbs } = await import('./thumbs')
+    const { ensureClipAudioPeak } = await import('./clip-audio-peak')
     const hydrated: ClipRecord[] = []
     for (const clip of clips) {
-      hydrated.push(await ensureClipThumbs(clip))
+      hydrated.push(await ensureClipAudioPeak(await ensureClipThumbs(clip)))
     }
     return {
       project,
@@ -310,19 +312,12 @@ export async function setAudioTrackSettings(
   await updateProjectAudioTrack(projectId, trackId, settings)
 }
 
-export async function setProjectAudioSettings(
-  projectId: ProjectId,
-  settings: ProjectAudioSettings,
-): Promise<void> {
-  await updateProjectAudioSettings(projectId, settings)
-}
-
-/** Set (or clear, with null) a clip's background-music volume override. */
-export async function setClipAudioVolume(
+/** Set a clip's volume levels (1 or null clears the stored override). */
+export async function setClipVolumes(
   clipId: ClipId,
-  volume: number | null,
+  volumes: ClipVolumeSettings,
 ): Promise<void> {
-  await updateClipAudioVolume(clipId, volume)
+  await updateClipVolumes(clipId, volumes)
 }
 
 export {

--- a/src/lib/project-transfer.test.ts
+++ b/src/lib/project-transfer.test.ts
@@ -25,7 +25,6 @@ function fakeAudio(contents: string[] = ['SONGBYTES']): ProjectAudioRecord {
       name: `song-${index + 1}.mp3`,
       addedAt: 1700000000000 + index,
     })),
-    defaultVolume: 0.4,
     fadeIn: true,
     fadeOut: false,
   }
@@ -94,7 +93,7 @@ describe('project backup round trip', () => {
   it('round-trips the music playlist, fades, and per-clip volumes', async () => {
     await markWatermarkRemoved('cs_test_transfer')
     const clips = [
-      fakeClip('clip_a', 'AAAA', { audioVolume: 0.8 }),
+      fakeClip('clip_a', 'AAAA', { clipVolume: 0.3, musicVolume: 0.8 }),
       fakeClip('clip_b', 'BBBB'),
     ]
     const backup = serializeProject(
@@ -104,7 +103,6 @@ describe('project backup round trip', () => {
     )
 
     const parsed = await parseProjectBackup(backup)
-    expect(parsed.audio?.defaultVolume).toBe(0.4)
     expect(parsed.audio?.fadeIn).toBe(true)
     expect(parsed.audio?.fadeOut).toBe(false)
     expect(parsed.audio?.tracks.map((track) => track.name)).toEqual([
@@ -113,22 +111,25 @@ describe('project backup round trip', () => {
     ])
     expect(await parsed.audio!.tracks[0].blob.text()).toBe('SONGBYTES')
     expect(await parsed.audio!.tracks[1].blob.text()).toBe('MORESONG')
-    expect(parsed.clips[0].audioVolume).toBe(0.8)
-    expect(parsed.clips[1].audioVolume).toBeUndefined()
+    expect(parsed.clips[0].clipVolume).toBe(0.3)
+    expect(parsed.clips[0].musicVolume).toBe(0.8)
+    expect(parsed.clips[1].clipVolume).toBeUndefined()
+    expect(parsed.clips[1].musicVolume).toBeUndefined()
     // Clip bytes stay aligned with the trailing audio section present.
     expect(await parsed.clips[1].blob.text()).toBe('BBBB')
 
     const project = await importProjectBackup(parsed)
     const audio = await getProjectAudio(project.id)
-    expect(audio?.defaultVolume).toBe(0.4)
     expect(audio?.fadeIn).toBe(true)
     expect(audio?.fadeOut).toBe(false)
     expect(audio?.tracks.map((track) => track.name)).toEqual(['song-1.mp3', 'song-2.mp3'])
     expect(await audio!.tracks[0].blob.text()).toBe('SONGBYTES')
     expect(await audio!.tracks[1].blob.text()).toBe('MORESONG')
     const imported = await getClipsForProject(project.id)
-    expect(imported[0].audioVolume).toBe(0.8)
-    expect(imported[1].audioVolume).toBeUndefined()
+    expect(imported[0].clipVolume).toBe(0.3)
+    expect(imported[0].musicVolume).toBe(0.8)
+    expect(imported[1].clipVolume).toBeUndefined()
+    expect(imported[1].musicVolume).toBeUndefined()
   })
 
   it('round-trips per-track playback settings (trim, level, fades)', async () => {

--- a/src/lib/project-transfer.test.ts
+++ b/src/lib/project-transfer.test.ts
@@ -93,7 +93,7 @@ describe('project backup round trip', () => {
   it('round-trips the music playlist, fades, and per-clip volumes', async () => {
     await markWatermarkRemoved('cs_test_transfer')
     const clips = [
-      fakeClip('clip_a', 'AAAA', { clipVolume: 0.3, musicVolume: 0.8 }),
+      fakeClip('clip_a', 'AAAA', { clipVolume: 0.3, musicVolume: 0.8, audioPeak: 0.45 }),
       fakeClip('clip_b', 'BBBB'),
     ]
     const backup = serializeProject(
@@ -113,8 +113,12 @@ describe('project backup round trip', () => {
     expect(await parsed.audio!.tracks[1].blob.text()).toBe('MORESONG')
     expect(parsed.clips[0].clipVolume).toBe(0.3)
     expect(parsed.clips[0].musicVolume).toBe(0.8)
+    // The normalization measurement travels too — imported clips skip the
+    // re-measure on their first load.
+    expect(parsed.clips[0].audioPeak).toBe(0.45)
     expect(parsed.clips[1].clipVolume).toBeUndefined()
     expect(parsed.clips[1].musicVolume).toBeUndefined()
+    expect(parsed.clips[1].audioPeak).toBeUndefined()
     // Clip bytes stay aligned with the trailing audio section present.
     expect(await parsed.clips[1].blob.text()).toBe('BBBB')
 
@@ -128,6 +132,7 @@ describe('project backup round trip', () => {
     const imported = await getClipsForProject(project.id)
     expect(imported[0].clipVolume).toBe(0.3)
     expect(imported[0].musicVolume).toBe(0.8)
+    expect(imported[0].audioPeak).toBe(0.45)
     expect(imported[1].clipVolume).toBeUndefined()
     expect(imported[1].musicVolume).toBeUndefined()
   })

--- a/src/lib/project-transfer.ts
+++ b/src/lib/project-transfer.ts
@@ -35,8 +35,10 @@ interface ManifestClip {
   lat?: number
   lng?: number
   locationAccuracyM?: number
-  /** Background-music volume override (0–1) while this clip plays. */
-  audioVolume?: number
+  /** The clip's own (foreground) sound level override (0–1). */
+  clipVolume?: number
+  /** Background-music level override (0–1) while this clip plays. */
+  musicVolume?: number
   /** Byte length of this clip's media in the blob section. */
   byteLength: number
 }
@@ -58,7 +60,6 @@ interface ManifestAudioTrack {
 }
 
 interface ManifestAudio {
-  defaultVolume: number
   fadeIn: boolean
   fadeOut: boolean
   tracks: ManifestAudioTrack[]
@@ -106,13 +107,13 @@ export function serializeProject(
       lat: clip.lat,
       lng: clip.lng,
       locationAccuracyM: clip.locationAccuracyM,
-      audioVolume: clip.audioVolume,
+      clipVolume: clip.clipVolume,
+      musicVolume: clip.musicVolume,
       byteLength: clip.blob.size,
     })),
   }
   if (audio && audio.tracks.length > 0) {
     manifest.audio = {
-      defaultVolume: audio.defaultVolume,
       fadeIn: audio.fadeIn,
       fadeOut: audio.fadeOut,
       tracks: audio.tracks.map((track) => ({
@@ -147,7 +148,6 @@ export function serializeProject(
 }
 
 export interface ParsedBackupAudio {
-  defaultVolume: number
   fadeIn: boolean
   fadeOut: boolean
   tracks: Array<Omit<ManifestAudioTrack, 'byteLength'> & { blob: Blob }>
@@ -220,7 +220,9 @@ export async function parseProjectBackup(file: Blob): Promise<ParsedBackup> {
       lat: clip.lat,
       lng: clip.lng,
       locationAccuracyM: clip.locationAccuracyM,
-      audioVolume: typeof clip.audioVolume === 'number' ? clip.audioVolume : undefined,
+      // Old backups carried an `audioVolume` mix share instead — ignored.
+      clipVolume: typeof clip.clipVolume === 'number' ? clip.clipVolume : undefined,
+      musicVolume: typeof clip.musicVolume === 'number' ? clip.musicVolume : undefined,
       blob: file.slice(offset, offset + clip.byteLength, mimeType),
     })
     offset += clip.byteLength
@@ -257,7 +259,6 @@ export async function parseProjectBackup(file: Blob): Promise<ParsedBackup> {
       offset += track.byteLength
     }
     audio = {
-      defaultVolume: manifestAudio.defaultVolume,
       fadeIn: manifestAudio.fadeIn !== false,
       fadeOut: manifestAudio.fadeOut !== false,
       tracks,
@@ -307,7 +308,8 @@ export async function importProjectBackup(
         lat: clip.lat,
         lng: clip.lng,
         locationAccuracyM: clip.locationAccuracyM,
-        audioVolume: clip.audioVolume,
+        clipVolume: clip.clipVolume,
+        musicVolume: clip.musicVolume,
       })
       // Restore trims (addClip resets them to the full clip).
       const trimmed = await updateClipTrim(added.id, clip.trimStartMs, clip.trimEndMs)
@@ -334,7 +336,6 @@ export async function importProjectBackup(
           durationMs: track.durationMs,
           name: track.name,
           // Playlist settings land with the first track; later adds keep them.
-          defaultVolume: parsed.audio.defaultVolume,
           fadeIn: parsed.audio.fadeIn,
           fadeOut: parsed.audio.fadeOut,
         })

--- a/src/lib/project-transfer.ts
+++ b/src/lib/project-transfer.ts
@@ -39,6 +39,9 @@ interface ManifestClip {
   clipVolume?: number
   /** Background-music level override (0–1) while this clip plays. */
   musicVolume?: number
+  /** Measured whole-clip audio peak (0–1) — restored so imported clips
+   * skip the normalization re-measure on their first load. */
+  audioPeak?: number
   /** Byte length of this clip's media in the blob section. */
   byteLength: number
 }
@@ -109,6 +112,7 @@ export function serializeProject(
       locationAccuracyM: clip.locationAccuracyM,
       clipVolume: clip.clipVolume,
       musicVolume: clip.musicVolume,
+      audioPeak: clip.audioPeak,
       byteLength: clip.blob.size,
     })),
   }
@@ -223,6 +227,10 @@ export async function parseProjectBackup(file: Blob): Promise<ParsedBackup> {
       // Old backups carried an `audioVolume` mix share instead — ignored.
       clipVolume: typeof clip.clipVolume === 'number' ? clip.clipVolume : undefined,
       musicVolume: typeof clip.musicVolume === 'number' ? clip.musicVolume : undefined,
+      audioPeak:
+        typeof clip.audioPeak === 'number' && Number.isFinite(clip.audioPeak)
+          ? Math.max(0, Math.min(1, clip.audioPeak))
+          : undefined,
       blob: file.slice(offset, offset + clip.byteLength, mimeType),
     })
     offset += clip.byteLength
@@ -310,6 +318,7 @@ export async function importProjectBackup(
         locationAccuracyM: clip.locationAccuracyM,
         clipVolume: clip.clipVolume,
         musicVolume: clip.musicVolume,
+        audioPeak: clip.audioPeak,
       })
       // Restore trims (addClip resets them to the full clip).
       const trimmed = await updateClipTrim(added.id, clip.trimStartMs, clip.trimEndMs)

--- a/src/lib/storage.test.ts
+++ b/src/lib/storage.test.ts
@@ -25,13 +25,13 @@ import {
   setKeepWatermark,
   toStoredBlob,
   undoDeleteLastClip,
-  updateClipAudioVolume,
+  updateClipAudioPeak,
+  updateClipVolumes,
   updateProjectAudioTrack,
   updateClipTrim,
-  updateProjectAudioSettings,
 } from './storage'
 import { markWatermarkRemoved } from './entitlement'
-import { DEFAULT_AUDIO_VOLUME, MAX_PROJECTS, effectiveDurationMs } from './types'
+import { MAX_PROJECTS, effectiveDurationMs } from './types'
 
 function fakeBlob(label: string): Blob {
   return new Blob([label], { type: 'video/webm' })
@@ -364,19 +364,12 @@ describe('storage layer', () => {
       durationMs: 30_000,
       name: 'song.mp3',
     })
-    expect(first.defaultVolume).toBe(DEFAULT_AUDIO_VOLUME)
     expect(first.fadeIn).toBe(true)
     expect(first.fadeOut).toBe(true)
     expect(first.tracks).toHaveLength(1)
     expect(await first.tracks[0].blob.text()).toBe('song')
 
-    await updateProjectAudioSettings(project.id, { defaultVolume: 0.6, fadeOut: false })
-    let audio = await getProjectAudio(project.id)
-    expect(audio?.defaultVolume).toBe(0.6)
-    expect(audio?.fadeIn).toBe(true)
-    expect(audio?.fadeOut).toBe(false)
-
-    // A second track appends and keeps the chosen settings.
+    // A second track appends and keeps the playlist settings.
     const second = await addProjectAudioTrack({
       projectId: project.id,
       blob: new Blob(['other'], { type: 'audio/wav' }),
@@ -385,10 +378,12 @@ describe('storage layer', () => {
       name: 'other.wav',
     })
     expect(second.tracks.map((track) => track.name)).toEqual(['song.mp3', 'other.wav'])
-    expect(second.defaultVolume).toBe(0.6)
-    expect(second.fadeOut).toBe(false)
+    expect(second.fadeIn).toBe(true)
+    expect(second.fadeOut).toBe(true)
 
     // Removing one track keeps the playlist; removing the last drops it.
+    let audio = await getProjectAudio(project.id)
+    expect(audio?.tracks).toHaveLength(2)
     await removeProjectAudioTrack(project.id, second.tracks[0].id)
     audio = await getProjectAudio(project.id)
     expect(audio?.tracks.map((track) => track.name)).toEqual(['other.wav'])
@@ -422,7 +417,6 @@ describe('storage layer', () => {
     })
     // Untouched fields survive; fadeOut still inherits from the playlist.
     expect(updated.tracks[0].fadeOut).toBeUndefined()
-    expect(updated.defaultVolume).toBe(DEFAULT_AUDIO_VOLUME)
 
     // Partial updates keep the other side of the trim window, and the end
     // can never cross the start.
@@ -439,18 +433,20 @@ describe('storage layer', () => {
     expect(junkTrim.tracks[0].trimEndMs).toBe(10_000)
     await updateProjectAudioTrack(project.id, trackId, { trimEndMs: 1_000 })
 
-    // The level clamps to 0–1 and junk falls back to full volume.
+    // The volume clamps to 0–1 and junk falls back to the default (the
+    // stored value is dropped, so audioTrackLevel resolves the default).
     expect(
       (await updateProjectAudioTrack(project.id, trackId, { volume: 7 })).tracks[0].volume,
     ).toBe(1)
     expect(
       (await updateProjectAudioTrack(project.id, trackId, { volume: Number.NaN })).tracks[0]
         .volume,
-    ).toBe(1)
+    ).toBeUndefined()
 
     // The settings persist.
     const stored = await getProjectAudio(project.id)
-    expect(stored?.tracks[0]).toMatchObject({ trimStartMs: 2_000, trimEndMs: 2_000, volume: 1 })
+    expect(stored?.tracks[0]).toMatchObject({ trimStartMs: 2_000, trimEndMs: 2_000 })
+    expect(stored?.tracks[0].volume).toBeUndefined()
 
     await expect(
       updateProjectAudioTrack(project.id, 'missing-track', { volume: 0.5 }),
@@ -475,7 +471,7 @@ describe('storage layer', () => {
     expect(await getProjectAudio(project.id)).toBeUndefined()
   })
 
-  it('sets, clamps, clears, and duplicates per-clip music volumes', async () => {
+  it('sets, clamps, clears, and duplicates per-clip volumes', async () => {
     const project = await createProject('Volumes')
     const clip = await addClip({
       projectId: project.id,
@@ -483,22 +479,58 @@ describe('storage layer', () => {
       mimeType: 'video/webm',
       durationMs: 1000,
     })
-    expect(clip.audioVolume).toBeUndefined()
+    expect(clip.clipVolume).toBeUndefined()
+    expect(clip.musicVolume).toBeUndefined()
 
-    await updateClipAudioVolume(clip.id, 1.7)
-    expect((await getClip(clip.id))?.audioVolume).toBe(1)
+    // Full volume is the default — values ≥ 1 store no override.
+    await updateClipVolumes(clip.id, { clipVolume: 1.7 })
+    expect((await getClip(clip.id))?.clipVolume).toBeUndefined()
 
-    await updateClipAudioVolume(clip.id, 0.4)
-    expect((await getClip(clip.id))?.audioVolume).toBe(0.4)
+    await updateClipVolumes(clip.id, { clipVolume: 0.4 })
+    expect((await getClip(clip.id))?.clipVolume).toBe(0.4)
 
-    // Duplicates inherit the override.
+    // Each side updates independently; the other is left as is.
+    await updateClipVolumes(clip.id, { musicVolume: 0.6 })
+    const both = await getClip(clip.id)
+    expect(both?.clipVolume).toBe(0.4)
+    expect(both?.musicVolume).toBe(0.6)
+
+    // Duplicates inherit the overrides.
     const copy = await duplicateClip(clip.id)
-    expect((await getClip(copy.id))?.audioVolume).toBe(0.4)
+    expect((await getClip(copy.id))?.clipVolume).toBe(0.4)
+    expect((await getClip(copy.id))?.musicVolume).toBe(0.6)
 
-    await updateClipAudioVolume(clip.id, null)
+    await updateClipVolumes(clip.id, { clipVolume: null, musicVolume: 1 })
     const cleared = await getClip(clip.id)
-    expect(cleared?.audioVolume).toBeUndefined()
-    expect(cleared && 'audioVolume' in cleared).toBe(false)
+    expect(cleared?.clipVolume).toBeUndefined()
+    expect(cleared && 'clipVolume' in cleared).toBe(false)
+    expect(cleared && 'musicVolume' in cleared).toBe(false)
+  })
+
+  it('persists the measured audio peak without touching updatedAt', async () => {
+    const project = await createProject('Peaks')
+    const clip = await addClip({
+      projectId: project.id,
+      blob: fakeBlob('p'),
+      mimeType: 'video/webm',
+      durationMs: 1000,
+    })
+    expect(clip.audioPeak).toBeUndefined()
+    const updatedAtBefore = (await listProjects()).find((p) => p.id === project.id)!.updatedAt
+
+    await updateClipAudioPeak(clip.id, 0.45)
+    expect((await getClip(clip.id))?.audioPeak).toBe(0.45)
+
+    // Junk clamps into 0–1 (never poisons playback math).
+    await updateClipAudioPeak(clip.id, Number.NaN)
+    expect((await getClip(clip.id))?.audioPeak).toBe(0)
+
+    // A measurement is not a user edit — home slot order must not churn.
+    const updatedAtAfter = (await listProjects()).find((p) => p.id === project.id)!.updatedAt
+    expect(updatedAtAfter).toBe(updatedAtBefore)
+
+    // A missing clip is a no-op, not an error (deleted mid-backfill).
+    await expect(updateClipAudioPeak('missing-clip', 0.5)).resolves.toBeUndefined()
   })
 
   it('does not leak AbortError unhandled rejections when a clip put fails', async () => {

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -356,6 +356,9 @@ export interface AddClipInput {
   /** Per-clip volume overrides — used when importing backups. */
   clipVolume?: number
   musicVolume?: number
+  /** Measured whole-clip audio peak — used when importing backups so the
+   * clip skips the normalization re-measure on its first load. */
+  audioPeak?: number
 }
 
 /**
@@ -400,6 +403,9 @@ export async function addClip(input: AddClipInput): Promise<ClipRecord> {
   }
   if (input.musicVolume !== undefined && clampVolume(input.musicVolume) < 1) {
     clip.musicVolume = clampVolume(input.musicVolume)
+  }
+  if (input.audioPeak !== undefined && Number.isFinite(input.audioPeak)) {
+    clip.audioPeak = Math.max(0, Math.min(1, input.audioPeak))
   }
 
   const tx = db.transaction(['clips', 'projects'], 'readwrite')

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -1,7 +1,6 @@
 import { openDB, type DBSchema, type IDBPDatabase } from 'idb'
 import { removeExportEntry } from './export/opfs'
 import {
-  DEFAULT_AUDIO_VOLUME,
   FREE_PROJECTS,
   MAX_PROJECTS,
   clampVolume,
@@ -354,8 +353,9 @@ export interface AddClipInput {
   /** Original capture time — used when importing backups so chapter titles
    * keep the real recording time. Defaults to now. */
   createdAt?: number
-  /** Background-music volume override — used when importing backups. */
-  audioVolume?: number
+  /** Per-clip volume overrides — used when importing backups. */
+  clipVolume?: number
+  musicVolume?: number
 }
 
 /**
@@ -395,8 +395,11 @@ export async function addClip(input: AddClipInput): Promise<ClipRecord> {
     lng: input.lng,
     locationAccuracyM: input.locationAccuracyM,
   }
-  if (input.audioVolume !== undefined) {
-    clip.audioVolume = clampVolume(input.audioVolume)
+  if (input.clipVolume !== undefined && clampVolume(input.clipVolume) < 1) {
+    clip.clipVolume = clampVolume(input.clipVolume)
+  }
+  if (input.musicVolume !== undefined && clampVolume(input.musicVolume) < 1) {
+    clip.musicVolume = clampVolume(input.musicVolume)
   }
 
   const tx = db.transaction(['clips', 'projects'], 'readwrite')
@@ -471,11 +474,18 @@ export async function updateClipTrim(
   return toMeta(updated)
 }
 
-/** Set a clip's background-music volume override; null returns it to the
- * project audio track's default. */
-export async function updateClipAudioVolume(
+export interface ClipVolumeSettings {
+  /** The clip's own (foreground) sound level; undefined = leave as is. */
+  clipVolume?: number | null
+  /** Music level while this clip plays; undefined = leave as is. */
+  musicVolume?: number | null
+}
+
+/** Set a clip's volume levels. Full volume (1) is the default, so a value
+ * of 1 or null clears the stored override. */
+export async function updateClipVolumes(
   clipId: ClipId,
-  volume: number | null,
+  volumes: ClipVolumeSettings,
 ): Promise<ClipMeta> {
   const db = await getDb()
   // Read + merge + write in one transaction so a concurrent clip mutation
@@ -487,14 +497,34 @@ export async function updateClipAudioVolume(
     throw new Error('Clip not found')
   }
   const updated: ClipRecord = { ...clip }
-  if (volume === null) {
-    delete updated.audioVolume
-  } else {
-    updated.audioVolume = clampVolume(volume)
+  const apply = (field: 'clipVolume' | 'musicVolume', value: number | null | undefined) => {
+    if (value === undefined) return
+    const clamped = value === null ? 1 : clampVolume(value)
+    if (clamped >= 1) {
+      delete updated[field]
+    } else {
+      updated[field] = clamped
+    }
   }
+  apply('clipVolume', volumes.clipVolume)
+  apply('musicVolume', volumes.musicVolume)
   await completeTransaction([tx.store.put(updated)], tx)
   await touchProject(clip.projectId)
   return toMeta(updated)
+}
+
+/** Persist a clip's measured audio peak (the normalization measurement).
+ * Not a user edit — the project's updatedAt is deliberately untouched. */
+export async function updateClipAudioPeak(clipId: ClipId, peak: number): Promise<void> {
+  const db = await getDb()
+  const tx = db.transaction('clips', 'readwrite')
+  const clip = await tx.store.get(clipId)
+  if (!clip) {
+    await tx.done
+    return
+  }
+  const audioPeak = Number.isFinite(peak) ? Math.max(0, Math.min(1, peak)) : 0
+  await completeTransaction([tx.store.put({ ...clip, audioPeak })], tx)
 }
 
 export async function getProjectAudio(
@@ -510,8 +540,7 @@ export interface AddProjectAudioTrackInput {
   mimeType: string
   durationMs: number
   name: string
-  /** Initial playlist settings — only honored when this is the first track. */
-  defaultVolume?: number
+  /** Initial playlist fade settings — only honored on the first track. */
   fadeIn?: boolean
   fadeOut?: boolean
 }
@@ -547,7 +576,6 @@ export async function addProjectAudioTrack(
     : {
         projectId: input.projectId,
         tracks: [track],
-        defaultVolume: clampVolume(input.defaultVolume ?? DEFAULT_AUDIO_VOLUME),
         fadeIn: input.fadeIn ?? true,
         fadeOut: input.fadeOut ?? true,
       }
@@ -622,46 +650,18 @@ export async function updateProjectAudioTrack(
     updatedTrack.trimEndMs = Math.max(start, Math.min(requestedEnd, track.durationMs))
   }
   if (settings.volume !== undefined) {
-    updatedTrack.volume = Number.isFinite(settings.volume)
-      ? Math.max(0, Math.min(1, settings.volume))
-      : 1
+    if (Number.isFinite(settings.volume)) {
+      updatedTrack.volume = Math.max(0, Math.min(1, settings.volume))
+    } else {
+      // A non-finite request must never persist — back to the default.
+      delete updatedTrack.volume
+    }
   }
   if (settings.fadeIn !== undefined) updatedTrack.fadeIn = settings.fadeIn
   if (settings.fadeOut !== undefined) updatedTrack.fadeOut = settings.fadeOut
   const updated: ProjectAudioRecord = {
     ...audio,
     tracks: audio.tracks.map((t) => (t.id === trackId ? updatedTrack : t)),
-  }
-  await completeTransaction([tx.store.put(updated)], tx)
-  await touchProject(projectId)
-  return updated
-}
-
-export interface ProjectAudioSettings {
-  defaultVolume?: number
-  fadeIn?: boolean
-  fadeOut?: boolean
-}
-
-export async function updateProjectAudioSettings(
-  projectId: ProjectId,
-  settings: ProjectAudioSettings,
-): Promise<ProjectAudioRecord> {
-  const db = await getDb()
-  const tx = db.transaction('audio', 'readwrite')
-  const audio = await tx.store.get(projectId)
-  if (!audio) {
-    await tx.done.catch(() => undefined)
-    throw new Error('This project has no background music')
-  }
-  const updated: ProjectAudioRecord = {
-    ...audio,
-    defaultVolume:
-      settings.defaultVolume !== undefined
-        ? clampVolume(settings.defaultVolume)
-        : audio.defaultVolume,
-    fadeIn: settings.fadeIn ?? audio.fadeIn,
-    fadeOut: settings.fadeOut ?? audio.fadeOut,
   }
   await completeTransaction([tx.store.put(updated)], tx)
   await touchProject(projectId)

--- a/src/lib/types.test.ts
+++ b/src/lib/types.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it } from 'vitest'
 import {
+  DEFAULT_TRACK_VOLUME,
   audioTrackKeptMs,
   audioTrackLevel,
+  clipMusicVolume,
+  clipSoundVolume,
   effectiveDurationMs,
   formatDuration,
   projectAudioTotalDurationMs,
@@ -28,13 +31,13 @@ describe('duration helpers', () => {
 describe('audio track playback helpers', () => {
   const playlist = { fadeIn: true, fadeOut: false }
 
-  it('defaults to the whole track at full level with playlist fades', () => {
+  it('defaults to the whole track at the default volume with playlist fades', () => {
     const playback = resolveAudioTrackPlayback({ durationMs: 30_000 }, playlist)
     expect(playback).toEqual({
       trimStartMs: 0,
       trimEndMs: 30_000,
       keptMs: 30_000,
-      volume: 1,
+      volume: DEFAULT_TRACK_VOLUME,
       fadeIn: true,
       fadeOut: false,
     })
@@ -84,12 +87,22 @@ describe('audio track playback helpers', () => {
     expect(playback.trimEndMs).toBe(Infinity)
   })
 
-  it('clamps the level and treats junk as full volume', () => {
-    expect(audioTrackLevel({})).toBe(1)
+  it('clamps the volume and treats junk as the default', () => {
+    expect(audioTrackLevel({})).toBe(DEFAULT_TRACK_VOLUME)
     expect(audioTrackLevel({ volume: 0.4 })).toBe(0.4)
     expect(audioTrackLevel({ volume: 3 })).toBe(1)
     expect(audioTrackLevel({ volume: -1 })).toBe(0)
-    expect(audioTrackLevel({ volume: Number.NaN })).toBe(1)
+    expect(audioTrackLevel({ volume: Number.NaN })).toBe(DEFAULT_TRACK_VOLUME)
+  })
+
+  it('defaults both per-clip levels to full volume and clamps them', () => {
+    expect(clipSoundVolume({})).toBe(1)
+    expect(clipSoundVolume({ clipVolume: 0.3 })).toBe(0.3)
+    expect(clipSoundVolume({ clipVolume: 5 })).toBe(1)
+    expect(clipSoundVolume({ clipVolume: Number.NaN })).toBe(1)
+    expect(clipMusicVolume({})).toBe(1)
+    expect(clipMusicVolume({ musicVolume: 0.7 })).toBe(0.7)
+    expect(clipMusicVolume({ musicVolume: -2 })).toBe(0)
   })
 
   it('sums kept (trimmed) lengths for the playlist coverage', () => {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -30,10 +30,16 @@ export interface ClipMeta {
   lat?: number
   lng?: number
   locationAccuracyM?: number
-  /** Music's share (0–1) of the audio mix while this clip plays: the clip's
-   * own sound gets the complement (0.8 music ⇒ 0.2 clip sound), so the mix
-   * can never clip. Absent = the project playlist's default share. */
-  audioVolume?: number
+  /** This clip's own (foreground) sound level (0–1). Absent = full. */
+  clipVolume?: number
+  /** Background-music level (0–1) while this clip plays, scaling the
+   * playing track's own volume (duck the music under speech). Absent =
+   * full (the track's volume alone). */
+  musicVolume?: number
+  /** Measured whole-clip audio peak (0–1) at the export's mixing rate —
+   * the persisted normalization measurement (0 = silent or undecodable).
+   * Absent = not yet measured; backfilled automatically on project load. */
+  audioPeak?: number
 }
 
 export interface ClipRecord extends ClipMeta {
@@ -63,8 +69,9 @@ export interface ProjectAudioTrack {
    * window plays; the next track starts where it ends. */
   trimStartMs?: number
   trimEndMs?: number
-  /** Track level (0–1) applied to the music side of the mix while this
-   * track plays (default 1 — the clip mix share is unaffected). */
+  /** Track volume (0–1): the music's level under the clips while this
+   * track plays (clips can duck it further via their own musicVolume).
+   * Absent = DEFAULT_TRACK_VOLUME. */
   volume?: number
   /** Ease this track in/out where it starts/ends. Absent = inherit the
    * playlist's fade flags (kept for records made before per-track fades). */
@@ -74,23 +81,21 @@ export interface ProjectAudioTrack {
 
 /**
  * A project's background music: tracks play one after the other under the
- * clips until the film ends (the last one is cut off there — nothing loops),
- * at a default volume clips can override individually.
+ * clips until the film ends (the last one is cut off there — nothing
+ * loops), each at its own volume, which clips can duck individually.
  */
 export interface ProjectAudioRecord {
   projectId: ProjectId
   tracks: ProjectAudioTrack[]
-  /** Music's default share (0–1) of the audio mix for clips without a
-   * per-clip override; clip sound gets the complement. */
-  defaultVolume: number
   /** Playlist-level fade defaults, inherited by tracks without their own
    * fadeIn/fadeOut flags (records made before per-track fades). */
   fadeIn: boolean
   fadeOut: boolean
 }
 
-/** 25% music / 75% clip sound — sits under speech without drowning it. */
-export const DEFAULT_AUDIO_VOLUME = 0.25
+/** Default track volume: music at 25% sits under speech without drowning
+ * it (both sides are peak-normalized, so 100% would rival the clips). */
+export const DEFAULT_TRACK_VOLUME = 0.25
 
 /** The fields that shape how one playlist track plays back. `durationMs`
  * is optional so export-side track shapes (which may not know it) fit. */
@@ -115,8 +120,8 @@ export interface AudioTrackPlayback {
 }
 
 /** Resolve a track's playback settings against its playlist's defaults:
- * trim clamped into the media, level defaulting to full, fades falling back
- * to the playlist flags. */
+ * trim clamped into the media, volume defaulting to DEFAULT_TRACK_VOLUME,
+ * fades falling back to the playlist flags. */
 export function resolveAudioTrackPlayback(
   track: AudioTrackPlaybackFields,
   playlist: { fadeIn: boolean; fadeOut: boolean },
@@ -143,9 +148,10 @@ export function audioTrackKeptMs(
   return Math.max(0, end - start)
 }
 
-/** The track's level (0–1) on the music side of the mix; default full. */
+/** The track's volume (0–1) — the music's level under the clips while it
+ * plays; default DEFAULT_TRACK_VOLUME. */
 export function audioTrackLevel(track: Pick<AudioTrackPlaybackFields, 'volume'>): number {
-  if (track.volume === undefined || !Number.isFinite(track.volume)) return 1
+  if (track.volume === undefined || !Number.isFinite(track.volume)) return DEFAULT_TRACK_VOLUME
   return Math.max(0, Math.min(1, track.volume))
 }
 
@@ -155,16 +161,19 @@ export function projectAudioTotalDurationMs(audio: Pick<ProjectAudioRecord, 'tra
 }
 
 export function clampVolume(volume: number): number {
-  if (!Number.isFinite(volume)) return DEFAULT_AUDIO_VOLUME
+  if (!Number.isFinite(volume)) return 1
   return Math.max(0, Math.min(1, volume))
 }
 
-/** Music's share of the mix while a clip plays: its override or the default. */
-export function clipAudioVolume(
-  clip: Pick<ClipMeta, 'audioVolume'>,
-  defaultVolume: number,
-): number {
-  return clampVolume(clip.audioVolume ?? defaultVolume)
+/** The clip's own (foreground) sound level (0–1); default full. */
+export function clipSoundVolume(clip: Pick<ClipMeta, 'clipVolume'>): number {
+  return clampVolume(clip.clipVolume ?? 1)
+}
+
+/** The music's level (0–1) while this clip plays, scaling the playing
+ * track's own volume; default full (no duck). */
+export function clipMusicVolume(clip: Pick<ClipMeta, 'musicVolume'>): number {
+  return clampVolume(clip.musicVolume ?? 1)
 }
 
 export interface AppMeta {

--- a/src/pages/project-page.tsx
+++ b/src/pages/project-page.tsx
@@ -301,7 +301,6 @@ export function ProjectPage(handle: Handle<ProjectPageProps>) {
                     fadeIn: track.fadeIn,
                     fadeOut: track.fadeOut,
                   })),
-                  defaultVolume: audio.defaultVolume,
                   fadeIn: audio.fadeIn,
                   fadeOut: audio.fadeOut,
                 }

--- a/src/styles/editor.css
+++ b/src/styles/editor.css
@@ -560,8 +560,8 @@
   flex: 0 0 auto;
 }
 
-/* Balance slider: clip sound on the left, music on the right. */
-.audio-mix-row {
+/* Per-clip volume sliders: the clip's own sound and the music under it. */
+.audio-volume-row {
   display: flex;
   align-items: center;
   gap: 7px;
@@ -569,7 +569,7 @@
 }
 
 .audio-volume-label {
-  flex: 0 0 64px;
+  flex: 0 0 88px;
   font-size: 0.72rem;
   font-weight: 600;
   color: var(--ink-muted);
@@ -578,7 +578,7 @@
   white-space: nowrap;
 }
 
-.audio-mix-row input[type='range'] {
+.audio-volume-row input[type='range'] {
   flex: 1 1 auto;
   min-width: 40px;
   height: 26px;
@@ -586,33 +586,14 @@
   touch-action: pan-y;
 }
 
-.audio-mix-side {
-  flex: 0 0 auto;
-  font-size: 0.7rem;
-  color: var(--ink-muted);
-  font-variant-numeric: tabular-nums;
-  white-space: nowrap;
-}
-
-.audio-mix-side strong {
+.audio-volume-value {
+  flex: 0 0 38px;
+  text-align: right;
+  font-size: 0.72rem;
   color: var(--ink);
   font-weight: 700;
-}
-
-.audio-volume-reset {
-  flex: 0 0 auto;
-  min-height: 26px;
-  padding: 2px 10px;
-  border-radius: 999px;
-  font-size: 0.72rem;
-  font-weight: 600;
-  color: var(--accent);
-  background: color-mix(in srgb, var(--accent) 14%, transparent);
-}
-
-.audio-volume-reset:disabled {
-  opacity: 0.35;
-  cursor: not-allowed;
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
 }
 
 /* Track rows open the audio detail view */
@@ -728,10 +709,11 @@
   margin-left: 0;
 }
 
-/* Per-clip music-volume badge on timeline tiles */
-.clip-thumb .clip-audio-badge {
+/* Per-clip volume badges on timeline tiles: music top-left, own sound
+   top-right (only overrides are shown). */
+.clip-thumb .clip-audio-badge,
+.clip-thumb .clip-volume-badge {
   position: absolute;
-  left: 4px;
   top: 4px;
   font-size: 0.62rem;
   color: #fff;
@@ -740,6 +722,15 @@
   border-radius: 999px;
   font-variant-numeric: tabular-nums;
   pointer-events: none;
+  white-space: nowrap;
+}
+
+.clip-thumb .clip-audio-badge {
+  left: 4px;
+}
+
+.clip-thumb .clip-volume-badge {
+  right: 4px;
 }
 
 /* Bottom clip action bar */

--- a/src/styles/editor.css
+++ b/src/styles/editor.css
@@ -710,11 +710,15 @@
 }
 
 /* Per-clip volume badges on timeline tiles: music top-left, own sound
-   top-right (only overrides are shown). */
+   top-right (only overrides are shown). Capped to half the tile so both
+   badges fit side by side even on minimum-width tiles. */
 .clip-thumb .clip-audio-badge,
 .clip-thumb .clip-volume-badge {
   position: absolute;
   top: 4px;
+  max-width: calc(50% - 6px);
+  overflow: hidden;
+  text-overflow: ellipsis;
   font-size: 0.62rem;
   color: #fff;
   background: rgba(0, 0, 0, 0.55);

--- a/tests/e2e/background-music.spec.ts
+++ b/tests/e2e/background-music.spec.ts
@@ -79,7 +79,6 @@ async function storedAudio(page: Page) {
     const audio = await storage.getProjectAudio(projects[0]!.id)
     return audio
       ? {
-          defaultVolume: audio.defaultVolume,
           fadeIn: audio.fadeIn,
           fadeOut: audio.fadeOut,
           tracks: audio.tracks.map(
@@ -108,12 +107,17 @@ async function storedAudio(page: Page) {
   })
 }
 
-async function storedClipVolumes(page: Page): Promise<Array<number | null>> {
+async function storedClipVolumes(
+  page: Page,
+): Promise<Array<{ clipVolume: number | null; musicVolume: number | null }>> {
   return page.evaluate(async () => {
     const storage = await import('/src/lib/storage.ts')
     const projects = await storage.listProjects()
     const clips = await storage.getClipMetasForProject(projects[0]!.id)
-    return clips.map((clip: { audioVolume?: number }) => clip.audioVolume ?? null)
+    return clips.map((clip: { clipVolume?: number; musicVolume?: number }) => ({
+      clipVolume: clip.clipVolume ?? null,
+      musicVolume: clip.musicVolume ?? null,
+    }))
   })
 }
 
@@ -135,7 +139,56 @@ test.describe('background music', () => {
     expect(await storedAudio(page)).toBeNull()
   })
 
-  test('builds a playlist: tracks, fades, default and per-clip volumes', async ({ page }) => {
+  test('normalizes clip audio automatically on project load', async ({ page }) => {
+    await openSeededProject(page, { clips: 2 })
+    // The loader backfill measures and persists every clip's audio peak
+    // (the fixture clips carry no audio track, so the stored peak is 0 —
+    // "measured, mix unscaled").
+    await expect
+      .poll(
+        () =>
+          page.evaluate(async () => {
+            const storage = await import('/src/lib/storage.ts')
+            const projects = await storage.listProjects()
+            const clips = await storage.getClipMetasForProject(projects[0]!.id)
+            return clips.every(
+              (clip: { audioPeak?: number }) => typeof clip.audioPeak === 'number',
+            )
+          }),
+        { timeout: 20_000 },
+      )
+      .toBe(true)
+  })
+
+  test('sets the clip sound volume without music (free plan)', async ({ page }) => {
+    await openSeededProject(page, { clips: 1 })
+    await openEditor(page)
+
+    // The clip-sound slider lives next to the (locked) Add music button —
+    // it is about the clip, not the playlist.
+    await setSlider(page, 'Clip 1 sound volume', 30)
+    await expect
+      .poll(async () => (await storedClipVolumes(page))[0]?.clipVolume)
+      .toBeCloseTo(0.3)
+    await expect(page.locator('.clip-volume-badge')).toHaveText(/30%/)
+
+    // The editor stage plays the clip at its level (no audio track in the
+    // fixture clips, so the normalization scale is 1).
+    await expect
+      .poll(() =>
+        page
+          .locator('.editor-clip-preview-wrap video')
+          .evaluate((el) => (el as HTMLVideoElement).volume),
+      )
+      .toBeCloseTo(0.3)
+
+    // Back to 100% clears the stored override and the badge.
+    await setSlider(page, 'Clip 1 sound volume', 100)
+    await expect.poll(async () => (await storedClipVolumes(page))[0]?.clipVolume).toBeNull()
+    await expect(page.locator('.clip-volume-badge')).toHaveCount(0)
+  })
+
+  test('builds a playlist: tracks, fades, and per-clip volumes', async ({ page }) => {
     await openPlusEditorWithClips(page, 2)
     await addMusic(page)
     await expect(page.locator('.toast')).toContainText(/music added/i)
@@ -145,9 +198,12 @@ test.describe('background music', () => {
       'test-song.wav',
     ])
     expect(audio?.tracks[0].durationMs).toBeGreaterThan(3000)
-    expect(audio?.defaultVolume).toBeCloseTo(0.25)
     expect(audio?.fadeIn).toBe(true)
     expect(audio?.fadeOut).toBe(true)
+    // Tracks default to the 25% volume (music under speech) — nothing is
+    // stored until the detail slider changes it.
+    expect(audio?.tracks[0].volume).toBeNull()
+    await expect(page.locator('.audio-track-duration')).toContainText('25%')
 
     // 4s of music under a 6s film: the coverage hint appears…
     await expect(page.locator('.audio-coverage-hint')).toContainText(/music ends at/i)
@@ -161,40 +217,61 @@ test.describe('background music', () => {
       'second-song.wav',
     ])
 
-    // Default mix slider persists (value = music's share).
-    await setSlider(page, 'Default audio mix', 40)
-    await expect.poll(async () => (await storedAudio(page))?.defaultVolume).toBeCloseTo(0.4)
-
-    // Per-clip override on the selected (last) clip. The row shows both
-    // sides of the balance: clip sound left, music right.
+    // The selected (last) clip gets two independent volume sliders, both
+    // at the 100% default.
     const tiles = page.locator('.clip-thumb[data-clip-id]')
     await expect(tiles.last()).toHaveClass(/selected/)
-    await setSlider(page, /Audio mix during clip 2/, 60)
-    await expect.poll(async () => await storedClipVolumes(page)).toEqual([null, 0.6])
+    await expect(page.getByRole('slider', { name: 'Clip 2 sound volume' })).toHaveValue('100')
+    await expect(
+      page.getByRole('slider', { name: 'Music volume during clip 2' }),
+    ).toHaveValue('100')
+
+    // Duck the music under clip 2.
+    await setSlider(page, 'Music volume during clip 2', 60)
+    await expect.poll(async () => await storedClipVolumes(page)).toEqual([
+      { clipVolume: null, musicVolume: null },
+      { clipVolume: null, musicVolume: 0.6 },
+    ])
     await expect(tiles.last().locator('.clip-audio-badge')).toHaveText(/60%/)
-    const clipMixRow = page.locator('.audio-mix-row').first()
-    await expect(clipMixRow).toContainText('Clip 40%')
-    await expect(clipMixRow).toContainText('60% Music')
 
-    // Selecting the other clip shows the default-following row.
+    // Quiet clip 2's own sound.
+    await setSlider(page, 'Clip 2 sound volume', 40)
+    await expect.poll(async () => await storedClipVolumes(page)).toEqual([
+      { clipVolume: null, musicVolume: null },
+      { clipVolume: 0.4, musicVolume: 0.6 },
+    ])
+    await expect(tiles.last().locator('.clip-volume-badge')).toHaveText(/40%/)
+
+    // Selecting the other clip shows its own (default) dials.
     await tiles.first().click()
-    await expect(page.locator('.audio-volume-label').first()).toContainText('Clip 1 · default')
+    await expect(page.getByRole('slider', { name: 'Clip 1 sound volume' })).toHaveValue('100')
+    await expect(
+      page.getByRole('slider', { name: 'Music volume during clip 1' }),
+    ).toHaveValue('100')
 
-    // Reset returns clip 2 to the default.
+    // Sliding back to 100% clears the stored overrides (100% IS the default).
     await tiles.last().click()
-    await page.getByRole('button', { name: /Reset this clip/ }).click()
-    await expect.poll(async () => await storedClipVolumes(page)).toEqual([null, null])
+    await setSlider(page, 'Music volume during clip 2', 100)
+    await setSlider(page, 'Clip 2 sound volume', 100)
+    await expect.poll(async () => await storedClipVolumes(page)).toEqual([
+      { clipVolume: null, musicVolume: null },
+      { clipVolume: null, musicVolume: null },
+    ])
     await expect(tiles.last().locator('.clip-audio-badge')).toHaveCount(0)
+    await expect(tiles.last().locator('.clip-volume-badge')).toHaveCount(0)
 
-    // Removing tracks one by one lands back on the empty Add music state.
+    // Removing tracks one by one lands back on the empty Add music state —
+    // the clip-sound slider stays (it is not a playlist control).
     await page.getByRole('button', { name: /Remove music track 2/ }).click()
     await expect(page.locator('.audio-track-row')).toHaveCount(1)
     await page.getByRole('button', { name: /Remove music track 1/ }).click()
     await expect(page.getByRole('button', { name: 'Add background music' })).toBeVisible()
+    await expect(page.getByRole('slider', { name: 'Clip 2 sound volume' })).toBeVisible()
+    await expect(page.getByRole('slider', { name: /Music volume/ })).toHaveCount(0)
     expect(await storedAudio(page)).toBeNull()
   })
 
-  test('track detail view trims, levels, and fades one track', async ({ page }) => {
+  test('track detail view trims, sets volume, and fades one track', async ({ page }) => {
     await openPlusEditorWithClips(page, 1)
     await addMusic(page)
 
@@ -204,9 +281,12 @@ test.describe('background music', () => {
     await expect(detail).toBeVisible()
     await expect(detail.locator('.trim-handle-left')).toBeVisible()
     await expect(detail.locator('.trim-handle-right')).toBeVisible()
-    // The timeline, mix rows, and clip actions yield to the detail view.
+    // The timeline, volume rows, and clip actions yield to the detail view.
     await expect(page.locator('.audio-strip')).toHaveCount(0)
     await expect(page.locator('.editor-actions')).toHaveCount(0)
+
+    // The volume slider opens at the 25% default — the music's base level.
+    await expect(detail.getByRole('slider', { name: 'Track volume' })).toHaveValue('25')
 
     // Escape closes it without saving.
     await page.keyboard.press('Escape')
@@ -226,8 +306,8 @@ test.describe('background music', () => {
     await page.mouse.up()
     await expect(detail.locator('.trim-kept-label')).toContainText(/kept/)
 
-    // Level + fades are per-track drafts, saved together on Done.
-    await setSlider(page, 'Track level', 60)
+    // Volume + fades are per-track drafts, saved together on Done.
+    await setSlider(page, 'Track volume', 60)
     await detail.getByRole('checkbox', { name: 'Fade this track in' }).uncheck()
     await detail.getByRole('button', { name: 'Done' }).click()
     await expect(detail).toBeHidden()
@@ -242,17 +322,17 @@ test.describe('background music', () => {
     expect(track.trackFadeIn).toBe(false)
     expect(track.trackFadeOut).toBe(true)
 
-    // The row reflects the kept length and level…
+    // The row reflects the kept length and volume…
     await expect(page.locator('.audio-track-duration')).toContainText(/kept · 60%/)
-    // …and Cancel discards a fresh draft (the level stays 60%).
+    // …and Cancel discards a fresh draft (the volume stays 60%).
     await page.getByRole('button', { name: /Edit music track 1/ }).click()
-    await setSlider(page, 'Track level', 20)
+    await setSlider(page, 'Track volume', 20)
     await detail.getByRole('button', { name: 'Cancel' }).click()
     await expect(detail).toBeHidden()
     await expect.poll(async () => (await storedAudio(page))?.tracks[0]?.volume).toBeCloseTo(0.6)
   })
 
-  test('export sequences the playlist at per-clip mixes with fades', async ({ page }) => {
+  test('export sequences the playlist at per-clip volumes with fades', async ({ page }) => {
     test.slow()
     // Two 3s fixture clips (video-only — the fixture encoder adds no audio
     // track), so every decodable sample in the export's audio IS the music.
@@ -268,14 +348,14 @@ test.describe('background music', () => {
 
       // Two in-page sine WAVs at DIFFERENT frequencies: track A (8s,
       // 110 Hz for the first 2s then 440 Hz, full amplitude, TRIMMED to
-      // its 2s–6s window) then track B (20s, 880 Hz, HALF amplitude, at
-      // HALF level). Track A's trim proves the kept window is honored on
-      // both sides: the film never hears the 110 Hz intro (trim start),
-      // and the hand-off to track B lands at 4s (trim end — an untrimmed
-      // 8s track A would still be playing 440 Hz there). Peak
-      // normalization should erase the 2× amplitude difference, so the
-      // RMS ratio between the windows tracks the shares × track B's
-      // level.
+      // its 2s–6s window, at the default 25% volume) then track B (20s,
+      // 880 Hz, HALF amplitude, at 50% volume). Track A's trim proves the
+      // kept window is honored on both sides: the film never hears the
+      // 110 Hz intro (trim start), and the hand-off to track B lands at
+      // 4s (trim end — an untrimmed 8s track A would still be playing
+      // 440 Hz there). Peak normalization should erase the 2× amplitude
+      // difference, so the RMS ratio between the windows tracks the
+      // track volumes × clip 1's music duck.
       const makeWav = (
         seconds: number,
         amplitude: number,
@@ -314,8 +394,8 @@ test.describe('background music', () => {
         durationMs: 8000,
         name: 'track-a.wav',
       })
-      // Keep track A's 2s–6s window; explicit fade-out off keeps the
-      // hand-off crisp for the frequency windows below.
+      // Keep track A's 2s–6s window at the default volume; explicit
+      // fade-out off keeps the hand-off crisp for the windows below.
       await storage.updateProjectAudioTrack(project.id, first.tracks[0].id, {
         trimStartMs: 2000,
         trimEndMs: 6000,
@@ -328,15 +408,15 @@ test.describe('background music', () => {
         durationMs: 20000,
         name: 'track-b.wav',
       })
-      // Track B plays at HALF level; explicit fade-in off keeps the
-      // post-hand-off measurement window clean.
+      // Track B plays at 50% volume (double the 25% default); explicit
+      // fade-in off keeps the post-hand-off measurement window clean.
       const audio = await storage.updateProjectAudioTrack(
         project.id,
         added.tracks[1].id,
         { volume: 0.5, fadeIn: false },
       )
-      // Clip 1 follows the 0.25 default; clip 2 is overridden to full volume.
-      await storage.updateClipAudioVolume(clips[1]!.id, 1)
+      // Clip 1 ducks its music to half; clip 2 keeps the full track level.
+      await storage.updateClipVolumes(clips[0]!.id, { musicVolume: 0.5 })
       const updatedClips = await storage.getClipsForProject(project.id)
 
       const result = await exportProject(updatedClips, {
@@ -361,7 +441,6 @@ test.describe('background music', () => {
               fadeOut: track.fadeOut,
             }),
           ),
-          defaultVolume: audio.defaultVolume,
           fadeIn: audio.fadeIn,
           fadeOut: audio.fadeOut,
         },
@@ -389,11 +468,11 @@ test.describe('background music', () => {
       }
       return {
         durationSec: decoded.duration,
-        // Track A under clip 1 (music share 0.25), past the 800ms fade-in.
+        // Track A under clip 1 (music 0.25 × 0.5), past the 800ms fade-in.
         clip1: rms(1.2, 2.6),
         clip1Freq: crossingsPerSec(1.2, 2.6) / 2,
-        // Track B under clip 2 (share 1.0), past the 4s hand-off, before
-        // the fade-out begins at 4.8s.
+        // Track B under clip 2 (music 0.5 × 1), past the 4s hand-off,
+        // before the fade-out begins at 4.8s.
         clip2: rms(4.2, 4.7),
         clip2Freq: crossingsPerSec(4.2, 4.7) / 2,
         fadeIn: rms(0, 0.08),
@@ -413,26 +492,32 @@ test.describe('background music', () => {
     expect(measured!.clip1Freq).toBeLessThan(540)
     expect(measured!.clip2Freq).toBeGreaterThan(700)
     expect(measured!.clip2Freq).toBeLessThan(1060)
-    // Normalization + shares + track level: both tracks normalize to the
-    // same peak despite track B being mastered at HALF the amplitude, so
-    // the RMS ratio tracks the shares (1.0 / 0.25 = 4) × track B's 0.5
-    // level ≈ 2. Without normalization it would read ≈ 1; with track B's
-    // level ignored, ≈ 4.
-    expect(measured!.clip2 / measured!.clip1).toBeGreaterThan(1.35)
-    expect(measured!.clip2 / measured!.clip1).toBeLessThan(2.8)
+    // Normalization + volumes: both tracks normalize to the same peak
+    // despite track B being mastered at HALF the amplitude, so the RMS
+    // ratio tracks (track B volume × clip 2 music) / (track A volume ×
+    // clip 1 music) = (0.5 × 1) / (0.25 × 0.5) = 4. Without
+    // normalization it would read ≈ 2; with the duck ignored, ≈ 2.
+    expect(measured!.clip2 / measured!.clip1).toBeGreaterThan(2.7)
+    expect(measured!.clip2 / measured!.clip1).toBeLessThan(5.9)
     // The film opens inside the fade-in and closes inside the fade-out.
     expect(measured!.fadeIn).toBeLessThan(measured!.clip1 * 0.5)
     expect(measured!.fadeOut).toBeLessThan(measured!.clip2 * 0.5)
     expect(measured!.durationSec).toBeGreaterThan(5.5)
   })
 
-  test('preview playback ramps both sides of the mix per clip', async ({ page }) => {
+  test('preview playback follows the per-clip volumes independently', async ({ page }) => {
     await openPlusEditorWithClips(page, 2)
-    await addMusic(page)
+    await addMusic(page, 'Add background music', makeWavFile('test-song.wav', 8))
 
-    // Clip 2 (selected) gets a music-heavy override so the ramp is observable.
-    await setSlider(page, /Audio mix during clip 2/, 80)
-    await expect.poll(async () => await storedClipVolumes(page)).toEqual([null, 0.8])
+    const tiles = page.locator('.clip-thumb[data-clip-id]')
+    // Clip 2 (selected): quiet its own sound; clip 1: duck the music.
+    await setSlider(page, 'Clip 2 sound volume', 30)
+    await tiles.first().click()
+    await setSlider(page, 'Music volume during clip 1', 40)
+    await expect.poll(async () => await storedClipVolumes(page)).toEqual([
+      { clipVolume: null, musicVolume: 0.4 },
+      { clipVolume: 0.3, musicVolume: null },
+    ])
 
     await page.getByRole('button', { name: 'Play project preview' }).click()
     const overlay = page.locator('.playback-overlay')
@@ -440,33 +525,39 @@ test.describe('background music', () => {
 
     const music = overlay.locator('audio')
     await expect(music).toHaveCount(1)
-    // Music is playing and gliding up toward clip 1's default volume (0.25).
     await expect
       .poll(() => music.evaluate((el) => !(el as HTMLAudioElement).paused))
       .toBe(true)
+    // Clip 1's music: 0.4 duck × 25% track volume × ≈2.46 normalization
+    // boost ≈ 0.25 (the measurement lands in the background).
     await expect
-      .poll(() => music.evaluate((el) => (el as HTMLAudioElement).volume), { timeout: 5000 })
+      .poll(() => music.evaluate((el) => (el as HTMLAudioElement).volume), { timeout: 30_000 })
       .toBeGreaterThan(0.15)
+    // Clip 1's own sound stays at FULL volume — a ducked music level never
+    // pulls the clip down (no complement coupling).
+    expect(
+      await overlay.locator('.playback-video').evaluate((el) => (el as HTMLVideoElement).volume),
+    ).toBeGreaterThan(0.95)
 
-    // Skip to clip 2: the volume glides up toward the 0.8 override. Freeze
-    // the playhead at clip 2's start right away — otherwise the end-of-film
-    // fade-out window could shrink the target under CI load and flake the
-    // volume assertion.
+    // Skip to clip 2: the music glides up toward the undocked level
+    // (0.25 × ≈2.46 ≈ 0.61) while the clip's own sound glides DOWN to its
+    // 30% volume. Freeze the playhead at clip 2's start right away —
+    // otherwise the end-of-film fade-out window could shrink the target
+    // under CI load and flake the volume assertion.
     await overlay.getByRole('button', { name: 'Next clip' }).click()
     await expect(overlay.locator('.playback-caption')).toContainText('Clip 2 / 2')
     await overlay
       .locator('.playback-video')
       .evaluate((el) => (el as HTMLVideoElement).pause())
     await expect
-      .poll(() => music.evaluate((el) => (el as HTMLAudioElement).volume), { timeout: 5000 })
-      .toBeGreaterThan(0.6)
-    // …and the clip's own sound ducks toward the complement (1 − 0.8).
+      .poll(() => music.evaluate((el) => (el as HTMLAudioElement).volume), { timeout: 10_000 })
+      .toBeGreaterThan(0.5)
     await expect
       .poll(
         () => overlay.locator('.playback-video').evaluate((el) => (el as HTMLVideoElement).volume),
-        { timeout: 5000 },
+        { timeout: 10_000 },
       )
-      .toBeLessThan(0.35)
+      .toBeLessThan(0.45)
 
     await overlay.getByRole('button', { name: 'Stop preview' }).click()
     await expect(overlay).toBeHidden()
@@ -478,8 +569,8 @@ test.describe('background music', () => {
     await openPlusEditorWithClips(page, 1)
     // Quietly mastered song: peak ≈ 8000/32768 ≈ 0.24, so the export mixes
     // it ≈ 3.7× hotter (0.9 / 0.24) than the raw file plays. The preview
-    // carries the same boost in the music element's volume (0.25 share ×
-    // ≈3.7 ≈ 0.92) — without it the volume would sit at the bare 0.25.
+    // carries the same boost in the music element's volume (25% track
+    // volume × ≈3.7 ≈ 0.92) — without it the volume would sit at 0.25.
     await addMusic(page, 'Add background music', makeWavFile('quiet-song.wav', 8, 8000))
 
     await page.getByRole('button', { name: 'Play project preview' }).click()
@@ -504,7 +595,7 @@ test.describe('background music', () => {
       })
       .toBeGreaterThan(3.3)
     expect(Number(await music.getAttribute('data-music-scale'))).toBeLessThanOrEqual(4)
-    // …and the element volume glides to share × boost ≈ 0.92.
+    // …and the element volume glides to track volume × boost ≈ 0.92.
     await expect
       .poll(() => music.evaluate((el) => (el as HTMLAudioElement).volume), { timeout: 10_000 })
       .toBeGreaterThan(0.85)
@@ -536,15 +627,15 @@ test.describe('background music', () => {
     const startedAt = await music.evaluate((el) => (el as HTMLAudioElement).currentTime)
     expect(startedAt).toBeGreaterThan(2.8)
     expect(startedAt).toBeLessThan(4.5)
-    // Level: 0.25 share × ≈3.7 normalization boost ⇒ element volume ≈ 0.92.
+    // Level: 25% track volume × ≈3.7 normalization boost ⇒ element ≈ 0.92.
     await expect
       .poll(() => music.evaluate((el) => (el as HTMLAudioElement).volume), { timeout: 30_000 })
       .toBeGreaterThan(0.85)
-    // The clip's own sound ducks to the complement of the mix (fixture
-    // clips decode no audio, so their normalization scale stays 1).
+    // The clip's own sound is INDEPENDENT of the bed — no ducking, it
+    // stays at its full (default) volume while the music plays.
     await expect
       .poll(() => stage.locator('video').evaluate((el) => (el as HTMLVideoElement).volume))
-      .toBeLessThan(0.8)
+      .toBeGreaterThan(0.95)
 
     // When the clip stops at its trim end, the bed stops with it.
     await expect

--- a/tests/e2e/editor-playback.spec.ts
+++ b/tests/e2e/editor-playback.spec.ts
@@ -187,6 +187,23 @@ test.describe('editor', () => {
     expect(imported.mimeType).toMatch(/video\//)
     expect(imported.width).toBeGreaterThan(0)
     expect(imported.height).toBeGreaterThan(0)
+
+    // The post-import refresh auto-normalizes the new clip: its audio peak
+    // is measured and persisted by the loader backfill.
+    await expect
+      .poll(
+        () =>
+          page.evaluate(async () => {
+            const storage = await import('/src/lib/storage.ts')
+            const projects = await storage.listProjects()
+            const clips = await storage.getClipMetasForProject(projects[0]!.id)
+            return clips.every(
+              (clip: { audioPeak?: number }) => typeof clip.audioPeak === 'number',
+            )
+          }),
+        { timeout: 20_000 },
+      )
+      .toBe(true)
   })
 
   test('empty timeline offers Add clips from your device', async ({ page }) => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Replaces the relative music/clip **mix-share** model with two **independent per-clip volume dials**, and makes clip audio normalization a **persisted, automatic post-recording step**.

### Per-clip volumes
- Selecting a clip in the timeline now shows **Clip N sound** (the clip's own volume, 0–100%, default 100% — works with or without music, including on the free plan) and **Clip N music** (ducks the music during that clip, 0–100%, default 100%).
- The **All clips** default-mix slider and the playlist `defaultVolume` are **removed**. The track detail view's volume slider is the music's base level now, defaulting to **25%** (normalized music sits under speech, same audible level as the old 25% share default).
- Effective music gain while a clip plays = track volume × that clip's music slider. The two sides no longer sum to 1; the mixers hard-clamp `[-1, 1]` (both sources are still peak-normalized to 0.9, and the default 25% track volume keeps sums well under the rail).
- 100% is the default, so sliding back to 100% clears the stored override; timeline tiles badge only overrides (`♪ 60%` music, `clip 40%` sound).
- Per user instruction, **no migration**: old `audioVolume` / `defaultVolume` values are simply ignored.

### Persisted normalization
- Every clip's whole-file audio peak is measured once (48 kHz, the export's exact scan) and stored as `ClipMeta.audioPeak`. Projects loading with unmeasured clips are backfilled automatically (serial loader backfill, like thumbnails).
- The normalization gain now applies **always** — with or without music — in the project preview, the editor clip stage, and both export engines, so takes recorded at different levels play back at consistent loudness everywhere.

### Plumbing
- `background-audio.ts`: mixer takes two per-segment envelopes (music + clip sound); `planSegmentGain` grows a `'hold'` edge mode for the clip envelope; new `applyGainEnvelope` covers music-free exports; the playlist-end foreground ease is gone (the sides are independent).
- Realtime engine mirrors the same model with gain nodes; clip normalization applies whenever the audio graph exists.
- `exportSignature`, project backup manifest (`clipVolume`/`musicVolume`, no `defaultVolume`), and last-export cache updated accordingly.

## Testing
- `npm run lint` ✓, `npm test` ✓ (211 tests, incl. new `clip-audio-peak` + reworked mixer/envelope tests), `npm run test:e2e` ✓ (65 tests), `npm run build` ✓.
- New/updated e2e coverage: automatic peak backfill on project load, free-plan clip-sound slider driving the editor stage volume, independent slider persistence + badges, export RMS ratio proving track volume × per-clip duck × normalization, preview following both dials without complement ducking.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7a10bf2a-772e-4bc6-beee-99e2bae8e048?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7a10bf2a-772e-4bc6-beee-99e2bae8e048&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added independent per-clip controls for sound and background music volume.
  * Added automatic clip-audio normalization for more consistent playback and exports.
  * Added track-level music volume controls with visible percentage values.
  * Updated timeline and audio controls to display separate clip and music volumes.
  * Project backups now preserve independent clip and music volume settings.

* **Bug Fixes**
  * Improved audio mixing, fades, and playback when clips have no background music.
  * Preserved volume settings reliably during refreshes, imports, and exports.
  * Improved consistency of audio levels across previews and exported videos.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->