### PR TITLE
Fix stale IndexedDB reconnect on iOS Safari (KODY-VIDEO-F)

### DIFF
--- a/src/lib/storage.test.ts
+++ b/src/lib/storage.test.ts
@@ -68,6 +68,29 @@ describe('storage layer', () => {
     })
   })
 
+  it('retries getSettings when the connection dies after the liveness probe', async () => {
+    const db = await getDb()
+    const originalTransaction = db.transaction.bind(db)
+    let metaProbes = 0
+    db.transaction = ((storeNames: string | string[], mode?: IDBTransactionMode) => {
+      const names = Array.isArray(storeNames) ? storeNames : [storeNames]
+      // getDb() probes with transaction('meta'); let that succeed, then close
+      // before the real getSettings read — the TOCTOU CodeRabbit flagged.
+      if (names.length === 1 && names[0] === 'meta' && mode === undefined) {
+        metaProbes += 1
+        if (metaProbes === 1) {
+          const tx = originalTransaction(storeNames, mode)
+          db.close()
+          return tx
+        }
+      }
+      return originalTransaction(storeNames, mode)
+    }) as typeof db.transaction
+
+    await expect(getSettings()).resolves.toMatchObject({ key: 'settings' })
+    expect(await getDb()).not.toBe(db)
+  })
+
   it('recognizes the IndexedDB closing/closed InvalidStateError signature', () => {
     expect(
       isStaleConnectionError(

--- a/src/lib/storage.test.ts
+++ b/src/lib/storage.test.ts
@@ -72,19 +72,21 @@ describe('storage layer', () => {
     const db = await getDb()
     const originalTransaction = db.transaction.bind(db)
     let metaProbes = 0
-    db.transaction = ((storeNames: string | string[], mode?: IDBTransactionMode) => {
+    db.transaction = ((...args: Parameters<typeof db.transaction>) => {
+      const storeNames = args[0]
+      const mode = args[1]
       const names = Array.isArray(storeNames) ? storeNames : [storeNames]
       // getDb() probes with transaction('meta'); let that succeed, then close
       // before the real getSettings read — the TOCTOU CodeRabbit flagged.
       if (names.length === 1 && names[0] === 'meta' && mode === undefined) {
         metaProbes += 1
         if (metaProbes === 1) {
-          const tx = originalTransaction(storeNames, mode)
+          const tx = originalTransaction(...args)
           db.close()
           return tx
         }
       }
-      return originalTransaction(storeNames, mode)
+      return originalTransaction(...args)
     }) as typeof db.transaction
 
     await expect(getSettings()).resolves.toMatchObject({ key: 'settings' })

--- a/src/lib/storage.test.ts
+++ b/src/lib/storage.test.ts
@@ -17,6 +17,7 @@ import {
   getProjectAudio,
   getSettings,
   getUndoSnapshot,
+  isStaleConnectionError,
   listProjects,
   moveClip,
   removeProjectAudioTrack,
@@ -49,6 +50,42 @@ describe('storage layer', () => {
     await setOnboardingDismissed(true)
 
     expect((await getSettings()).onboardingDismissed).toBe(true)
+  })
+
+  it('reopens when the cached IDB connection is closing (iOS Safari)', async () => {
+    // KODY-VIDEO-F: iOS Safari closes the connection on background/navigation
+    // while our module still caches the handle. close() puts the connection in
+    // the "closing" state where transaction() throws InvalidStateError before
+    // the close event drops the singleton — the same window getSettings hit.
+    const stale = await getDb()
+    stale.close()
+
+    await expect(getSettings()).resolves.toMatchObject({ key: 'settings' })
+    const reopened = await getDb()
+    expect(reopened).not.toBe(stale)
+    await expect(createProject('After reopen')).resolves.toMatchObject({
+      name: 'After reopen',
+    })
+  })
+
+  it('recognizes the IndexedDB closing/closed InvalidStateError signature', () => {
+    expect(
+      isStaleConnectionError(
+        new DOMException(
+          "Failed to execute 'transaction' on 'IDBDatabase': The database connection is closing.",
+          'InvalidStateError',
+        ),
+      ),
+    ).toBe(true)
+    expect(
+      isStaleConnectionError(
+        new DOMException('The database connection is closed.', 'InvalidStateError'),
+      ),
+    ).toBe(true)
+    expect(isStaleConnectionError(new DOMException('Quota exceeded', 'QuotaExceededError'))).toBe(
+      false,
+    )
+    expect(isStaleConnectionError(new Error('nope'))).toBe(false)
   })
 
   it('heals a DB left empty by a version-less open (diag-style)', async () => {

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -102,8 +102,10 @@ export function isStaleConnectionError(error: unknown): boolean {
 }
 
 function forgetCachedDb(closedDb?: IDBPDatabase<ClipsDB> | null): void {
-  // A concurrent reopen may already own the cache — don't clobber it.
-  if (closedDb && activeDb && closedDb !== activeDb) return
+  // Only clear when the terminating handle is still the active one (or no
+  // handle was supplied). If activeDb is null, a reconnect may already be
+  // in flight — leave that pending promise alone.
+  if (closedDb != null && activeDb !== closedDb) return
   activeDb = null
   dbPromise = null
 }
@@ -125,6 +127,16 @@ function openTrackedDb(): Promise<IDBPDatabase<ClipsDB>> {
     return db
   })
   return tracked
+}
+
+function discardStaleDb(stale: IDBPDatabase<ClipsDB> | null, pending: Promise<IDBPDatabase<ClipsDB>> | null): void {
+  if (pending && dbPromise !== pending) return
+  forgetCachedDb(stale)
+  try {
+    stale?.close()
+  } catch {
+    // Already closing/closed.
+  }
 }
 
 /**
@@ -152,19 +164,26 @@ export async function getDb(): Promise<IDBPDatabase<ClipsDB>> {
       return db
     } catch (error) {
       if (!isStaleConnectionError(error) || attempt === 1) throw error
-      if (dbPromise === pending) {
-        const stale = activeDb
-        forgetCachedDb(stale)
-        try {
-          stale?.close()
-        } catch {
-          // Already closing/closed.
-        }
-      }
+      discardStaleDb(activeDb, pending)
     }
   }
   // Unreachable: the loop either returns or throws on the final attempt.
   throw new Error('Failed to open IndexedDB')
+}
+
+/**
+ * Run an IndexedDB op, reopening once if Safari closes the connection after
+ * getDb()'s liveness probe (or mid-await inside an idempotent read/write).
+ */
+export async function withDb<T>(fn: (db: IDBPDatabase<ClipsDB>) => Promise<T>): Promise<T> {
+  try {
+    const db = await getDb()
+    return await fn(db)
+  } catch (error) {
+    if (!isStaleConnectionError(error)) throw error
+    discardStaleDb(activeDb, dbPromise)
+    return await fn(await getDb())
+  }
 }
 
 /** Test helper: close open connections and clear the module-level DB handle. */
@@ -183,19 +202,20 @@ export async function __resetDbForTests(): Promise<void> {
 }
 
 export async function getSettings(): Promise<AppMeta> {
-  const db = await getDb()
-  const existing = await db.get('meta', 'settings')
-  const defaults: AppMeta = {
-    key: 'settings',
-    maxProjects: MAX_PROJECTS,
-    lastOpenedProjectId: null,
-    onboardingDismissed: false,
-  }
-  const settings = existing ? { ...defaults, ...existing } : defaults
-  if (!existing || existing.onboardingDismissed === undefined) {
-    await db.put('meta', settings)
-  }
-  return settings
+  return withDb(async (db) => {
+    const existing = await db.get('meta', 'settings')
+    const defaults: AppMeta = {
+      key: 'settings',
+      maxProjects: MAX_PROJECTS,
+      lastOpenedProjectId: null,
+      onboardingDismissed: false,
+    }
+    const settings = existing ? { ...defaults, ...existing } : defaults
+    if (!existing || existing.onboardingDismissed === undefined) {
+      await db.put('meta', settings)
+    }
+    return settings
+  })
 }
 
 export async function setLastOpenedProjectId(projectId: ProjectId | null): Promise<void> {

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -46,6 +46,7 @@ export const DB_NAME = 'kody-video'
 export const DB_VERSION = 3
 
 let dbPromise: Promise<IDBPDatabase<ClipsDB>> | null = null
+let activeDb: IDBPDatabase<ClipsDB> | null = null
 
 /**
  * Finish an explicit idb transaction without leaking AbortError.
@@ -93,15 +94,77 @@ export function ensureObjectStores(db: {
   }
 }
 
-export function getDb(): Promise<IDBPDatabase<ClipsDB>> {
-  if (!dbPromise) {
-    dbPromise = openDB<ClipsDB>(DB_NAME, DB_VERSION, {
-      upgrade(db) {
-        ensureObjectStores(db)
-      },
-    })
+/** True when IndexedDB rejected because the cached connection is gone. */
+export function isStaleConnectionError(error: unknown): boolean {
+  if (!(error instanceof DOMException) && !(error instanceof Error)) return false
+  if (error.name !== 'InvalidStateError') return false
+  return /database connection is (closing|closed)/i.test(error.message)
+}
+
+function forgetCachedDb(closedDb?: IDBPDatabase<ClipsDB> | null): void {
+  // A concurrent reopen may already own the cache — don't clobber it.
+  if (closedDb && activeDb && closedDb !== activeDb) return
+  activeDb = null
+  dbPromise = null
+}
+
+function openTrackedDb(): Promise<IDBPDatabase<ClipsDB>> {
+  // Capture this open's handle in terminated — activeDb may already point at
+  // a newer reconnect by the time the close event runs.
+  const tracked = openDB<ClipsDB>(DB_NAME, DB_VERSION, {
+    upgrade(db) {
+      ensureObjectStores(db)
+    },
+    terminated() {
+      // iOS Safari often closes IDB when the page is backgrounded. Drop the
+      // singleton so the next getDb() opens a fresh connection.
+      void tracked.then((db) => forgetCachedDb(db))
+    },
+  }).then((db) => {
+    activeDb = db
+    return db
+  })
+  return tracked
+}
+
+/**
+ * Open (or reuse) the app IndexedDB connection.
+ *
+ * The handle is cached, but browsers — especially iOS Safari — may close it
+ * out from under us. getDb() clears the cache on close and, if a caller still
+ * holds a closing handle, probes and reopens once so getSettings/load-home
+ * does not surface InvalidStateError.
+ */
+export async function getDb(): Promise<IDBPDatabase<ClipsDB>> {
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    if (!dbPromise) {
+      dbPromise = openTrackedDb().catch((error) => {
+        forgetCachedDb()
+        throw error
+      })
+    }
+    const pending = dbPromise
+    try {
+      const db = await pending
+      // transaction() throws InvalidStateError while the connection is
+      // closing/closed — before the close event clears our cache (KODY-VIDEO-F).
+      db.transaction('meta')
+      return db
+    } catch (error) {
+      if (!isStaleConnectionError(error) || attempt === 1) throw error
+      if (dbPromise === pending) {
+        const stale = activeDb
+        forgetCachedDb(stale)
+        try {
+          stale?.close()
+        } catch {
+          // Already closing/closed.
+        }
+      }
+    }
   }
-  return dbPromise
+  // Unreachable: the loop either returns or throws on the final attempt.
+  throw new Error('Failed to open IndexedDB')
 }
 
 /** Test helper: close open connections and clear the module-level DB handle. */
@@ -110,7 +173,7 @@ export async function __resetDbForTests(): Promise<void> {
     const db = await dbPromise.catch(() => null)
     db?.close()
   }
-  dbPromise = null
+  forgetCachedDb()
   await new Promise<void>((resolve, reject) => {
     const req = indexedDB.deleteDatabase(DB_NAME)
     req.onsuccess = () => resolve()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sentry [KODY-VIDEO-F](https://kent-c-dodds-tech-llc.sentry.io/issues/7655115515/) (`InvalidStateError: The database connection is closing`) fired from `getSettings` during `load-home` on iOS Safari.

`getDb()` cached a singleton IndexedDB connection and reused it after the browser closed the handle (common when Safari backgrounds the page). There was no close/terminate handling and no reopen path.

## Fix

- Clear the cached connection when the browser terminates it (`idb` `terminated` / close), without clobbering a newer in-flight reopen
- Probe with a cheap `transaction('meta')` before returning a cached handle; on closing/closed `InvalidStateError`, drop the cache and reopen once
- Retry idempotent `getSettings` via `withDb` when the connection dies after the probe (TOCTOU on iOS Safari)
- Cover the closing-handle race, post-probe close, and the error-signature helper in `storage.test.ts`

## Risk

Low — isolated storage reconnect with tests; no auth/billing/migration surface.

## Test plan

- [x] `npx vitest run src/lib/storage.test.ts`
- [x] `npm run build`
- [x] `npx vitest run`
- [x] `node scripts/manual-smoke.mjs`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fbdde470-4191-44a0-847b-1d0a96eefdb1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fbdde470-4191-44a0-847b-1d0a96eefdb1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability when reconnecting to local browser storage after a database connection closes unexpectedly.
  - Automatically recovers from stale or closing connections and retries the operation once.
  - Prevents failed or terminated connections from being reused.

- **Tests**
  - Added coverage for connection recovery and error classification, including quota and generic errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->