### PR TITLE
Link an example video made with Kody Video on the About page

### DIFF
--- a/src/pages/about-page.tsx
+++ b/src/pages/about-page.tsx
@@ -256,7 +256,15 @@ export function AboutPage(handle: Handle) {
                 watch the tour on YouTube
               </a>
               . The same video plays right in the quick-start card the first time you open the
-              camera.
+              camera. Want a real result straight out of the app? Here&rsquo;s{' '}
+              <a
+                href="https://x.com/kentcdodds/status/2084891368724533456"
+                target="_blank"
+                rel="noreferrer noopener"
+              >
+                a video Kent made with Kody Video
+              </a>
+              .
             </p>
           </section>
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Follow-up to #126: the About page's "See it in action" section now also links [a real video Kent made with Kody Video](https://x.com/kentcdodds/status/2084891368724533456) (X post), as a practical example of what the app produces — alongside the existing YouTube tour link.

## Testing

- `npm run lint` passes; the home e2e spec (which covers the app shell) passes.
- Verified the section renders with the new link on the dev server:

![About page See it in action section with the new X link](https://cursor.com/artifacts/c/art-5dbc3342-4ebe-43c7-84e9-ca6801134e6b)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f70b95db-a9e4-451e-8216-bdf0ade25b7f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f70b95db-a9e4-451e-8216-bdf0ade25b7f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an external link to a video showcasing the product in action.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->