### PR TITLE
Filter browser-extension host-bridge Sentry noise (KODY-VIDEO-H)

### DIFF
--- a/src/lib/error-reporting.test.ts
+++ b/src/lib/error-reporting.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import {
+  isBrowserExtensionHostObjectNoiseEvent,
   isCloudflareInsightsBeaconEvent,
   isExpectedUserError,
   isMonitoringSelfTestEvent,
@@ -137,6 +138,57 @@ describe('isReportingHostname / local capture paths', () => {
     expect(() =>
       reportComponentError(new ReferenceError('importProgress is not defined')),
     ).not.toThrow()
+  })
+})
+
+describe('isBrowserExtensionHostObjectNoiseEvent', () => {
+  it('drops the classic host-bridge Object Not Found rejection (KODY-VIDEO-H)', () => {
+    expect(
+      isBrowserExtensionHostObjectNoiseEvent({
+        exception: {
+          values: [
+            {
+              type: 'UnhandledRejection',
+              value:
+                'Non-Error promise rejection captured with value: Object Not Found Matching Id:1, MethodName:update, ParamCount:4',
+            },
+          ],
+        },
+      }),
+    ).toBe(true)
+  })
+
+  it('drops when the signature appears only in message', () => {
+    expect(
+      isBrowserExtensionHostObjectNoiseEvent({
+        message: 'Object Not Found Matching Id:2, MethodName:update, ParamCount:4',
+      }),
+    ).toBe(true)
+  })
+
+  it('keeps ordinary application errors', () => {
+    expect(
+      isBrowserExtensionHostObjectNoiseEvent({
+        exception: {
+          values: [{ type: 'Error', value: 'Export failed: encoder closed' }],
+        },
+      }),
+    ).toBe(false)
+  })
+
+  it('keeps unrelated Object Not Found wording without the host-bridge shape', () => {
+    expect(
+      isBrowserExtensionHostObjectNoiseEvent({
+        exception: {
+          values: [
+            {
+              type: 'NotFoundError',
+              value: 'The object can not be found here.',
+            },
+          ],
+        },
+      }),
+    ).toBe(false)
   })
 })
 

--- a/src/lib/error-reporting.ts
+++ b/src/lib/error-reporting.ts
@@ -83,6 +83,29 @@ export function isProjectLimitEvent(event: FilterableSentryEvent): boolean {
   return false
 }
 
+/**
+ * Browser-extension / host-bridge noise (often Edge/Chrome on Windows).
+ * Rejects a non-Error string like
+ * "Object Not Found Matching Id:1, MethodName:update, ParamCount:4" with no
+ * app stack — not from Kody Video (no chrome.tabs / extension surface).
+ * KODY-VIDEO-H.
+ */
+const BROWSER_EXTENSION_HOST_OBJECT_NOISE =
+  /Object Not Found Matching Id:\d+, MethodName:\w+, ParamCount:\d+/
+
+export function isBrowserExtensionHostObjectNoiseEvent(
+  event: FilterableSentryEvent,
+): boolean {
+  const exceptionValues = event.exception?.values ?? []
+  for (const value of exceptionValues) {
+    if (BROWSER_EXTENSION_HOST_OBJECT_NOISE.test(value.value ?? '')) return true
+  }
+  return (
+    typeof event.message === 'string' &&
+    BROWSER_EXTENSION_HOST_OBJECT_NOISE.test(event.message)
+  )
+}
+
 function frameUrl(frame: FilterableStackFrame): string {
   return frame.abs_path ?? frame.filename ?? ''
 }
@@ -218,6 +241,7 @@ function loadSentry(): Promise<SentryLike> | null {
         if (isMonitoringSelfTestEvent(event)) return null
         if (isCloudflareInsightsBeaconEvent(event)) return null
         if (isProjectLimitEvent(event)) return null
+        if (isBrowserExtensionHostObjectNoiseEvent(event)) return null
         return event
       },
     })


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sentry [KODY-VIDEO-H](https://kent-c-dodds-tech-llc.sentry.io/issues/7655189205/) reports an unhandled non-Error rejection:

`Object Not Found Matching Id:1, MethodName:update, ParamCount:4`

Seer’s RCA pointed at a Chrome extension / `chrome.tabs.update` in another repo. That does not hold for this codebase: Kody Video is a client-side PWA with no extension surface, the event has an empty stack/culprit, and the mechanism is the global `unhandledrejection` handler. This signature is well-known browser extension / host-bridge noise (often Edge/Chrome on Windows).

## Change

- Add a narrow `beforeSend` filter in `src/lib/error-reporting.ts` matching only the host-bridge shape (`Object Not Found Matching Id:N, MethodName:…, ParamCount:…`).
- Unit tests for drop/keep cases (including unrelated `NotFoundError` copy).

## Risk

Low — isolated Sentry filter; no product behavior change.

## Status

Squash-merged as `2678e6f`. Main CI + Cloudflare Pages deploy green. Sentry issue marked ignored.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-150fe0ad-afd3-41b5-8eaa-e51766f82332?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-150fe0ad-afd3-41b5-8eaa-e51766f82332&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

