### PR TITLE
Filter Vite CSS preload failures from Sentry (KODY-VIDEO-J)

### DIFF
--- a/src/lib/error-reporting.test.ts
+++ b/src/lib/error-reporting.test.ts
@@ -5,6 +5,7 @@ import {
   isMonitoringSelfTestEvent,
   isProjectLimitEvent,
   isReportingHostname,
+  isViteCssPreloadError,
   reportComponentError,
   reportError,
 } from './error-reporting'
@@ -230,6 +231,53 @@ describe('isCloudflareInsightsBeaconEvent', () => {
       isCloudflareInsightsBeaconEvent({
         exception: {
           values: [{ type: 'TypeError', value: 't.entries.at is not a function' }],
+        },
+      }),
+    ).toBe(false)
+  })
+})
+
+describe('isViteCssPreloadError', () => {
+  it('drops Vite CSS preload helper failures for hashed assets', () => {
+    expect(
+      isViteCssPreloadError({
+        exception: {
+          values: [
+            {
+              type: 'Error',
+              value: 'Unable to preload CSS for /assets/fonts-CbakDoPd.css',
+            },
+          ],
+        },
+      }),
+    ).toBe(true)
+  })
+
+  it('drops when the signature appears only in message', () => {
+    expect(
+      isViteCssPreloadError({
+        message: 'Unable to preload CSS for /assets/home-abc123.css',
+      }),
+    ).toBe(true)
+  })
+
+  it('keeps ordinary application errors', () => {
+    expect(
+      isViteCssPreloadError({
+        exception: {
+          values: [{ type: 'Error', value: 'Export failed: encoder closed' }],
+        },
+      }),
+    ).toBe(false)
+  })
+
+  it('keeps unrelated preload wording', () => {
+    expect(
+      isViteCssPreloadError({
+        exception: {
+          values: [
+            { type: 'Error', value: 'Unable to preload image for /assets/hero.webp' },
+          ],
         },
       }),
     ).toBe(false)

--- a/src/lib/error-reporting.ts
+++ b/src/lib/error-reporting.ts
@@ -103,6 +103,24 @@ export function isCloudflareInsightsBeaconEvent(
   )
 }
 
+/**
+ * Vite's CSS preload helper rejects when a hashed stylesheet link errors
+ * (deploy/edge race, stale HTTP cache, brief network blip). Same class as
+ * the boot/lazy-page chunk recoveries — not an app logic bug. Narrow match
+ * on Vite's exact message (KODY-VIDEO-J).
+ */
+export function isViteCssPreloadError(event: FilterableSentryEvent): boolean {
+  const exceptionValues = event.exception?.values ?? []
+  for (const value of exceptionValues) {
+    const text = value.value ?? ''
+    if (/^Unable to preload CSS for \S+/.test(text)) return true
+  }
+  return (
+    typeof event.message === 'string' &&
+    /^Unable to preload CSS for \S+/.test(event.message)
+  )
+}
+
 /** Marker set while an export runs; still present at boot = the page died
  * mid-export (tab crash / out-of-memory kill — no JS error ever fires). */
 const EXPORT_MARKER_KEY = 'kodyVideo.exportInFlight'
@@ -218,6 +236,7 @@ function loadSentry(): Promise<SentryLike> | null {
         if (isMonitoringSelfTestEvent(event)) return null
         if (isCloudflareInsightsBeaconEvent(event)) return null
         if (isProjectLimitEvent(event)) return null
+        if (isViteCssPreloadError(event)) return null
         return event
       },
     })

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -36,8 +36,10 @@ queueMicrotask(() => {
 })
 
 // Fonts after first paint so ~74KB of woff2 never contends with LCP.
+// Swallow preload failures (deploy-window / cache races): system fonts are
+// fine, and an unhandled rejection here was opening Sentry issues (KODY-VIDEO-J).
 const loadFonts = () => {
-  void import('./styles/fonts.css')
+  void import('./styles/fonts.css').catch(() => undefined)
 }
 if (document.readyState === 'complete') {
   loadFonts()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sentry [KODY-VIDEO-J](https://kent-c-dodds-tech-llc.sentry.io/issues/7655189306/): `Unable to preload CSS for /assets/fonts-CbakDoPd.css` — Vite’s CSS preload helper rejecting when a hashed stylesheet fails to load.

**Root cause:** Transient deploy/edge/cache races (same class as the existing boot + lazy-page chunk recoveries). Four events clustered ~7 minutes after release `b5deb4e8`; the fonts CSS URL returns 200 now. Not an app logic bug.

**Change (outcome: filtered):**
- Narrow `beforeSend` filter for Vite’s exact `Unable to preload CSS for …` signature
- Catch the fire-and-forget `fonts.css` dynamic import so it cannot surface as an unhandled rejection (system fonts are fine)

Sibling [KODY-VIDEO-G](https://kent-c-dodds-tech-llc.sentry.io/issues/7655139592/) (lazy chunk fetch) is related deploy-race class but already handled via `lazy-page` recovery + intentional `reportError` — left alone.

Rebased/merged with main after #129 (extension host noise filter) and #131 landed; both `beforeSend` filters retained.

## Test plan

- [x] Unit tests for `isViteCssPreloadError`
- [x] `npm run build`
- [x] `npx vitest run` (pre-merge)
- [x] `node scripts/manual-smoke.mjs` (32/32, pre-merge)
- [ ] CI green on merge commit with main

## Risk

Low — wiring/filter only; no auth, billing, or storage changes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9aea098a-063d-4004-977d-66840c63755e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9aea098a-063d-4004-977d-66840c63755e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

