### PR TITLE
Fix false-positive silent WebCodecs export detection (KODY-VIDEO-K)

### DIFF
--- a/src/lib/export/index.ts
+++ b/src/lib/export/index.ts
@@ -7,6 +7,7 @@ import { sweepExportCache, withExportCacheReserved } from './export-cache'
 import { planExport } from './plan'
 import {
   AUDIO_SILENCE_PEAK,
+  classifyOutputAudioPeak,
   decodedAudioMaxPeak,
   loadWatermarkImage,
   measureBlobAudioPeak,
@@ -145,7 +146,8 @@ async function verifyOutputAudio(
     )
     return measured.failure === 'too large to verify' ? 'unknown' : 'undecodable'
   }
-  if (measured.peak >= AUDIO_SILENCE_PEAK) return 'ok'
+  const verdict = classifyOutputAudioPeak(inputPeak, measured.peak)
+  if (verdict !== 'silent') return verdict
   reportError(
     new Error('Export output audio is silent despite audible clip audio (encode/mux fault)'),
     'export-audio-output',

--- a/src/lib/export/shared.test.ts
+++ b/src/lib/export/shared.test.ts
@@ -1,5 +1,37 @@
 import { describe, expect, it } from 'vitest'
-import { blobForPlayback } from './shared'
+import {
+  AUDIO_PEAK_RETENTION_RATIO,
+  AUDIO_SILENCE_PEAK,
+  blobForPlayback,
+  classifyOutputAudioPeak,
+} from './shared'
+
+describe('classifyOutputAudioPeak', () => {
+  it('returns unknown when inputs never cleared the silence floor', () => {
+    expect(classifyOutputAudioPeak(0, 0)).toBe('unknown')
+    expect(classifyOutputAudioPeak(AUDIO_SILENCE_PEAK - 0.0001, 0)).toBe('unknown')
+  })
+
+  it('returns ok when the output peak clears the absolute silence floor', () => {
+    expect(classifyOutputAudioPeak(0.5, AUDIO_SILENCE_PEAK)).toBe('ok')
+    expect(classifyOutputAudioPeak(0.5, 0.2)).toBe('ok')
+  })
+
+  it('treats near-floor encode attenuation as ok, not a silent mux', () => {
+    // KODY-VIDEO-K: Android Chrome WebCodecs, input 0.0065 → output 0.0048.
+    // Absolute floor alone false-positive'd; relative retention keeps it.
+    expect(classifyOutputAudioPeak(0.0065, 0.0048)).toBe('ok')
+    expect(classifyOutputAudioPeak(0.01, 0.01 * AUDIO_PEAK_RETENTION_RATIO)).toBe('ok')
+  })
+
+  it('flags a collapsed output peak as a silent encode/mux fault', () => {
+    expect(classifyOutputAudioPeak(0.5, 0)).toBe('silent')
+    expect(classifyOutputAudioPeak(0.5, 0.004)).toBe('silent')
+    expect(
+      classifyOutputAudioPeak(0.01, 0.01 * AUDIO_PEAK_RETENTION_RATIO - 0.0001),
+    ).toBe('silent')
+  })
+})
 
 describe('blobForPlayback', () => {
   it('returns the same blob when mime matches or is omitted', () => {

--- a/src/lib/export/shared.ts
+++ b/src/lib/export/shared.ts
@@ -253,6 +253,30 @@ export function resetAudioDiagnostics(): void {
 /** Near-silence floor shared by the input and output audio diagnostics. */
 export const AUDIO_SILENCE_PEAK = 0.005
 
+/**
+ * Fraction of the decoded input peak the muxed output must retain before a
+ * below-floor absolute peak is treated as "still present". Lossy AAC can
+ * nudge a near-floor peak under {@link AUDIO_SILENCE_PEAK} without dropping
+ * the track; a real encode/mux fault collapses energy to ~0.
+ */
+export const AUDIO_PEAK_RETENTION_RATIO = 0.25
+
+/**
+ * Decide whether a finished export's audio peak indicates an encode/mux
+ * silence fault. Absolute floor first; when the output sits just under it,
+ * compare against the input so near-floor encode attenuation is not a false
+ * positive (Sentry KODY-VIDEO-K: input 0.0065 → output 0.0048).
+ */
+export function classifyOutputAudioPeak(
+  inputPeak: number,
+  outputPeak: number,
+): 'ok' | 'silent' | 'unknown' {
+  if (inputPeak < AUDIO_SILENCE_PEAK) return 'unknown'
+  if (outputPeak >= AUDIO_SILENCE_PEAK) return 'ok'
+  if (outputPeak >= inputPeak * AUDIO_PEAK_RETENTION_RATIO) return 'ok'
+  return 'silent'
+}
+
 /** Loudest decoded input peak this export (0 when nothing decoded). */
 export function decodedAudioMaxPeak(): number {
   if (audioObservations.length === 0) return 0


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Sentry [KODY-VIDEO-K](https://kent-c-dodds-tech-llc.sentry.io/issues/7655191202/) reported `Export output audio is silent despite audible clip audio` on Android Chrome / WebCodecs.
- Seer hypothesized an Android WebCodecs mute/drop; event extras disagree: `inputPeak: 0.0065`, `outputPeak: 0.0048` (threshold `0.005`). The track was still present — lossy encode nudged a near-floor peak under the absolute silence floor.
- `verifyOutputAudio` now uses `classifyOutputAudioPeak`: absolute floor first, then a 25% input-peak retention check so near-floor attenuation is not treated as a silent mux fault (real faults still collapse to ~0).

## Test plan

- [x] Unit tests for `classifyOutputAudioPeak` (includes the Sentry peak pair)
- [x] `npx vitest run` (218 passed)
- [x] `npm run lint` / `npm run build`
- [ ] CI green
- [ ] Confirm no siblings share this root cause (none among open unresolved export-audio issues)

## Risk

Low — isolated comparator change with tests; true silent-mux fallback path unchanged for collapsed peaks.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1c45bd4c-d864-4200-8c58-ea81cfae894b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1c45bd4c-d864-4200-8c58-ea81cfae894b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

