### PR TITLE
Polyfill Array.prototype.at for older Chromium shells (KODY-VIDEO-M)

### DIFF
--- a/src/lib/array-at-polyfill.test.ts
+++ b/src/lib/array-at-polyfill.test.ts
@@ -1,0 +1,48 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { installArrayAtPolyfill } from './array-at-polyfill'
+
+describe('installArrayAtPolyfill', () => {
+  const originalAt = Array.prototype.at
+
+  afterEach(() => {
+    Object.defineProperty(Array.prototype, 'at', {
+      value: originalAt,
+      writable: true,
+      enumerable: false,
+      configurable: true,
+    })
+  })
+
+  it('is a no-op when Array.prototype.at already exists', () => {
+    expect(typeof Array.prototype.at).toBe('function')
+    const before = Array.prototype.at
+    installArrayAtPolyfill()
+    expect(Array.prototype.at).toBe(before)
+  })
+
+  it('restores Array.prototype.at when missing (KODY-VIDEO-M)', () => {
+    // Simulate the unsupported environment that hit Router init.
+    Reflect.deleteProperty(Array.prototype, 'at')
+    expect(typeof Array.prototype.at).toBe('undefined')
+
+    installArrayAtPolyfill()
+
+    expect(typeof Array.prototype.at).toBe('function')
+    expect(['a', 'b', 'c'].at(-1)).toBe('c')
+    expect(['a', 'b', 'c'].at(0)).toBe('a')
+    expect(['a', 'b', 'c'].at(1)).toBe('b')
+    expect(['a', 'b', 'c'].at(10)).toBe(undefined)
+    expect(['a', 'b', 'c'].at(-10)).toBe(undefined)
+    expect([].at(-1)).toBe(undefined)
+  })
+
+  it('matches native negative-index and truncates fractional indexes', () => {
+    Reflect.deleteProperty(Array.prototype, 'at')
+    installArrayAtPolyfill()
+
+    const items = ['zero', 'one', 'two']
+    expect(items.at(-2)).toBe('one')
+    expect(items.at(1.9)).toBe('one')
+    expect(items.at(-1.2)).toBe('two')
+  })
+})

--- a/src/lib/array-at-polyfill.ts
+++ b/src/lib/array-at-polyfill.ts
@@ -13,7 +13,12 @@ export function installArrayAtPolyfill(): void {
 
   Object.defineProperty(Array.prototype, 'at', {
     value: function at(this: ArrayLike<unknown>, index: number): unknown {
-      const length = this.length >>> 0
+      // LengthOfArrayLike / ToLength: clamp to [0, Number.MAX_SAFE_INTEGER].
+      const rawLength = Number(this.length)
+      const length =
+        !Number.isFinite(rawLength) || rawLength <= 0
+          ? 0
+          : Math.min(Math.trunc(rawLength), Number.MAX_SAFE_INTEGER)
       const relative = Math.trunc(index) || 0
       const k = relative >= 0 ? relative : length + relative
       if (k < 0 || k >= length) return undefined

--- a/src/lib/array-at-polyfill.ts
+++ b/src/lib/array-at-polyfill.ts
@@ -1,0 +1,28 @@
+/**
+ * Array.prototype.at (ES2022) is used by @remix-run/route-pattern during
+ * Router init (parsePart → appendText → tokens.at(-1)). Vite's build target
+ * is chrome107+, which includes `.at`, but some Chromium WebViews / older
+ * shells still report as Chrome without the method — that threw
+ * "TypeError: i.at is not a function" (KODY-VIDEO-M) before any route rendered.
+ *
+ * Spec-shaped polyfill; no-op when the native method exists.
+ * @see https://tc39.es/ecma262/multipage/indexed-collections.html#sec-array.prototype.at
+ */
+export function installArrayAtPolyfill(): void {
+  if (typeof Array.prototype.at === 'function') return
+
+  Object.defineProperty(Array.prototype, 'at', {
+    value: function at(this: ArrayLike<unknown>, index: number): unknown {
+      const length = this.length >>> 0
+      const relative = Math.trunc(index) || 0
+      const k = relative >= 0 ? relative : length + relative
+      if (k < 0 || k >= length) return undefined
+      return this[k]
+    },
+    writable: true,
+    enumerable: false,
+    configurable: true,
+  })
+}
+
+installArrayAtPolyfill()

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,3 +1,5 @@
+// Must run before Router / @remix-run/route-pattern (KODY-VIDEO-M).
+import './lib/array-at-polyfill'
 import { createRoot } from 'remix/ui'
 import { App } from './app'
 import { initErrorReporting, reportComponentError } from './lib/error-reporting'


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sentry [KODY-VIDEO-M](https://kent-c-dodds-tech-llc.sentry.io/issues/7655199767/): `TypeError: i.at is not a function` in `Router(src/router)`.

**Root cause (confirmed Seer RCA against repo):**
- `Router` calls `matcher.add(pattern, page)` for each route
- `@remix-run/route-pattern` `TrieMatcher.add` → `parsePattern` → `parsePart` → `appendText` uses `tokens.at(-1)`
- Some Chromium shells (tagged chrome/windows) lack `Array.prototype.at`, so Router throws before any page renders

Vite already targets `chrome107+` (which has `.at` natively). This polyfill covers older/embedded Chromium that still reaches production without the method. No-op when native `.at` exists.

**Change (outcome: fixed):**
- Spec-shaped `Array.prototype.at` polyfill installed first from `main.tsx`
- Unit tests covering no-op, restore-when-missing, and negative/fractional indexes

## Test plan

- [x] Unit tests for polyfill (`src/lib/array-at-polyfill.test.ts`)
- [x] `npm run build`
- [x] `npx vitest run` (225 tests)
- [x] `node scripts/manual-smoke.mjs` (32/32)

## Risk

Low — isolated boot-time polyfill; no auth, billing, storage, or camera path changes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8d3cb9eb-c020-4331-acf0-247aa5d508fc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8d3cb9eb-c020-4331-acf0-247aa5d508fc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for array indexing with `.at()`, including positive, negative, fractional, and out-of-range indexes.
  * The compatibility support activates automatically when native browser support is unavailable.

* **Tests**
  * Added coverage for supported indexing behavior, empty arrays, missing values, and preservation of existing browser implementations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->