### PR TITLE
Move the tour video to a first-timer card on the home page

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,9 +271,9 @@ under `/api/` so no service worker or cached shell can interfere:
   production hostnames — dev and tests never report). Export and import
   failures the UI surfaces as friendly messages are also captured, tagged
   with the failing step, so real-device bugs surface.
-- The onboarding tour video streams from `media.kody.video` (an R2 bucket
-  behind the app's own zone — no third-party player, no tracking) and only
-  when the user taps play on it.
+- The home-screen tour video (shown to first-time users) streams from
+  `media.kody.video` (an R2 bucket behind the app's own zone — no third-party
+  player, no tracking) and only when the user taps play on it.
 
 ## Scripts
 

--- a/src/components/onboarding-overlay.tsx
+++ b/src/components/onboarding-overlay.tsx
@@ -1,19 +1,10 @@
 import type { Handle } from 'remix/ui'
-import { on, ref } from 'remix/ui'
+import { on } from 'remix/ui'
 import { BrandMark } from './brand-mark'
-import { IconPlay } from './icons'
 
 interface OnboardingOverlayProps {
   onDismiss: () => void
 }
-
-/**
- * Promo/tour video, self-hosted on R2 behind the site's own domain (no
- * third-party player, no tracking). Streamed only when the user taps play —
- * the card itself costs nothing but the precached poster.
- */
-const TOUR_VIDEO_URL = 'https://media.kody.video/promo/kody-video-promo-v1.mp4'
-const TOUR_POSTER_URL = '/art/kody-video-tour-poster.webp'
 
 const steps = [
   {
@@ -35,8 +26,6 @@ const steps = [
 ]
 
 export function OnboardingOverlay(handle: Handle<OnboardingOverlayProps>) {
-  let tourPlaying = false
-  let tourVideo: HTMLVideoElement | null = null
   return () => (
     <div className="onboarding-overlay" role="dialog" aria-label="Kody Video quick start">
       <div className="onboarding-card">
@@ -58,49 +47,6 @@ export function OnboardingOverlay(handle: Handle<OnboardingOverlayProps>) {
             </li>
           ))}
         </ol>
-        {/* Mounted (hidden) before the teaser is tapped so play() can run
-            inside the tap's gesture — mobile browsers block unmuted playback
-            that starts after an async re-render. */}
-        <video
-          className={tourPlaying ? 'onboarding-tour-video' : 'visually-hidden'}
-          src={TOUR_VIDEO_URL}
-          poster={TOUR_POSTER_URL}
-          controls
-          tabIndex={0}
-          playsInline
-          preload="none"
-          mix={ref((node, signal) => {
-            tourVideo = node as HTMLVideoElement
-            signal.addEventListener('abort', () => {
-              tourVideo = null
-            })
-          })}
-        />
-        {tourPlaying ? null : (
-          <button
-            type="button"
-            className="onboarding-tour"
-            mix={on('click', () => {
-              tourPlaying = true
-              // In-gesture play() is what mobile autoplay policies require
-              // for sound. If it still rejects, the controls are visible.
-              void tourVideo?.play().catch(() => {})
-              void handle.update()
-              // The activated teaser button is about to disappear — hand
-              // keyboard focus to the player so its controls stay reachable.
-              requestAnimationFrame(() => {
-                tourVideo?.focus()
-              })
-            })}
-          >
-            <img src={TOUR_POSTER_URL} alt="" width={44} height={78} />
-            <div>
-              <strong>Watch the tour</strong>
-              <p>Kent demos the whole flow in a minute and a half.</p>
-            </div>
-            <IconPlay />
-          </button>
-        )}
         <button
           type="button"
           className="btn btn-primary"

--- a/src/components/tour-card.tsx
+++ b/src/components/tour-card.tsx
@@ -1,0 +1,76 @@
+import type { Handle } from 'remix/ui'
+import { on, ref } from 'remix/ui'
+import { IconClose, IconPlay } from './icons'
+
+/**
+ * Promo/tour video, self-hosted on R2 behind the site's own domain (no
+ * third-party player, no tracking). Streamed only when the user taps play —
+ * the card itself costs nothing but the precached poster.
+ */
+const TOUR_VIDEO_URL = 'https://media.kody.video/promo/kody-video-promo-v1.mp4'
+const TOUR_POSTER_URL = '/art/kody-video-tour-poster.webp'
+
+interface TourCardProps {
+  onDismiss: () => void
+}
+
+/** First-timer home card: tap-to-play tour video with a persistent dismiss. */
+export function TourCard(handle: Handle<TourCardProps>) {
+  let playing = false
+  let video: HTMLVideoElement | null = null
+  return () => (
+    <section className="tour-card" aria-label="Kody Video tour">
+      {/* Mounted (hidden) before the teaser is tapped so play() can run
+          inside the tap's gesture — mobile browsers block unmuted playback
+          that starts after an async re-render. */}
+      <video
+        className={playing ? 'tour-card-video' : 'visually-hidden'}
+        src={TOUR_VIDEO_URL}
+        poster={TOUR_POSTER_URL}
+        controls
+        tabIndex={0}
+        playsInline
+        preload="none"
+        mix={ref((node, signal) => {
+          video = node as HTMLVideoElement
+          signal.addEventListener('abort', () => {
+            video = null
+          })
+        })}
+      />
+      {playing ? null : (
+        <button
+          type="button"
+          className="tour-card-teaser"
+          mix={on('click', () => {
+            playing = true
+            // In-gesture play() is what mobile autoplay policies require
+            // for sound. If it still rejects, the controls are visible.
+            void video?.play().catch(() => {})
+            void handle.update()
+            // The activated teaser button is about to disappear — hand
+            // keyboard focus to the player so its controls stay reachable.
+            requestAnimationFrame(() => {
+              video?.focus()
+            })
+          })}
+        >
+          <img src={TOUR_POSTER_URL} alt="" width={44} height={78} />
+          <span className="tour-card-copy">
+            <strong>New here? Watch the tour</strong>
+            <span>Kent demos the whole flow — record, arrange, share — in a minute and a half.</span>
+          </span>
+          <IconPlay />
+        </button>
+      )}
+      <button
+        type="button"
+        className="install-hint-dismiss tour-card-dismiss"
+        aria-label="Dismiss tour"
+        mix={on('click', () => handle.props.onDismiss())}
+      >
+        <IconClose size={16} />
+      </button>
+    </section>
+  )
+}

--- a/src/lib/project-actions.ts
+++ b/src/lib/project-actions.ts
@@ -70,6 +70,8 @@ export interface HomeLoaderData {
   exportCacheBytes: number
   /** True when the one-time Kody Video Plus purchase is unlocked. */
   plus: boolean
+  /** Home "Watch the tour" card dismissed (first-timer teaser). */
+  tourCardDismissed: boolean
 }
 
 export async function loadHomePage(): Promise<HomeLoaderData> {
@@ -79,7 +81,13 @@ export async function loadHomePage(): Promise<HomeLoaderData> {
     estimateExportCacheBytes(),
     getSettings(),
   ])
-  return { projects, storage, exportCacheBytes, plus: settings.watermarkRemoved === true }
+  return {
+    projects,
+    storage,
+    exportCacheBytes,
+    plus: settings.watermarkRemoved === true,
+    tourCardDismissed: settings.tourCardDismissed === true,
+  }
 }
 
 export async function loadHomeProjects(): Promise<ProjectSummary[]> {

--- a/src/lib/storage.test.ts
+++ b/src/lib/storage.test.ts
@@ -23,6 +23,7 @@ import {
   removeProjectAudioTrack,
   renameProject,
   setOnboardingDismissed,
+  setTourCardDismissed,
   setKeepWatermark,
   toStoredBlob,
   undoDeleteLastClip,
@@ -46,10 +47,13 @@ describe('storage layer', () => {
   it('uses Kody Video storage settings', async () => {
     expect(DB_NAME).toBe('kody-video')
     expect((await getSettings()).onboardingDismissed).toBe(false)
+    expect((await getSettings()).tourCardDismissed).toBeUndefined()
 
     await setOnboardingDismissed(true)
+    await setTourCardDismissed(true)
 
     expect((await getSettings()).onboardingDismissed).toBe(true)
+    expect((await getSettings()).tourCardDismissed).toBe(true)
   })
 
   it('reopens when the cached IDB connection is closing (iOS Safari)', async () => {

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -230,6 +230,12 @@ export async function setOnboardingDismissed(onboardingDismissed: boolean): Prom
   await db.put('meta', { ...settings, onboardingDismissed })
 }
 
+export async function setTourCardDismissed(tourCardDismissed: boolean): Promise<void> {
+  const db = await getDb()
+  const settings = await getSettings()
+  await db.put('meta', { ...settings, tourCardDismissed })
+}
+
 export async function setLocationTaggingEnabled(locationTaggingEnabled: boolean): Promise<void> {
   const db = await getDb()
   const settings = await getSettings()

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -181,6 +181,8 @@ export interface AppMeta {
   maxProjects: number
   lastOpenedProjectId: ProjectId | null
   onboardingDismissed: boolean
+  /** Home-page "Watch the tour" card dismissed (first-timer teaser). */
+  tourCardDismissed?: boolean
   /** One-time "Remove Watermark" purchase (verified via Stripe). */
   watermarkRemoved?: boolean
   purchaseSessionId?: string | null

--- a/src/pages/about-page.tsx
+++ b/src/pages/about-page.tsx
@@ -255,8 +255,8 @@ export function AboutPage(handle: Handle) {
               >
                 watch the tour on YouTube
               </a>
-              . The same video plays right in the quick-start card the first time you open the
-              camera. Want a real result straight out of the app? Here&rsquo;s{' '}
+              . The same video plays right on the home screen when you&rsquo;re new here. Want a
+              real result straight out of the app? Here&rsquo;s{' '}
               <a
                 href="https://x.com/kentcdodds/status/2084891368724533456"
                 target="_blank"

--- a/src/pages/home-page.tsx
+++ b/src/pages/home-page.tsx
@@ -14,6 +14,7 @@ import {
   IconPlus,
   IconShareIos,
 } from '../components/icons'
+import { TourCard } from '../components/tour-card'
 import { UpsellSheet } from '../components/upsell-sheet'
 import { RestoreSheet } from '../components/restore-sheet'
 import { RenameSheet } from '../components/rename-sheet'
@@ -21,7 +22,13 @@ import { StorageMeter } from '../components/storage-meter'
 import { downloadBlob, shareOrDownload } from '../lib/media'
 import { loadHomePage, type HomeLoaderData, type ProjectSummary } from '../lib/project-actions'
 import { projectBackupFilename, serializeProject } from '../lib/project-transfer'
-import { deleteProject, getClipsForProject, getProjectAudio, renameProject } from '../lib/storage'
+import {
+  deleteProject,
+  getClipsForProject,
+  getProjectAudio,
+  renameProject,
+  setTourCardDismissed,
+} from '../lib/storage'
 import { clearExportCache } from '../lib/export/export-cache'
 import { reportError } from '../lib/error-reporting'
 import { canPromptInstall, promptInstall, subscribeInstallPrompt } from '../lib/install-prompt'
@@ -66,6 +73,7 @@ export function HomePage(handle: Handle) {
   let busy = false
   let notice: string | null = null
   let showInstallHint = shouldShowIosInstallHint()
+  let tourCardHidden = false
   let upselling = false
   let restoring = false
   let installPopoverOpen = false
@@ -381,6 +389,16 @@ export function HomePage(handle: Handle) {
               <IconClose size={16} />
             </button>
           </div>
+        ) : null}
+
+        {projects.length === 0 && !data.tourCardDismissed && !tourCardHidden ? (
+          <TourCard
+            onDismiss={() => {
+              tourCardHidden = true
+              void setTourCardDismissed(true)
+              void handle.update()
+            }}
+          />
         ) : null}
 
         <section className="project-slots" aria-label="Kody Video projects">

--- a/src/styles/home.css
+++ b/src/styles/home.css
@@ -741,24 +741,38 @@
   font-size: 0.88rem;
 }
 
-.onboarding-tour {
+.onboarding-card .btn {
+  width: 100%;
+}
+
+/* First-timer tour card (home) */
+
+.tour-card {
+  position: relative;
+  margin: 10px 0 0;
+  padding: 8px 44px 8px 8px;
+  border-radius: 16px;
+  border: 1px solid color-mix(in srgb, var(--accent) 45%, transparent);
+  background: var(--accent-soft);
+}
+
+.tour-card-teaser {
   display: grid;
   grid-template-columns: 44px 1fr 24px;
   gap: 12px;
   align-items: center;
   width: 100%;
-  margin: 0 0 16px;
-  padding: 8px 12px 8px 8px;
-  border-radius: 16px;
-  border: 1px solid color-mix(in srgb, var(--accent) 45%, transparent);
-  background: var(--accent-soft);
+  margin: 0;
+  padding: 0;
+  border: none;
+  background: transparent;
   color: inherit;
   font: inherit;
   text-align: left;
   cursor: pointer;
 }
 
-.onboarding-tour img {
+.tour-card-teaser img {
   width: 44px;
   height: 78px;
   object-fit: cover;
@@ -766,22 +780,41 @@
   display: block;
 }
 
-.onboarding-tour svg {
+.tour-card-teaser svg {
   color: var(--accent);
 }
 
-.onboarding-tour-video {
+.tour-card-copy {
+  display: block;
+}
+
+.tour-card-copy strong {
+  display: block;
+  font-size: 0.95rem;
+}
+
+.tour-card-copy span {
+  display: block;
+  margin-top: 2px;
+  color: var(--ink-muted);
+  line-height: 1.35;
+  font-size: 0.85rem;
+}
+
+.tour-card-video {
   display: block;
   width: min(100%, 236px);
   aspect-ratio: 9 / 16;
-  margin: 0 auto 16px;
-  border-radius: 16px;
+  margin: 0 auto;
+  border-radius: 12px;
   background: var(--stage-bg);
   object-fit: contain;
 }
 
-.onboarding-card .btn {
-  width: 100%;
+.tour-card-dismiss {
+  position: absolute;
+  top: 8px;
+  right: 8px;
 }
 
 @media (max-height: 720px) {

--- a/tests/e2e/home.spec.ts
+++ b/tests/e2e/home.spec.ts
@@ -9,30 +9,40 @@ test.describe('home & app shell', () => {
     await expect(overlay).toBeVisible()
     await expect(overlay).toContainText('Hold to record')
     await expect(overlay).toContainText('Tap Go')
-
-    // Tour teaser swaps to an inline player that streams from media.kody.video.
-    const tourTeaser = overlay.getByRole('button', { name: /watch the tour/i })
-    await expect(tourTeaser).toBeVisible()
-    await tourTeaser.click()
-    const tourVideo = overlay.locator('video.onboarding-tour-video')
-    await expect(tourVideo).toBeVisible()
-    await expect(tourVideo).toHaveAttribute(
-      'src',
-      /^https:\/\/media\.kody\.video\//,
-    )
-    // The tap itself must start playback (in-gesture play() is what mobile
-    // autoplay policies require) — rendered state alone can't prove that.
-    await expect
-      .poll(() => tourVideo.evaluate((video: HTMLVideoElement) => video.currentTime))
-      .toBeGreaterThan(0)
-    await expect(tourTeaser).toBeHidden()
-
     await page.getByRole('button', { name: 'Start recording' }).click()
     await expect(overlay).toBeHidden()
 
     await page.reload()
     await expect(page.locator('.record-stage')).toBeVisible()
     await expect(page.locator('.onboarding-overlay')).toBeHidden()
+  })
+
+  test('first-timer tour card plays the tour and dismisses for good', async ({ page }) => {
+    await page.goto('/')
+    const card = page.locator('.tour-card')
+    await expect(card).toBeVisible()
+
+    // Teaser swaps to an inline player that streams from media.kody.video.
+    const teaser = card.getByRole('button', { name: /watch the tour/i })
+    await teaser.click()
+    const video = card.locator('video.tour-card-video')
+    await expect(video).toBeVisible()
+    await expect(video).toHaveAttribute('src', /^https:\/\/media\.kody\.video\//)
+    // The tap itself must start playback (in-gesture play() is what mobile
+    // autoplay policies require) — rendered state alone can't prove that.
+    // Generous timeout: the video streams over the real network and the
+    // parallel suite competes for bandwidth.
+    await expect
+      .poll(() => video.evaluate((el: HTMLVideoElement) => el.currentTime), { timeout: 20_000 })
+      .toBeGreaterThan(0)
+    await expect(teaser).toBeHidden()
+
+    // Dismissal persists across reloads.
+    await card.getByRole('button', { name: 'Dismiss tour' }).click()
+    await expect(card).toBeHidden()
+    await page.reload()
+    await expect(page.locator('.project-slots')).toBeVisible()
+    await expect(page.locator('.tour-card')).toBeHidden()
   })
 
   test('footer shows privacy line with a tappable storage gauge', async ({ page }) => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Follow-up to #126: the tour video moves from the new-project onboarding overlay to a card on the **home page**, so first-time visitors see it before they ever open the camera.

- **New `TourCard` component** (`src/components/tour-card.tsx`): "New here? Watch the tour" teaser (poster thumbnail + play icon) that swaps to an inline 9:16 player streaming from `media.kody.video`. Same mobile-safe mechanics as before — the video element is mounted hidden with `preload="none"` so `play()` runs inside the tap's gesture, and keyboard focus is handed to the player when the teaser disappears.
- **Visibility:** shown only when the user has **no projects** and hasn't dismissed it. The X dismiss persists (`tourCardDismissed` in the app meta), and creating a project hides it naturally.
- **Onboarding overlay** reverts to its pre-#126 form (the 4 quick-start steps + Start recording) — no video there anymore.
- About page + README copy updated to say the tour lives on the home screen.

## Testing

- `npm run lint`, `npm test` (218 unit tests, including the new `tourCardDismissed` settings coverage), `npm run test:e2e` (66 tests) all pass.
- New e2e test: card visible on first visit → tap teaser → player streams from `media.kody.video` and `currentTime` advances → X dismisses → still hidden after reload.
- Manually verified in a headless Chrome session (screenshots/video in the agent run).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f70b95db-a9e4-451e-8216-bdf0ade25b7f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f70b95db-a9e4-451e-8216-bdf0ade25b7f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

