### PR TITLE
Persist tour card dismissal into the cached home data

### DIFF
--- a/src/pages/home-page.tsx
+++ b/src/pages/home-page.tsx
@@ -73,7 +73,6 @@ export function HomePage(handle: Handle) {
   let busy = false
   let notice: string | null = null
   let showInstallHint = shouldShowIosInstallHint()
-  let tourCardHidden = false
   let upselling = false
   let restoring = false
   let installPopoverOpen = false
@@ -391,10 +390,13 @@ export function HomePage(handle: Handle) {
           </div>
         ) : null}
 
-        {projects.length === 0 && !data.tourCardDismissed && !tourCardHidden ? (
+        {projects.length === 0 && !data.tourCardDismissed ? (
           <TourCard
             onDismiss={() => {
-              tourCardHidden = true
+              // Mutate the loaded data (it is also the module-level
+              // lastHomeData cache) so a remount before the async persist
+              // lands doesn't resurrect the card.
+              data!.tourCardDismissed = true
               void setTourCardDismissed(true)
               void handle.update()
             }}

--- a/tests/e2e/home.spec.ts
+++ b/tests/e2e/home.spec.ts
@@ -37,9 +37,16 @@ test.describe('home & app shell', () => {
       .toBeGreaterThan(0)
     await expect(teaser).toBeHidden()
 
-    // Dismissal persists across reloads.
+    // Dismissal persists across SPA navigation (cached home data) …
     await card.getByRole('button', { name: 'Dismiss tour' }).click()
     await expect(card).toBeHidden()
+    await page.getByRole('link', { name: 'About Kody Video' }).click()
+    await expect(page.locator('.about-screen')).toBeVisible()
+    await page.goBack()
+    await expect(page.locator('.project-slots')).toBeVisible()
+    await expect(page.locator('.tour-card')).toBeHidden()
+
+    // … and across full reloads (persisted meta).
     await page.reload()
     await expect(page.locator('.project-slots')).toBeVisible()
     await expect(page.locator('.tour-card')).toBeHidden()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Follow-up to #133, which was merged before this Bugbot fix landed on its branch.

Bugbot flagged (correctly) that dismissing the tour card only set component-local state while persisting asynchronously — the module-level `lastHomeData` cache still said "not dismissed", so navigating away and back (SPA navigation reuses the cache) resurrected the card until the fresh IndexedDB load landed.

- Dismissal now mutates the loaded home data (the same object as the `lastHomeData` cache), so a remount before the async persist can't bring the card back; the local `tourCardHidden` flag became redundant and is gone.
- The tour-card e2e test now also covers the SPA-navigation path (home → About → back) in addition to the full-reload path.

## Testing

`npm run lint` and the home e2e spec (14 tests, including the extended tour-card test) pass.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f70b95db-a9e4-451e-8216-bdf0ade25b7f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f70b95db-a9e4-451e-8216-bdf0ade25b7f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

