### PR TITLE
Play the tour in a native dialog so the home layout never reflows

### DIFF
--- a/src/components/tour-card.tsx
+++ b/src/components/tour-card.tsx
@@ -14,55 +14,36 @@ interface TourCardProps {
   onDismiss: () => void
 }
 
-/** First-timer home card: tap-to-play tour video with a persistent dismiss. */
+/**
+ * First-timer home card: the teaser opens the tour in a native `<dialog>`
+ * (top layer — the page layout underneath never reflows) with a persistent
+ * dismiss on the card itself.
+ */
 export function TourCard(handle: Handle<TourCardProps>) {
-  let playing = false
+  let dialog: HTMLDialogElement | null = null
   let video: HTMLVideoElement | null = null
+
   return () => (
     <section className="tour-card" aria-label="Kody Video tour">
-      {/* Mounted (hidden) before the teaser is tapped so play() can run
-          inside the tap's gesture — mobile browsers block unmuted playback
-          that starts after an async re-render. */}
-      <video
-        className={playing ? 'tour-card-video' : 'visually-hidden'}
-        src={TOUR_VIDEO_URL}
-        poster={TOUR_POSTER_URL}
-        controls
-        tabIndex={0}
-        playsInline
-        preload="none"
-        mix={ref((node, signal) => {
-          video = node as HTMLVideoElement
-          signal.addEventListener('abort', () => {
-            video = null
-          })
+      <button
+        type="button"
+        className="tour-card-teaser"
+        mix={on('click', () => {
+          // showModal() + play() in the same tap: the dialog needs no
+          // re-render to appear, and mobile autoplay policies require the
+          // unmuted play() to run inside the gesture. If play() still
+          // rejects, the controls are right there.
+          dialog?.showModal()
+          void video?.play().catch(() => {})
         })}
-      />
-      {playing ? null : (
-        <button
-          type="button"
-          className="tour-card-teaser"
-          mix={on('click', () => {
-            playing = true
-            // In-gesture play() is what mobile autoplay policies require
-            // for sound. If it still rejects, the controls are visible.
-            void video?.play().catch(() => {})
-            void handle.update()
-            // The activated teaser button is about to disappear — hand
-            // keyboard focus to the player so its controls stay reachable.
-            requestAnimationFrame(() => {
-              video?.focus()
-            })
-          })}
-        >
-          <img src={TOUR_POSTER_URL} alt="" width={44} height={78} />
-          <span className="tour-card-copy">
-            <strong>New here? Watch the tour</strong>
-            <span>Kent demos the whole flow — record, arrange, share — in a minute and a half.</span>
-          </span>
-          <IconPlay />
-        </button>
-      )}
+      >
+        <img src={TOUR_POSTER_URL} alt="" width={44} height={78} />
+        <span className="tour-card-copy">
+          <strong>New here? Watch the tour</strong>
+          <span>Kent demos the whole flow — record, arrange, share — in a minute and a half.</span>
+        </span>
+        <IconPlay />
+      </button>
       <button
         type="button"
         className="install-hint-dismiss tour-card-dismiss"
@@ -71,6 +52,50 @@ export function TourCard(handle: Handle<TourCardProps>) {
       >
         <IconClose size={16} />
       </button>
+      <dialog
+        className="tour-dialog"
+        aria-label="Kody Video tour video"
+        mix={[
+          ref((node, signal) => {
+            dialog = node as HTMLDialogElement
+            signal.addEventListener('abort', () => {
+              dialog = null
+            })
+          }),
+          // Esc (native cancel) and every other close path land here — the
+          // audio must never keep playing behind a closed dialog.
+          on('close', () => video?.pause()),
+          // The dialog has no padding, so clicks on the element itself can
+          // only come from the ::backdrop — tap outside to close.
+          on('click', (event) => {
+            if (event.target === event.currentTarget) dialog?.close()
+          }),
+        ]}
+      >
+        <video
+          className="tour-dialog-video"
+          src={TOUR_VIDEO_URL}
+          poster={TOUR_POSTER_URL}
+          controls
+          tabIndex={0}
+          playsInline
+          preload="none"
+          mix={ref((node, signal) => {
+            video = node as HTMLVideoElement
+            signal.addEventListener('abort', () => {
+              video = null
+            })
+          })}
+        />
+        <button
+          type="button"
+          className="btn-icon tour-dialog-close"
+          aria-label="Close tour"
+          mix={on('click', () => dialog?.close())}
+        >
+          <IconClose />
+        </button>
+      </dialog>
     </section>
   )
 }

--- a/src/styles/home.css
+++ b/src/styles/home.css
@@ -801,20 +801,45 @@
   font-size: 0.85rem;
 }
 
-.tour-card-video {
-  display: block;
-  width: min(100%, 236px);
-  aspect-ratio: 9 / 16;
-  margin: 0 auto;
-  border-radius: 12px;
-  background: var(--stage-bg);
-  object-fit: contain;
-}
-
 .tour-card-dismiss {
   position: absolute;
   top: 8px;
   right: 8px;
+}
+
+/* Tour video dialog: native <dialog> top layer — never reflows the page. */
+
+.tour-dialog {
+  padding: 0;
+  border: none;
+  background: transparent;
+  overflow: visible;
+  outline: none;
+}
+
+.tour-dialog::backdrop {
+  /* --overlay-scrim, hardcoded: custom properties don't reach ::backdrop
+     in all engines. */
+  background: rgba(7, 20, 17, 0.72);
+  backdrop-filter: blur(12px);
+}
+
+.tour-dialog-video {
+  display: block;
+  width: min(86vw, calc(80dvh * 9 / 16));
+  aspect-ratio: 9 / 16;
+  border-radius: 16px;
+  background: var(--stage-bg);
+  object-fit: contain;
+  box-shadow: var(--shadow);
+}
+
+.tour-dialog-close {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  background: var(--chip-bg);
+  color: var(--ink);
 }
 
 @media (max-height: 720px) {

--- a/tests/e2e/home.spec.ts
+++ b/tests/e2e/home.spec.ts
@@ -24,7 +24,10 @@ test.describe('home & app shell', () => {
 
     // Teaser opens a top-layer <dialog> playing from media.kody.video —
     // the page layout underneath must not reflow while it plays.
-    const slotsBox = await page.locator('.project-slots').boundingBox()
+    const slots = page.locator('.project-slots')
+    await expect(slots).toBeVisible()
+    const slotsBox = await slots.boundingBox()
+    expect(slotsBox).not.toBeNull()
     const teaser = card.getByRole('button', { name: /watch the tour/i })
     await teaser.click()
     const dialog = page.locator('dialog.tour-dialog')
@@ -38,7 +41,7 @@ test.describe('home & app shell', () => {
     await expect
       .poll(() => video.evaluate((el: HTMLVideoElement) => el.currentTime), { timeout: 20_000 })
       .toBeGreaterThan(0)
-    expect(await page.locator('.project-slots').boundingBox()).toEqual(slotsBox)
+    expect(await slots.boundingBox()).toEqual(slotsBox)
 
     // Esc closes the dialog and stops the audio.
     await page.keyboard.press('Escape')

--- a/tests/e2e/home.spec.ts
+++ b/tests/e2e/home.spec.ts
@@ -22,11 +22,14 @@ test.describe('home & app shell', () => {
     const card = page.locator('.tour-card')
     await expect(card).toBeVisible()
 
-    // Teaser swaps to an inline player that streams from media.kody.video.
+    // Teaser opens a top-layer <dialog> playing from media.kody.video —
+    // the page layout underneath must not reflow while it plays.
+    const slotsBox = await page.locator('.project-slots').boundingBox()
     const teaser = card.getByRole('button', { name: /watch the tour/i })
     await teaser.click()
-    const video = card.locator('video.tour-card-video')
-    await expect(video).toBeVisible()
+    const dialog = page.locator('dialog.tour-dialog')
+    await expect(dialog).toBeVisible()
+    const video = dialog.locator('video.tour-dialog-video')
     await expect(video).toHaveAttribute('src', /^https:\/\/media\.kody\.video\//)
     // The tap itself must start playback (in-gesture play() is what mobile
     // autoplay policies require) — rendered state alone can't prove that.
@@ -35,7 +38,15 @@ test.describe('home & app shell', () => {
     await expect
       .poll(() => video.evaluate((el: HTMLVideoElement) => el.currentTime), { timeout: 20_000 })
       .toBeGreaterThan(0)
-    await expect(teaser).toBeHidden()
+    expect(await page.locator('.project-slots').boundingBox()).toEqual(slotsBox)
+
+    // Esc closes the dialog and stops the audio.
+    await page.keyboard.press('Escape')
+    await expect(dialog).toBeHidden()
+    await expect
+      .poll(() => video.evaluate((el: HTMLVideoElement) => el.paused))
+      .toBe(true)
+    await expect(teaser).toBeVisible()
 
     // Dismissal persists across SPA navigation (cached home data) …
     await card.getByRole('button', { name: 'Dismiss tour' }).click()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Follow-up to #133/#134: playing the tour inline grew the card and squished the project slots (the slots grid is a flex child that absorbs the height). The tour now opens in a **native `<dialog>` via `showModal()`** — Remix UI has no dedicated modal component but fully types the native element, and the top layer is exactly what we want: the page underneath can't reflow, and Esc/focus handling come from the platform.

- The teaser card stays compact; tapping it calls `dialog.showModal()` + `video.play()` in the same gesture (the dialog needs no re-render to appear, and mobile autoplay policies require the unmuted `play()` inside the tap).
- Close paths: Esc (native cancel), tapping the scrim (the dialog has no padding, so clicks on the element itself only come from `::backdrop`), or the X button. Every close pauses the video so audio can't keep playing behind a closed dialog; reopening resumes from the same spot.
- The card's persistent dismiss (X) is unchanged.

## Testing

- `npm run lint`, `npm test`, `npm run test:e2e` (66 tests) all pass.
- The tour e2e test now asserts the **project-slots bounding box is identical before and during playback** (the regression this PR fixes), that playback starts from the tap, and that Esc closes the dialog and pauses the audio.
- Manually verified in headless Chrome (demo video in the agent run).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f70b95db-a9e4-451e-8216-bdf0ade25b7f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f70b95db-a9e4-451e-8216-bdf0ade25b7f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tour teaser videos now open in a native modal with controls and responsive sizing.
  * Video playback starts immediately when the teaser is tapped.
  * Modals can be closed using the close button, outside click, or Escape.
  * Video playback automatically pauses when the modal closes.

* **Bug Fixes**
  * Opening a tour video no longer shifts the surrounding page layout.
  * Closing the modal restores the tour teaser.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->