### PR TITLE
Harden iOS clip audio decode retries (KODY-VIDEO-P)

### DIFF
--- a/src/lib/export/index.ts
+++ b/src/lib/export/index.ts
@@ -98,7 +98,9 @@ async function runExport(
       return result
     } catch (error) {
       console.warn('WebCodecs export failed; falling back to realtime stitcher', error)
-      resetAudioDiagnostics()
+      // Keep the decode-failure report gate: both engines share decodeClipAudio,
+      // and a second Sentry event for the same export is just noise (Bugbot).
+      resetAudioDiagnostics({ retainFailureReport: true })
       resetVideoDiagnostics()
     }
   }

--- a/src/lib/export/shared.test.ts
+++ b/src/lib/export/shared.test.ts
@@ -2,8 +2,12 @@ import { describe, expect, it } from 'vitest'
 import {
   AUDIO_PEAK_RETENTION_RATIO,
   AUDIO_SILENCE_PEAK,
+  audioDecodeFailureDetail,
   blobForPlayback,
   classifyOutputAudioPeak,
+  decodeBlobAudio,
+  decodeClipAudio,
+  resetAudioDiagnostics,
 } from './shared'
 
 describe('classifyOutputAudioPeak', () => {
@@ -55,5 +59,74 @@ describe('blobForPlayback', () => {
     const mistyped = new Blob(['clip'], { type: 'video/webm' })
     const fixed = blobForPlayback(mistyped, 'video/mp4')
     expect(fixed.type).toBe('video/mp4')
+  })
+})
+
+describe('audioDecodeFailureDetail', () => {
+  it('includes mime and typed error identity for triage', () => {
+    expect(audioDecodeFailureDetail(new DOMException('bad codec', 'EncodingError'), 'video/mp4')).toBe(
+      ' (video/mp4; EncodingError: bad codec)',
+    )
+  })
+
+  it('falls back when mime or message is empty', () => {
+    expect(audioDecodeFailureDetail(new Error(''), '')).toBe(' (unknown-mime; unknown)')
+    expect(audioDecodeFailureDetail('boom', 'audio/wav')).toBe(' (audio/wav; boom)')
+  })
+})
+
+/** Tiny mono 16-bit PCM WAV used to exercise the mediabunny decode path. */
+function makeWavBlob(amplitude = 0.5, durationSec = 0.25, freq = 440): Blob {
+  const rate = 8000
+  const samples = Math.round(durationSec * rate)
+  const bytes = new DataView(new ArrayBuffer(44 + samples * 2))
+  const writeAscii = (offset: number, text: string) => {
+    for (let i = 0; i < text.length; i += 1) bytes.setUint8(offset + i, text.charCodeAt(i))
+  }
+  writeAscii(0, 'RIFF')
+  bytes.setUint32(4, 36 + samples * 2, true)
+  writeAscii(8, 'WAVE')
+  writeAscii(12, 'fmt ')
+  bytes.setUint32(16, 16, true)
+  bytes.setUint16(20, 1, true)
+  bytes.setUint16(22, 1, true)
+  bytes.setUint32(24, rate, true)
+  bytes.setUint32(28, rate * 2, true)
+  bytes.setUint16(32, 2, true)
+  bytes.setUint16(34, 16, true)
+  writeAscii(36, 'data')
+  bytes.setUint32(40, samples * 2, true)
+  for (let i = 0; i < samples; i += 1) {
+    bytes.setInt16(
+      44 + i * 2,
+      Math.round(Math.sin((2 * Math.PI * freq * i) / rate) * amplitude * 32767),
+      true,
+    )
+  }
+  return new Blob([bytes.buffer], { type: 'audio/wav' })
+}
+
+describe('decodeBlobAudio', () => {
+  it('decodes WAV and disposes the Input without leaking the track', async () => {
+    const decoded = await decodeBlobAudio(makeWavBlob(), 48000)
+    expect(decoded).not.toBeNull()
+    expect(decoded!.sampleRate).toBe(48000)
+    expect(decoded!.duration).toBeGreaterThan(0.2)
+    // A second decode of the same bytes must still work after dispose().
+    const again = await decodeBlobAudio(makeWavBlob(), 48000)
+    expect(again).not.toBeNull()
+  })
+
+  it('returns null for blobs with no decodable audio track', async () => {
+    expect(await decodeBlobAudio(new Blob(['not media'], { type: 'video/webm' }), 48000)).toBeNull()
+  })
+})
+
+describe('decodeClipAudio', () => {
+  it('records a decoded observation for audible clips', async () => {
+    resetAudioDiagnostics()
+    const decoded = await decodeClipAudio(makeWavBlob(), 48000)
+    expect(decoded).not.toBeNull()
+    expect(decoded!.getChannelData(0).some((s) => Math.abs(s) > 0.1)).toBe(true)
   })
 })

--- a/src/lib/export/shared.test.ts
+++ b/src/lib/export/shared.test.ts
@@ -4,6 +4,7 @@ import {
   AUDIO_SILENCE_PEAK,
   audioDecodeFailureDetail,
   blobForPlayback,
+  boundedAudioMimeType,
   classifyOutputAudioPeak,
   decodeBlobAudio,
   decodeClipAudio,
@@ -72,6 +73,15 @@ describe('audioDecodeFailureDetail', () => {
   it('falls back when mime or message is empty', () => {
     expect(audioDecodeFailureDetail(new Error(''), '')).toBe(' (unknown-mime; unknown)')
     expect(audioDecodeFailureDetail('boom', 'audio/wav')).toBe(' (audio/wav; boom)')
+  })
+
+  it('caps oversized mime strings in both helper surfaces', () => {
+    const huge = `video/${'a'.repeat(500)}`
+    expect(boundedAudioMimeType(huge).length).toBe(120)
+    const detail = audioDecodeFailureDetail(new Error('nope'), huge)
+    expect(detail.length).toBeLessThan(280)
+    expect(detail).toContain(boundedAudioMimeType(huge))
+    expect(detail).not.toContain('a'.repeat(200))
   })
 })
 

--- a/src/lib/export/shared.test.ts
+++ b/src/lib/export/shared.test.ts
@@ -117,8 +117,13 @@ describe('decodeBlobAudio', () => {
     expect(again).not.toBeNull()
   })
 
-  it('returns null for blobs with no decodable audio track', async () => {
-    expect(await decodeBlobAudio(new Blob(['not media'], { type: 'video/webm' }), 48000)).toBeNull()
+  it('fails fast on unrecognizable input without burning the retry budget', async () => {
+    const started = performance.now()
+    await expect(
+      decodeBlobAudio(new Blob(['not media'], { type: 'video/webm' }), 48000),
+    ).rejects.toThrow(/unsupported or unrecognizable/i)
+    // Permanent format errors must not walk MEDIA_LOAD_RETRY_DELAYS_MS (~3.7s).
+    expect(performance.now() - started).toBeLessThan(1000)
   })
 })
 

--- a/src/lib/export/shared.test.ts
+++ b/src/lib/export/shared.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import {
+  __isAudioDecodeFailureReportArmedForTests,
   AUDIO_PEAK_RETENTION_RATIO,
   AUDIO_SILENCE_PEAK,
   audioDecodeFailureDetail,
@@ -143,5 +144,23 @@ describe('decodeClipAudio', () => {
     const decoded = await decodeClipAudio(makeWavBlob(), 48000)
     expect(decoded).not.toBeNull()
     expect(decoded!.getChannelData(0).some((s) => Math.abs(s) > 0.1)).toBe(true)
+  })
+
+  it('keeps the failure-report gate closed across a fallback-style reset', async () => {
+    resetAudioDiagnostics()
+    expect(__isAudioDecodeFailureReportArmedForTests()).toBe(true)
+    await decodeClipAudio(new Blob(['not media'], { type: 'video/webm' }), 48000)
+    expect(__isAudioDecodeFailureReportArmedForTests()).toBe(false)
+
+    // WebCodecs → realtime fallback clears observations but must not re-arm
+    // the gate (otherwise the same export double-reports to Sentry).
+    resetAudioDiagnostics({ retainFailureReport: true })
+    expect(__isAudioDecodeFailureReportArmedForTests()).toBe(false)
+    await decodeClipAudio(new Blob(['not media'], { type: 'video/webm' }), 48000)
+    expect(__isAudioDecodeFailureReportArmedForTests()).toBe(false)
+
+    // A fresh export re-arms.
+    resetAudioDiagnostics()
+    expect(__isAudioDecodeFailureReportArmedForTests()).toBe(true)
   })
 })

--- a/src/lib/export/shared.ts
+++ b/src/lib/export/shared.ts
@@ -253,9 +253,24 @@ interface ClipAudioObservation {
 
 let audioObservations: ClipAudioObservation[] = []
 
-export function resetAudioDiagnostics(): void {
+/**
+ * Clear per-export audio observations. By default also re-arms the once-per-
+ * export decode-failure Sentry gate. Pass `retainFailureReport` when the
+ * WebCodecs → realtime fallback resets mid-export so the same user action
+ * cannot emit two "Clip audio decode failed" events.
+ */
+export function resetAudioDiagnostics(
+  options: { retainFailureReport?: boolean } = {},
+): void {
   audioObservations = []
-  audioDecodeFailureReported = false
+  if (!options.retainFailureReport) {
+    audioDecodeFailureReported = false
+  }
+}
+
+/** Test-only: whether the next decode failure would call reportError. */
+export function __isAudioDecodeFailureReportArmedForTests(): boolean {
+  return !audioDecodeFailureReported
 }
 
 /** Near-silence floor shared by the input and output audio diagnostics. */

--- a/src/lib/export/shared.ts
+++ b/src/lib/export/shared.ts
@@ -248,6 +248,7 @@ let audioObservations: ClipAudioObservation[] = []
 
 export function resetAudioDiagnostics(): void {
   audioObservations = []
+  audioDecodeFailureReported = false
 }
 
 /** Near-silence floor shared by the input and output audio diagnostics. */
@@ -382,61 +383,105 @@ function audioBufferPeak(buffer: AudioBuffer): number {
 }
 
 /**
+ * Short, non-PII detail for remote triage when clip audio decode throws.
+ * The catch used to swallow the underlying error entirely (KODY-VIDEO-P),
+ * which left Seer guessing at a retired media-element path.
+ */
+export function audioDecodeFailureDetail(error: unknown, mimeType: string): string {
+  const mime = mimeType.trim() || 'unknown-mime'
+  if (error instanceof Error) {
+    const name = error.name && error.name !== 'Error' ? error.name : ''
+    const message = error.message.trim().slice(0, 120)
+    const cause = name && message ? `${name}: ${message}` : name || message || 'unknown'
+    return ` (${mime}; ${cause})`
+  }
+  const text = String(error).trim().slice(0, 120)
+  return text ? ` (${mime}; ${text})` : ` (${mime})`
+}
+
+/**
  * Decode a blob's audio track into one AudioBuffer at the requested sample
  * rate. Mediabunny demuxes and decodes (fragmented MP4, WebM/Opus, rotation
  * of containers — all one path); the result is resampled when the source
  * rate differs. Returns null when there is no decodable audio.
+ *
+ * Retries on throw: iOS WebKit has a small pool of hardware decoder slots
+ * (same race `loadClipVideo` already backs off for). A busy slot can make
+ * WebCodecs AudioDecoder reject a blob that decodes on the next attempt —
+ * without retries every failed decode becomes a silent export.
  */
 export async function decodeBlobAudio(blob: Blob, sampleRate: number): Promise<AudioBuffer | null> {
-  const input = new Input({ source: new BlobSource(blob), formats: ALL_FORMATS })
-  const track = await input.getPrimaryAudioTrack()
-  if (!track || !(await track.canDecode())) return null
-
-  const sink = new AudioBufferSink(track)
-  const pieces: Array<{ buffer: AudioBuffer; timestamp: number }> = []
-  let sourceRate = 0
-  let channels = 1
-  let endSec = 0
-  for await (const wrapped of sink.buffers()) {
-    pieces.push({ buffer: wrapped.buffer, timestamp: wrapped.timestamp })
-    sourceRate = wrapped.buffer.sampleRate
-    channels = Math.max(channels, wrapped.buffer.numberOfChannels)
-    endSec = Math.max(endSec, wrapped.timestamp + wrapped.duration)
-  }
-  if (pieces.length === 0 || sourceRate <= 0 || endSec <= 0) return null
-
-  const merged = new AudioBuffer({
-    length: Math.max(1, Math.ceil(endSec * sourceRate)),
-    sampleRate: sourceRate,
-    numberOfChannels: channels,
-  })
-  // Contiguous placement: rounding each piece's timestamp independently can
-  // drift ±1 sample against its neighbor, leaving one-sample overlaps/gaps
-  // (audible as faint crackle). Snap to the running end when they agree.
-  let runningOffset = 0
-  for (const piece of pieces) {
-    const computed = Math.round(piece.timestamp * sourceRate)
-    const offset = Math.abs(computed - runningOffset) <= 2 ? runningOffset : computed
-    for (let ch = 0; ch < channels; ch += 1) {
-      const sourceChannel = Math.min(ch, piece.buffer.numberOfChannels - 1)
-      const data = piece.buffer.getChannelData(sourceChannel)
-      const available = merged.length - offset
-      if (available <= 0) continue
-      merged.copyToChannel(available < data.length ? data.subarray(0, available) : data, ch, offset)
+  let lastError: unknown
+  for (let attempt = 0; attempt <= MEDIA_LOAD_RETRY_DELAYS_MS.length; attempt += 1) {
+    try {
+      return await decodeBlobAudioOnce(blob, sampleRate)
+    } catch (error) {
+      lastError = error
+      const delay = MEDIA_LOAD_RETRY_DELAYS_MS[attempt]
+      if (delay === undefined) break
+      await wait(delay)
     }
-    // Clamp to capacity: an offset past the end must not inflate the
-    // running position and pull later in-range pieces past it via the snap.
-    runningOffset = Math.min(offset + piece.buffer.length, merged.length)
   }
-  if (sourceRate === sampleRate) return merged
+  throw lastError
+}
 
-  const length = Math.max(1, Math.ceil(merged.duration * sampleRate))
-  const offline = new OfflineAudioContext(channels, length, sampleRate)
-  const source = offline.createBufferSource()
-  source.buffer = merged
-  source.connect(offline.destination)
-  source.start()
-  return offline.startRendering()
+async function decodeBlobAudioOnce(blob: Blob, sampleRate: number): Promise<AudioBuffer | null> {
+  const input = new Input({ source: new BlobSource(blob), formats: ALL_FORMATS })
+  try {
+    const track = await input.getPrimaryAudioTrack()
+    if (!track || !(await track.canDecode())) return null
+
+    const sink = new AudioBufferSink(track)
+    const pieces: Array<{ buffer: AudioBuffer; timestamp: number }> = []
+    let sourceRate = 0
+    let channels = 1
+    let endSec = 0
+    for await (const wrapped of sink.buffers()) {
+      pieces.push({ buffer: wrapped.buffer, timestamp: wrapped.timestamp })
+      sourceRate = wrapped.buffer.sampleRate
+      channels = Math.max(channels, wrapped.buffer.numberOfChannels)
+      endSec = Math.max(endSec, wrapped.timestamp + wrapped.duration)
+    }
+    if (pieces.length === 0 || sourceRate <= 0 || endSec <= 0) return null
+
+    const merged = new AudioBuffer({
+      length: Math.max(1, Math.ceil(endSec * sourceRate)),
+      sampleRate: sourceRate,
+      numberOfChannels: channels,
+    })
+    // Contiguous placement: rounding each piece's timestamp independently can
+    // drift ±1 sample against its neighbor, leaving one-sample overlaps/gaps
+    // (audible as faint crackle). Snap to the running end when they agree.
+    let runningOffset = 0
+    for (const piece of pieces) {
+      const computed = Math.round(piece.timestamp * sourceRate)
+      const offset = Math.abs(computed - runningOffset) <= 2 ? runningOffset : computed
+      for (let ch = 0; ch < channels; ch += 1) {
+        const sourceChannel = Math.min(ch, piece.buffer.numberOfChannels - 1)
+        const data = piece.buffer.getChannelData(sourceChannel)
+        const available = merged.length - offset
+        if (available <= 0) continue
+        merged.copyToChannel(available < data.length ? data.subarray(0, available) : data, ch, offset)
+      }
+      // Clamp to capacity: an offset past the end must not inflate the
+      // running position and pull later in-range pieces past it via the snap.
+      runningOffset = Math.min(offset + piece.buffer.length, merged.length)
+    }
+    if (sourceRate === sampleRate) return merged
+
+    const length = Math.max(1, Math.ceil(merged.duration * sampleRate))
+    const offline = new OfflineAudioContext(channels, length, sampleRate)
+    const source = offline.createBufferSource()
+    source.buffer = merged
+    source.connect(offline.destination)
+    source.start()
+    return offline.startRendering()
+  } finally {
+    // Free demuxer + any WebCodecs AudioDecoder the sink still holds —
+    // iOS in particular runs out of decoder slots when Inputs accumulate
+    // across clip-peak backfill, preview normalize, and export.
+    input.dispose()
+  }
 }
 
 /**
@@ -475,13 +520,21 @@ export async function decodeClipAudio(
     }
     audioObservations.push({ path: 'none', peak: 0, mimeType: blob.type })
     return null
-  } catch {
+  } catch (error) {
     audioObservations.push({ path: 'failed', peak: 0, mimeType: blob.type })
     if (!audioDecodeFailureReported) {
       audioDecodeFailureReported = true
-      reportError(new Error('Clip audio decode failed — export audio will be silent'), 'export-audio', {
-        mimeType: blob.type,
-      })
+      reportError(
+        new Error(
+          `Clip audio decode failed — export audio will be silent${audioDecodeFailureDetail(error, blob.type)}`,
+          { cause: error },
+        ),
+        'export-audio',
+        {
+          mimeType: blob.type,
+          cause: error instanceof Error ? `${error.name}: ${error.message}`.slice(0, 200) : String(error).slice(0, 200),
+        },
+      )
     }
     return null
   }

--- a/src/lib/export/shared.ts
+++ b/src/lib/export/shared.ts
@@ -389,13 +389,18 @@ function audioBufferPeak(buffer: AudioBuffer): number {
   return peak
 }
 
+/** Cap mime diagnostics — blob.type is caller-controlled (publishable DSN). */
+export function boundedAudioMimeType(mimeType: string): string {
+  return mimeType.trim().slice(0, 120) || 'unknown-mime'
+}
+
 /**
  * Short, non-PII detail for remote triage when clip audio decode throws.
  * The catch used to swallow the underlying error entirely (KODY-VIDEO-P),
  * which left Seer guessing at a retired media-element path.
  */
 export function audioDecodeFailureDetail(error: unknown, mimeType: string): string {
-  const mime = mimeType.trim() || 'unknown-mime'
+  const mime = boundedAudioMimeType(mimeType)
   if (error instanceof Error) {
     const name = error.name && error.name !== 'Error' ? error.name : ''
     const message = error.message.trim().slice(0, 120)
@@ -404,6 +409,11 @@ export function audioDecodeFailureDetail(error: unknown, mimeType: string): stri
   }
   const text = String(error).trim().slice(0, 120)
   return text ? ` (${mime}; ${text})` : ` (${mime})`
+}
+
+/** Permanent demux/lifecycle failures — retrying only burns ~3.7s per clip. */
+function isNonRetryableAudioDecodeError(error: unknown): boolean {
+  return error instanceof UnsupportedInputFormatError || error instanceof InputDisposedError
 }
 
 /**
@@ -417,10 +427,6 @@ export function audioDecodeFailureDetail(error: unknown, mimeType: string): stri
  * WebCodecs AudioDecoder reject a blob that decodes on the next attempt —
  * without retries every failed decode becomes a silent export.
  */
-/** Permanent demux/lifecycle failures — retrying only burns ~3.7s per clip. */
-function isNonRetryableAudioDecodeError(error: unknown): boolean {
-  return error instanceof UnsupportedInputFormatError || error instanceof InputDisposedError
-}
 
 export async function decodeBlobAudio(blob: Blob, sampleRate: number): Promise<AudioBuffer | null> {
   let lastError: unknown
@@ -522,29 +528,31 @@ export async function decodeClipAudio(
   sampleRate = 48000,
 ): Promise<AudioBuffer | null> {
   try {
+    const mimeType = boundedAudioMimeType(blob.type)
     const decoded = await decodeBlobAudio(blob, sampleRate)
     if (decoded) {
       audioObservations.push({
         path: 'decoded',
         peak: audioBufferPeak(decoded),
-        mimeType: blob.type,
+        mimeType,
       })
       return decoded
     }
-    audioObservations.push({ path: 'none', peak: 0, mimeType: blob.type })
+    audioObservations.push({ path: 'none', peak: 0, mimeType })
     return null
   } catch (error) {
-    audioObservations.push({ path: 'failed', peak: 0, mimeType: blob.type })
+    const mimeType = boundedAudioMimeType(blob.type)
+    audioObservations.push({ path: 'failed', peak: 0, mimeType })
     if (!audioDecodeFailureReported) {
       audioDecodeFailureReported = true
       reportError(
         new Error(
-          `Clip audio decode failed — export audio will be silent${audioDecodeFailureDetail(error, blob.type)}`,
+          `Clip audio decode failed — export audio will be silent${audioDecodeFailureDetail(error, mimeType)}`,
           { cause: error },
         ),
         'export-audio',
         {
-          mimeType: blob.type,
+          mimeType,
           cause: error instanceof Error ? `${error.name}: ${error.message}`.slice(0, 200) : String(error).slice(0, 200),
         },
       )

--- a/src/lib/export/shared.ts
+++ b/src/lib/export/shared.ts
@@ -1,4 +1,11 @@
-import { ALL_FORMATS, AudioBufferSink, BlobSource, Input } from 'mediabunny'
+import {
+  ALL_FORMATS,
+  AudioBufferSink,
+  BlobSource,
+  Input,
+  InputDisposedError,
+  UnsupportedInputFormatError,
+} from 'mediabunny'
 import { reportError } from '../error-reporting'
 import { isMediaElementFailure, MediaElementFailureError } from './media-error'
 
@@ -410,6 +417,11 @@ export function audioDecodeFailureDetail(error: unknown, mimeType: string): stri
  * WebCodecs AudioDecoder reject a blob that decodes on the next attempt —
  * without retries every failed decode becomes a silent export.
  */
+/** Permanent demux/lifecycle failures — retrying only burns ~3.7s per clip. */
+function isNonRetryableAudioDecodeError(error: unknown): boolean {
+  return error instanceof UnsupportedInputFormatError || error instanceof InputDisposedError
+}
+
 export async function decodeBlobAudio(blob: Blob, sampleRate: number): Promise<AudioBuffer | null> {
   let lastError: unknown
   for (let attempt = 0; attempt <= MEDIA_LOAD_RETRY_DELAYS_MS.length; attempt += 1) {
@@ -417,6 +429,7 @@ export async function decodeBlobAudio(blob: Blob, sampleRate: number): Promise<A
       return await decodeBlobAudioOnce(blob, sampleRate)
     } catch (error) {
       lastError = error
+      if (isNonRetryableAudioDecodeError(error)) break
       const delay = MEDIA_LOAD_RETRY_DELAYS_MS[attempt]
       if (delay === undefined) break
       await wait(delay)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes [KODY-VIDEO-P](https://kent-c-dodds-tech-llc.sentry.io/issues/7655426253/) — `Clip audio decode failed — export audio will be silent` on iOS Safari.

Seer’s RCA assumed a media-element `MEDIA_ERR_SRC_NOT_SUPPORTED` path, but clip audio already decodes via mediabunny/`AudioBufferSink`. The real gaps in that path:

1. **No retry** when WebCodecs audio decode throws (iOS has a small hardware decoder pool; `loadClipVideo` already backs off for the same class of race).
2. **`Input` never disposed**, so demuxer/decoder resources can accumulate across peak backfill, preview normalize, and export.
3. **Underlying cause swallowed** — Sentry only saw a generic message, so triage was blind.

## Changes

- Retry `decodeBlobAudio` with the same backoff as `loadClipVideo` (skip permanent `UnsupportedInputFormatError` / `InputDisposedError`).
- Always `input.dispose()` in a `finally`.
- Put mime + cause into the reported Error message (and `error.cause`); bound mime length.
- Reset the once-per-export failure flag at export start; retain it across WebCodecs→realtime fallback.
- Unit tests for detail helper, dispose-safe decode, fail-fast unsupported format, and failure-gate retention.

## Status

**Merged** as `570fcb79` · Sentry resolved inCommit · Cloudflare Pages success.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a1dc01a4-23d1-419e-b617-76ec53f853c8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a1dc01a4-23d1-419e-b617-76ec53f853c8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved audio decoding reliability by retrying temporary failures and stopping promptly on unsupported or invalid media.
  - Ensured decoded audio is safely combined, resampled, and cleaned up during processing.
  - Improved error reporting with clearer, concise details when audio decoding fails.
  - Preserved diagnostic information across clips while preventing repetitive failure reports.

- **Tests**
  - Expanded coverage for audio decoding, WAV generation, failure handling, media validation, and diagnostic reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->