### PR TITLE
Fix iOS black exports when preview canvas isn't ready (KODY-VIDEO-Q)

### DIFF
--- a/src/lib/export/encode-realtime.ts
+++ b/src/lib/export/encode-realtime.ts
@@ -1,4 +1,5 @@
 import { pickRecorderMimeType } from '../media'
+import { isIosBrowser } from '../platform'
 import { clipMusicVolume, clipSoundVolume, resolveAudioTrackPlayback } from '../types'
 import {
   FADE_IN_MS,
@@ -17,12 +18,13 @@ import {
   drawCover,
   drawWatermark,
   loadClipVideo,
+  noteEncodeCanvasKind,
   pickOutputSize,
   recordVideoLumaSample,
+  resolveEncodeCanvas,
   seekTo,
   tagExportError,
   wait,
-  waitForPreviewCanvas,
   type ExportResult,
 } from './shared'
 
@@ -67,25 +69,30 @@ export async function exportRealtime(
     }
   }
 
-  // Encode from the overlay's on-DOM canvas whenever possible: iOS Safari's
+  // Encode from an on-DOM canvas whenever possible: iOS Safari's
   // canvas.captureStream() delivers BLACK frames for canvases that aren't
-  // attached to the document (the preview looked fine — it was a different,
-  // visible canvas — while the detached encode canvas produced a black
-  // export). Rendering into the visible canvas fixes that and makes the
-  // preview show every frame. The overlay mounts a tick after the export
-  // starts, so wait briefly for it before falling back.
-  let canvas = await waitForPreviewCanvas(options.getPreviewCanvas)
-  const encodingIntoPreview = canvas !== null
-  if (!canvas) {
-    canvas = document.createElement('canvas')
-  }
+  // attached to the document (KODY-VIDEO-Q). Prefer the overlay preview; if
+  // it isn't mounted in time on iOS, attach a tiny host rather than a
+  // detached element. Chromium is fine with a detached fallback.
+  const ios = isIosBrowser()
+  const encodeCanvas = await resolveEncodeCanvas({
+    getPreviewCanvas: options.getPreviewCanvas,
+    preferPreview: true,
+    requireAttached: ios,
+  })
+  noteEncodeCanvasKind(encodeCanvas.kind)
+  const { canvas, encodingIntoPreview } = encodeCanvas
   canvas.width = width
   canvas.height = height
   const ctx = canvas.getContext('2d', { alpha: false })
-  if (!ctx) throw new Error('Canvas not available')
+  if (!ctx) {
+    encodeCanvas.release()
+    throw new Error('Canvas not available')
+  }
   ctx.fillStyle = '#000'
   ctx.fillRect(0, 0, width, height)
 
+  try {
   const canvasStream = canvas.captureStream(30)
   if (canvasStream.getVideoTracks().length === 0) {
     throw new Error('This browser cannot capture canvas video for export')
@@ -373,6 +380,9 @@ export async function exportRealtime(
     blob,
     mimeType: blob.type || 'video/webm',
     fileExtension: isMp4 ? 'mp4' : 'webm',
+  }
+  } finally {
+    encodeCanvas.release()
   }
 }
 

--- a/src/lib/export/encode-webcodecs.ts
+++ b/src/lib/export/encode-webcodecs.ts
@@ -47,9 +47,10 @@ import {
   loadClipVideo,
   tagExportError,
   pickOutputSize,
+  noteEncodeCanvasKind,
   recordVideoLumaSample,
+  resolveEncodeCanvas,
   seekTo,
-  waitForPreviewCanvas,
   type ExportResult,
 } from './shared'
 
@@ -141,61 +142,69 @@ export async function exportWithWebCodecs(
     throw new Error('No supported export codec')
   }
 
-  // iOS ONLY: encode into the on-DOM overlay canvas — WebKit has a history
-  // of treating detached canvases as black in capture paths (see the
-  // black-export saga). Everywhere else the encode canvas stays DETACHED:
-  // drawing every frame through a visible, compositor-synchronized canvas
-  // rate-limited a 9× export to a constant ~6× on Android. The preview gets
-  // throttled downscaled blits instead — it only shows what's processing.
-  let canvas = isIosBrowser() ? await waitForPreviewCanvas(getPreviewCanvas) : null
-  const encodingIntoPreview = canvas !== null
-  if (!canvas) {
-    canvas = document.createElement('canvas')
-  }
+  // iOS ONLY: encode into an on-DOM canvas — WebKit treats detached canvases
+  // as black in capture/encode paths (black-export saga / KODY-VIDEO-Q).
+  // Prefer the overlay preview; if it isn't mounted in time, attach a tiny
+  // host rather than falling back to a detached element. Everywhere else the
+  // encode canvas stays DETACHED: drawing every frame through a visible,
+  // compositor-synchronized canvas rate-limited a 9× export to ~6× on
+  // Android. The preview gets throttled downscaled blits instead.
+  const ios = isIosBrowser()
+  const encodeCanvas = await resolveEncodeCanvas({
+    getPreviewCanvas,
+    preferPreview: ios,
+    requireAttached: ios,
+  })
+  noteEncodeCanvasKind(encodeCanvas.kind)
+  const { canvas, encodingIntoPreview } = encodeCanvas
   canvas.width = width
   canvas.height = height
   const ctx = canvas.getContext('2d', { alpha: false })
-  if (!ctx) throw new Error('Canvas not available')
-
-  // Stream the mux to disk when OPFS is available: long exports are too
-  // big for an in-memory buffer (a half-hour project is ~1GB — the
-  // BufferTarget path OOM-killed the tab right at 100%).
-  const opfs = await createOpfsExportFile(choice.container)
-  const output = new Output({
-    format:
-      choice.container === 'mp4'
-        ? // Trailing moov so chapter/geotag injection can append udta
-          // without rewriting stco/co64. Exports are saved/shared, not
-          // streamed, so faststart matters little here.
-          new Mp4OutputFormat({ fastStart: false })
-        : new WebMOutputFormat(),
-    target: opfs ? new StreamTarget(opfs.writable, { chunked: true }) : new BufferTarget(),
-  })
-  const videoSource = new CanvasSource(canvas, {
-    codec: choice.videoCodec,
-    quality: new Quality({ bitrate: videoBitrateFor(width, height) }),
-    keyFrameInterval: KEYFRAME_INTERVAL_SEC,
-  })
-  output.addVideoTrack(videoSource, { frameRate: FPS })
-  const audioSource = new AudioBufferSource({
-    codec: choice.audioCodec,
-    quality: new Quality({ bitrate: AUDIO_BITRATE }),
-  })
-  output.addAudioTrack(audioSource)
-  await output.start()
-
-  const state: PumpState = {
-    lastVideoTsSec: -1,
-    nextFrameTsSec: 0,
-    outputOffsetSec: 0,
-    doneMs: 0,
-    frameCount: 0,
-    lastPreviewAtMs: 0,
+  if (!ctx) {
+    encodeCanvas.release()
+    throw new Error('Canvas not available')
   }
 
-  const clipsInPlan = plan.segments.map((s) => s.clip)
-  const multiDay = clipsSpanMultipleDays(clipsInPlan)
-  const chapters: Mp4Chapter[] = []
+  try {
+    // Stream the mux to disk when OPFS is available: long exports are too
+    // big for an in-memory buffer (a half-hour project is ~1GB — the
+    // BufferTarget path OOM-killed the tab right at 100%).
+    const opfs = await createOpfsExportFile(choice.container)
+    const output = new Output({
+      format:
+        choice.container === 'mp4'
+          ? // Trailing moov so chapter/geotag injection can append udta
+            // without rewriting stco/co64. Exports are saved/shared, not
+            // streamed, so faststart matters little here.
+            new Mp4OutputFormat({ fastStart: false })
+          : new WebMOutputFormat(),
+      target: opfs ? new StreamTarget(opfs.writable, { chunked: true }) : new BufferTarget(),
+    })
+    const videoSource = new CanvasSource(canvas, {
+      codec: choice.videoCodec,
+      quality: new Quality({ bitrate: videoBitrateFor(width, height) }),
+      keyFrameInterval: KEYFRAME_INTERVAL_SEC,
+    })
+    output.addVideoTrack(videoSource, { frameRate: FPS })
+    const audioSource = new AudioBufferSource({
+      codec: choice.audioCodec,
+      quality: new Quality({ bitrate: AUDIO_BITRATE }),
+    })
+    output.addAudioTrack(audioSource)
+    await output.start()
+
+    const state: PumpState = {
+      lastVideoTsSec: -1,
+      nextFrameTsSec: 0,
+      outputOffsetSec: 0,
+      doneMs: 0,
+      frameCount: 0,
+      lastPreviewAtMs: 0,
+    }
+
+    const clipsInPlan = plan.segments.map((s) => s.clip)
+    const multiDay = clipsSpanMultipleDays(clipsInPlan)
+    const chapters: Mp4Chapter[] = []
 
   // Background music: playlist tracks are decoded lazily (one at a time,
   // released as the timeline passes them) and BLENDED with each segment's
@@ -501,6 +510,9 @@ export async function exportWithWebCodecs(
     // Metadata injection returns a NEW in-memory blob; when it ran, the
     // on-disk file no longer matches what the user gets.
     opfsBacked: opfs !== null && blob === diskBlob,
+  }
+  } finally {
+    encodeCanvas.release()
   }
 }
 

--- a/src/lib/export/shared.test.ts
+++ b/src/lib/export/shared.test.ts
@@ -166,3 +166,61 @@ describe('decodeClipAudio', () => {
     expect(__isAudioDecodeFailureReportArmedForTests()).toBe(true)
   })
 })
+
+describe('waitForPreviewCanvas / resolveEncodeCanvas', () => {
+  it('returns a connected preview canvas once it mounts', async () => {
+    let preview: HTMLCanvasElement | null = null
+    const pending = waitForPreviewCanvas(() => preview, 500)
+    const canvas = document.createElement('canvas')
+    document.body.appendChild(canvas)
+    preview = canvas
+    await expect(pending).resolves.toBe(canvas)
+    canvas.remove()
+  })
+
+  it('times out when the preview never connects', async () => {
+    await expect(waitForPreviewCanvas(() => null, 80)).resolves.toBeNull()
+  })
+
+  it('prefers the connected preview canvas', async () => {
+    const preview = document.createElement('canvas')
+    document.body.appendChild(preview)
+    const resolved = await resolveEncodeCanvas({
+      getPreviewCanvas: () => preview,
+      preferPreview: true,
+      requireAttached: true,
+      previewTimeoutMs: 200,
+    })
+    expect(resolved.kind).toBe('preview')
+    expect(resolved.encodingIntoPreview).toBe(true)
+    expect(resolved.canvas).toBe(preview)
+    expect(resolved.canvas.isConnected).toBe(true)
+    resolved.release()
+    preview.remove()
+  })
+
+  it('attaches an on-DOM host when requireAttached and preview is missing', async () => {
+    const resolved = await resolveEncodeCanvas({
+      getPreviewCanvas: () => null,
+      preferPreview: true,
+      requireAttached: true,
+      previewTimeoutMs: 80,
+    })
+    expect(resolved.kind).toBe('attached-fallback')
+    expect(resolved.encodingIntoPreview).toBe(false)
+    expect(resolved.canvas.isConnected).toBe(true)
+    expect(document.body.contains(resolved.canvas)).toBe(true)
+    resolved.release()
+    expect(resolved.canvas.isConnected).toBe(false)
+  })
+
+  it('returns a detached canvas when attachment is not required', async () => {
+    const resolved = await resolveEncodeCanvas({
+      preferPreview: false,
+      requireAttached: false,
+    })
+    expect(resolved.kind).toBe('detached')
+    expect(resolved.canvas.isConnected).toBe(false)
+    resolved.release()
+  })
+})

--- a/src/lib/export/shared.test.ts
+++ b/src/lib/export/shared.test.ts
@@ -196,6 +196,8 @@ describe('waitForPreviewCanvas / resolveEncodeCanvas', () => {
     expect(resolved.canvas).toBe(preview)
     expect(resolved.canvas.isConnected).toBe(true)
     resolved.release()
+    // Caller-owned preview must survive release (only attached-fallback hosts detach).
+    expect(preview.isConnected).toBe(true)
     preview.remove()
   })
 

--- a/src/lib/export/shared.test.ts
+++ b/src/lib/export/shared.test.ts
@@ -10,6 +10,8 @@ import {
   decodeBlobAudio,
   decodeClipAudio,
   resetAudioDiagnostics,
+  resolveEncodeCanvas,
+  waitForPreviewCanvas,
 } from './shared'
 
 describe('classifyOutputAudioPeak', () => {

--- a/src/lib/export/shared.ts
+++ b/src/lib/export/shared.ts
@@ -368,12 +368,13 @@ export interface ResolvedEncodeCanvas {
   release: () => void
 }
 
-/** Tiny on-DOM host: WebKit needs isConnected; CSS size is irrelevant. */
+/** Tiny on-DOM host: WebKit needs isConnected; keep it in the paint path
+ * (off-screen 1×1) — opacity:0 / display:none can skip captureStream frames. */
 function createAttachedEncodeCanvas(): HTMLCanvasElement {
   const canvas = document.createElement('canvas')
   canvas.setAttribute('aria-hidden', 'true')
   canvas.style.cssText =
-    'position:fixed;left:0;top:0;width:1px;height:1px;opacity:0;pointer-events:none;'
+    'position:fixed;left:-9999px;top:0;width:1px;height:1px;pointer-events:none;'
   document.body.appendChild(canvas)
   return canvas
 }

--- a/src/lib/export/shared.ts
+++ b/src/lib/export/shared.ts
@@ -331,15 +331,19 @@ export function reportSilentExportAudio(context: Record<string, unknown>): void 
   )
 }
 
+/** How long engines poll for the export-overlay canvas before falling back. */
+export const PREVIEW_CANVAS_WAIT_MS = 1500
+
 /** The export overlay mounts just after the export starts — wait briefly.
  * Encoding into the on-DOM overlay canvas (instead of a detached one) is
  * load-bearing on Safari, which renders detached canvases as black in
  * captureStream and related paths. */
 export async function waitForPreviewCanvas(
   getPreviewCanvas: (() => HTMLCanvasElement | null) | undefined,
+  timeoutMs = PREVIEW_CANVAS_WAIT_MS,
 ): Promise<HTMLCanvasElement | null> {
   if (!getPreviewCanvas) return null
-  const deadline = performance.now() + 1500
+  const deadline = performance.now() + timeoutMs
   for (;;) {
     const canvas = getPreviewCanvas()
     if (canvas?.isConnected) return canvas
@@ -348,13 +352,92 @@ export async function waitForPreviewCanvas(
   }
 }
 
+/**
+ * Where the encode canvas came from. `detached` is fine on Chromium but
+ * black on iOS WebKit — engines must use `requireAttached` there so the
+ * fallback is an on-DOM host, never an orphan element (KODY-VIDEO-Q).
+ */
+export type EncodeCanvasKind = 'preview' | 'attached-fallback' | 'detached'
+
+export interface ResolvedEncodeCanvas {
+  canvas: HTMLCanvasElement
+  kind: EncodeCanvasKind
+  /** True when the encode canvas IS the visible preview (no blit needed). */
+  encodingIntoPreview: boolean
+  /** Remove an attached fallback host; no-op for preview/detached. */
+  release: () => void
+}
+
+/** Tiny on-DOM host: WebKit needs isConnected; CSS size is irrelevant. */
+function createAttachedEncodeCanvas(): HTMLCanvasElement {
+  const canvas = document.createElement('canvas')
+  canvas.setAttribute('aria-hidden', 'true')
+  canvas.style.cssText =
+    'position:fixed;left:0;top:0;width:1px;height:1px;opacity:0;pointer-events:none;'
+  document.body.appendChild(canvas)
+  return canvas
+}
+
+/**
+ * Pick the canvas the encoder draws into.
+ * - `preferPreview`: wait for the export overlay (live preview + Safari-safe).
+ * - `requireAttached`: never return a detached canvas (iOS WebKit).
+ */
+export async function resolveEncodeCanvas(options: {
+  getPreviewCanvas?: () => HTMLCanvasElement | null
+  preferPreview: boolean
+  requireAttached: boolean
+  previewTimeoutMs?: number
+}): Promise<ResolvedEncodeCanvas> {
+  if (options.preferPreview) {
+    const preview = await waitForPreviewCanvas(
+      options.getPreviewCanvas,
+      options.previewTimeoutMs,
+    )
+    if (preview) {
+      return {
+        canvas: preview,
+        kind: 'preview',
+        encodingIntoPreview: true,
+        release: () => undefined,
+      }
+    }
+  }
+
+  if (options.requireAttached) {
+    const canvas = createAttachedEncodeCanvas()
+    return {
+      canvas,
+      kind: 'attached-fallback',
+      encodingIntoPreview: false,
+      release: () => {
+        canvas.remove()
+      },
+    }
+  }
+
+  return {
+    canvas: document.createElement('canvas'),
+    kind: 'detached',
+    encodingIntoPreview: false,
+    release: () => undefined,
+  }
+}
+
 /** Video-side twin of the audio diagnostics: sampled encode-canvas luma.
  * A black exported video with no error is otherwise invisible remotely. */
 let videoLumaSamples: number[] = []
 let videoSampleCanvas: HTMLCanvasElement | null = null
+let encodeCanvasKind: EncodeCanvasKind | null = null
 
 export function resetVideoDiagnostics(): void {
   videoLumaSamples = []
+  encodeCanvasKind = null
+}
+
+/** Record which canvas path this export used (for black-frame triage). */
+export function noteEncodeCanvasKind(kind: EncodeCanvasKind): void {
+  encodeCanvasKind = kind
 }
 
 /** Downsample the encode canvas to 8×8 and record the frame's mean luma. */
@@ -388,6 +471,7 @@ export function reportBlackExportVideo(context: Record<string, unknown>): void {
     ...context,
     samples: videoLumaSamples.length,
     maxLuma: Number(maxLuma.toFixed(2)),
+    encodeCanvas: encodeCanvasKind,
   })
 }
 

--- a/src/pages/project-page.tsx
+++ b/src/pages/project-page.tsx
@@ -251,6 +251,12 @@ export function ProjectPage(handle: Handle<ProjectPageProps>) {
 
     void (async () => {
       try {
+        // Flush the exporting UI so ExportOverlay's canvas is connected before
+        // engines poll for it. A fire-and-forget update raced the wait on
+        // slow iOS and fell back to a detached (black) canvas (KODY-VIDEO-Q).
+        await handle.update()
+        if (exportRun !== runId) return
+
         // Unchanged project + a persisted last export = instant "ready":
         // missing the share sheet must never cost a re-encode. Retry
         // bypasses this (force) and always renders fresh.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sentry [KODY-VIDEO-Q](https://kent-c-dodds-tech-llc.sentry.io/issues/7655530890/): on iOS, export sampled frames were all near-black.

**Root cause:** When `waitForPreviewCanvas` timed out (overlay not connected within 1500ms), both encode engines fell back to `document.createElement('canvas')` — a detached canvas. WebKit encodes that path as black frames. The overlay mount was also raced via a fire-and-forget `handle.update()`.

**Fix:**
- Add `resolveEncodeCanvas`: prefer the overlay preview; on iOS (`requireAttached`) fall back to a tiny on-DOM host instead of a detached element.
- Await `handle.update()` after entering the exporting state so the overlay can mount before engines poll.
- Include `encodeCanvas` kind in the black-frame Sentry report for triage.

## Test plan

- [x] Unit tests for `waitForPreviewCanvas` / `resolveEncodeCanvas` (preview, attached-fallback, detached)
- [x] `npm run lint` / `npm run build`
- [x] `npx vitest run` (241 passed)
- [x] `node scripts/manual-smoke.mjs` (32/32 passed)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4f4ad881-431e-4c79-8c4c-23536587334e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4f4ad881-431e-4c79-8c4c-23536587334e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved video export reliability across iOS, WebKit, and other browsers.
  - Export now selects an appropriate preview or fallback canvas automatically.
  - Fixed issues involving disconnected preview canvases during export.
  - Ensured export resources are released after completion or setup failures.
  - Improved handling when export runs are replaced by newer attempts.

- **Diagnostics**
  - Added clearer export diagnostics identifying the canvas used during encoding.

- **Tests**
  - Added coverage for canvas selection, mounting, timeout, fallback, and cleanup scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->