### PR TITLE
Fall back to remux + decodeAudioData for iOS clip audio (KODY-VIDEO-R)

### DIFF
--- a/src/lib/export/shared.test.ts
+++ b/src/lib/export/shared.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest'
+import { makeTestClipBlob } from '../testing/make-test-clip'
 import {
   __isAudioDecodeFailureReportArmedForTests,
   AUDIO_PEAK_RETENTION_RATIO,
@@ -8,7 +9,10 @@ import {
   boundedAudioMimeType,
   classifyOutputAudioPeak,
   decodeBlobAudio,
+  decodeBlobAudioViaWebAudio,
   decodeClipAudio,
+  isWebKitAudioDecoderNotFoundError,
+  resampleAudioBuffer,
   resetAudioDiagnostics,
   resolveEncodeCanvas,
   waitForPreviewCanvas,
@@ -137,6 +141,61 @@ describe('decodeBlobAudio', () => {
     ).rejects.toThrow(/unsupported or unrecognizable/i)
     // Permanent format errors must not walk MEDIA_LOAD_RETRY_DELAYS_MS (~3.7s).
     expect(performance.now() - started).toBeLessThan(1000)
+  })
+})
+
+describe('isWebKitAudioDecoderNotFoundError', () => {
+  it('matches WebKit NotFoundError DOMExceptions and Error.name', () => {
+    expect(isWebKitAudioDecoderNotFoundError(new DOMException('The object can not be found here.', 'NotFoundError'))).toBe(
+      true,
+    )
+    const named = new Error('The object can not be found here.')
+    named.name = 'NotFoundError'
+    expect(isWebKitAudioDecoderNotFoundError(named)).toBe(true)
+    expect(isWebKitAudioDecoderNotFoundError(new Error('nope'))).toBe(false)
+    expect(isWebKitAudioDecoderNotFoundError(new DOMException('bad', 'EncodingError'))).toBe(false)
+  })
+})
+
+describe('resampleAudioBuffer', () => {
+  it('preserves content when the rate already matches', () => {
+    const source = new AudioBuffer({ length: 8, sampleRate: 48000, numberOfChannels: 1 })
+    source.getChannelData(0).set([0, 0.5, 1, 0.5, 0, -0.5, -1, -0.5])
+    expect(resampleAudioBuffer(source, 48000)).toBe(source)
+  })
+
+  it('resamples to the target rate without OfflineAudioContext', () => {
+    const source = new AudioBuffer({ length: 8, sampleRate: 8000, numberOfChannels: 1 })
+    source.getChannelData(0).fill(0.25)
+    const out = resampleAudioBuffer(source, 16000)
+    expect(out.sampleRate).toBe(16000)
+    expect(out.length).toBe(16)
+    expect(out.getChannelData(0)[0]).toBeCloseTo(0.25, 5)
+  })
+})
+
+describe('decodeBlobAudioViaWebAudio', () => {
+  it('decodes a WAV through remux/decodeAudioData', async () => {
+    const decoded = await decodeBlobAudioViaWebAudio(makeWavBlob(), 48000)
+    expect(decoded).not.toBeNull()
+    expect(decoded!.sampleRate).toBe(48000)
+    expect(decoded!.duration).toBeGreaterThan(0.2)
+    expect(decoded!.getChannelData(0).some((s) => Math.abs(s) > 0.1)).toBe(true)
+  })
+
+  it('decodes audio from a video container clip (KODY-VIDEO-R fallback)', async () => {
+    const clip = await makeTestClipBlob(400, 440)
+    const decoded = await decodeBlobAudioViaWebAudio(clip, 48000)
+    expect(decoded).not.toBeNull()
+    expect(decoded!.sampleRate).toBe(48000)
+    expect(decoded!.duration).toBeGreaterThan(0.2)
+    expect(decoded!.getChannelData(0).some((s) => Math.abs(s) > 0.05)).toBe(true)
+  })
+
+  it('returns null for garbage bytes', async () => {
+    await expect(
+      decodeBlobAudioViaWebAudio(new Blob(['not media'], { type: 'video/mp4' }), 48000),
+    ).resolves.toBeNull()
   })
 })
 

--- a/src/lib/export/shared.ts
+++ b/src/lib/export/shared.ts
@@ -2,8 +2,12 @@ import {
   ALL_FORMATS,
   AudioBufferSink,
   BlobSource,
+  BufferTarget,
+  Conversion,
   Input,
   InputDisposedError,
+  Mp4OutputFormat,
+  Output,
   UnsupportedInputFormatError,
 } from 'mediabunny'
 import { reportError } from '../error-reporting'
@@ -511,28 +515,144 @@ export function audioDecodeFailureDetail(error: unknown, mimeType: string): stri
   return text ? ` (${mime}; ${text})` : ` (${mime})`
 }
 
-/** Permanent demux/lifecycle failures — retrying only burns ~3.7s per clip. */
+/**
+ * Permanent demux/lifecycle failures — retrying only burns ~3.7s per clip.
+ * WebKit's WebCodecs AudioDecoder also throws NotFoundError for AAC-in-MP4
+ * even when `canDecode()` is true (KODY-VIDEO-R); that never recovers on
+ * retry, so fail over to the Web Audio remux path immediately.
+ */
 function isNonRetryableAudioDecodeError(error: unknown): boolean {
-  return error instanceof UnsupportedInputFormatError || error instanceof InputDisposedError
+  if (error instanceof UnsupportedInputFormatError || error instanceof InputDisposedError) {
+    return true
+  }
+  return isWebKitAudioDecoderNotFoundError(error)
+}
+
+/** WebKit DOMException from a dead WebCodecs AudioDecoder configure/decode. */
+export function isWebKitAudioDecoderNotFoundError(error: unknown): boolean {
+  if (typeof DOMException !== 'undefined' && error instanceof DOMException) {
+    return error.name === 'NotFoundError'
+  }
+  return error instanceof Error && error.name === 'NotFoundError'
+}
+
+/**
+ * Linear resample for export mixing. Avoids OfflineAudioContext — on iOS
+ * WebKit that API has thrown NotFoundError for otherwise-valid buffers, and
+ * mediabunny itself documents flaky OfflineAudioContext concatenation.
+ */
+export function resampleAudioBuffer(source: AudioBuffer, sampleRate: number): AudioBuffer {
+  if (source.sampleRate === sampleRate) return source
+  const ratio = sampleRate / source.sampleRate
+  const length = Math.max(1, Math.round(source.length * ratio))
+  const out = new AudioBuffer({
+    length,
+    sampleRate,
+    numberOfChannels: source.numberOfChannels,
+  })
+  for (let ch = 0; ch < source.numberOfChannels; ch += 1) {
+    const input = source.getChannelData(ch)
+    const output = out.getChannelData(ch)
+    if (input.length === 0) continue
+    for (let i = 0; i < length; i += 1) {
+      const srcPos = i / ratio
+      const i0 = Math.min(Math.floor(srcPos), input.length - 1)
+      const i1 = Math.min(i0 + 1, input.length - 1)
+      const t = srcPos - i0
+      output[i] = input[i0]! * (1 - t) + input[i1]! * t
+    }
+  }
+  return out
+}
+
+/**
+ * Remux the blob's audio track into an audio-only MP4 (bitstream copy when
+ * the codec is already AAC; otherwise mediabunny transcodes). Safari's
+ * `decodeAudioData` often refuses video/mp4 containers but accepts audio/mp4.
+ */
+async function remuxAudioOnlyMp4(blob: Blob): Promise<ArrayBuffer | null> {
+  const input = new Input({ source: new BlobSource(blob), formats: ALL_FORMATS })
+  try {
+    if (!(await input.getPrimaryAudioTrack())) return null
+    const target = new BufferTarget()
+    const output = new Output({
+      format: new Mp4OutputFormat({ fastStart: 'in-memory' }),
+      target,
+    })
+    const conversion = await Conversion.init({
+      input,
+      output,
+      video: { discard: true },
+      showWarnings: false,
+    })
+    if (!conversion.isValid) return null
+    await conversion.execute()
+    return target.buffer ?? null
+  } finally {
+    input.dispose()
+  }
+}
+
+async function decodeAudioDataBuffer(
+  bytes: ArrayBuffer,
+  sampleRate: number,
+): Promise<AudioBuffer> {
+  // OfflineAudioContext exposes decodeAudioData without needing a running
+  // (user-gesture) AudioContext — important for peak backfill on iOS.
+  const ctx = new OfflineAudioContext(1, 1, sampleRate)
+  const decoded = await ctx.decodeAudioData(bytes.slice(0))
+  return resampleAudioBuffer(decoded, sampleRate)
+}
+
+/**
+ * Web Audio fallback when WebCodecs AudioDecoder cannot produce samples.
+ * Remuxes to audio/mp4 first (iOS refuses many video/mp4 blobs), then tries
+ * the original bytes for browsers that can decode audio-from-video directly.
+ */
+export async function decodeBlobAudioViaWebAudio(
+  blob: Blob,
+  sampleRate: number,
+): Promise<AudioBuffer | null> {
+  try {
+    const remuxed = await remuxAudioOnlyMp4(blob)
+    if (remuxed && remuxed.byteLength > 0) {
+      try {
+        return await decodeAudioDataBuffer(remuxed, sampleRate)
+      } catch {
+        // Remuxed bytes rejected — try the source container below.
+      }
+    }
+  } catch {
+    // Remux itself can fail on exotic codecs; fall through.
+  }
+
+  try {
+    return await decodeAudioDataBuffer(await blob.arrayBuffer(), sampleRate)
+  } catch {
+    return null
+  }
 }
 
 /**
  * Decode a blob's audio track into one AudioBuffer at the requested sample
- * rate. Mediabunny demuxes and decodes (fragmented MP4, WebM/Opus, rotation
- * of containers — all one path); the result is resampled when the source
- * rate differs. Returns null when there is no decodable audio.
+ * rate. Primary path: mediabunny + WebCodecs AudioDecoder (fragmented MP4,
+ * WebM/Opus, …). Fallback: remux audio-only MP4 + `decodeAudioData` for iOS
+ * WebKit, where AudioDecoder reports support then throws NotFoundError
+ * (KODY-VIDEO-R) or `canDecode()` is false on older Safari.
  *
- * Retries on throw: iOS WebKit has a small pool of hardware decoder slots
- * (same race `loadClipVideo` already backs off for). A busy slot can make
- * WebCodecs AudioDecoder reject a blob that decodes on the next attempt —
- * without retries every failed decode becomes a silent export.
+ * Retries transient WebCodecs throws (decoder-slot races) before falling
+ * back. Permanent format errors skip both retries and the fallback.
  */
 
 export async function decodeBlobAudio(blob: Blob, sampleRate: number): Promise<AudioBuffer | null> {
   let lastError: unknown
   for (let attempt = 0; attempt <= MEDIA_LOAD_RETRY_DELAYS_MS.length; attempt += 1) {
     try {
-      return await decodeBlobAudioOnce(blob, sampleRate)
+      const decoded = await decodeBlobAudioOnce(blob, sampleRate)
+      if (decoded) return decoded
+      // No track / WebCodecs canDecode=false — still try the Web Audio path
+      // (older iOS Safari) before giving up on a silent export.
+      break
     } catch (error) {
       lastError = error
       if (isNonRetryableAudioDecodeError(error)) break
@@ -541,7 +661,23 @@ export async function decodeBlobAudio(blob: Blob, sampleRate: number): Promise<A
       await wait(delay)
     }
   }
-  throw lastError
+
+  if (
+    lastError instanceof UnsupportedInputFormatError ||
+    lastError instanceof InputDisposedError
+  ) {
+    throw lastError
+  }
+
+  try {
+    const fallback = await decodeBlobAudioViaWebAudio(blob, sampleRate)
+    if (fallback) return fallback
+  } catch {
+    // Prefer the WebCodecs error for Sentry triage when both paths fail.
+  }
+
+  if (lastError !== undefined) throw lastError
+  return null
 }
 
 async function decodeBlobAudioOnce(blob: Blob, sampleRate: number): Promise<AudioBuffer | null> {
@@ -586,15 +722,7 @@ async function decodeBlobAudioOnce(blob: Blob, sampleRate: number): Promise<Audi
       // running position and pull later in-range pieces past it via the snap.
       runningOffset = Math.min(offset + piece.buffer.length, merged.length)
     }
-    if (sourceRate === sampleRate) return merged
-
-    const length = Math.max(1, Math.ceil(merged.duration * sampleRate))
-    const offline = new OfflineAudioContext(channels, length, sampleRate)
-    const source = offline.createBufferSource()
-    source.buffer = merged
-    source.connect(offline.destination)
-    source.start()
-    return offline.startRendering()
+    return resampleAudioBuffer(merged, sampleRate)
   } finally {
     // Free demuxer + any WebCodecs AudioDecoder the sink still holds —
     // iOS in particular runs out of decoder slots when Inputs accumulate


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes [KODY-VIDEO-R](https://kent-c-dodds-tech-llc.sentry.io/issues/7655555909/) — `Clip audio decode failed — export audio will be silent` on iOS Safari with `NotFoundError: The object can not be found here.`

### Root cause (Seer was wrong)

Seer assumed `AudioContext.decodeAudioData()` on a `video/mp4` blob. That path is long gone — clip audio already goes through mediabunny’s WebCodecs `AudioBufferSink`. [KODY-VIDEO-P](https://github.com/kentcdodds/kody-video/pull/136) added retries + cause surfacing; this event is that cause:

- Production, iOS Safari, mime `video/mp4;codecs=avc1.640028,mp4a.40.2`
- WebKit’s WebCodecs `AudioDecoder` throws `NotFoundError` even when `canDecode()` is true
- Retries cannot recover; both export engines share `decodeClipAudio`

### Fix

1. After the WebCodecs path returns null or throws (except permanent demux errors), remux the audio track to **audio-only MP4** via mediabunny `Conversion` (bitstream copy for AAC) and decode with `decodeAudioData`.
2. Treat WebKit `NotFoundError` as non-retryable so we fail over quickly.
3. Resample with linear interpolation instead of `OfflineAudioContext`.

### Status

**Squash-merged** as `c9d4c79e` · Sentry resolved inCommit · Cloudflare Pages success.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7e29a55b-c6c8-4119-be8f-68f8de06fdb3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7e29a55b-c6c8-4119-be8f-68f8de06fdb3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved audio decoding reliability across browsers, including WebKit.
  - Added fallback handling for audio in video containers and recoverable decoding failures.
  - Added audio resampling support for consistent playback and processing.
  - Invalid or unsupported media now fails gracefully without unnecessary retries.

- **Tests**
  - Added coverage for browser-specific errors, resampling, WAV decoding, fallback decoding, and invalid media.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->