### PR TITLE
Filter lazy chunk import failures from Sentry (KODY-VIDEO-S)

### DIFF
--- a/src/lib/error-reporting.test.ts
+++ b/src/lib/error-reporting.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import {
   isBrowserExtensionHostObjectNoiseEvent,
+  isChunkLoadErrorEvent,
   isCloudflareInsightsBeaconEvent,
   isExpectedUserError,
   isMonitoringSelfTestEvent,
@@ -330,6 +331,64 @@ describe('isViteCssPreloadError', () => {
           values: [
             { type: 'Error', value: 'Unable to preload image for /assets/hero.webp' },
           ],
+        },
+      }),
+    ).toBe(false)
+  })
+})
+
+describe('isChunkLoadErrorEvent', () => {
+  it('drops Safari / WebKit module script import failures (KODY-VIDEO-S)', () => {
+    expect(
+      isChunkLoadErrorEvent({
+        exception: {
+          values: [
+            {
+              type: 'TypeError',
+              value: 'Importing a module script failed.',
+            },
+          ],
+        },
+      }),
+    ).toBe(true)
+  })
+
+  it('drops Chromium / Vite dynamic import failures (KODY-VIDEO-G)', () => {
+    expect(
+      isChunkLoadErrorEvent({
+        exception: {
+          values: [
+            {
+              type: 'TypeError',
+              value:
+                'Failed to fetch dynamically imported module: https://kody.video/assets/project-page-ZRp-szjZ.js',
+            },
+          ],
+        },
+      }),
+    ).toBe(true)
+  })
+
+  it('drops webpack-style and alternate dynamic-import wording', () => {
+    expect(
+      isChunkLoadErrorEvent({
+        exception: {
+          values: [{ type: 'Error', value: 'Loading chunk 5 failed' }],
+        },
+      }),
+    ).toBe(true)
+    expect(
+      isChunkLoadErrorEvent({
+        message: 'error loading dynamically imported module',
+      }),
+    ).toBe(true)
+  })
+
+  it('keeps ordinary application errors', () => {
+    expect(
+      isChunkLoadErrorEvent({
+        exception: {
+          values: [{ type: 'Error', value: 'Export failed: encoder closed' }],
         },
       }),
     ).toBe(false)

--- a/src/lib/error-reporting.ts
+++ b/src/lib/error-reporting.ts
@@ -144,6 +144,24 @@ export function isViteCssPreloadError(event: FilterableSentryEvent): boolean {
   )
 }
 
+/**
+ * Dynamic import() of a content-hashed route chunk failed (Chrome/Vite,
+ * webpack, Safari/WebKit). lazy-page already auto-reloads once after
+ * purging SW/cache; these are deploy-race / transient network noise, not
+ * app logic bugs (KODY-VIDEO-S, KODY-VIDEO-G). Keep in sync with
+ * `isChunkLoadError` in lazy-page.tsx.
+ */
+const CHUNK_LOAD_ERROR =
+  /Failed to fetch dynamically imported module|error loading dynamically imported module|Loading chunk [\w-]+ failed|Importing a module script failed/i
+
+export function isChunkLoadErrorEvent(event: FilterableSentryEvent): boolean {
+  const exceptionValues = event.exception?.values ?? []
+  for (const value of exceptionValues) {
+    if (CHUNK_LOAD_ERROR.test(value.value ?? '')) return true
+  }
+  return typeof event.message === 'string' && CHUNK_LOAD_ERROR.test(event.message)
+}
+
 /** Marker set while an export runs; still present at boot = the page died
  * mid-export (tab crash / out-of-memory kill — no JS error ever fires). */
 const EXPORT_MARKER_KEY = 'kodyVideo.exportInFlight'
@@ -261,6 +279,7 @@ function loadSentry(): Promise<SentryLike> | null {
         if (isProjectLimitEvent(event)) return null
         if (isBrowserExtensionHostObjectNoiseEvent(event)) return null
         if (isViteCssPreloadError(event)) return null
+        if (isChunkLoadErrorEvent(event)) return null
         return event
       },
     })


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sentry [KODY-VIDEO-S](https://kent-c-dodds-tech-llc.sentry.io/issues/7655580347/): `TypeError: Importing a module script failed.` on iOS Safari during lazy-page load (`step: lazy-page`).

**Root cause:** Dynamic `import()` of a content-hashed route chunk failed (deploy-race / stale chunk URL / transient network). `lazyPage` already matches this Safari signature and auto-reloads once after purging SW + Cache Storage — but `reportError` still opens a triage issue.

**Change (outcome: filtered):**
- Narrow `beforeSend` filter for the same chunk-load signatures as `isChunkLoadError` (Safari, Chromium/Vite, webpack)
- Sibling [KODY-VIDEO-G](https://kent-c-dodds-tech-llc.sentry.io/issues/7655139592/) (`Failed to fetch dynamically imported module…`) covered by the same filter

## Test plan

- [x] Unit tests for `isChunkLoadErrorEvent`
- [x] `npm run build`
- [x] `npx vitest run` (251 passed)
- [x] `node scripts/manual-smoke.mjs` (32/32)
- [x] CI green on PR and merge commit

## Risk

Low — wiring/filter only; no auth, billing, or storage changes. Recovery UX unchanged.

**Shipped:** squash-merged as `4c6a918`; Sentry S + G ignored.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dd91bebe-7734-42de-bdc8-7bba78c26ee7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dd91bebe-7734-42de-bdc8-7bba78c26ee7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

