### PR TITLE
Align comments with Kody Video Plus naming

### DIFF
--- a/functions/api/verify-purchase.ts
+++ b/functions/api/verify-purchase.ts
@@ -1,6 +1,6 @@
 /**
  * Cloudflare Pages Function: verify a Stripe Checkout session for the
- * "Remove Watermark" purchase. The only backend surface in the app — it
+ * Kody Video Plus purchase. The only backend surface in the app — it
  * never stores anything and never sees media; it just asks Stripe whether
  * the session really completed (including 100%-off promo checkouts).
  *

--- a/src/components/restore-sheet.tsx
+++ b/src/components/restore-sheet.tsx
@@ -9,7 +9,7 @@ interface RestoreSheetProps {
 }
 
 /**
- * Restore the "Remove Watermark" purchase on a new device: paste the link
+ * Restore the Kody Video Plus purchase on a new device: paste the link
  * from the Stripe receipt email (or the checkout session id) and re-verify.
  */
 export function RestoreSheet(handle: Handle<RestoreSheetProps>) {

--- a/src/lib/entitlement.ts
+++ b/src/lib/entitlement.ts
@@ -1,7 +1,7 @@
 import { getDb, getSettings } from './storage'
 import type { AppMeta } from './types'
 
-/** Stripe Payment Link for the one-time "Remove Watermark" unlock ($0.99). */
+/** Stripe Payment Link for the one-time Kody Video Plus unlock ($0.99). */
 export const REMOVE_WATERMARK_LINK = 'https://buy.stripe.com/00wfZi71ibU30rk9hU2Ry07'
 
 const SESSION_ID_PATTERN = /cs_(?:live|test)_[a-zA-Z0-9]+/

--- a/src/lib/project-actions.ts
+++ b/src/lib/project-actions.ts
@@ -50,7 +50,7 @@ export interface ProjectLoaderData {
   audio: ProjectAudioRecord | null
   canUndo: boolean
   onboardingDismissed: boolean
-  /** True when the one-time "Remove Watermark" purchase is unlocked. */
+  /** True when the one-time Kody Video Plus purchase is unlocked. */
   watermarkRemoved: boolean
   /**
    * Plus opt-in: keep the Kody mark on exports after purchase (default off).

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -183,7 +183,7 @@ export interface AppMeta {
   onboardingDismissed: boolean
   /** Home-page "Watch the tour" card dismissed (first-timer teaser). */
   tourCardDismissed?: boolean
-  /** One-time "Remove Watermark" purchase (verified via Stripe). */
+  /** One-time Kody Video Plus purchase (verified via Stripe). */
   watermarkRemoved?: boolean
   purchaseSessionId?: string | null
   /**


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Updates leftover “Remove Watermark” comments to say **Kody Video Plus**, matching the app UI, Stripe product/payment link, and Discord purchase alerts.
- No behavior change.

## Context
Stripe product + payment link and `@kentcdodds/stripe-alerts` Discord labels were renamed away from “remove watermark” to **Kody Video Plus** for consistency with the in-app name.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e583f1de-2669-424b-9ccb-74dd7243d27b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e583f1de-2669-424b-9ccb-74dd7243d27b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

