### PR TITLE
Hint users when export falls back to the realtime canvas path

### DIFF
--- a/src/components/export-overlay.tsx
+++ b/src/components/export-overlay.tsx
@@ -1,5 +1,5 @@
 import type { Handle } from 'remix/ui'
-import { ref } from 'remix/ui'
+import { on, ref } from 'remix/ui'
 
 interface ExportOverlayProps {
   projectName: string
@@ -10,6 +10,11 @@ interface ExportOverlayProps {
    * preview matches the final video.
    */
   watermarked: boolean
+  /**
+   * True once this run entered the realtime canvas + MediaRecorder path.
+   * Shows a dismissible compatibility notice (session-only; resets next export).
+   */
+  usedFallback: boolean
   /** Bound to the canvas the export engines mirror sampled frames onto. */
   bindPreviewCanvas: (canvas: HTMLCanvasElement | null) => void
 }
@@ -20,9 +25,12 @@ interface ExportOverlayProps {
  * being encoded above a big progress bar.
  */
 export function ExportOverlay(handle: Handle<ExportOverlayProps>) {
+  let fallbackNoticeDismissed = false
+
   return () => {
-    const { projectName, progress, watermarked } = handle.props
+    const { projectName, progress, watermarked, usedFallback } = handle.props
     const percent = Math.round(progress * 100)
+    const showFallbackNotice = usedFallback && !fallbackNoticeDismissed
     return (
       <div className="export-overlay" role="dialog" aria-label="Exporting video">
         <div className="export-overlay-stage">
@@ -35,6 +43,25 @@ export function ExportOverlay(handle: Handle<ExportOverlayProps>) {
           />
         </div>
         <div className="export-overlay-info">
+          {showFallbackNotice ? (
+            <div className="export-fallback-notice" role="status">
+              <p>
+                This device is using a compatibility export — slower and more limited than usual.
+                When it finishes, you can save a project backup and export on a computer for higher
+                quality.
+              </p>
+              <button
+                type="button"
+                className="link-button"
+                mix={on('click', () => {
+                  fallbackNoticeDismissed = true
+                  void handle.update()
+                })}
+              >
+                Dismiss
+              </button>
+            </div>
+          ) : null}
           <h2>Exporting your video…</h2>
           <p className="muted">
             {projectName} — keep the app open

--- a/src/components/export-sheet.tsx
+++ b/src/components/export-sheet.tsx
@@ -5,6 +5,9 @@ import { BrandMark } from './brand-mark'
 
 export type ExportStatus = 'exporting' | 'ready' | 'error'
 
+/** Same destination the About page credits — native hold-to-record on iPhone. */
+export const OK_VIDEO_URL = 'https://okvideo.app'
+
 interface ExportSheetProps {
   /** The exporting state renders as the full-screen ExportOverlay instead. */
   status: 'ready' | 'error'
@@ -21,12 +24,18 @@ interface ExportSheetProps {
   purchased: boolean
   /** Plus opt-in: keep stamping the mark on future exports. */
   keepWatermark: boolean
+  /**
+   * True when this run used the realtime canvas fallback. Shows a dismissible
+   * backup / try-elsewhere hint (session-only; resets on the next export).
+   */
+  usedFallback: boolean
   /** A share/save is in flight — dismissal would drop its result notice. */
   busy: boolean
   onKeepWatermarkChange: (keep: boolean) => void
   onShare: () => void
   onSave: () => void
   onSaveClips: () => void
+  onSaveBackup: () => void
   onRemoveWatermark: () => void
   onRestorePurchase: () => void
   onRetry: () => void
@@ -42,6 +51,8 @@ interface ExportSheetProps {
  */
 export function ExportSheet(handle: Handle<ExportSheetProps>) {
   const { props } = handle
+  let fallbackHintDismissed = false
+
   return () => {
     const {
       status,
@@ -53,17 +64,20 @@ export function ExportSheet(handle: Handle<ExportSheetProps>) {
       watermarked,
       purchased,
       keepWatermark,
+      usedFallback,
       busy,
       onKeepWatermarkChange,
       onShare,
       onSave,
       onSaveClips,
+      onSaveBackup,
       onRemoveWatermark,
       onRestorePurchase,
       onRetry,
       onReExport,
       onClose,
     } = props
+    const showFallbackHint = usedFallback && !fallbackHintDismissed
     return (
       <>
         <div
@@ -92,6 +106,16 @@ export function ExportSheet(handle: Handle<ExportSheetProps>) {
                 {formatFileInfo(fileExtension, fileSizeBytes)} — it stays on this device until you
                 share it.
               </p>
+              {showFallbackHint
+                ? fallbackHint({
+                    busy,
+                    onSaveBackup,
+                    onDismiss: () => {
+                      fallbackHintDismissed = true
+                      void handle.update()
+                    },
+                  })
+                : null}
               {notice ? <p className="sheet-message">{notice}</p> : null}
               <div className="sheet-actions">
                 {canShare ? (
@@ -193,6 +217,16 @@ export function ExportSheet(handle: Handle<ExportSheetProps>) {
             <>
               <h3>Export hit a snag</h3>
               <p className="sheet-message is-error">{error ?? 'Something went wrong.'}</p>
+              {showFallbackHint
+                ? fallbackHint({
+                    busy,
+                    onSaveBackup,
+                    onDismiss: () => {
+                      fallbackHintDismissed = true
+                      void handle.update()
+                    },
+                  })
+                : null}
               {notice ? <p className="sheet-message">{notice}</p> : null}
               <div className="sheet-actions">
                 <button
@@ -226,6 +260,42 @@ export function ExportSheet(handle: Handle<ExportSheetProps>) {
       </>
     )
   }
+}
+
+function fallbackHint(props: {
+  busy: boolean
+  onSaveBackup: () => void
+  onDismiss: () => void
+}) {
+  const { busy, onSaveBackup, onDismiss } = props
+  return (
+    <div className="export-fallback-hint" role="status">
+      <p>
+        This device used a compatibility export. For higher quality, save a project backup and
+        import it on a computer (Chrome works best) via About → Import a backup.
+      </p>
+      <div className="export-fallback-hint-actions">
+        <button
+          type="button"
+          className="btn btn-secondary"
+          disabled={busy}
+          mix={on('click', () => onSaveBackup())}
+        >
+          Save project backup
+        </button>
+        <button type="button" className="link-button" disabled={busy} mix={on('click', onDismiss)}>
+          Dismiss
+        </button>
+      </div>
+      <p className="export-fallback-okvideo muted">
+        On iPhone,{' '}
+        <a href={OK_VIDEO_URL} target="_blank" rel="noreferrer noopener">
+          OK Video
+        </a>{' '}
+        is a native alternative.
+      </p>
+    </div>
+  )
 }
 
 function formatFileInfo(ext: string | null, bytes: number | null): string {

--- a/src/lib/export/encode-realtime.ts
+++ b/src/lib/export/encode-realtime.ts
@@ -380,6 +380,7 @@ export async function exportRealtime(
     blob,
     mimeType: blob.type || 'video/webm',
     fileExtension: isMp4 ? 'mp4' : 'webm',
+    engine: 'realtime',
   }
   } finally {
     encodeCanvas.release()

--- a/src/lib/export/encode-webcodecs.ts
+++ b/src/lib/export/encode-webcodecs.ts
@@ -506,6 +506,7 @@ export async function exportWithWebCodecs(
     blob,
     mimeType,
     fileExtension: choice.container,
+    engine: 'webcodecs',
     opfsName: opfs?.name,
     // Metadata injection returns a NEW in-memory blob; when it ran, the
     // on-disk file no longer matches what the user gets.

--- a/src/lib/export/index.test.ts
+++ b/src/lib/export/index.test.ts
@@ -1,0 +1,88 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { ClipRecord } from '../types'
+
+vi.mock('./encode-realtime', () => ({
+  exportRealtime: vi.fn(async () => ({
+    blob: new Blob([new Uint8Array(2048)], { type: 'video/webm' }),
+    mimeType: 'video/webm',
+    fileExtension: 'webm' as const,
+    engine: 'realtime' as const,
+  })),
+}))
+
+vi.mock('./encode-webcodecs', () => ({
+  supportsWebCodecsExport: vi.fn(() => false),
+  exportWithWebCodecs: vi.fn(),
+}))
+
+import { exportRealtime } from './encode-realtime'
+import { exportWithWebCodecs, supportsWebCodecsExport } from './encode-webcodecs'
+import { exportProject } from './index'
+
+function clip(): ClipRecord {
+  return {
+    id: 'clip_fallback_test',
+    projectId: 'proj_fallback_test',
+    blob: new Blob([new Uint8Array(64)], { type: 'video/webm' }),
+    mimeType: 'video/webm',
+    durationMs: 400,
+    trimStartMs: 0,
+    trimEndMs: 400,
+    createdAt: Date.now(),
+    width: 320,
+    height: 568,
+  }
+}
+
+describe('exportProject fallback signaling', () => {
+  beforeEach(() => {
+    vi.mocked(supportsWebCodecsExport).mockReturnValue(false)
+    vi.mocked(exportWithWebCodecs).mockReset()
+    vi.mocked(exportRealtime).mockClear()
+  })
+
+  it('calls onFallback once when WebCodecs is unavailable', async () => {
+    const onFallback = vi.fn()
+    const result = await exportProject([clip()], {
+      watermark: false,
+      onFallback,
+    })
+    expect(onFallback).toHaveBeenCalledTimes(1)
+    expect(exportWithWebCodecs).not.toHaveBeenCalled()
+    expect(exportRealtime).toHaveBeenCalledTimes(1)
+    expect(result.engine).toBe('realtime')
+  })
+
+  it('calls onFallback after WebCodecs fails', async () => {
+    vi.mocked(supportsWebCodecsExport).mockReturnValue(true)
+    vi.mocked(exportWithWebCodecs).mockRejectedValue(new Error('encode boom'))
+    const onFallback = vi.fn()
+    const result = await exportProject([clip()], {
+      watermark: false,
+      onFallback,
+    })
+    expect(exportWithWebCodecs).toHaveBeenCalledTimes(1)
+    expect(onFallback).toHaveBeenCalledTimes(1)
+    expect(exportRealtime).toHaveBeenCalledTimes(1)
+    expect(result.engine).toBe('realtime')
+  })
+
+  it('does not call onFallback when WebCodecs succeeds', async () => {
+    vi.mocked(supportsWebCodecsExport).mockReturnValue(true)
+    vi.mocked(exportWithWebCodecs).mockResolvedValue({
+      blob: new Blob([new Uint8Array(2048)], { type: 'video/mp4' }),
+      mimeType: 'video/mp4',
+      fileExtension: 'mp4',
+      engine: 'webcodecs',
+    })
+    // Silence verification needs no audible input peak — leave diagnostics empty.
+    const onFallback = vi.fn()
+    const result = await exportProject([clip()], {
+      watermark: false,
+      onFallback,
+    })
+    expect(onFallback).not.toHaveBeenCalled()
+    expect(exportRealtime).not.toHaveBeenCalled()
+    expect(result.engine).toBe('webcodecs')
+  })
+})

--- a/src/lib/export/index.ts
+++ b/src/lib/export/index.ts
@@ -39,6 +39,12 @@ export interface ExportOptions {
   /** Background-music playlist mixed under the clips at their per-clip
    * volumes; tracks play one after the other until the film ends. */
   background?: BackgroundAudio | null
+  /**
+   * Fired once when the export enters the realtime canvas + MediaRecorder
+   * path (no WebCodecs, or WebCodecs failed). Lets the UI offer a backup /
+   * try-elsewhere hint without waiting for the finished file.
+   */
+  onFallback?: () => void
 }
 
 /**
@@ -105,6 +111,7 @@ async function runExport(
     }
   }
 
+  options.onFallback?.()
   const result = await exportRealtime(plan, {
     audioContext: options.audioContext,
     onProgress: options.onProgress,

--- a/src/lib/export/shared.ts
+++ b/src/lib/export/shared.ts
@@ -949,10 +949,14 @@ export function wait(ms: number): Promise<void> {
   })
 }
 
+export type ExportEngine = 'webcodecs' | 'realtime'
+
 export interface ExportResult {
   blob: Blob
   mimeType: string
   fileExtension: 'mp4' | 'webm'
+  /** Which stitcher produced this file. Omitted on recovered cache hits. */
+  engine?: ExportEngine
   /** Name of the OPFS exports-directory file this export streamed into. */
   opfsName?: string
   /** True when `blob` is exactly the bytes of the `opfsName` file (false

--- a/src/pages/project-page.tsx
+++ b/src/pages/project-page.tsx
@@ -22,12 +22,17 @@ import {
   isIosBrowser,
   projectFilename,
   shareFile,
+  shareOrDownload,
 } from '../lib/media'
 import { loadProjectPage, type ProjectLoaderData } from '../lib/project-actions'
+import { projectBackupFilename, serializeProject } from '../lib/project-transfer'
 import { createProject, setKeepWatermark, setOnboardingDismissed } from '../lib/storage'
-import { requestPersistentStorage } from '../lib/storage-space'
+import { formatBytes, requestPersistentStorage } from '../lib/storage-space'
 import { navigate } from '../router'
 import { NEW_PROJECT_ID, type ProjectId } from '../lib/types'
+
+/** Android share targets get flaky well below this; bigger backups download. */
+const SHARE_BACKUP_LIMIT_BYTES = 50 * 1024 * 1024
 
 /** Resolve after the next animation frame (or a short timeout when rAF is busy). */
 function waitForNextPaint(): Promise<void> {
@@ -57,6 +62,8 @@ interface ExportUiState {
   notice: string | null
   /** Whether THIS export was stamped (entitlement can change mid-sheet). */
   watermarked: boolean
+  /** True once this run entered the realtime canvas fallback. */
+  usedFallback: boolean
 }
 
 interface ProjectPageProps {
@@ -230,6 +237,7 @@ export function ProjectPage(handle: Handle<ProjectPageProps>) {
       error: null,
       notice: null,
       watermarked,
+      usedFallback: false,
     })
     // Long exports must survive the screen dimming: without a wake lock the
     // OS suspends the tab mid-export and the user returns to a restart.
@@ -271,6 +279,7 @@ export function ProjectPage(handle: Handle<ProjectPageProps>) {
               error: null,
               notice: 'Restored your last export — nothing changed since. Retry re-renders.',
               watermarked: recovered.watermarked,
+              usedFallback: false,
             })
             return
           }
@@ -312,6 +321,13 @@ export function ProjectPage(handle: Handle<ProjectPageProps>) {
                 }
               : undefined,
           getPreviewCanvas: () => previewCanvas,
+          onFallback: () => {
+            if (exportRun !== runId) return
+            if (exportState && exportState.status === 'exporting' && !exportState.usedFallback) {
+              exportState = { ...exportState, usedFallback: true }
+              void handle.update()
+            }
+          },
           onProgress: (ratio) => {
             if (exportRun !== runId) return
             if (exportState && exportState.status === 'exporting') {
@@ -338,6 +354,7 @@ export function ProjectPage(handle: Handle<ProjectPageProps>) {
           error: null,
           notice: null,
           watermarked,
+          usedFallback: result.engine === 'realtime' || (exportState?.usedFallback ?? false),
         })
       } catch (err) {
         // Report even when the run was abandoned (closed sheet / retry) —
@@ -363,6 +380,7 @@ export function ProjectPage(handle: Handle<ProjectPageProps>) {
           error: err instanceof Error ? err.message : 'Export failed.',
           notice: null,
           watermarked,
+          usedFallback: exportState?.usedFallback ?? false,
         })
       } finally {
         // The export ended in this session (success or error) — it did not die.
@@ -503,6 +521,7 @@ export function ProjectPage(handle: Handle<ProjectPageProps>) {
             projectName={project.name}
             progress={exportState?.progress ?? 0}
             watermarked={exportState?.watermarked === true}
+            usedFallback={exportState?.usedFallback === true}
             bindPreviewCanvas={bindPreviewCanvas}
           />
         ) : null}
@@ -513,6 +532,7 @@ export function ProjectPage(handle: Handle<ProjectPageProps>) {
             error={exportState.error}
             notice={exportState.notice}
             watermarked={exportState.watermarked}
+            usedFallback={exportState.usedFallback}
             purchased={data.watermarkRemoved}
             keepWatermark={data.keepWatermark}
             busy={exportActionCount > 0}
@@ -579,6 +599,41 @@ export function ProjectPage(handle: Handle<ProjectPageProps>) {
                   setExportNotice('Zipping failed — try again.')
                 })
                 .finally(endExportAction)
+            }}
+            onSaveBackup={() => {
+              beginExportAction()
+              setExportNotice('Building project backup… keep this open.')
+              void (async () => {
+                try {
+                  if (clips.length === 0) {
+                    throw new Error('Nothing to back up — this project has no clips.')
+                  }
+                  const backup = serializeProject(project, clips, data!.audio)
+                  const filename = projectBackupFilename(project.name)
+                  const sizeLabel = formatBytes(backup.size)
+                  if (backup.size > SHARE_BACKUP_LIMIT_BYTES) {
+                    await downloadBlob(backup, filename)
+                    setExportNotice(
+                      `Backup (${sizeLabel}) saved to your downloads — too large for the share sheet. ` +
+                        'Open kody.video → About → Import a backup to restore it.',
+                    )
+                  } else {
+                    const outcome = await shareOrDownload(backup, filename)
+                    if (outcome !== 'cancelled') {
+                      setExportNotice(
+                        `Backup (${sizeLabel}) saved. Open kody.video → About → Import a backup to restore it.`,
+                      )
+                    }
+                  }
+                } catch (err) {
+                  reportError(err, 'export-backup')
+                  setExportNotice(
+                    err instanceof Error ? err.message : 'Could not create the backup — try again.',
+                  )
+                } finally {
+                  endExportAction()
+                }
+              })()
             }}
             onRetry={() => startExport({ force: true })}
             onReExport={() => startExport({ force: true })}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -681,6 +681,51 @@ a {
   margin: 0;
 }
 
+.export-fallback-notice {
+  margin: 0 0 12px;
+  padding: 10px 12px;
+  text-align: left;
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  background: color-mix(in srgb, var(--panel-bg) 88%, var(--accent) 12%);
+}
+
+.export-fallback-notice p {
+  margin: 0 0 6px;
+  font-size: 0.92rem;
+  line-height: 1.4;
+  color: var(--ink);
+}
+
+.export-fallback-hint {
+  margin: 12px 0 0;
+  padding: 12px;
+  text-align: left;
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  background: color-mix(in srgb, var(--panel-bg) 88%, var(--accent) 12%);
+}
+
+.export-fallback-hint > p {
+  margin: 0;
+  font-size: 0.92rem;
+  line-height: 1.45;
+}
+
+.export-fallback-hint-actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 10px;
+  margin-top: 10px;
+}
+
+.export-fallback-okvideo {
+  margin: 10px 0 0;
+  font-size: 0.85rem;
+  line-height: 1.4;
+}
+
 /* Project preview playback (OK Video: tap edges to skip, middle to stop). */
 .playback-overlay {
   position: absolute;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

When export uses the realtime canvas + MediaRecorder fallback (no WebCodecs, or WebCodecs failed), tell the user what happened and give them a way out:

- **During export:** dismissible compatibility notice on the overlay (keep the app open; no backup I/O mid-encode)
- **On ready/error:** dismissible hint with **Save project backup**, steps to import on a computer (Chrome), and a light [OK Video](https://okvideo.app) mention for iPhone
- Dismissal is session-only — the hint shows again on every fallback export
- Cached “restored last export” hits do **not** show the hint

## Implementation

- `onFallback` callback on `exportProject` + `engine` on `ExportResult`
- Wire through `project-page` → overlay/sheet
- Unit tests for fallback signaling (mocked engines)

## Risk

**Medium** — user-facing export UX; needs Bugbot + green CI before merge.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-038f2dec-6b5d-48af-92f1-eddd906b494b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-038f2dec-6b5d-48af-92f1-eddd906b494b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

