### PR TITLE
Filter WebKit EmptyRanges media-controls Sentry noise (KODY-VIDEO-N)

### DIFF
--- a/src/lib/error-reporting.test.ts
+++ b/src/lib/error-reporting.test.ts
@@ -8,6 +8,7 @@ import {
   isProjectLimitEvent,
   isReportingHostname,
   isViteCssPreloadError,
+  isWebKitEmptyRangesNoiseEvent,
   reportComponentError,
   reportError,
 } from './error-reporting'
@@ -389,6 +390,64 @@ describe('isChunkLoadErrorEvent', () => {
       isChunkLoadErrorEvent({
         exception: {
           values: [{ type: 'Error', value: 'Export failed: encoder closed' }],
+        },
+      }),
+    ).toBe(false)
+  })
+})
+
+describe('isWebKitEmptyRangesNoiseEvent', () => {
+  it('drops Safari EmptyRanges ReferenceError from media controls (KODY-VIDEO-N)', () => {
+    expect(
+      isWebKitEmptyRangesNoiseEvent({
+        exception: {
+          values: [
+            {
+              type: 'ReferenceError',
+              value: "Can't find variable: EmptyRanges",
+              stacktrace: {
+                frames: [{ filename: 'undefined' }],
+              },
+            },
+          ],
+        },
+      }),
+    ).toBe(true)
+  })
+
+  it('drops the V8 wording of the same missing binding', () => {
+    expect(
+      isWebKitEmptyRangesNoiseEvent({
+        exception: {
+          values: [
+            {
+              type: 'ReferenceError',
+              value: 'EmptyRanges is not defined',
+            },
+          ],
+        },
+      }),
+    ).toBe(true)
+  })
+
+  it('drops when the signature appears only in message', () => {
+    expect(
+      isWebKitEmptyRangesNoiseEvent({
+        message: "Can't find variable: EmptyRanges",
+      }),
+    ).toBe(true)
+  })
+
+  it('keeps ordinary application ReferenceErrors', () => {
+    expect(
+      isWebKitEmptyRangesNoiseEvent({
+        exception: {
+          values: [
+            {
+              type: 'ReferenceError',
+              value: "Can't find variable: importProgress",
+            },
+          ],
         },
       }),
     ).toBe(false)

--- a/src/lib/error-reporting.ts
+++ b/src/lib/error-reporting.ts
@@ -162,6 +162,30 @@ export function isChunkLoadErrorEvent(event: FilterableSentryEvent): boolean {
   return typeof event.message === 'string' && CHUNK_LOAD_ERROR.test(event.message)
 }
 
+/**
+ * WebKit modern-media-controls bug: MediaController.NullMedia.buffered /
+ * played / seekable return an unqualified `EmptyRanges` (should be
+ * MediaController.EmptyRanges). Surfaces as an unhandled ReferenceError with
+ * a non-app stack (`filename: "undefined"`) when the media weak ref is
+ * collected — Safari/iOS only, not in Kody Video (KODY-VIDEO-N).
+ * Fixed upstream: https://bugs.webkit.org/show_bug.cgi?id=318284
+ */
+const WEBKIT_EMPTY_RANGES_REF =
+  /Can't find variable: EmptyRanges|EmptyRanges is not defined/
+
+export function isWebKitEmptyRangesNoiseEvent(
+  event: FilterableSentryEvent,
+): boolean {
+  const exceptionValues = event.exception?.values ?? []
+  for (const value of exceptionValues) {
+    if (WEBKIT_EMPTY_RANGES_REF.test(value.value ?? '')) return true
+  }
+  return (
+    typeof event.message === 'string' &&
+    WEBKIT_EMPTY_RANGES_REF.test(event.message)
+  )
+}
+
 /** Marker set while an export runs; still present at boot = the page died
  * mid-export (tab crash / out-of-memory kill — no JS error ever fires). */
 const EXPORT_MARKER_KEY = 'kodyVideo.exportInFlight'
@@ -280,6 +304,7 @@ function loadSentry(): Promise<SentryLike> | null {
         if (isBrowserExtensionHostObjectNoiseEvent(event)) return null
         if (isViteCssPreloadError(event)) return null
         if (isChunkLoadErrorEvent(event)) return null
+        if (isWebKitEmptyRangesNoiseEvent(event)) return null
         return event
       },
     })


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sentry [KODY-VIDEO-N](https://kent-c-dodds-tech-llc.sentry.io/issues/7655237965/) reports unhandled:

`ReferenceError: Can't find variable: EmptyRanges`

This is **not** Kody Video code (`EmptyRanges` does not appear in the repo). Events are Safari/iOS (sometimes tagged `app.browser: other` on iOS WebViews), stack filename `"undefined"` with `js_no_source`, and the global `onerror` mechanism — classic WebKit-internal JS.

Root cause is a WebKit modern-media-controls bug: `MediaController.NullMedia` getters for `buffered` / `played` / `seekable` return an unqualified `EmptyRanges` instead of `MediaController.EmptyRanges` once the media weak reference is collected ([webkit.org/b/318284](https://bugs.webkit.org/show_bug.cgi?id=318284), fixed upstream in WebKit). Until that ships in Safari, events keep arriving (17 so far).

## Change

- Narrow `beforeSend` filter in `src/lib/error-reporting.ts` matching only `Can't find variable: EmptyRanges` / `EmptyRanges is not defined`.
- Unit tests for drop/keep cases.

## Risk

Low — isolated Sentry filter; no product behavior change.

## Status

Squash-merged as `c43ff4e`. Main CI + Cloudflare Pages deploy green. Sentry issue marked ignored.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0d14d5b4-54cd-4868-88fe-395c4574f7e7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0d14d5b4-54cd-4868-88fe-395c4574f7e7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented Safari/WebKit browser noise related to `EmptyRanges` reference errors from appearing in error monitoring.
  * Continued reporting unrelated application reference errors as expected.
* **Tests**
  * Added coverage for Safari and V8 error formats, message-only errors, and unrelated reference errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->