### PR TITLE
Filter Safari/Chrome translator DOM NotFoundError noise (KODY-VIDEO-D)

### DIFF
--- a/src/lib/error-reporting.test.ts
+++ b/src/lib/error-reporting.test.ts
@@ -531,4 +531,49 @@ describe('isTranslatorDomMutationNoiseEvent', () => {
       }),
     ).toBe(false)
   })
+
+  it('does not pair type and message across chained exception values', () => {
+    expect(
+      isTranslatorDomMutationNoiseEvent({
+        exception: {
+          values: [
+            {
+              type: 'NotFoundError',
+              value: 'Requested device not found',
+            },
+            {
+              type: 'Error',
+              value:
+                "Failed to execute 'removeChild' on 'Node': The node to be removed is not a child of this node.",
+            },
+          ],
+        },
+      }),
+    ).toBe(false)
+  })
+
+  it('treats empty filename with real abs_path as a usable frame', () => {
+    expect(
+      isTranslatorDomMutationNoiseEvent({
+        exception: {
+          values: [
+            {
+              type: 'NotFoundError',
+              value: 'The object can not be found here.',
+              stacktrace: {
+                frames: [
+                  {
+                    filename: '',
+                    abs_path: 'https://kody.video/assets/index-abc123.js',
+                    function: 'trimClip',
+                    in_app: false,
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      }),
+    ).toBe(false)
+  })
 })

--- a/src/lib/error-reporting.test.ts
+++ b/src/lib/error-reporting.test.ts
@@ -7,6 +7,7 @@ import {
   isMonitoringSelfTestEvent,
   isProjectLimitEvent,
   isReportingHostname,
+  isTranslatorDomMutationNoiseEvent,
   isViteCssPreloadError,
   reportComponentError,
   reportError,
@@ -389,6 +390,143 @@ describe('isChunkLoadErrorEvent', () => {
       isChunkLoadErrorEvent({
         exception: {
           values: [{ type: 'Error', value: 'Export failed: encoder closed' }],
+        },
+      }),
+    ).toBe(false)
+  })
+})
+
+describe('isTranslatorDomMutationNoiseEvent', () => {
+  it('drops Chromium removeChild NotFoundError with mutation stack (KCD-S5 class)', () => {
+    expect(
+      isTranslatorDomMutationNoiseEvent({
+        exception: {
+          values: [
+            {
+              type: 'NotFoundError',
+              value:
+                "Failed to execute 'removeChild' on 'Node': The node to be removed is not a child of this node.",
+              stacktrace: {
+                frames: [
+                  {
+                    filename: '/assets/index-abc123.js',
+                    function: 'removeChild',
+                    in_app: false,
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      }),
+    ).toBe(true)
+  })
+
+  it('drops Safari Translate NotFoundError with empty stack (KODY-VIDEO-D)', () => {
+    expect(
+      isTranslatorDomMutationNoiseEvent({
+        exception: {
+          values: [
+            {
+              type: 'NotFoundError',
+              value: 'The object can not be found here.',
+            },
+          ],
+        },
+      }),
+    ).toBe(true)
+  })
+
+  it('drops Safari NotFoundError with native removeChild frame (KCD-ZE class)', () => {
+    expect(
+      isTranslatorDomMutationNoiseEvent({
+        exception: {
+          values: [
+            {
+              type: 'NotFoundError',
+              value: 'The object can not be found here.',
+              stacktrace: {
+                frames: [
+                  {
+                    filename: '[native code]',
+                    function: 'removeChild',
+                    in_app: false,
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      }),
+    ).toBe(true)
+  })
+
+  it('keeps intentional reportError captures tagged with step', () => {
+    expect(
+      isTranslatorDomMutationNoiseEvent({
+        tags: { step: 'export-audio' },
+        exception: {
+          values: [
+            {
+              type: 'NotFoundError',
+              value: 'The object can not be found here.',
+            },
+          ],
+        },
+      }),
+    ).toBe(false)
+  })
+
+  it('keeps in-app DOM bugs that happen to share the message', () => {
+    expect(
+      isTranslatorDomMutationNoiseEvent({
+        exception: {
+          values: [
+            {
+              type: 'NotFoundError',
+              value:
+                "Failed to execute 'removeChild' on 'Node': The node to be removed is not a child of this node.",
+              stacktrace: {
+                frames: [
+                  {
+                    filename: '/assets/project-page-abc.js',
+                    function: 'trimClip',
+                    in_app: true,
+                  },
+                  {
+                    filename: '[native code]',
+                    function: 'removeChild',
+                    in_app: false,
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      }),
+    ).toBe(false)
+  })
+
+  it('keeps ordinary application errors', () => {
+    expect(
+      isTranslatorDomMutationNoiseEvent({
+        exception: {
+          values: [{ type: 'Error', value: 'Export failed: encoder closed' }],
+        },
+      }),
+    ).toBe(false)
+  })
+
+  it('keeps unrelated NotFoundError wording', () => {
+    expect(
+      isTranslatorDomMutationNoiseEvent({
+        exception: {
+          values: [
+            {
+              type: 'NotFoundError',
+              value: 'Requested device not found',
+            },
+          ],
         },
       }),
     ).toBe(false)

--- a/src/lib/error-reporting.ts
+++ b/src/lib/error-reporting.ts
@@ -32,6 +32,8 @@ const CLOUDFLARE_INSIGHTS_BEACON_URL_MARKER =
 type FilterableStackFrame = {
   filename?: string
   abs_path?: string
+  function?: string
+  in_app?: boolean
 }
 
 type FilterableSentryEvent = {
@@ -43,6 +45,7 @@ type FilterableSentryEvent = {
     }>
   }
   message?: string
+  tags?: Record<string, unknown>
 }
 
 type SentryLike = {
@@ -160,6 +163,84 @@ export function isChunkLoadErrorEvent(event: FilterableSentryEvent): boolean {
     if (CHUNK_LOAD_ERROR.test(value.value ?? '')) return true
   }
   return typeof event.message === 'string' && CHUNK_LOAD_ERROR.test(event.message)
+}
+
+/**
+ * Chrome / Chromium Google Translate (and Safari Translate) reparent text
+ * nodes so the framework's next removeChild/insertBefore throws NotFoundError.
+ * Safari uses the short DOMException message; Chromium names the method.
+ * Same class as KCD-S5 / KCD-XQ / KCD-ZE on kentcdodds.com (KODY-VIDEO-D).
+ *
+ * Remix 3 is not React — do not require a react-dom frame. Keep events that
+ * have in-app frames or a `step` tag (intentional reportError captures such
+ * as WebKit AudioDecoder NotFoundError during export).
+ */
+const TRANSLATOR_DOM_MUTATION_MESSAGE =
+  /Failed to execute '(?:removeChild|insertBefore)' on 'Node': The node (?:to be removed|before which the new node is to be inserted) is not a child of this node\.|The object can not be found here\./i
+
+const DOM_MUTATION_STACK = /removeChild|insertBefore|commitDeletion|commitMutation/i
+
+function eventExceptionMessages(event: FilterableSentryEvent): string[] {
+  const messages = (event.exception?.values ?? [])
+    .map((value) => value.value ?? '')
+    .filter(Boolean)
+  if (typeof event.message === 'string' && event.message) {
+    messages.push(event.message)
+  }
+  return messages
+}
+
+function exceptionFrames(event: FilterableSentryEvent): FilterableStackFrame[] {
+  return (event.exception?.values ?? []).flatMap(
+    (value) => value.stacktrace?.frames ?? [],
+  )
+}
+
+function hasOnlyUnusableStackFrames(event: FilterableSentryEvent): boolean {
+  const frames = exceptionFrames(event)
+  if (frames.length === 0) return true
+  return frames.every((frame) => {
+    const filename = frame.filename ?? frame.abs_path
+    return (
+      filename == null ||
+      filename === '' ||
+      filename === 'undefined' ||
+      filename === 'null'
+    )
+  })
+}
+
+export function isTranslatorDomMutationNoiseEvent(
+  event: FilterableSentryEvent,
+): boolean {
+  // Intentional app captures (export AudioDecoder failover, etc.) keep reporting.
+  if (event.tags?.step != null && event.tags.step !== '') return false
+
+  const exceptionValues = event.exception?.values ?? []
+  const messageMatches = eventExceptionMessages(event).some((message) =>
+    TRANSLATOR_DOM_MUTATION_MESSAGE.test(message),
+  )
+  if (!messageMatches) return false
+
+  const namedNotFound = exceptionValues.some(
+    (value) => value.type === 'NotFoundError' || value.type === 'DOMException',
+  )
+  // Message-only events without a typed exception are too ambiguous.
+  if (!namedNotFound && exceptionValues.length > 0) return false
+  if (exceptionValues.length === 0) return false
+
+  const frames = exceptionFrames(event)
+  if (frames.some((frame) => frame.in_app === true)) return false
+
+  const frameBlob = frames
+    .map((frame) => `${frameUrl(frame)} ${frame.function ?? ''}`)
+    .join('\n')
+  if (DOM_MUTATION_STACK.test(frameBlob)) return true
+
+  // Safari often delivers this DOMException as an unhandledrejection with no
+  // usable stack (KODY-VIDEO-D). Chromium's removeChild wording is distinctive
+  // enough to drop on empty frames too; both still require NotFoundError above.
+  return hasOnlyUnusableStackFrames(event)
 }
 
 /** Marker set while an export runs; still present at boot = the page died
@@ -280,6 +361,7 @@ function loadSentry(): Promise<SentryLike> | null {
         if (isBrowserExtensionHostObjectNoiseEvent(event)) return null
         if (isViteCssPreloadError(event)) return null
         if (isChunkLoadErrorEvent(event)) return null
+        if (isTranslatorDomMutationNoiseEvent(event)) return null
         return event
       },
     })

--- a/src/lib/error-reporting.ts
+++ b/src/lib/error-reporting.ts
@@ -170,6 +170,7 @@ export function isChunkLoadErrorEvent(event: FilterableSentryEvent): boolean {
  * nodes so the framework's next removeChild/insertBefore throws NotFoundError.
  * Safari uses the short DOMException message; Chromium names the method.
  * Same class as KCD-S5 / KCD-XQ / KCD-ZE on kentcdodds.com (KODY-VIDEO-D).
+ * See also facebook/react#11538.
  *
  * Remix 3 is not React — do not require a react-dom frame. Keep events that
  * have in-app frames or a `step` tag (intentional reportError captures such

--- a/src/lib/error-reporting.ts
+++ b/src/lib/error-reporting.ts
@@ -180,14 +180,8 @@ const TRANSLATOR_DOM_MUTATION_MESSAGE =
 
 const DOM_MUTATION_STACK = /removeChild|insertBefore|commitDeletion|commitMutation/i
 
-function eventExceptionMessages(event: FilterableSentryEvent): string[] {
-  const messages = (event.exception?.values ?? [])
-    .map((value) => value.value ?? '')
-    .filter(Boolean)
-  if (typeof event.message === 'string' && event.message) {
-    messages.push(event.message)
-  }
-  return messages
+function isUnusableFramePath(path: string): boolean {
+  return path === '' || path === 'undefined' || path === 'null'
 }
 
 function exceptionFrames(event: FilterableSentryEvent): FilterableStackFrame[] {
@@ -199,15 +193,18 @@ function exceptionFrames(event: FilterableSentryEvent): FilterableStackFrame[] {
 function hasOnlyUnusableStackFrames(event: FilterableSentryEvent): boolean {
   const frames = exceptionFrames(event)
   if (frames.length === 0) return true
-  return frames.every((frame) => {
-    const filename = frame.filename ?? frame.abs_path
-    return (
-      filename == null ||
-      filename === '' ||
-      filename === 'undefined' ||
-      filename === 'null'
-    )
-  })
+  // Prefer frameUrl so empty filename still falls through to abs_path.
+  return frames.every((frame) => isUnusableFramePath(frameUrl(frame)))
+}
+
+function isTranslatorTypedMessage(
+  value: NonNullable<
+    NonNullable<FilterableSentryEvent['exception']>['values']
+  >[number],
+): boolean {
+  const typed =
+    value.type === 'NotFoundError' || value.type === 'DOMException'
+  return typed && TRANSLATOR_DOM_MUTATION_MESSAGE.test(value.value ?? '')
 }
 
 export function isTranslatorDomMutationNoiseEvent(
@@ -217,17 +214,9 @@ export function isTranslatorDomMutationNoiseEvent(
   if (event.tags?.step != null && event.tags.step !== '') return false
 
   const exceptionValues = event.exception?.values ?? []
-  const messageMatches = eventExceptionMessages(event).some((message) =>
-    TRANSLATOR_DOM_MUTATION_MESSAGE.test(message),
-  )
-  if (!messageMatches) return false
-
-  const namedNotFound = exceptionValues.some(
-    (value) => value.type === 'NotFoundError' || value.type === 'DOMException',
-  )
-  // Message-only events without a typed exception are too ambiguous.
-  if (!namedNotFound && exceptionValues.length > 0) return false
-  if (exceptionValues.length === 0) return false
+  // Type + translator message must land on the same exception value so a
+  // chained capture cannot pair an unrelated NotFoundError with a DOM message.
+  if (!exceptionValues.some(isTranslatorTypedMessage)) return false
 
   const frames = exceptionFrames(event)
   if (frames.some((frame) => frame.in_app === true)) return false


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sentry [KODY-VIDEO-D](https://kent-c-dodds-tech-llc.sentry.io/issues/7654565346/) reports unhandled:

`NotFoundError: The object can not be found here.`

Event evidence: iOS Safari, `DOMException.code: 8`, Finnish locale (`fi-FI`), empty stack, `onunhandledrejection`. Same signature as ignored KCD-ZE / KCD-S5 / KCD-XQ on kentcdodds.com — browser page-translate (Safari Translate / Chrome Google Translate) reparents DOM text nodes so the framework’s next `removeChild`/`insertBefore` throws.

Not a Kody Video logic bug, and not reasonably fixable in-app (external DOM mutation). Remix 3 is not React, so the filter does **not** require a `react-dom` frame.

## Change

- Narrow `beforeSend` filter `isTranslatorDomMutationNoiseEvent` matching Chromium `removeChild`/`insertBefore` wording or Safari’s short NotFoundError message.
- Drop only when the same exception value is typed `NotFoundError`/`DOMException`, has no `in_app` frames, and either mutation-stack evidence or unusable/empty frames.
- Keep events with a `step` tag (intentional `reportError` captures such as export AudioDecoder).
- Unit tests for drop/keep cases (including chained-exception and empty-`filename`+`abs_path` cases from review).

## Risk

Low — isolated Sentry filter; no product behavior change.

## Outcome

**Merged** as `7debe8ba`. KODY-VIDEO-D marked **ignored** in Sentry (filter stops new events).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e38c0893-8538-46b3-a156-0fc35d4823b4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e38c0893-8538-46b3-a156-0fc35d4823b4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Reduced error-reporting noise from known Google Translate and Safari Translate DOM mutation errors.
  - Preserved intentionally tagged error reports, application-related DOM issues, ordinary errors, and unrelated not-found errors.
- **Tests**
  - Added coverage for translator-related error filtering and cases that must continue to be reported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->