### PR TITLE
Support drag-and-drop of .kodyvideo backups

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,8 @@ For a phone on the same network, use your machine’s LAN URL over HTTPS, or tun
 - Project **backup/import**: one `.kodyvideo` file per project (clips, trims,
   location data, background music + volumes) — a safety net, and the way to
   move a project between devices or browser origins (storage is per-origin);
-  ⋯ → Save backup on a slot, import from the About page
+  ⋯ → Save backup on a slot, import from the About page or by dropping a
+  `.kodyvideo` file anywhere in the app
 - Installable PWA (manifest + Workbox service worker for the app shell)
 - **No accounts, no uploads, no analytics**
 

--- a/manual-test-checklist.md
+++ b/manual-test-checklist.md
@@ -41,9 +41,9 @@ npm test           # unit tests
   device** during record/export/save/zip
 - **Projects**: slots show poster art; rename via the options sheet; delete
   uses the styled confirm (no browser dialog) and frees stored clips; backup
-  downloads a `.kodyvideo` file and import (About → Import a backup) restores
-  it; import at the plan limit is refused with a clear message; slot order is
-  stable
+  downloads a `.kodyvideo` file and import (About → Import a backup, or drop
+  the file anywhere in the app) restores it; import at the plan limit is
+  refused with a clear message; slot order is stable
 - **Storage**: the footer storage gauge opens a "X of Y used" popover on
   tap; ≥80% shows the amber banner, ≥92%
   turns critical; the banner offers one-tap "Clear cached exports"; the boot

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -1,6 +1,7 @@
 import type { Handle } from 'remix/ui'
 import { on } from 'remix/ui'
 import { registerSW } from 'virtual:pwa-register'
+import { BackupDropOverlay } from './components/backup-drop-overlay'
 import { lazyPage } from './components/lazy-page'
 import { registerUpdateHandles } from './lib/app-update'
 import { Router } from './router'
@@ -53,6 +54,7 @@ export function App(handle: Handle) {
           '/terms': () => <TermsPage />,
         }}
       />
+      <BackupDropOverlay />
       {needRefresh ? (
         <div className="update-toast" role="status">
           <span>

--- a/src/components/backup-drop-overlay.tsx
+++ b/src/components/backup-drop-overlay.tsx
@@ -1,0 +1,128 @@
+import type { Handle } from 'remix/ui'
+import { on } from 'remix/ui'
+import { reportError } from '../lib/error-reporting'
+import {
+  BackupFormatError,
+  dataTransferHasFiles,
+  importKodyVideoBackupFile,
+  kodyVideoBackupFilesFromList,
+} from '../lib/project-transfer'
+import { navigate } from '../router'
+
+/**
+ * App-wide drop target for `.kodyvideo` backups. OS file drags never expose
+ * names until drop, so we highlight whenever files are dragged in and only
+ * import a matching backup. Other file types are ignored.
+ */
+export function BackupDropOverlay(handle: Handle) {
+  let dragDepth = 0
+  let hovering = false
+  let importing = false
+  let progress: string | null = null
+  let error: string | null = null
+
+  const setHovering = (next: boolean) => {
+    if (hovering === next) return
+    hovering = next
+    void handle.update()
+  }
+
+  const resetDrag = () => {
+    dragDepth = 0
+    setHovering(false)
+  }
+
+  const importBackup = (file: File) => {
+    if (importing) return
+    void (async () => {
+      importing = true
+      error = null
+      progress = 'Reading backup…'
+      void handle.update()
+      try {
+        const project = await importKodyVideoBackupFile(file, (done, total) => {
+          progress = `Importing clip ${Math.min(done + 1, total)} of ${total}…`
+          void handle.update()
+        })
+        navigate(`/project/${project.id}`)
+      } catch (err) {
+        if (!(err instanceof BackupFormatError)) reportError(err, 'import-drop')
+        error = err instanceof Error ? err.message : 'Could not import that file'
+      } finally {
+        progress = null
+        importing = false
+        void handle.update()
+      }
+    })()
+  }
+
+  const onDragEnter = (event: DragEvent) => {
+    if (!dataTransferHasFiles(event.dataTransfer)) return
+    event.preventDefault()
+    dragDepth += 1
+    setHovering(true)
+  }
+
+  const onDragOver = (event: DragEvent) => {
+    if (!dataTransferHasFiles(event.dataTransfer)) return
+    event.preventDefault()
+    if (event.dataTransfer) event.dataTransfer.dropEffect = 'copy'
+    setHovering(true)
+  }
+
+  const onDragLeave = (event: DragEvent) => {
+    if (!dataTransferHasFiles(event.dataTransfer)) return
+    dragDepth = Math.max(0, dragDepth - 1)
+    if (dragDepth === 0) setHovering(false)
+  }
+
+  const onDrop = (event: DragEvent) => {
+    if (!dataTransferHasFiles(event.dataTransfer)) return
+    event.preventDefault()
+    resetDrag()
+    const file = kodyVideoBackupFilesFromList(event.dataTransfer?.files)[0]
+    if (!file) return
+    importBackup(file)
+  }
+
+  window.addEventListener('dragenter', onDragEnter, { signal: handle.signal })
+  window.addEventListener('dragover', onDragOver, { signal: handle.signal })
+  window.addEventListener('dragleave', onDragLeave, { signal: handle.signal })
+  window.addEventListener('drop', onDrop, { signal: handle.signal })
+
+  return () => (
+    <>
+      {hovering && !importing ? (
+        <div className="backup-drop-overlay" role="status" aria-live="polite">
+          <strong>Drop to import</strong>
+          <p>
+            Restore a <code>.kodyvideo</code> backup as a new project.
+          </p>
+        </div>
+      ) : null}
+      {importing && progress ? (
+        <div className="backup-drop-overlay is-importing" role="status" aria-live="polite">
+          <strong>Importing backup</strong>
+          <p>
+            {progress} Keep this tab open.
+          </p>
+        </div>
+      ) : null}
+      {error && !importing ? (
+        <div className="backup-drop-error" role="alert">
+          <span>{error}</span>
+          <button
+            type="button"
+            className="link-button"
+            mix={on('click', () => {
+              error = null
+              void handle.update()
+            })}
+          >
+            Dismiss
+          </button>
+        </div>
+      ) : null}
+    </>
+  )
+}

--- a/src/lib/project-transfer.test.ts
+++ b/src/lib/project-transfer.test.ts
@@ -1,7 +1,11 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 import {
   BackupFormatError,
+  dataTransferHasFiles,
+  importKodyVideoBackupFile,
   importProjectBackup,
+  isKodyVideoBackupFile,
+  kodyVideoBackupFilesFromList,
   parseProjectBackup,
   projectBackupFilename,
   serializeProject,
@@ -272,5 +276,35 @@ describe('project backup round trip', () => {
   it('builds a sensible filename', () => {
     expect(projectBackupFilename('Röad Trip!!')).toBe('r-ad-trip.kodyvideo')
     expect(projectBackupFilename('   ')).toBe('project.kodyvideo')
+  })
+
+  it('recognizes dropped .kodyvideo files by extension', () => {
+    expect(isKodyVideoBackupFile({ name: 'road-trip.kodyvideo' })).toBe(true)
+    expect(isKodyVideoBackupFile({ name: 'Road-Trip.KODYVIDEO' })).toBe(true)
+    expect(isKodyVideoBackupFile({ name: 'clip.mp4' })).toBe(false)
+    expect(isKodyVideoBackupFile({ name: 'notes.kodyvideo.bak' })).toBe(false)
+    expect(
+      kodyVideoBackupFilesFromList([
+        new File(['a'], 'trip.kodyvideo'),
+        new File(['b'], 'clip.mp4', { type: 'video/mp4' }),
+        new File(['c'], 'Second.KodyVideo'),
+      ]).map((file) => file.name),
+    ).toEqual(['trip.kodyvideo', 'Second.KodyVideo'])
+    expect(kodyVideoBackupFilesFromList(null)).toEqual([])
+    expect(dataTransferHasFiles({ types: ['Files'] } as unknown as DataTransfer)).toBe(true)
+    expect(dataTransferHasFiles({ types: ['text/uri-list'] } as unknown as DataTransfer)).toBe(
+      false,
+    )
+    expect(dataTransferHasFiles(null)).toBe(false)
+  })
+
+  it('imports a backup file through the shared picker/drop helper', async () => {
+    const backup = serializeProject(fakeProject('Dropped'), [fakeClip('clip_a', 'MEDIA')])
+    const file = new File([backup], 'dropped.kodyvideo', { type: 'application/octet-stream' })
+    const project = await importKodyVideoBackupFile(file)
+    const clips = await getClipsForProject(project.id)
+    expect(project.name).toBe('Dropped')
+    expect(clips).toHaveLength(1)
+    expect(await clips[0]!.blob.text()).toBe('MEDIA')
   })
 })

--- a/src/lib/project-transfer.test.ts
+++ b/src/lib/project-transfer.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 import {
+  __resetProjectTransferForTests,
   BackupFormatError,
   dataTransferHasFiles,
   importKodyVideoBackupFile,
@@ -10,7 +11,13 @@ import {
   projectBackupFilename,
   serializeProject,
 } from './project-transfer'
-import { __resetDbForTests, getClipsForProject, getProjectAudio, listProjects } from './storage'
+import {
+  __resetDbForTests,
+  getClipsForProject,
+  getProjectAudio,
+  listProjects,
+  ProjectLimitError,
+} from './storage'
 import { markWatermarkRemoved } from './entitlement'
 import type { ClipRecord, Project, ProjectAudioRecord } from './types'
 
@@ -53,6 +60,7 @@ function fakeClip(id: string, content: string, extra: Partial<ClipRecord> = {}):
 
 describe('project backup round trip', () => {
   beforeEach(async () => {
+    __resetProjectTransferForTests()
     await __resetDbForTests()
   })
 
@@ -306,5 +314,24 @@ describe('project backup round trip', () => {
     expect(project.name).toBe('Dropped')
     expect(clips).toHaveLength(1)
     expect(await clips[0]!.blob.text()).toBe('MEDIA')
+  })
+
+  it('serializes overlapping imports so the free-plan cap still holds', async () => {
+    const backup = serializeProject(fakeProject('One'), [fakeClip('clip_a', 'MEDIA')])
+    const fileA = new File([backup], 'one.kodyvideo', { type: 'application/octet-stream' })
+    const fileB = new File([backup], 'two.kodyvideo', { type: 'application/octet-stream' })
+    const results = await Promise.allSettled([
+      importKodyVideoBackupFile(fileA),
+      importKodyVideoBackupFile(fileB),
+    ])
+    const fulfilled = results.filter((result) => result.status === 'fulfilled')
+    const rejected = results.filter((result) => result.status === 'rejected')
+    expect(fulfilled).toHaveLength(1)
+    expect(rejected).toHaveLength(1)
+    expect(rejected[0]).toMatchObject({ status: 'rejected' })
+    if (rejected[0]?.status === 'rejected') {
+      expect(rejected[0].reason).toBeInstanceOf(ProjectLimitError)
+    }
+    expect(await listProjects()).toHaveLength(1)
   })
 })

--- a/src/lib/project-transfer.ts
+++ b/src/lib/project-transfer.ts
@@ -101,7 +101,7 @@ export function kodyVideoBackupFilesFromList(
   files: Iterable<File> | ArrayLike<File> | null | undefined,
 ): File[] {
   if (!files) return []
-  return [...files].filter(isKodyVideoBackupFile)
+  return Array.from(files).filter(isKodyVideoBackupFile)
 }
 
 /** True when a drag payload may contain OS files (names are hidden until drop). */

--- a/src/lib/project-transfer.ts
+++ b/src/lib/project-transfer.ts
@@ -7,6 +7,7 @@ import {
   updateClipTrim,
   updateProjectAudioTrack,
 } from './storage'
+import { requestPersistentStorage } from './storage-space'
 import type { ClipRecord, Project, ProjectAudioRecord } from './types'
 
 /**
@@ -78,6 +79,8 @@ interface Manifest {
   audio?: ManifestAudio
 }
 
+export const KODY_VIDEO_BACKUP_EXTENSION = '.kodyvideo'
+
 export function projectBackupFilename(projectName: string): string {
   const slug =
     projectName
@@ -85,7 +88,25 @@ export function projectBackupFilename(projectName: string): string {
       .replace(/[^a-z0-9]+/g, '-')
       .replace(/(^-|-$)/g, '')
       .slice(0, 40) || 'project'
-  return `${slug}.kodyvideo`
+  return `${slug}${KODY_VIDEO_BACKUP_EXTENSION}`
+}
+
+/** True when the picked/dropped file uses the Kody Video backup extension. */
+export function isKodyVideoBackupFile(file: Pick<File, 'name'>): boolean {
+  return file.name.toLowerCase().endsWith(KODY_VIDEO_BACKUP_EXTENSION)
+}
+
+/** Backup files from a picker or drop, in the order they were supplied. */
+export function kodyVideoBackupFilesFromList(
+  files: Iterable<File> | ArrayLike<File> | null | undefined,
+): File[] {
+  if (!files) return []
+  return [...files].filter(isKodyVideoBackupFile)
+}
+
+/** True when a drag payload may contain OS files (names are hidden until drop). */
+export function dataTransferHasFiles(dataTransfer: DataTransfer | null | undefined): boolean {
+  return Boolean(dataTransfer?.types.includes('Files'))
 }
 
 /** Bundle a project into one shareable/downloadable backup Blob. */
@@ -285,6 +306,20 @@ function assertImportableClip(clip: ParsedBackup['clips'][number]): void {
   if (!finite || clip.durationMs <= 0 || clip.blob.size <= 0) {
     throw new BackupFormatError('This backup file is damaged')
   }
+}
+
+/**
+ * Parse a backup file and persist it as a new project. Requests persistent
+ * storage on success (same as the About picker / drop import paths).
+ */
+export async function importKodyVideoBackupFile(
+  file: File,
+  onProgress?: (doneClips: number, totalClips: number) => void,
+): Promise<Project> {
+  const parsed = await parseProjectBackup(file)
+  const project = await importProjectBackup(parsed, onProgress)
+  requestPersistentStorage()
+  return project
 }
 
 /** Create a fresh project (new ids) from a parsed backup. */

--- a/src/lib/project-transfer.ts
+++ b/src/lib/project-transfer.ts
@@ -297,6 +297,27 @@ export async function parseProjectBackup(file: Blob): Promise<ParsedBackup> {
   return { projectName: String(manifest.projectName || 'Imported project'), clips, audio }
 }
 
+let importLock: Promise<void> = Promise.resolve()
+
+/** Test-only: drop a hung lock so browser-mode cases start independent. */
+export function __resetProjectTransferForTests(): void {
+  importLock = Promise.resolve()
+}
+
+async function withImportLock<T>(run: () => Promise<T>): Promise<T> {
+  const previous = importLock
+  let release!: () => void
+  importLock = new Promise<void>((resolve) => {
+    release = resolve
+  })
+  await previous
+  try {
+    return await run()
+  } finally {
+    release()
+  }
+}
+
 function assertImportableClip(clip: ParsedBackup['clips'][number]): void {
   const finite =
     Number.isFinite(clip.durationMs) &&
@@ -324,6 +345,13 @@ export async function importKodyVideoBackupFile(
 
 /** Create a fresh project (new ids) from a parsed backup. */
 export async function importProjectBackup(
+  parsed: ParsedBackup,
+  onProgress?: (doneClips: number, totalClips: number) => void,
+): Promise<Project> {
+  return withImportLock(() => persistImportedProject(parsed, onProgress))
+}
+
+async function persistImportedProject(
   parsed: ParsedBackup,
   onProgress?: (doneClips: number, totalClips: number) => void,
 ): Promise<Project> {

--- a/src/pages/about-page.tsx
+++ b/src/pages/about-page.tsx
@@ -7,17 +7,8 @@ import { buildDateLabel, commitUrl, shortVersion } from '../lib/build-info'
 import { reportError } from '../lib/error-reporting'
 import { clearExportCache, estimateExportCacheBytes } from '../lib/export/export-cache'
 import { listRearCameras } from '../lib/media'
-import {
-  BackupFormatError,
-  importProjectBackup,
-  parseProjectBackup,
-} from '../lib/project-transfer'
-import {
-  estimateStorageSpace,
-  formatBytes,
-  requestPersistentStorage,
-  type StorageSpace,
-} from '../lib/storage-space'
+import { BackupFormatError, importKodyVideoBackupFile } from '../lib/project-transfer'
+import { estimateStorageSpace, formatBytes, type StorageSpace } from '../lib/storage-space'
 import { navigate } from '../router'
 
 /** Prefilled GitHub issue so bug reports arrive with device context attached. */
@@ -155,12 +146,10 @@ export function AboutPage(handle: Handle) {
       importProgress = 'Reading backup…'
       void handle.update()
       try {
-        const parsed = await parseProjectBackup(file)
-        const project = await importProjectBackup(parsed, (done, total) => {
+        const project = await importKodyVideoBackupFile(file, (done, total) => {
           importProgress = `Importing clip ${Math.min(done + 1, total)} of ${total}…`
           void handle.update()
         })
-        requestPersistentStorage()
         // Land directly in the imported project — unambiguous success.
         navigate(`/project/${project.id}`)
       } catch (err) {
@@ -357,7 +346,7 @@ export function AboutPage(handle: Handle) {
             <p>
               Every project can be saved as a single <code>.kodyvideo</code> file (⋯ →{' '}
               <strong>Save backup</strong> on the home screen) — a safety net, and the way to move
-              a project between devices. Restore one here:
+              a project between devices. Restore one here, or drop the file anywhere in the app:
             </p>
             <label className={`btn btn-ghost about-import${importing ? ' is-disabled' : ''}`}>
               Import a backup

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -609,6 +609,71 @@ a {
   padding: 0;
 }
 
+.backup-drop-overlay {
+  position: absolute;
+  inset: 0;
+  z-index: 18;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: calc(24px + var(--safe-top)) 24px calc(24px + var(--safe-bottom));
+  background: var(--overlay-scrim-strong);
+  color: var(--ink);
+  text-align: center;
+  pointer-events: none;
+  animation: fade-in 160ms ease both;
+}
+
+.backup-drop-overlay strong {
+  font-family: var(--font-display);
+  font-size: 1.45rem;
+  letter-spacing: -0.03em;
+}
+
+.backup-drop-overlay p {
+  margin: 0;
+  max-width: 22rem;
+  color: var(--ink-muted);
+  line-height: 1.45;
+}
+
+.backup-drop-overlay code {
+  color: var(--ink);
+}
+
+.backup-drop-overlay.is-importing {
+  pointer-events: auto;
+}
+
+.backup-drop-error {
+  position: absolute;
+  left: 12px;
+  right: 12px;
+  bottom: calc(16px + var(--safe-bottom));
+  z-index: 19;
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 12px 14px;
+  border-radius: 14px;
+  background: color-mix(in srgb, var(--danger) 18%, var(--bg-elevated));
+  border: 1px solid color-mix(in srgb, var(--danger) 38%, transparent);
+  color: var(--danger-ink);
+  font-size: 0.92rem;
+  line-height: 1.4;
+  box-shadow: var(--shadow);
+  animation: rise-in 220ms ease both;
+}
+
+.backup-drop-error .link-button {
+  flex: 0 0 auto;
+  color: var(--danger-ink);
+  font-weight: 700;
+}
+
 .toast {
   position: absolute;
   left: 50%;

--- a/tests/e2e/projects.spec.ts
+++ b/tests/e2e/projects.spec.ts
@@ -1,3 +1,4 @@
+import { readFile } from 'node:fs/promises'
 import { test, expect, type Page } from '@playwright/test'
 import { gotoHome, seedProject, unlockPlus } from './helpers'
 
@@ -70,6 +71,68 @@ test.describe('project slots', () => {
     await page.goto('/about')
     await page.locator('.about-import input[type="file"]').setInputFiles(backupPath)
     // Import navigates straight into the restored project.
+    await page.waitForURL(/\/project\//, { timeout: 30_000 })
+    const restored = await page.evaluate(async () => {
+      const storage = await import('/src/lib/storage.ts')
+      const projects = await storage.listProjects()
+      if (projects.length !== 1) return null
+      const clips = await storage.getClipMetasForProject(projects[0]!.id)
+      return { clips: clips.length }
+    })
+    expect(restored).toEqual({ clips: 1 })
+  })
+
+  test('dropping a .kodyvideo file on home restores the project', async ({ page }) => {
+    await createProjectWithClip(page)
+    await page.locator('.slot-options').click()
+    const downloadPromise = page.waitForEvent('download')
+    await page.getByRole('button', { name: 'Save backup' }).click()
+    const backupPath = await (await downloadPromise).path()
+    if (!backupPath) throw new Error('backup download path missing')
+    const backupBytes = [...(await readFile(backupPath))]
+
+    await page.locator('.slot-options').click()
+    await page.getByRole('button', { name: 'Delete' }).click()
+    await page.locator('.confirm-sheet').getByRole('button', { name: 'Delete' }).click()
+    await expect(page.locator('.project-slot.filled')).toHaveCount(0)
+
+    await page.evaluate(() => {
+      const file = new File(['nope'], 'notes.txt', { type: 'text/plain' })
+      const dt = new DataTransfer()
+      dt.items.add(file)
+      window.dispatchEvent(
+        new DragEvent('drop', { bubbles: true, cancelable: true, dataTransfer: dt }),
+      )
+    })
+    await expect(page).toHaveURL(/\/$/)
+    await expect(page.locator('.project-slot.filled')).toHaveCount(0)
+
+    await page.evaluate((bytes) => {
+      const file = new File([new Uint8Array(bytes)], 'restored.kodyvideo', {
+        type: 'application/octet-stream',
+      })
+      const dt = new DataTransfer()
+      dt.items.add(file)
+      window.dispatchEvent(
+        new DragEvent('dragenter', { bubbles: true, cancelable: true, dataTransfer: dt }),
+      )
+      window.dispatchEvent(
+        new DragEvent('dragover', { bubbles: true, cancelable: true, dataTransfer: dt }),
+      )
+    }, backupBytes)
+    await expect(page.locator('.backup-drop-overlay')).toContainText('Drop to import')
+
+    await page.evaluate((bytes) => {
+      const file = new File([new Uint8Array(bytes)], 'restored.kodyvideo', {
+        type: 'application/octet-stream',
+      })
+      const dt = new DataTransfer()
+      dt.items.add(file)
+      window.dispatchEvent(
+        new DragEvent('drop', { bubbles: true, cancelable: true, dataTransfer: dt }),
+      )
+    }, backupBytes)
+
     await page.waitForURL(/\/project\//, { timeout: 30_000 })
     const restored = await page.evaluate(async () => {
       const storage = await import('/src/lib/storage.ts')


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Dropping a `.kodyvideo` backup anywhere in the app now restores it as a new project, using the same import path as About → Import a backup.

- Detect `.kodyvideo` files on drop (case-insensitive) and ignore other file types
- Show a drop overlay while files are dragged in, then import progress / errors
- Share `importKodyVideoBackupFile()` between the About picker and the drop target
- Serialize overlapping imports so the free/Plus project cap still holds
- Cover extension filtering, the shared importer, concurrent-cap protection, and an e2e drop round-trip

## Test plan

- [x] Lint: `npm run lint`
- [x] Unit: `project-transfer` including concurrent import cap
- [x] E2E: `tests/e2e/projects.spec.ts` including the new drop test
- [x] Manual: drop overlay + restore round-trip on local dev server
- [ ] CI + Bugbot on the latest commit

Preview: https://cursor-kodyvideo-drag-drop-a.kody-video.pages.dev
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2d438c95-b846-46c0-84b1-f7174264a4b7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2d438c95-b846-46c0-84b1-f7174264a4b7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Import `.kodyvideo` backups by dropping them anywhere in the app.
  - View progress while projects and clips are restored.
  - Automatically open the restored project after a successful import.
  - Receive clear, dismissible feedback when an import fails.
  - Invalid or unsupported files are ignored during drag-and-drop.

- **Documentation**
  - Updated backup restoration guidance and testing instructions to include drag-and-drop importing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->