### PR TITLE
Add an audio input chooser for multi-mic devices

### DIFF
--- a/manual-test-checklist.md
+++ b/manual-test-checklist.md
@@ -90,6 +90,10 @@ see the README) — plain `http://<lan-ip>` fails in most browsers.
 - [ ] A take with a dead/covered mic shows "Mic isn't picking up sound" after
   ~2.5s; a take with sound clears it
 - [ ] Torch toggle appears on devices with a flash; zoom chips when supported
+- [ ] With more than one mic (wired/Bluetooth headset, USB interface), the
+  mic button appears in the top-right chrome; picking one records takes from
+  it and the choice sticks across restarts; unplugging it falls back to the
+  default mic without failing the take; a single-mic device shows no button
 - [ ] Long digital ranges: the top zoom chip caps at 10× but drag-zoom still
   reaches the camera's true max (e.g. 30×), with the HUD showing real values
 - [ ] Multi-rear-lens Androids show the lens chip (e.g. "1/3"); choice sticks

--- a/src/components/icons.tsx
+++ b/src/components/icons.tsx
@@ -267,6 +267,17 @@ export function IconInfo(handle: Handle<IconProps>) {
   )
 }
 
+/** Microphone capsule with stand: audio input chooser. */
+export function IconMic(handle: Handle<IconProps>) {
+  return () => (
+    <svg {...baseProps(handle.props.size ?? 22)}>
+      <rect x="9" y="3" width="6" height="10.5" rx="3" />
+      <path d="M5.5 11.5a6.5 6.5 0 0013 0" />
+      <path d="M12 18v3" />
+    </svg>
+  )
+}
+
 /** Monitor with a record dot: screen recording. */
 export function IconScreen(handle: Handle<IconProps & { on?: boolean }>) {
   return () => (

--- a/src/components/mic-picker-sheet.tsx
+++ b/src/components/mic-picker-sheet.tsx
@@ -1,0 +1,67 @@
+import type { Handle } from 'remix/ui'
+import { on, ref } from 'remix/ui'
+import type { AudioInputOption } from '../lib/audio-input'
+import { attachSheetModal } from '../lib/sheet-modal'
+
+interface MicPickerSheetProps {
+  inputs: AudioInputOption[]
+  /** Mic upcoming takes record from (null = system default, no highlight). */
+  activeId: string | null
+  onPick: (id: string) => void
+  onClose: () => void
+}
+
+/** Bottom sheet listing microphones — shown when the device has more than one. */
+export function MicPickerSheet(handle: Handle<MicPickerSheetProps>) {
+  return () => {
+    const { inputs, activeId, onPick, onClose } = handle.props
+    return (
+      <>
+        <div className="sheet-backdrop" mix={on('click', () => onClose())} />
+        <div
+          className="sheet mic-picker-sheet"
+          role="dialog"
+          aria-modal="true"
+          aria-label="Choose a microphone"
+          mix={ref((node, signal) =>
+            attachSheetModal(node as HTMLElement, signal, {
+              onDismiss: () => handle.props.onClose(),
+            }),
+          )}
+        >
+          <h3>Microphone</h3>
+          <p className="sheet-lede muted">New recordings use the selected mic.</p>
+          <div className="mic-options" role="group" aria-label="Microphones">
+            {inputs.map((input, index) => {
+              const isActive = input.id === activeId
+              return (
+                <button
+                  key={input.id}
+                  type="button"
+                  className={`mic-option-btn${isActive ? ' is-active' : ''}`}
+                  aria-pressed={isActive}
+                  mix={on('click', () => onPick(input.id))}
+                >
+                  {/* Labels are empty until mic permission is granted. */}
+                  <span className="mic-option-label">
+                    {input.label || `Microphone ${index + 1}`}
+                  </span>
+                  {isActive ? (
+                    <span className="mic-option-check" aria-hidden="true">
+                      ✓
+                    </span>
+                  ) : null}
+                </button>
+              )
+            })}
+          </div>
+          <div className="sheet-actions">
+            <button type="button" className="btn btn-ghost" mix={on('click', () => onClose())}>
+              Cancel
+            </button>
+          </div>
+        </div>
+      </>
+    )
+  }
+}

--- a/src/components/record-screen.tsx
+++ b/src/components/record-screen.tsx
@@ -40,11 +40,13 @@ import {
   IconFlip,
   IconLens,
   IconLocation,
+  IconMic,
   IconPlay,
   IconScreen,
   IconTimer,
   IconTorch,
 } from './icons'
+import { MicPickerSheet } from './mic-picker-sheet'
 import { RecordTimer } from './record-timer'
 import { isInteractiveTarget } from '../lib/keyboard'
 
@@ -125,6 +127,8 @@ export function RecordScreen(handle: Handle<RecordScreenProps>) {
   let screenRecordStartedAt = 0
   /** The current/last take's mic never rose above the silence floor. */
   let micSilent = false
+  /** Bottom sheet for choosing which microphone records takes. */
+  let micPickerOpen = false
   let locationTagging = props.locationTaggingEnabled ?? false
 
   const screenRecordingSupported = isScreenRecordingSupported()
@@ -1091,6 +1095,21 @@ export function RecordScreen(handle: Handle<RecordScreenProps>) {
                 <IconScreen on={screenRecording} />
               </button>
             ) : null}
+            {camera.audioInputs.length > 1 ? (
+              <button
+                type="button"
+                className="btn-icon"
+                aria-label="Choose microphone"
+                aria-haspopup="dialog"
+                disabled={recording || screenRecording || countdown !== null}
+                mix={on('click', () => {
+                  micPickerOpen = true
+                  void handle.update()
+                })}
+              >
+                <IconMic />
+              </button>
+            ) : null}
             {camera.torchAvailable ? (
               <button
                 type="button"
@@ -1244,6 +1263,24 @@ export function RecordScreen(handle: Handle<RecordScreenProps>) {
             Go
           </button>
         </div>
+
+        {micPickerOpen ? (
+          <MicPickerSheet
+            inputs={camera.audioInputs}
+            activeId={camera.audioInputId}
+            onPick={(id) => {
+              micPickerOpen = false
+              void handle.update()
+              void camera.setAudioInput(id).catch(() => {
+                props.showToast('Could not switch the microphone')
+              })
+            }}
+            onClose={() => {
+              micPickerOpen = false
+              void handle.update()
+            }}
+          />
+        ) : null}
       </div>
     )
   }

--- a/src/lib/audio-input.test.ts
+++ b/src/lib/audio-input.test.ts
@@ -1,0 +1,137 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  listAudioInputs,
+  rememberAudioInput,
+  rememberedAudioInput,
+  resolveAudioInput,
+  resolvePreferredAudioInputId,
+} from './audio-input'
+
+function device(kind: MediaDeviceKind, deviceId: string, label = ''): MediaDeviceInfo {
+  return {
+    kind,
+    deviceId,
+    label,
+    groupId: `group-${deviceId}`,
+    toJSON() {
+      return { kind, deviceId, label }
+    },
+  } as MediaDeviceInfo
+}
+
+function stubEnumerate(devices: MediaDeviceInfo[]): void {
+  vi.spyOn(navigator.mediaDevices, 'enumerateDevices').mockResolvedValue(devices)
+}
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  rememberAudioInput(null)
+})
+
+describe('listAudioInputs', () => {
+  it('returns only audio inputs with real device ids', async () => {
+    stubEnumerate([
+      device('videoinput', 'cam-1', 'Back Camera'),
+      device('audioinput', 'mic-1', 'Built-in Microphone'),
+      device('audioinput', '', ''),
+      device('audiooutput', 'speaker-1', 'Speakers'),
+      device('audioinput', 'mic-2', 'USB Microphone'),
+    ])
+    expect(await listAudioInputs()).toEqual([
+      { id: 'mic-1', label: 'Built-in Microphone' },
+      { id: 'mic-2', label: 'USB Microphone' },
+    ])
+  })
+
+  it("drops Chrome's default/communications aliases when physical mics exist", async () => {
+    stubEnumerate([
+      device('audioinput', 'default', 'Default - USB Microphone'),
+      device('audioinput', 'communications', 'Communications - USB Microphone'),
+      device('audioinput', 'mic-1', 'USB Microphone'),
+      device('audioinput', 'mic-2', 'Headset Microphone'),
+    ])
+    expect(await listAudioInputs()).toEqual([
+      { id: 'mic-1', label: 'USB Microphone' },
+      { id: 'mic-2', label: 'Headset Microphone' },
+    ])
+  })
+
+  it('keeps the aliases when they are the only entries', async () => {
+    stubEnumerate([device('audioinput', 'default', 'Default')])
+    expect(await listAudioInputs()).toEqual([{ id: 'default', label: 'Default' }])
+  })
+
+  it('returns empty on enumeration failure', async () => {
+    vi.spyOn(navigator.mediaDevices, 'enumerateDevices').mockRejectedValue(
+      new Error('enumeration failed'),
+    )
+    expect(await listAudioInputs()).toEqual([])
+  })
+})
+
+describe('remembered audio input', () => {
+  it('round-trips through localStorage and clears on null', () => {
+    expect(rememberedAudioInput()).toBeNull()
+    rememberAudioInput({ id: 'mic-1', label: 'USB Microphone' })
+    expect(rememberedAudioInput()).toEqual({ id: 'mic-1', label: 'USB Microphone' })
+    rememberAudioInput(null)
+    expect(rememberedAudioInput()).toBeNull()
+  })
+
+  it('ignores malformed stored values', () => {
+    localStorage.setItem('kodyVideo.audioInput', '{"id":42}')
+    expect(rememberedAudioInput()).toBeNull()
+  })
+})
+
+describe('resolveAudioInput', () => {
+  const inputs = [
+    { id: 'mic-1', label: 'Built-in Microphone' },
+    { id: 'mic-2', label: 'USB Microphone' },
+  ]
+
+  it('is undefined when nothing was chosen', () => {
+    expect(resolveAudioInput(inputs)).toBeUndefined()
+  })
+
+  it('prefers the exact remembered id', () => {
+    rememberAudioInput({ id: 'mic-2', label: 'USB Microphone' })
+    expect(resolveAudioInput(inputs)).toBe('mic-2')
+  })
+
+  it('re-matches by label when the id rotated (site-data clear)', () => {
+    rememberAudioInput({ id: 'old-rotated-id', label: 'USB Microphone' })
+    expect(resolveAudioInput(inputs)).toBe('mic-2')
+  })
+
+  it('falls back to the default (undefined) when the mic is unplugged', () => {
+    rememberAudioInput({ id: 'bt-mic', label: 'Bluetooth Microphone' })
+    expect(resolveAudioInput(inputs)).toBeUndefined()
+    // The choice stays remembered so a reconnected mic wins again.
+    expect(rememberedAudioInput()).toEqual({ id: 'bt-mic', label: 'Bluetooth Microphone' })
+  })
+
+  it('never matches by an empty label', () => {
+    rememberAudioInput({ id: 'gone', label: '' })
+    expect(
+      resolveAudioInput([
+        { id: 'mic-3', label: '' },
+        { id: 'mic-4', label: '' },
+      ]),
+    ).toBeUndefined()
+  })
+})
+
+describe('resolvePreferredAudioInputId', () => {
+  it('skips enumeration entirely when nothing was chosen', async () => {
+    const spy = vi.spyOn(navigator.mediaDevices, 'enumerateDevices')
+    expect(await resolvePreferredAudioInputId()).toBeUndefined()
+    expect(spy).not.toHaveBeenCalled()
+  })
+
+  it('enumerates and resolves a remembered mic', async () => {
+    stubEnumerate([device('audioinput', 'mic-1', 'USB Microphone')])
+    rememberAudioInput({ id: 'mic-1', label: 'USB Microphone' })
+    expect(await resolvePreferredAudioInputId()).toBe('mic-1')
+  })
+})

--- a/src/lib/audio-input.ts
+++ b/src/lib/audio-input.ts
@@ -1,0 +1,90 @@
+/**
+ * Microphone (audio input) selection. Phones and desktops often expose more
+ * than one mic — built-in, wired headset, Bluetooth, USB interfaces — and the
+ * browser default is not always the one the user wants on a take. The record
+ * screen offers a chooser when more than one input exists; the choice is
+ * remembered across sessions and every capture path (per-take mic, iOS
+ * combined stream, screen-recording narration) resolves it before opening.
+ */
+
+export interface AudioInputOption {
+  id: string
+  /** Empty until the user has granted microphone permission. */
+  label: string
+}
+
+const AUDIO_INPUT_STORAGE_KEY = 'kodyVideo.audioInput'
+
+interface RememberedAudioInput {
+  id: string
+  /** Device ids rotate when the browser clears site data; the label lets
+   * the same physical mic be re-matched afterwards. */
+  label: string
+}
+
+export async function listAudioInputs(): Promise<AudioInputOption[]> {
+  if (!navigator.mediaDevices?.enumerateDevices) return []
+  try {
+    const devices = await navigator.mediaDevices.enumerateDevices()
+    // Pre-permission enumerations return placeholder entries with empty
+    // ids — not openable, not choosable.
+    const mics = devices.filter(
+      (device) => device.kind === 'audioinput' && device.deviceId.length > 0,
+    )
+    // Chrome additionally lists "default" (and on Windows "communications")
+    // aliases of physical mics — duplicates in a picker. Drop them whenever
+    // the physical entries themselves are present.
+    const physical = mics.filter(
+      (device) => device.deviceId !== 'default' && device.deviceId !== 'communications',
+    )
+    const chooseFrom = physical.length > 0 ? physical : mics
+    return chooseFrom.map((device) => ({ id: device.deviceId, label: device.label }))
+  } catch {
+    return []
+  }
+}
+
+export function rememberedAudioInput(): RememberedAudioInput | null {
+  try {
+    const raw = localStorage.getItem(AUDIO_INPUT_STORAGE_KEY)
+    if (!raw) return null
+    const parsed = JSON.parse(raw) as Partial<RememberedAudioInput>
+    if (typeof parsed.id !== 'string' || typeof parsed.label !== 'string') return null
+    return { id: parsed.id, label: parsed.label }
+  } catch {
+    return null
+  }
+}
+
+export function rememberAudioInput(option: AudioInputOption | null): void {
+  try {
+    if (option) localStorage.setItem(AUDIO_INPUT_STORAGE_KEY, JSON.stringify(option))
+    else localStorage.removeItem(AUDIO_INPUT_STORAGE_KEY)
+  } catch {
+    // Storage unavailable (private mode) — the choice just won't persist.
+  }
+}
+
+/**
+ * The remembered mic resolved against a current enumeration: exact id when
+ * still present, otherwise the same label (ids rotate on site-data clears),
+ * otherwise nothing — the system default records the take. A remembered mic
+ * that is merely unplugged right now stays remembered: reconnecting it (e.g.
+ * a Bluetooth mic coming back) makes it win again, like OS audio routing.
+ */
+export function resolveAudioInput(inputs: AudioInputOption[]): string | undefined {
+  const remembered = rememberedAudioInput()
+  if (!remembered) return undefined
+  if (inputs.some((input) => input.id === remembered.id)) return remembered.id
+  if (remembered.label.length > 0) {
+    const byLabel = inputs.find((input) => input.label === remembered.label)
+    if (byLabel) return byLabel.id
+  }
+  return undefined
+}
+
+/** Enumerate-and-resolve for callers without a current device list. */
+export async function resolvePreferredAudioInputId(): Promise<string | undefined> {
+  if (!rememberedAudioInput()) return undefined
+  return resolveAudioInput(await listAudioInputs())
+}

--- a/src/lib/camera.ts
+++ b/src/lib/camera.ts
@@ -1,3 +1,10 @@
+import {
+  listAudioInputs,
+  rememberAudioInput,
+  resolveAudioInput,
+  resolvePreferredAudioInputId,
+  type AudioInputOption,
+} from './audio-input'
 import { engageRecordAudioSession, releaseRecordAudioSession } from './audio-session'
 import {
   canFlipCamera,
@@ -43,6 +50,17 @@ async function openCombinedOrVideoStream(
   deviceId: string | undefined,
 ): Promise<MediaStream> {
   if (HOLD_MIC_WITH_CAMERA) {
+    // The chosen mic (audio input chooser) rides along in the combined
+    // request; a stale/unplugged id rejects the whole call, so retry with
+    // the default mic before giving up on audio entirely.
+    const audioDeviceId = await resolvePreferredAudioInputId()
+    if (audioDeviceId) {
+      try {
+        return await openCameraStream(facing, { audio: true, deviceId, audioDeviceId })
+      } catch {
+        // Fall through to the default-mic request below.
+      }
+    }
     try {
       return await openCameraStream(facing, { audio: true, deviceId })
     } catch {
@@ -136,10 +154,17 @@ export interface Camera {
   rearLensCount: number
   /** Index of the active rear lens, when facing the environment. */
   rearLensIndex: number
+  /** Microphones the user can choose from (chooser shows when >1). */
+  audioInputs: AudioInputOption[]
+  /** Mic the next take records from (null = system default). */
+  audioInputId: string | null
   /** Attach the preview element (from a `ref()` mixin); starts the camera. */
   attachVideo: (element: HTMLVideoElement, signal: AbortSignal) => void
   /** Cycle to the next rear lens (no-op while facing the user). */
   switchRearLens: () => Promise<void>
+  /** Record upcoming takes from a specific mic; persists across sessions.
+   * Never call mid-take — the chooser UI is disabled while recording. */
+  setAudioInput: (id: string) => Promise<void>
   start: () => Promise<void>
   flip: () => Promise<void>
   stop: () => void
@@ -200,8 +225,11 @@ export function createCamera(notify: () => void): Camera {
     micPermission: 'unknown',
     rearLensCount: 0,
     rearLensIndex: 0,
+    audioInputs: [],
+    audioInputId: null,
     attachVideo,
     switchRearLens,
+    setAudioInput,
     start,
     flip,
     stop,
@@ -331,6 +359,84 @@ export function createCamera(notify: () => void): Camera {
     }
   }
 
+  /** Discover microphones for the input chooser. Labels (and on some
+   * browsers the entries themselves) only populate once mic permission is
+   * granted, so this re-runs after the priming prompt resolves and on
+   * devicechange (headsets plugging in / Bluetooth mics connecting). */
+  async function syncAudioInputs(): Promise<void> {
+    const inputs = await listAudioInputs()
+    camera.audioInputs = inputs
+    // Highlight the explicit preference when one resolves; otherwise the
+    // mic that is actually live (iOS combined stream, warm per-take mic).
+    camera.audioInputId =
+      resolveAudioInput(inputs) ??
+      camera.stream
+        ?.getAudioTracks()
+        .find((track) => track.readyState === 'live')
+        ?.getSettings().deviceId ??
+      null
+    notify()
+  }
+
+  /**
+   * Record upcoming takes from a specific mic. Non-iOS, the mic is opened
+   * per take, so remembering the choice is almost the whole job — except a
+   * still-warm mic from the previous take, which must be swapped now or the
+   * next take would silently reuse the old device.
+   */
+  async function setAudioInput(id: string): Promise<void> {
+    const option = camera.audioInputs.find((input) => input.id === id)
+    if (!option) return
+    rememberAudioInput(option)
+    camera.audioInputId = id
+    notify()
+
+    if (HOLD_MIC_WITH_CAMERA) {
+      // iOS: the mic lives inside the combined camera stream — switching
+      // means reopening camera + mic as one request (a separately-acquired
+      // audio track is the muted-track pattern this module avoids).
+      const current = camera.stream
+      if (!current || current.getAudioTracks().length === 0) return
+      const epoch = cameraEpoch
+      const deviceId = current.getVideoTracks()[0]?.getSettings().deviceId
+      const next = await openCameraStream(facingIntent, {
+        audio: true,
+        deviceId,
+        audioDeviceId: id,
+      })
+      if (cameraEpoch !== epoch || camera.stream !== current) {
+        stopStream(next)
+        return
+      }
+      replaceStream(next)
+      return
+    }
+
+    const hadLiveMic =
+      camera.stream?.getAudioTracks().some((track) => track.readyState === 'live') ?? false
+    window.clearTimeout(micReleaseTimer)
+    micReleaseTimer = 0
+    stopAudioTracks(camera.stream)
+    if (!hadLiveMic) return
+    // Keep the swap warm: the old mic was held between takes so the next
+    // take wouldn't pay a fresh acquisition's silent ramp-up — the newly
+    // chosen mic should get the same head start (and surface open failures
+    // now rather than mid-hold).
+    try {
+      const track = await openMicrophoneTrack({ deviceId: id })
+      const latest = camera.stream
+      if (!latest) {
+        track.stop()
+        return
+      }
+      latest.addTrack(track)
+      releaseMic({ keepWarm: true })
+    } catch {
+      // No mic opened at all (openMicrophoneTrack already falls back to the
+      // default device) — the next take's enableMic reports the error.
+    }
+  }
+
   async function start(): Promise<void> {
     if (startInFlight) {
       await startInFlight
@@ -385,6 +491,7 @@ export function createCamera(notify: () => void): Camera {
         camera.canFlip = await canFlipCamera()
         notify()
         void syncRearLenses(next)
+        void syncAudioInputs()
         // Mic permission priming (see primeMicrophonePermission): asking
         // mid-hold is silently denied by some browsers (Brave/Android never
         // shows the prompt). Prompt now, at a normal moment. The claim is
@@ -398,6 +505,9 @@ export function createCamera(notify: () => void): Camera {
             camera.micPermission = state
             if (state === 'unknown') micPrimed = false
             notify()
+            // The grant is what populates audio device ids/labels — the
+            // enumeration from the camera open alone may miss them.
+            if (state === 'granted') void syncAudioInputs()
           })
         }
       } catch (err) {
@@ -583,7 +693,16 @@ export function createCamera(notify: () => void): Camera {
       if (!current) throw new Error('Camera not ready')
       const epoch = cameraEpoch
       const deviceId = current.getVideoTracks()[0]?.getSettings().deviceId
-      const next = await openCameraStream(facingIntent, { audio: true, deviceId })
+      const audioDeviceId = resolveAudioInput(camera.audioInputs)
+      let next: MediaStream
+      try {
+        next = await openCameraStream(facingIntent, { audio: true, deviceId, audioDeviceId })
+      } catch (err) {
+        // A stale chosen-mic id rejects the whole combined call — the take
+        // must still get audio from the default mic.
+        if (!audioDeviceId) throw err
+        next = await openCameraStream(facingIntent, { audio: true, deviceId })
+      }
       // The camera may have been stopped or swapped while the permission
       // prompt was open — never adopt into that lifecycle's back.
       if (cameraEpoch !== epoch || camera.stream !== current) {
@@ -604,7 +723,11 @@ export function createCamera(notify: () => void): Camera {
         return
       }
 
-      const audioTrack = await openMicrophoneTrack()
+      // The chooser's pick (already resolved against the current
+      // enumeration) — never the display-only live-track fallback.
+      const audioTrack = await openMicrophoneTrack({
+        deviceId: resolveAudioInput(camera.audioInputs),
+      })
       const latest = camera.stream
       if (!latest) {
         audioTrack.stop()
@@ -666,7 +789,12 @@ export function createCamera(notify: () => void): Camera {
 
   function attachVideo(element: HTMLVideoElement, signal: AbortSignal): void {
     videoEl = element
+    // Mics come and go mid-session (Bluetooth connecting, headsets plugging
+    // in) — keep the chooser's list current while the preview is mounted.
+    const onDeviceChange = () => void syncAudioInputs()
+    navigator.mediaDevices?.addEventListener?.('devicechange', onDeviceChange)
     signal.addEventListener('abort', () => {
+      navigator.mediaDevices?.removeEventListener?.('devicechange', onDeviceChange)
       videoEl = null
       stop()
     })

--- a/src/lib/camera.ts
+++ b/src/lib/camera.ts
@@ -203,6 +203,8 @@ export function createCamera(notify: () => void): Camera {
   let facingIntent: FacingMode = 'environment'
   let startInFlight: Promise<void> | null = null
   let micInFlight: Promise<void> | null = null
+  /** Active setAudioInput switch — take starts must not race it. */
+  let audioSwitchInFlight: Promise<void> | null = null
   let micPrimed = false
   /** Pending deferred mic stop (releaseMic with keepWarm). */
   let micReleaseTimer = 0
@@ -383,8 +385,23 @@ export function createCamera(notify: () => void): Camera {
    * per take, so remembering the choice is almost the whole job — except a
    * still-warm mic from the previous take, which must be swapped now or the
    * next take would silently reuse the old device.
+   *
+   * Switches are serialized with each other AND with take starts: a hold
+   * that lands right after a pick must record from the picked mic, never
+   * race the swap (enableMic awaits the in-flight switch).
    */
   async function setAudioInput(id: string): Promise<void> {
+    const previous = audioSwitchInFlight ?? Promise.resolve()
+    const run = previous.catch(() => undefined).then(() => performAudioSwitch(id))
+    audioSwitchInFlight = run
+    try {
+      await run
+    } finally {
+      if (audioSwitchInFlight === run) audioSwitchInFlight = null
+    }
+  }
+
+  async function performAudioSwitch(id: string): Promise<void> {
     const option = camera.audioInputs.find((input) => input.id === id)
     if (!option) return
     rememberAudioInput(option)
@@ -399,11 +416,19 @@ export function createCamera(notify: () => void): Camera {
       if (!current || current.getAudioTracks().length === 0) return
       const epoch = cameraEpoch
       const deviceId = current.getVideoTracks()[0]?.getSettings().deviceId
-      const next = await openCameraStream(facingIntent, {
-        audio: true,
-        deviceId,
-        audioDeviceId: id,
-      })
+      let next: MediaStream
+      try {
+        next = await openCameraStream(facingIntent, {
+          audio: true,
+          deviceId,
+          audioDeviceId: id,
+        })
+      } catch {
+        // The picked mic disconnected between enumeration and open — keep
+        // the preview alive on the default mic (matching the fallback in
+        // openCombinedOrVideoStream / reopenCombinedStream).
+        next = await openCameraStream(facingIntent, { audio: true, deviceId })
+      }
       if (cameraEpoch !== epoch || camera.stream !== current) {
         stopStream(next)
         return
@@ -669,6 +694,12 @@ export function createCamera(notify: () => void): Camera {
   }
 
   async function enableMic(): Promise<void> {
+    // A pick from the mic chooser may still be swapping devices (reopening
+    // the combined stream on iOS, re-warming the mic elsewhere) — the take
+    // must record from the picked mic, so let the switch land first.
+    while (audioSwitchInFlight) {
+      await audioSwitchInFlight.catch(() => undefined)
+    }
     // A deferred take-end release must never fire mid-take: this take owns
     // the (possibly still-warm) mic now.
     window.clearTimeout(micReleaseTimer)
@@ -693,7 +724,7 @@ export function createCamera(notify: () => void): Camera {
       if (!current) throw new Error('Camera not ready')
       const epoch = cameraEpoch
       const deviceId = current.getVideoTracks()[0]?.getSettings().deviceId
-      const audioDeviceId = resolveAudioInput(camera.audioInputs)
+      const audioDeviceId = await resolvePreferredAudioInputId()
       let next: MediaStream
       try {
         next = await openCameraStream(facingIntent, { audio: true, deviceId, audioDeviceId })
@@ -723,10 +754,13 @@ export function createCamera(notify: () => void): Camera {
         return
       }
 
-      // The chooser's pick (already resolved against the current
-      // enumeration) — never the display-only live-track fallback.
+      // The chooser's pick, resolved against a fresh enumeration — never
+      // camera.audioInputs, which fills asynchronously after camera start
+      // (an early first take must still honor the persisted choice) — and
+      // never the display-only live-track fallback. Resolution
+      // short-circuits without enumerating when nothing was ever chosen.
       const audioTrack = await openMicrophoneTrack({
-        deviceId: resolveAudioInput(camera.audioInputs),
+        deviceId: await resolvePreferredAudioInputId(),
       })
       const latest = camera.stream
       if (!latest) {

--- a/src/lib/media.ts
+++ b/src/lib/media.ts
@@ -47,13 +47,22 @@ export interface OpenCameraOptions {
   audio?: boolean
   /** Open a specific camera (rear lens switching); falls back to facing. */
   deviceId?: string
+  /** Record from a specific microphone (audio input chooser). Only applies
+   * when audio is requested; a stale id rejects the whole call, so callers
+   * retry without it (see camera.ts). */
+  audioDeviceId?: string
 }
 
 export async function openCameraStream(
   facing: FacingMode,
   options: OpenCameraOptions = {},
 ): Promise<MediaStream> {
-  const withAudio = options.audio === true
+  const audio: MediaStreamConstraints['audio'] =
+    options.audio === true
+      ? options.audioDeviceId
+        ? { deviceId: { exact: options.audioDeviceId } }
+        : true
+      : false
   const baseConstraints: MediaTrackConstraints = {
     width: { ideal: 1280 },
     height: { ideal: 720 },
@@ -65,7 +74,7 @@ export async function openCameraStream(
   if (options.deviceId) {
     try {
       return await navigator.mediaDevices.getUserMedia({
-        audio: withAudio,
+        audio,
         video: { ...baseConstraints, deviceId: { exact: options.deviceId } },
       })
     } catch {
@@ -73,7 +82,7 @@ export async function openCameraStream(
       // retry the exact device bare before giving up on it.
       try {
         return await navigator.mediaDevices.getUserMedia({
-          audio: withAudio,
+          audio,
           video: { deviceId: { exact: options.deviceId } },
         })
       } catch {
@@ -84,13 +93,13 @@ export async function openCameraStream(
 
   try {
     return await navigator.mediaDevices.getUserMedia({
-      audio: withAudio,
+      audio,
       video: { ...baseConstraints, facingMode: { ideal: facing } },
     })
   } catch (error) {
     if (isOverconstrained(error)) {
       return navigator.mediaDevices.getUserMedia({
-        audio: withAudio,
+        audio,
         video: true,
       })
     }
@@ -187,23 +196,42 @@ export async function preferredIosRearCameraId(): Promise<string | undefined> {
   return undefined
 }
 
+export interface OpenMicrophoneOptions {
+  /** Record from a specific microphone (audio input chooser); a stale or
+   * unplugged id falls back to the system default. */
+  deviceId?: string
+}
+
 /** Grab a mic track only for the duration of a recording. */
-export async function openMicrophoneTrack(): Promise<MediaStreamTrack> {
+export async function openMicrophoneTrack(
+  options: OpenMicrophoneOptions = {},
+): Promise<MediaStreamTrack> {
   // Camera-app audio, not voice-call audio: echoCancellation/noiseSuppression/
   // autoGainControl route the mic through the "communications" processing
   // path (especially on Android), which sounds muffled, pumpy, and narrow.
   // Real camera apps record the raw mic — so do we. Bare boolean constraint
   // values are treated as ideal, so unsupported devices still open the mic.
-  const mic = await navigator.mediaDevices.getUserMedia({
-    audio: {
-      echoCancellation: false,
-      noiseSuppression: false,
-      autoGainControl: false,
-      channelCount: { ideal: 2 },
-      sampleRate: { ideal: 48000 },
-    },
-    video: false,
-  })
+  const baseAudio: MediaTrackConstraints = {
+    echoCancellation: false,
+    noiseSuppression: false,
+    autoGainControl: false,
+    channelCount: { ideal: 2 },
+    sampleRate: { ideal: 48000 },
+  }
+  const open = (audio: MediaTrackConstraints) =>
+    navigator.mediaDevices.getUserMedia({ audio, video: false })
+  let mic: MediaStream
+  if (options.deviceId) {
+    try {
+      mic = await open({ ...baseAudio, deviceId: { exact: options.deviceId } })
+    } catch {
+      // Stale/unplugged chosen mic — the take records from the default mic
+      // rather than failing outright.
+      mic = await open(baseAudio)
+    }
+  } else {
+    mic = await open(baseAudio)
+  }
   const track = mic.getAudioTracks()[0]
   if (!track) {
     mic.getTracks().forEach((t) => t.stop())

--- a/src/lib/screen-recorder.ts
+++ b/src/lib/screen-recorder.ts
@@ -8,6 +8,7 @@
  * exact same recorder + clip pipeline as camera takes.
  */
 
+import { resolvePreferredAudioInputId } from './audio-input'
 import { openMicrophoneTrack } from './media'
 import { HoldRecorder, type RecordingResult } from './recorder'
 
@@ -46,9 +47,12 @@ export async function startScreenRecording(): Promise<ScreenRecordingSession> {
     throw new Error('No screen video available')
   }
 
-  // Narration mic — best effort. A denied mic must not kill the capture;
-  // the take just records without narration (or with shared audio only).
-  const micTrack = await openMicrophoneTrack().catch(() => null)
+  // Narration mic — best effort, honoring the audio input chooser. A denied
+  // mic must not kill the capture; the take just records without narration
+  // (or with shared audio only).
+  const micTrack = await resolvePreferredAudioInputId()
+    .then((deviceId) => openMicrophoneTrack({ deviceId }))
+    .catch(() => null)
 
   const audioSources = [...display.getAudioTracks(), ...(micTrack ? [micTrack] : [])]
   let audioContext: AudioContext | null = null

--- a/src/styles/record.css
+++ b/src/styles/record.css
@@ -417,6 +417,48 @@
   pointer-events: none;
 }
 
+/* Microphone chooser sheet (shown when the device has more than one mic). */
+.mic-options {
+  display: grid;
+  gap: 8px;
+  margin-top: 14px;
+}
+
+.mic-option-btn {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  min-height: var(--tap);
+  border-radius: 16px;
+  padding: 10px 16px;
+  text-align: left;
+  font-weight: 700;
+  font-size: 1rem;
+  background: color-mix(in srgb, var(--ink) 7%, transparent);
+  border: 1px solid var(--line);
+  transition: transform 160ms ease, background 160ms ease;
+}
+
+.mic-option-btn:active {
+  transform: scale(0.985);
+  background: color-mix(in srgb, var(--accent) 18%, transparent);
+}
+
+.mic-option-btn.is-active {
+  border-color: color-mix(in srgb, var(--accent) 55%, transparent);
+  background: color-mix(in srgb, var(--accent) 12%, transparent);
+}
+
+.mic-option-label {
+  overflow-wrap: anywhere;
+}
+
+.mic-option-check {
+  flex-shrink: 0;
+  color: var(--accent);
+}
+
 /* Narrow phones: keep tools + Go on one row without overflow. */
 @media (max-width: 360px) {
   .record-tools {

--- a/tests/e2e/mic-picker.spec.ts
+++ b/tests/e2e/mic-picker.spec.ts
@@ -1,0 +1,101 @@
+import { test, expect } from '@playwright/test'
+import { openNewProject, recordClip } from './helpers'
+
+/**
+ * Audio input chooser: with more than one microphone a mic button appears in
+ * the record chrome, opens a picker sheet, and the choice is requested (by
+ * exact device id) when the take's mic is opened — with a graceful fallback
+ * to the default mic when the exact request cannot be satisfied (the fake
+ * media stack has no such device, which conveniently exercises exactly that
+ * path).
+ */
+
+declare global {
+  interface Window {
+    __audioRequests: unknown[]
+  }
+}
+
+/** Adds a second (fake) audio input and records every audio constraint
+ * passed to getUserMedia. */
+async function installSecondMic(page: import('@playwright/test').Page): Promise<void> {
+  await page.addInitScript(() => {
+    const media = navigator.mediaDevices
+    const originalEnumerate = media.enumerateDevices.bind(media)
+    media.enumerateDevices = async () => {
+      const devices = await originalEnumerate()
+      const extra = {
+        deviceId: 'usb-desk-mic',
+        groupId: 'usb-desk-mic-group',
+        kind: 'audioinput',
+        label: 'USB Desk Microphone',
+        toJSON() {
+          return this
+        },
+      } as MediaDeviceInfo
+      return [...devices, extra]
+    }
+    window.__audioRequests = []
+    const originalGum = media.getUserMedia.bind(media)
+    media.getUserMedia = async (constraints?: MediaStreamConstraints) => {
+      if (constraints?.audio) {
+        window.__audioRequests.push(JSON.parse(JSON.stringify(constraints.audio)))
+      }
+      return originalGum(constraints)
+    }
+  })
+}
+
+test.describe('audio input chooser', () => {
+  test('hidden when only one microphone exists', async ({ page }) => {
+    await page.addInitScript(() => {
+      const media = navigator.mediaDevices
+      const originalEnumerate = media.enumerateDevices.bind(media)
+      media.enumerateDevices = async () => {
+        const devices = await originalEnumerate()
+        const firstMic = devices.find((device) => device.kind === 'audioinput')
+        return [
+          ...devices.filter((device) => device.kind !== 'audioinput'),
+          ...(firstMic ? [firstMic] : []),
+        ]
+      }
+    })
+    await openNewProject(page)
+    // The list syncs after mic priming; poll instead of asserting instantly.
+    await page.waitForTimeout(1000)
+    await expect(page.getByRole('button', { name: 'Choose microphone' })).toHaveCount(0)
+  })
+
+  test('picks a mic, requests it for the take, and remembers the choice', async ({ page }) => {
+    await installSecondMic(page)
+    await openNewProject(page)
+
+    const micButton = page.getByRole('button', { name: 'Choose microphone' })
+    await micButton.click()
+
+    const sheet = page.getByRole('dialog', { name: 'Choose a microphone' })
+    await expect(sheet).toBeVisible()
+    await sheet.getByRole('button', { name: 'USB Desk Microphone' }).click()
+    await expect(sheet).toHaveCount(0)
+
+    // The choice persists for future sessions.
+    await expect
+      .poll(() => page.evaluate(() => localStorage.getItem('kodyVideo.audioInput')))
+      .toContain('usb-desk-mic')
+
+    // A take asks for the chosen mic by exact id...
+    await recordClip(page)
+    const requests = await page.evaluate(() => window.__audioRequests)
+    expect(
+      requests.some((audio) => JSON.stringify(audio).includes('"exact":"usb-desk-mic"')),
+    ).toBe(true)
+    // ...and the clip still saved (recordClip asserted it): the nonexistent
+    // fake device fell back to the default mic instead of failing the take.
+
+    // Reopening the picker highlights the remembered mic.
+    await micButton.click()
+    await expect(
+      page.getByRole('button', { name: /USB Desk Microphone/ }),
+    ).toHaveAttribute('aria-pressed', 'true')
+  })
+})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

When the device exposes more than one microphone (wired/Bluetooth headset, USB interface, external transmitter), a mic button now appears in the record screen's top-right chrome. Tapping it opens a bottom sheet listing the available mics; the pick is highlighted, persisted across sessions, and used by every capture path.

<a href="https://cursor.com/agents/bc-4f5bc355-5252-444f-ac05-11ed5a61dfe3/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmic_chooser_pick_record_demo.mp4"><img src="https://cursor.com/artifacts/c/art-bb346744-1262-4675-aef0-2b3c2285f413" alt="mic_chooser_pick_record_demo.mp4" /></a>

![Mic picker sheet listing three microphones](https://cursor.com/artifacts/c/art-92398135-de7b-43a7-9b77-b410ead14c66) ![After picking and recording a take, the USB mic is checked](https://cursor.com/artifacts/c/art-851b6ecb-5aba-4810-a756-b89b5b96121f)

(The red "Mic isn't picking up sound" pill in the second shot is the documented fake-media quirk of the headless test VM — the fake mic produces silence.)

## How

- `src/lib/audio-input.ts` (new): enumerates `audioinput` devices (dropping Chrome's `default`/`communications` aliases and pre-permission placeholder entries), remembers the chosen mic in `localStorage` (`kodyVideo.audioInput`, storing id + label so a site-data clear can re-match the same physical mic by label), and resolves the remembered pick against the current device list. An unplugged mic falls back to the system default while staying remembered, so reconnecting it wins again — like OS audio routing.
- `src/lib/media.ts`: `openMicrophoneTrack` accepts a `deviceId` and retries without it when the exact request rejects (stale/unplugged id must not fail the take); `openCameraStream` accepts `audioDeviceId` for the iOS combined camera+mic request.
- `src/lib/camera.ts`: exposes `audioInputs`/`audioInputId`/`setAudioInput`. The list syncs at camera start, again after mic-permission priming resolves (that grant is what populates audio device ids/labels), and on `devicechange` while the preview is mounted. Per-take mic acquisition and both iOS combined-open paths pass the resolved pick with fallbacks. Switching swaps a still-warm mic immediately so the next take can't silently reuse the old device.
- `src/lib/screen-recorder.ts`: narration mic honors the same preference.
- UI: `IconMic`, `MicPickerSheet` (reuses the sheet-modal pattern), chooser button in `record-screen.tsx` shown only when >1 mic and disabled while recording.

## Testing

- 12 new unit tests (`src/lib/audio-input.test.ts`): alias/placeholder filtering, persistence round-trip, id/label/fallback resolution.
- New e2e spec (`tests/e2e/mic-picker.spec.ts`): button hidden with a single mic; with a stubbed second mic, picking it persists the choice, the next take requests `deviceId: { exact: … }`, the nonexistent fake device falls back to the default mic without failing the take, and reopening the picker highlights the pick.
- Full suites green: `npm run lint`, `npm test` (283 passed), `npm run test:e2e` (69 passed).
- Manual demo in the headless VM (video above): pick the USB mic, record a take, choice persists and is checked on reopen.
- `manual-test-checklist.md` gained a real-device entry for the chooser.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4f5bc355-5252-444f-ac05-11ed5a61dfe3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4f5bc355-5252-444f-ac05-11ed5a61dfe3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added microphone selection for recording when multiple microphones are available.
  * Microphone choices persist across sessions and restore automatically when available.
  * Added fallback to the default microphone if the selected device is unplugged or unavailable.
  * Added an accessible microphone picker with selection states, dismissal, and cancellation.
  * Screen recording now uses the preferred microphone when possible.
  * The microphone control is hidden when only one microphone is available.
* **Documentation**
  * Added manual testing guidance for multi-microphone scenarios.
* **Tests**
  * Added automated coverage for microphone discovery, persistence, fallback, and recording behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->