### PR TITLE
Add landscape project orientation (Plus)

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,13 @@ For a phone on the same network, use your machine’s LAN URL over HTTPS, or tun
   editor's clip stage plays the music under the selected clip from its
   exact spot on the film's timeline (normalization boosts cap at the
   browser's volume ceiling in previews)
+- **Landscape projects** (Plus): a per-project orientation setting on the
+  camera view. Landscape shifts the entire interface — the phone-shaped
+  shell widens to the viewport, the record controls become a right-hand
+  rail, the editor puts the player beside the timeline, and a hint asks for
+  the device to be turned while it's still upright. Exports are forced into
+  the project's orientation (mismatched clips center-crop), and the setting
+  travels in backups. Default stays portrait; existing projects are untouched
 - Project preview playback: tap edges to skip clips, tap middle to stop
 - Up to **6** stable project slots (create / open / rename / delete, poster art from your clips)
 - Big Go CTA: on-device export to **one video file**, then Share (system sheet) or Save
@@ -204,9 +211,10 @@ API is missing.
 
 The free plan includes one project, and exports carry a small Kody Video mark
 in the corner. Kody Video Plus — a one-time $0.99 Stripe Payment Link —
-removes the watermark, unlocks six project slots, and unlocks background
-music: the export sheet (or a locked home slot, or the locked "Add music"
-button in the editor) links to checkout, Stripe redirects back to
+removes the watermark, unlocks six project slots, background music, and
+landscape projects: the export sheet (or a locked home slot, the locked "Add
+music" button in the editor, or the locked orientation toggle on the camera
+view) links to checkout, Stripe redirects back to
 `/unlocked?session_id=…`, and a single Cloudflare Pages Function
 (`functions/api/verify-purchase.ts`) verifies the session server-side before
 the entitlement is stored in IndexedDB. 100%-off promotion codes (friends /

--- a/manual-test-checklist.md
+++ b/manual-test-checklist.md
@@ -28,8 +28,9 @@ npm test           # unit tests
   on the free plan; with Plus it flips the project to landscape — the shell
   widens, a "turn your device" hint shows while upright, the record controls
   become a right-hand rail sideways, and exports come out landscape (portrait
-  clips center-crop); the setting survives reload and backup/import; toggling
-  back to portrait restores everything
+  clips center-crop); the setting survives reload; toggling back to portrait
+  restores everything (backup/import round-trip of the setting is covered by
+  the unit suite)
 - **Location**: toggle asks permission, `aria-pressed` reflects state, new
   clips carry exact coordinates, toasts confirm on/off
 - **Editor**: opens at the most recent clip; tap selects; tiles show

--- a/manual-test-checklist.md
+++ b/manual-test-checklist.md
@@ -24,6 +24,12 @@ npm test           # unit tests
   default-state project (no notification); free plan locks slots 2–6 behind
   the Plus upsell; Plus unlocks 6 and blocks the 7th; the upsell sheet copy
   and buttons
+- **Orientation (Plus)**: the camera-view toggle is locked (opens the upsell)
+  on the free plan; with Plus it flips the project to landscape — the shell
+  widens, a "turn your device" hint shows while upright, the record controls
+  become a right-hand rail sideways, and exports come out landscape (portrait
+  clips center-crop); the setting survives reload and backup/import; toggling
+  back to portrait restores everything
 - **Location**: toggle asks permission, `aria-pressed` reflects state, new
   clips carry exact coordinates, toasts confirm on/off
 - **Editor**: opens at the most recent clip; tap selects; tiles show

--- a/src/components/icons.tsx
+++ b/src/components/icons.tsx
@@ -236,6 +236,22 @@ export function IconLens(handle: Handle<IconProps>) {
   )
 }
 
+/** Project orientation: the frame the film is shaped for, portrait or
+ * landscape, with a rotate arrow suggesting the switch. */
+export function IconOrientation(handle: Handle<IconProps & { landscape?: boolean }>) {
+  return () => (
+    <svg {...baseProps(handle.props.size ?? 22)}>
+      {handle.props.landscape ? (
+        <rect x="3" y="7" width="15" height="10" rx="2" />
+      ) : (
+        <rect x="5" y="4" width="10" height="15" rx="2" />
+      )}
+      <path d="M17.5 20a3.5 3.5 0 003.5-3.5V15" />
+      <path d="M19.2 16.8L21 15l1.8 1.8" />
+    </svg>
+  )
+}
+
 export function IconLock(handle: Handle<IconProps>) {
   return () => (
     <svg {...baseProps(handle.props.size ?? 22)}>

--- a/src/components/record-screen.tsx
+++ b/src/components/record-screen.tsx
@@ -32,6 +32,7 @@ import {
   type ClipRecord,
   type Project,
   type ProjectId,
+  type ProjectOrientation,
 } from '../lib/types'
 import {
   IconBack,
@@ -40,6 +41,8 @@ import {
   IconFlip,
   IconLens,
   IconLocation,
+  IconLock,
+  IconOrientation,
   IconPlay,
   IconScreen,
   IconTimer,
@@ -71,6 +74,12 @@ interface RecordScreenProps {
   interactionLocked: boolean
   /** Opt-in: tag new clips with device location (shell may pass persisted setting). */
   locationTaggingEnabled?: boolean
+  /** The film's orientation — landscape shifts the whole interface. */
+  orientation: ProjectOrientation
+  /** Kody Video Plus unlocked (landscape projects are a Plus perk). */
+  plus: boolean
+  /** Change the project's orientation (the page owns gating + upsell). */
+  onSetOrientation: (orientation: ProjectOrientation) => void
   onOpenEditor: () => void
   onOpenExport: () => void
   onPlay: () => void
@@ -994,6 +1003,18 @@ export function RecordScreen(handle: Handle<RecordScreenProps>) {
             </div>
           ) : null}
 
+          {/* Landscape project on a portrait viewport: what the camera
+              captures follows how the device is held, so the one thing that
+              makes the footage landscape is turning the phone. Visibility is
+              CSS-driven (portrait viewports only). */}
+          {props.orientation === 'landscape' && !recording && !screenRecording ? (
+            <div className="orientation-hint" role="status">
+              <IconOrientation size={28} landscape />
+              <strong>Turn your device sideways</strong>
+              <span>this is a landscape project</span>
+            </div>
+          ) : null}
+
           <div
             className="zoom-hud"
             aria-hidden="true"
@@ -1076,6 +1097,29 @@ export function RecordScreen(handle: Handle<RecordScreenProps>) {
             ) : null}
           </div>
           <div className="record-top-actions">
+            <button
+              type="button"
+              className={`btn-icon orientation-toggle${props.orientation === 'landscape' ? ' is-active' : ''}`}
+              aria-label={
+                props.orientation === 'landscape'
+                  ? 'Switch to a portrait project'
+                  : 'Switch to a landscape project (Kody Video Plus)'
+              }
+              aria-pressed={props.orientation === 'landscape'}
+              disabled={recording || screenRecording || countdown !== null}
+              mix={on('click', () => {
+                props.onSetOrientation(
+                  props.orientation === 'landscape' ? 'portrait' : 'landscape',
+                )
+              })}
+            >
+              <IconOrientation landscape={props.orientation === 'landscape'} />
+              {!props.plus ? (
+                <span className="orientation-plus-lock" aria-hidden="true">
+                  <IconLock size={11} />
+                </span>
+              ) : null}
+            </button>
             {screenRecordingSupported ? (
               <button
                 type="button"

--- a/src/components/upsell-sheet.tsx
+++ b/src/components/upsell-sheet.tsx
@@ -31,7 +31,7 @@ export function UpsellSheet(handle: Handle<UpsellSheetProps>) {
           <h3>Kody Video Plus</h3>
           <p className="sheet-copy">
             The free plan includes 1 project. Plus is a one-time $0.99 purchase that unlocks{' '}
-            {MAX_PROJECTS} project slots, background music for your films, and removes the
+            {MAX_PROJECTS} project slots, background music, landscape projects, and removes the
             watermark from exports — forever, on this device and any device you restore it on.
           </p>
           <div className="sheet-actions">

--- a/src/lib/export/encode-realtime.ts
+++ b/src/lib/export/encode-realtime.ts
@@ -1,6 +1,11 @@
 import { pickRecorderMimeType } from '../media'
 import { isIosBrowser } from '../platform'
-import { clipMusicVolume, clipSoundVolume, resolveAudioTrackPlayback } from '../types'
+import {
+  clipMusicVolume,
+  clipSoundVolume,
+  resolveAudioTrackPlayback,
+  type ProjectOrientation,
+} from '../types'
 import {
   FADE_IN_MS,
   FADE_OUT_MS,
@@ -41,6 +46,9 @@ export interface RealtimeExportOptions {
   watermarkImage?: HTMLImageElement | null
   /** Background-music playlist mixed under the clips (per-clip volumes). */
   background?: BackgroundAudio | null
+  /** Force the output into the project's orientation (absent = follow the
+   * first clip). */
+  orientation?: ProjectOrientation
 }
 
 /**
@@ -57,13 +65,21 @@ export async function exportRealtime(
   let height: number
   try {
     const probe = await loadClipVideo(probeClip.blob, 8000, probeClip.mimeType)
-    ;({ width, height } = pickOutputSize(probe.video.videoWidth, probe.video.videoHeight))
+    ;({ width, height } = pickOutputSize(
+      probe.video.videoWidth,
+      probe.video.videoHeight,
+      options.orientation,
+    ))
     probe.release()
   } catch (error) {
     // Probing is not worth dying over: recorded clips carry their capture
     // dimensions, and pickOutputSize has sane defaults for the rest.
     if ((probeClip.width ?? 0) > 0 && (probeClip.height ?? 0) > 0) {
-      ;({ width, height } = pickOutputSize(probeClip.width!, probeClip.height!))
+      ;({ width, height } = pickOutputSize(
+        probeClip.width!,
+        probeClip.height!,
+        options.orientation,
+      ))
     } else {
       throw tagExportError(error, { engine: 'realtime', where: 'probe-size', clipIndex: 0 })
     }

--- a/src/lib/export/encode-webcodecs.ts
+++ b/src/lib/export/encode-webcodecs.ts
@@ -23,6 +23,7 @@ import {
   clipSoundVolume,
   resolveAudioTrackPlayback,
   type ClipRecord,
+  type ProjectOrientation,
 } from '../types'
 import {
   applyGainEnvelope,
@@ -131,12 +132,13 @@ export async function exportWithWebCodecs(
   getPreviewCanvas?: () => HTMLCanvasElement | null,
   watermarkImage?: HTMLImageElement | null,
   background?: BackgroundAudio | null,
+  orientation?: ProjectOrientation,
 ): Promise<ExportResult> {
   if (!supportsWebCodecsExport()) {
     throw new Error('WebCodecs is not available')
   }
 
-  const { width, height } = await probeOutputSize(plan)
+  const { width, height } = await probeOutputSize(plan, orientation)
   const choice = await pickCodecs(width, height)
   if (!choice) {
     throw new Error('No supported export codec')
@@ -541,14 +543,18 @@ async function injectMetadataBestEffort(
   }
 }
 
-/** Output dimensions from the first clip's real (rotated) display size. */
-async function probeOutputSize(plan: ExportPlan): Promise<{ width: number; height: number }> {
+/** Output dimensions from the first clip's real (rotated) display size,
+ * forced into the project's orientation when it carries one. */
+async function probeOutputSize(
+  plan: ExportPlan,
+  orientation?: ProjectOrientation,
+): Promise<{ width: number; height: number }> {
   const clip = plan.segments[0]!.clip
   try {
     const input = new Input({ source: new BlobSource(clip.blob), formats: ALL_FORMATS })
     const track = await input.getPrimaryVideoTrack()
     if (track && track.displayWidth > 0 && track.displayHeight > 0) {
-      return pickOutputSize(track.displayWidth, track.displayHeight)
+      return pickOutputSize(track.displayWidth, track.displayHeight, orientation)
     }
   } catch {
     // Fall through to the element probe.
@@ -556,7 +562,7 @@ async function probeOutputSize(plan: ExportPlan): Promise<{ width: number; heigh
   try {
     const probe = await loadClipVideo(clip.blob, 8000, clip.mimeType)
     try {
-      return pickOutputSize(probe.video.videoWidth, probe.video.videoHeight)
+      return pickOutputSize(probe.video.videoWidth, probe.video.videoHeight, orientation)
     } finally {
       probe.release()
     }
@@ -564,7 +570,7 @@ async function probeOutputSize(plan: ExportPlan): Promise<{ width: number; heigh
     // Recorded clips carry their capture dimensions — probing must never be
     // the reason an export dies (pickOutputSize also has sane defaults).
     if ((clip.width ?? 0) > 0 && (clip.height ?? 0) > 0) {
-      return pickOutputSize(clip.width!, clip.height!)
+      return pickOutputSize(clip.width!, clip.height!, orientation)
     }
     throw tagExportError(error, { engine: 'webcodecs', where: 'probe-size', clipIndex: 0 })
   }

--- a/src/lib/export/index.ts
+++ b/src/lib/export/index.ts
@@ -1,5 +1,5 @@
 import { reportError } from '../error-reporting'
-import type { ClipRecord } from '../types'
+import type { ClipRecord, ProjectOrientation } from '../types'
 import type { BackgroundAudio } from './background-audio'
 import { exportRealtime } from './encode-realtime'
 import { exportWithWebCodecs, supportsWebCodecsExport } from './encode-webcodecs'
@@ -39,6 +39,9 @@ export interface ExportOptions {
   /** Background-music playlist mixed under the clips at their per-clip
    * volumes; tracks play one after the other until the film ends. */
   background?: BackgroundAudio | null
+  /** Force the output into the project's orientation. Absent = follow the
+   * first clip's aspect (how every project exported before the setting). */
+  orientation?: ProjectOrientation
   /**
    * Fired once when the export enters the realtime canvas + MediaRecorder
    * path (no WebCodecs, or WebCodecs failed). Lets the UI offer a backup /
@@ -89,6 +92,7 @@ async function runExport(
         options.getPreviewCanvas,
         watermarkImage,
         options.background,
+        options.orientation,
       )
       reportSilentExportAudio({ engine: 'webcodecs', outputMime: result.mimeType })
       reportBlackExportVideo({ engine: 'webcodecs', outputMime: result.mimeType })
@@ -118,6 +122,7 @@ async function runExport(
     getPreviewCanvas: options.getPreviewCanvas,
     watermarkImage,
     background: options.background,
+    orientation: options.orientation,
   })
   reportSilentExportAudio({ engine: 'realtime', outputMime: result.mimeType })
   reportBlackExportVideo({ engine: 'realtime', outputMime: result.mimeType })

--- a/src/lib/export/last-export.test.ts
+++ b/src/lib/export/last-export.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest'
+import type { ClipRecord } from '../types'
+import { exportSignature } from './last-export'
+
+function fakeClip(id: string): ClipRecord {
+  return {
+    id,
+    projectId: 'proj_x',
+    blob: new Blob(['clip'], { type: 'video/mp4' }),
+    mimeType: 'video/mp4',
+    durationMs: 1500,
+    trimStartMs: 0,
+    trimEndMs: 1500,
+    createdAt: 1700000000000,
+  }
+}
+
+describe('exportSignature', () => {
+  it('signs portrait projects identically to before the orientation setting', () => {
+    const clips = [fakeClip('clip_a')]
+    // Cached exports from app versions without the setting must survive the
+    // update: absent and explicit-portrait orientations both sign like the
+    // old three-argument call.
+    expect(exportSignature(clips, true, null, 'portrait')).toBe(
+      exportSignature(clips, true, null),
+    )
+    expect(exportSignature(clips, true, null, undefined)).toBe(
+      exportSignature(clips, true, null),
+    )
+  })
+
+  it('signs landscape differently so the cached export re-renders', () => {
+    const clips = [fakeClip('clip_a')]
+    expect(exportSignature(clips, true, null, 'landscape')).not.toBe(
+      exportSignature(clips, true, null, 'portrait'),
+    )
+  })
+})

--- a/src/lib/export/last-export.ts
+++ b/src/lib/export/last-export.ts
@@ -14,6 +14,7 @@ import {
   type ClipRecord,
   type ProjectAudioRecord,
   type ProjectId,
+  type ProjectOrientation,
 } from '../types'
 import { withExportCacheReserved } from './export-cache'
 import { readOpfsFile, removeExportEntry, streamToOpfsFile } from './opfs'
@@ -26,9 +27,14 @@ export function exportSignature(
   clips: ClipRecord[],
   watermarked: boolean,
   audio?: Pick<ProjectAudioRecord, 'tracks' | 'fadeIn' | 'fadeOut'> | null,
+  orientation?: ProjectOrientation,
 ): string {
   return JSON.stringify({
     watermarked,
+    // Only landscape signs (JSON drops undefined): every portrait project's
+    // signature stays byte-identical to before the setting existed, so
+    // cached exports survive the app update.
+    orientation: orientation === 'landscape' ? 'landscape' : undefined,
     clips: clips.map((clip) => [
       clip.id,
       clip.trimStartMs,

--- a/src/lib/export/shared.test.ts
+++ b/src/lib/export/shared.test.ts
@@ -12,11 +12,38 @@ import {
   decodeBlobAudioViaWebAudio,
   decodeClipAudio,
   isWebKitAudioDecoderNotFoundError,
+  pickOutputSize,
   resampleAudioBuffer,
   resetAudioDiagnostics,
   resolveEncodeCanvas,
   waitForPreviewCanvas,
 } from './shared'
+
+describe('pickOutputSize', () => {
+  it('follows the source aspect, capped at 1280 on the long edge', () => {
+    expect(pickOutputSize(1080, 1920)).toEqual({ width: 720, height: 1280 })
+    expect(pickOutputSize(1920, 1080)).toEqual({ width: 1280, height: 720 })
+    // Never upscales; keeps dimensions even.
+    expect(pickOutputSize(321, 569)).toEqual({ width: 322, height: 570 })
+  })
+
+  it('forces a landscape project onto portrait sources by swapping dims', () => {
+    expect(pickOutputSize(1080, 1920, 'landscape')).toEqual({ width: 1280, height: 720 })
+    expect(pickOutputSize(320, 568, 'landscape')).toEqual({ width: 568, height: 320 })
+    // Already landscape: untouched.
+    expect(pickOutputSize(1920, 1080, 'landscape')).toEqual({ width: 1280, height: 720 })
+  })
+
+  it('forces a portrait project onto landscape sources by swapping dims', () => {
+    expect(pickOutputSize(1920, 1080, 'portrait')).toEqual({ width: 720, height: 1280 })
+    expect(pickOutputSize(1080, 1920, 'portrait')).toEqual({ width: 720, height: 1280 })
+  })
+
+  it('leaves square sources alone in both orientations', () => {
+    expect(pickOutputSize(1000, 1000, 'landscape')).toEqual({ width: 1000, height: 1000 })
+    expect(pickOutputSize(1000, 1000, 'portrait')).toEqual({ width: 1000, height: 1000 })
+  })
+})
 
 describe('classifyOutputAudioPeak', () => {
   it('returns unknown when inputs never cleared the silence floor', () => {

--- a/src/lib/export/shared.ts
+++ b/src/lib/export/shared.ts
@@ -11,6 +11,7 @@ import {
   UnsupportedInputFormatError,
 } from 'mediabunny'
 import { reportError } from '../error-reporting'
+import type { ProjectOrientation } from '../types'
 import { isMediaElementFailure, MediaElementFailureError } from './media-error'
 
 /** Helpers shared by the WebCodecs and realtime export engines. */
@@ -230,13 +231,28 @@ export function drawCoverFrom(
 /**
  * Pick output dimensions from the first clip's real pixel size: preserve its
  * aspect ratio, cap the long edge at 1280, never upscale, keep dims even.
+ *
+ * When the project carries an explicit `orientation`, the output must match
+ * it regardless of what the first clip happens to be: a mismatched source
+ * has its dimensions swapped (the same cover-fit draw that letterboxes
+ * nothing then center-crops every frame into the rotated canvas).
  */
-export function pickOutputSize(sourceWidth: number, sourceHeight: number): {
+export function pickOutputSize(
+  sourceWidth: number,
+  sourceHeight: number,
+  orientation?: ProjectOrientation,
+): {
   width: number
   height: number
 } {
-  const w = sourceWidth > 0 ? sourceWidth : 720
-  const h = sourceHeight > 0 ? sourceHeight : 1280
+  let w = sourceWidth > 0 ? sourceWidth : 720
+  let h = sourceHeight > 0 ? sourceHeight : 1280
+  if (
+    (orientation === 'landscape' && h > w) ||
+    (orientation === 'portrait' && w > h)
+  ) {
+    ;[w, h] = [h, w]
+  }
   const scale = Math.min(1, 1280 / Math.max(w, h))
   const even = (n: number) => Math.max(2, 2 * Math.round((n * scale) / 2))
   return { width: even(w), height: even(h) }

--- a/src/lib/export/shared.ts
+++ b/src/lib/export/shared.ts
@@ -235,7 +235,10 @@ export function drawCoverFrom(
  * When the project carries an explicit `orientation`, the output must match
  * it regardless of what the first clip happens to be: a mismatched source
  * has its dimensions swapped (the same cover-fit draw that letterboxes
- * nothing then center-crops every frame into the rotated canvas).
+ * nothing then center-crops every frame into the rotated canvas). A square
+ * source is deliberately left square — it already satisfies either
+ * orientation, and inventing a non-square target would crop pixels for no
+ * reason.
  */
 export function pickOutputSize(
   sourceWidth: number,

--- a/src/lib/project-transfer.test.ts
+++ b/src/lib/project-transfer.test.ts
@@ -102,6 +102,39 @@ describe('project backup round trip', () => {
     expect(parsed.audio).toBeNull()
   })
 
+  it('round-trips the project orientation (Plus devices)', async () => {
+    await markWatermarkRemoved('cs_test_transfer')
+    const backup = serializeProject(
+      { ...fakeProject('Wide'), orientation: 'landscape' },
+      [fakeClip('clip_a', 'AAAA')],
+    )
+    const parsed = await parseProjectBackup(backup)
+    expect(parsed.orientation).toBe('landscape')
+
+    const project = await importProjectBackup(parsed)
+    expect((await listProjects()).find((p) => p.id === project.id)?.orientation).toBe(
+      'landscape',
+    )
+  })
+
+  it('parses backups without an orientation as portrait (older backups)', async () => {
+    const backup = serializeProject(fakeProject(), [fakeClip('clip_a', 'AAAA')])
+    const parsed = await parseProjectBackup(backup)
+    expect(parsed.orientation).toBe('portrait')
+  })
+
+  it('imports a landscape backup on a free device as a portrait project', async () => {
+    const backup = serializeProject(
+      { ...fakeProject('Wide'), orientation: 'landscape' },
+      [fakeClip('clip_a', 'AAAA')],
+    )
+    const parsed = await parseProjectBackup(backup)
+    const project = await importProjectBackup(parsed)
+
+    expect(await getClipsForProject(project.id)).toHaveLength(1)
+    expect((await listProjects()).find((p) => p.id === project.id)?.orientation).toBeUndefined()
+  })
+
   it('round-trips the music playlist, fades, and per-clip volumes', async () => {
     await markWatermarkRemoved('cs_test_transfer')
     const clips = [

--- a/src/lib/project-transfer.ts
+++ b/src/lib/project-transfer.ts
@@ -8,7 +8,7 @@ import {
   updateProjectAudioTrack,
 } from './storage'
 import { requestPersistentStorage } from './storage-space'
-import type { ClipRecord, Project, ProjectAudioRecord } from './types'
+import type { ClipRecord, Project, ProjectAudioRecord, ProjectOrientation } from './types'
 
 /**
  * Single-file project backup, used both as a safety net and to move a
@@ -74,6 +74,9 @@ interface Manifest {
   app: 'kody-video'
   exportedAt: number
   projectName: string
+  /** The film's orientation (absent = portrait). Older app versions ignore
+   * this field and import the clips as a portrait project. */
+  orientation?: 'landscape'
   clips: ManifestClip[]
   /** Background-music playlist (absent on projects without one). */
   audio?: ManifestAudio
@@ -120,6 +123,7 @@ export function serializeProject(
     app: 'kody-video',
     exportedAt: Date.now(),
     projectName: project.name,
+    ...(project.orientation === 'landscape' ? { orientation: 'landscape' as const } : {}),
     clips: clips.map((clip) => ({
       mimeType: clip.mimeType,
       durationMs: clip.durationMs,
@@ -180,6 +184,8 @@ export interface ParsedBackupAudio {
 
 export interface ParsedBackup {
   projectName: string
+  /** The film's orientation ('portrait' when the backup carries none). */
+  orientation: ProjectOrientation
   clips: Array<Omit<ManifestClip, 'byteLength'> & { blob: Blob }>
   /** Background-music playlist, when the backup carries one. */
   audio: ParsedBackupAudio | null
@@ -294,7 +300,12 @@ export async function parseProjectBackup(file: Blob): Promise<ParsedBackup> {
     }
   }
 
-  return { projectName: String(manifest.projectName || 'Imported project'), clips, audio }
+  return {
+    projectName: String(manifest.projectName || 'Imported project'),
+    orientation: manifest.orientation === 'landscape' ? 'landscape' : 'portrait',
+    clips,
+    audio,
+  }
 }
 
 let importLock: Promise<void> = Promise.resolve()
@@ -355,7 +366,12 @@ async function persistImportedProject(
   parsed: ParsedBackup,
   onProgress?: (doneClips: number, totalClips: number) => void,
 ): Promise<Project> {
-  const project = await createProject(parsed.projectName)
+  const plus = await isWatermarkRemoved()
+  // Landscape projects are a Plus perk, like background music: restoring a
+  // Plus-made backup on a free device keeps the clips as a portrait project
+  // (the setting is skipped, never a creation failure).
+  const orientation = plus && parsed.orientation === 'landscape' ? 'landscape' : undefined
+  const project = await createProject(parsed.projectName, { orientation })
   try {
     let done = 0
     onProgress?.(0, parsed.clips.length)
@@ -398,7 +414,7 @@ async function persistImportedProject(
     // up front — never a silent partial playlist). On entitled devices any
     // track failure fails the import like a clip failure would, so the
     // rollback below never leaves half the music behind.
-    if (parsed.audio && (await isWatermarkRemoved())) {
+    if (parsed.audio && plus) {
       for (const track of parsed.audio.tracks) {
         const bytes = await track.blob.arrayBuffer()
         const record = await addProjectAudioTrack({

--- a/src/lib/storage.test.ts
+++ b/src/lib/storage.test.ts
@@ -20,9 +20,11 @@ import {
   isStaleConnectionError,
   listProjects,
   moveClip,
+  PlusRequiredError,
   removeProjectAudioTrack,
   renameProject,
   setOnboardingDismissed,
+  setProjectOrientation,
   setTourCardDismissed,
   setKeepWatermark,
   toStoredBlob,
@@ -274,6 +276,52 @@ describe('storage layer', () => {
 
   it('deleteProjectIfPristine keeps a project created with a default-shaped name', async () => {
     const project = await createProject('Project 2')
+
+    expect(await deleteProjectIfPristine(project.id)).toBe(false)
+    expect(await listProjects()).toHaveLength(1)
+  })
+
+  it('gates landscape orientation behind the Plus purchase', async () => {
+    const project = await createProject('Free plan')
+    await expect(setProjectOrientation(project.id, 'landscape')).rejects.toBeInstanceOf(
+      PlusRequiredError,
+    )
+    await expect(setProjectOrientation(project.id, 'landscape')).rejects.toThrow(/plus/i)
+    expect((await listProjects())[0]?.orientation).toBeUndefined()
+    // Portrait is the default and never gated.
+    await setProjectOrientation(project.id, 'portrait')
+    expect((await listProjects())[0]?.orientation).toBeUndefined()
+  })
+
+  it('sets and clears the project orientation for Plus users', async () => {
+    await markWatermarkRemoved('cs_test_storage')
+    const project = await createProject('Widescreen')
+    const landscape = await setProjectOrientation(project.id, 'landscape')
+    expect(landscape.orientation).toBe('landscape')
+    expect((await listProjects())[0]?.orientation).toBe('landscape')
+
+    // Back to portrait clears the stored field entirely — indistinguishable
+    // from a project made before the setting existed.
+    const portrait = await setProjectOrientation(project.id, 'portrait')
+    expect(portrait.orientation).toBeUndefined()
+    expect('orientation' in ((await listProjects())[0] ?? {})).toBe(false)
+  })
+
+  it('creates landscape projects when asked (Plus only)', async () => {
+    await expect(
+      createProject('Free landscape', { orientation: 'landscape' }),
+    ).rejects.toBeInstanceOf(PlusRequiredError)
+
+    await markWatermarkRemoved('cs_test_storage')
+    const project = await createProject('Plus landscape', { orientation: 'landscape' })
+    expect(project.orientation).toBe('landscape')
+    expect((await listProjects())[0]?.orientation).toBe('landscape')
+  })
+
+  it('deleteProjectIfPristine keeps landscape projects', async () => {
+    await markWatermarkRemoved('cs_test_storage')
+    const project = await createProject()
+    await setProjectOrientation(project.id, 'landscape')
 
     expect(await deleteProjectIfPristine(project.id)).toBe(false)
     expect(await listProjects()).toHaveLength(1)

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -14,6 +14,7 @@ import {
   type ProjectAudioRecord,
   type ProjectAudioTrack,
   type ProjectId,
+  type ProjectOrientation,
 } from './types'
 
 interface ClipsDB extends DBSchema {
@@ -267,7 +268,10 @@ export class ProjectLimitError extends Error {
   override readonly name = 'ProjectLimitError'
 }
 
-export async function createProject(name?: string): Promise<Project> {
+export async function createProject(
+  name?: string,
+  options?: { orientation?: ProjectOrientation },
+): Promise<Project> {
   const db = await getDb()
   const existing = await listProjects()
   const settings = await getSettings()
@@ -284,6 +288,7 @@ export async function createProject(name?: string): Promise<Project> {
       'The free plan includes 1 project — Kody Video Plus unlocks 6 (and removes the watermark).',
     )
   }
+  if (options?.orientation === 'landscape') assertLandscapeAllowed(settings)
 
   const now = Date.now()
   const chosenName = name?.trim()
@@ -297,6 +302,7 @@ export async function createProject(name?: string): Promise<Project> {
   // Marks eligibility for the default-state cleanup on exit — a
   // caller-chosen name is meaningful and must never be auto-deleted.
   if (!chosenName) project.nameIsDefault = true
+  if (options?.orientation === 'landscape') project.orientation = 'landscape'
   await db.put('projects', project)
   await setLastOpenedProjectId(project.id)
   return project
@@ -320,13 +326,50 @@ export async function renameProject(id: ProjectId, name: string): Promise<Projec
   return updated
 }
 
+/**
+ * A Kody Video Plus perk was used without the entitlement. Surfaced in-app
+ * as the upsell; expected product behavior, never a crash report.
+ */
+export class PlusRequiredError extends Error {
+  override readonly name = 'PlusRequiredError'
+}
+
+function assertLandscapeAllowed(settings: Pick<AppMeta, 'watermarkRemoved'>): void {
+  if (settings.watermarkRemoved !== true) {
+    throw new PlusRequiredError('Landscape projects are a Kody Video Plus perk.')
+  }
+}
+
+/**
+ * Set the project's orientation. Landscape requires the Plus entitlement
+ * (enforced here so every path — toggle, import — hits the same gate);
+ * switching back to portrait is always allowed and clears the stored field,
+ * so a portrait project is indistinguishable from one made before the
+ * setting existed.
+ */
+export async function setProjectOrientation(
+  id: ProjectId,
+  orientation: ProjectOrientation,
+): Promise<Project> {
+  const db = await getDb()
+  const project = await db.get('projects', id)
+  if (!project) throw new Error('Project not found')
+  if (orientation === 'landscape') assertLandscapeAllowed(await getSettings())
+  const updated: Project = { ...project, updatedAt: Date.now() }
+  if (orientation === 'landscape') updated.orientation = 'landscape'
+  else delete updated.orientation
+  await db.put('projects', updated)
+  return updated
+}
+
 export async function deleteProject(id: ProjectId): Promise<void> {
   await deleteProjectRecords(id, { onlyIfPristine: false })
 }
 
 /**
  * Delete the project only when it is still indistinguishable from a freshly
- * created one: no clips, never renamed, no background music. Exiting such a
+ * created one: no clips, never renamed, default (portrait) orientation, no
+ * background music. Exiting such a
  * project should leave nothing behind — deleting it changes nothing the user
  * can see, so it happens silently. Any leftover undo snapshot (last clip
  * deleted, never restored) goes with it. Returns true when it was deleted.
@@ -354,6 +397,7 @@ async function deleteProjectRecords(
     const pristine =
       project.clipIds.length === 0 &&
       project.nameIsDefault === true &&
+      project.orientation === undefined &&
       (!audio || audio.tracks.length === 0)
     if (!pristine) {
       await tx.done

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -351,14 +351,24 @@ export async function setProjectOrientation(
   id: ProjectId,
   orientation: ProjectOrientation,
 ): Promise<Project> {
-  const db = await getDb()
-  const project = await db.get('projects', id)
-  if (!project) throw new Error('Project not found')
+  // Entitlement first, then a single read-modify-write transaction: rapid
+  // toggles issue overlapping calls, and IndexedDB serializes same-scope
+  // readwrite transactions in creation order — so the user's last tap is
+  // also the last commit. A read outside the transaction (or an await
+  // between paths) would let an earlier landscape write land after a later
+  // portrait one.
   if (orientation === 'landscape') assertLandscapeAllowed(await getSettings())
+  const db = await getDb()
+  const tx = db.transaction('projects', 'readwrite')
+  const project = await tx.store.get(id)
+  if (!project) {
+    await tx.done
+    throw new Error('Project not found')
+  }
   const updated: Project = { ...project, updatedAt: Date.now() }
   if (orientation === 'landscape') updated.orientation = 'landscape'
   else delete updated.orientation
-  await db.put('projects', updated)
+  await completeTransaction([tx.store.put(updated)], tx)
   return updated
 }
 

--- a/src/lib/types.test.ts
+++ b/src/lib/types.test.ts
@@ -8,6 +8,7 @@ import {
   effectiveDurationMs,
   formatDuration,
   projectAudioTotalDurationMs,
+  projectOrientation,
   resolveAudioTrackPlayback,
 } from './types'
 
@@ -25,6 +26,18 @@ describe('duration helpers', () => {
   it('formats short and long durations', () => {
     expect(formatDuration(1500)).toBe('1.5s')
     expect(formatDuration(61500)).toBe('1:01.5')
+  })
+})
+
+describe('project orientation', () => {
+  it('defaults to portrait for projects without the field (older records)', () => {
+    expect(projectOrientation({})).toBe('portrait')
+    expect(projectOrientation({ orientation: undefined })).toBe('portrait')
+  })
+
+  it('reads an explicit orientation', () => {
+    expect(projectOrientation({ orientation: 'landscape' })).toBe('landscape')
+    expect(projectOrientation({ orientation: 'portrait' })).toBe('portrait')
   })
 })
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,6 +1,10 @@
 export type ProjectId = string
 export type ClipId = string
 
+/** The film's shape: portrait (the default, phone-style) or landscape.
+ * Landscape is a Kody Video Plus perk. */
+export type ProjectOrientation = 'portrait' | 'landscape'
+
 export interface Project {
   id: ProjectId
   name: string
@@ -11,6 +15,16 @@ export interface Project {
    * rename, and never set for caller-chosen names, so a deliberate name
    * (even one shaped like "Project 2") is never mistaken for the default. */
   nameIsDefault?: boolean
+  /** The film's orientation. Absent = portrait (every project made before
+   * this setting existed is a portrait project). */
+  orientation?: ProjectOrientation
+}
+
+/** A project's orientation, defaulting portrait for records without one. */
+export function projectOrientation(
+  project: Pick<Project, 'orientation'>,
+): ProjectOrientation {
+  return project.orientation === 'landscape' ? 'landscape' : 'portrait'
 }
 
 export interface ClipMeta {

--- a/src/pages/project-page.tsx
+++ b/src/pages/project-page.tsx
@@ -26,10 +26,20 @@ import {
 } from '../lib/media'
 import { loadProjectPage, type ProjectLoaderData } from '../lib/project-actions'
 import { projectBackupFilename, serializeProject } from '../lib/project-transfer'
-import { createProject, setKeepWatermark, setOnboardingDismissed } from '../lib/storage'
+import {
+  createProject,
+  setKeepWatermark,
+  setOnboardingDismissed,
+  setProjectOrientation,
+} from '../lib/storage'
 import { formatBytes, requestPersistentStorage } from '../lib/storage-space'
 import { navigate } from '../router'
-import { NEW_PROJECT_ID, type ProjectId } from '../lib/types'
+import {
+  NEW_PROJECT_ID,
+  projectOrientation,
+  type ProjectId,
+  type ProjectOrientation,
+} from '../lib/types'
 
 /** Android share targets get flaky well below this; bigger backups download. */
 const SHARE_BACKUP_LIMIT_BYTES = 50 * 1024 * 1024
@@ -96,6 +106,9 @@ export function ProjectPage(handle: Handle<ProjectPageProps>) {
   let exportState: ExportUiState | null = null
   let restoring = false
   let upselling = false
+  /** Orientation chosen on a "/project/new" shell before anything is
+   * persisted — applied when the first clip creates the project. */
+  let pendingOrientation: ProjectOrientation | null = null
   /** In-flight share/save COUNT (concurrent actions must not clear each
    * other's busy state) — the export sheet must not dismiss while > 0. */
   let exportActionCount = 0
@@ -168,6 +181,82 @@ export function ProjectPage(handle: Handle<ProjectPageProps>) {
     }, 2600)
   }
 
+  /** The film's orientation this page renders for: the persisted project's
+   * setting, or the pending pick on a not-yet-persisted "/project/new". */
+  const effectiveOrientation = (): ProjectOrientation => {
+    const project = data?.project
+    if (project && project.id !== NEW_PROJECT_ID) return projectOrientation(project)
+    return pendingOrientation ?? 'portrait'
+  }
+
+  /**
+   * Landscape shifts the whole shell, not just this page: the app frame is
+   * phone-shaped (480px column) by default, and the record/editor layouts
+   * re-arrange for a wide viewport. Both hang off a document-level data
+   * attribute so the CSS can reach the shell (#root) above the app tree.
+   * Installed PWAs additionally get a best-effort orientation lock — the
+   * manifest defaults the app to portrait, and an explicit lock is the only
+   * way a landscape project can rotate there. In a browser tab the lock
+   * rejects (fullscreen-only) and the user simply turns the phone.
+   */
+  let appliedShellOrientation: ProjectOrientation | null = null
+  const syncShellOrientation = (orientation: ProjectOrientation) => {
+    if (appliedShellOrientation === orientation) return
+    appliedShellOrientation = orientation
+    document.documentElement.dataset.projectOrientation = orientation
+    try {
+      const lockable = screen.orientation as ScreenOrientation & {
+        lock?: (lock: string) => Promise<void>
+      }
+      if (orientation === 'landscape') {
+        void lockable.lock?.('landscape').catch(() => undefined)
+      } else {
+        screen.orientation.unlock()
+      }
+    } catch {
+      // Orientation API missing or lock not allowed here — rotation stays manual.
+    }
+  }
+  handle.signal.addEventListener('abort', () => {
+    delete document.documentElement.dataset.projectOrientation
+    try {
+      screen.orientation.unlock()
+    } catch {
+      // Orientation API missing — nothing was locked.
+    }
+  })
+
+  const setOrientation = (next: ProjectOrientation) => {
+    if (!data) return
+    if (next === 'landscape' && !data.watermarkRemoved) {
+      upselling = true
+      void handle.update()
+      return
+    }
+    const project = data.project
+    if (!project || project.id === NEW_PROJECT_ID) {
+      pendingOrientation = next
+      void handle.update()
+      return
+    }
+    // Optimistic: the whole interface swings on this — the write's result
+    // is exactly this state, so only a failure needs a resync.
+    data = {
+      ...data,
+      project: {
+        ...project,
+        ...(next === 'landscape' ? { orientation: 'landscape' as const } : {}),
+        ...(next === 'portrait' ? { orientation: undefined } : {}),
+      },
+    }
+    void handle.update()
+    void setProjectOrientation(project.id, next).catch((err) => {
+      reportError(err, 'set-orientation')
+      showToast(err instanceof Error ? err.message : 'Could not switch orientation')
+      refresh()
+    })
+  }
+
   // Lazy creation: a "/project/new" project is persisted only when the
   // first clip finishes recording. The promise is memoized so overlapping
   // takes (or a camera take racing a screen take) create exactly one.
@@ -181,7 +270,9 @@ export function ProjectPage(handle: Handle<ProjectPageProps>) {
     if (project && project.id !== NEW_PROJECT_ID) return Promise.resolve(project.id)
     ensureProjectPromise ??= (async () => {
       try {
-        const created = await createProject()
+        const created = await createProject(undefined, {
+          orientation: pendingOrientation === 'landscape' ? 'landscape' : undefined,
+        })
         createdProjectId = created.id
         // Their recordings should survive storage pressure.
         requestPersistentStorage()
@@ -224,7 +315,12 @@ export function ProjectPage(handle: Handle<ProjectPageProps>) {
     }
 
     const watermarked = shouldWatermarkExports(data)
-    const signature = exportSignature(clips, watermarked, audio)
+    // Only an explicit landscape choice forces the output shape; portrait
+    // projects keep following their first clip (desktop and screen
+    // recordings are landscape media in "portrait" projects — cropping
+    // those would be a regression, not a feature).
+    const orientation = effectiveOrientation() === 'landscape' ? 'landscape' : undefined
+    const signature = exportSignature(clips, watermarked, audio, orientation)
     // Stop camera/mic immediately rather than waiting on record-screen
     // unmount. On iOS the combined mic+camera session can hold decoder
     // slots past the first paints, and WebKit reports that race as
@@ -304,6 +400,7 @@ export function ProjectPage(handle: Handle<ProjectPageProps>) {
         const result = await exportProject(clips, {
           audioContext,
           watermark: watermarked,
+          orientation,
           background:
             audio && audio.tracks.length > 0
               ? {
@@ -451,9 +548,13 @@ export function ProjectPage(handle: Handle<ProjectPageProps>) {
     const exportFilename = exportState?.result
       ? projectFilename(project.name, exportState.result.fileExtension)
       : null
+    const orientation = effectiveOrientation()
+    syncShellOrientation(orientation)
 
     return (
-      <div className="screen project-screen">
+      <div
+        className={`screen project-screen${orientation === 'landscape' ? ' orientation-landscape' : ''}`}
+      >
         {/* While exporting, the screens unmount entirely: the camera is
             released (no dead preview burning battery behind the overlay) and
             the full-screen progress takes over. */}
@@ -466,6 +567,9 @@ export function ProjectPage(handle: Handle<ProjectPageProps>) {
             storage={data.storage}
             locationTaggingEnabled={data.locationTaggingEnabled}
             interactionLocked={overlayOpen}
+            orientation={orientation}
+            plus={data.watermarkRemoved}
+            onSetOrientation={setOrientation}
             onOpenEditor={() => {
               mode = 'editor'
               void handle.update()

--- a/src/pages/project-page.tsx
+++ b/src/pages/project-page.tsx
@@ -516,6 +516,8 @@ export function ProjectPage(handle: Handle<ProjectPageProps>) {
     const clips = data.clips
 
     if (!project || data.error) {
+      // Whatever project shaped the shell is gone — error UI is portrait.
+      syncShellOrientation('portrait')
       if (data.error === 'Project not found') {
         handle.queueTask(() => navigate('/', { replace: true }))
         return null
@@ -541,7 +543,13 @@ export function ProjectPage(handle: Handle<ProjectPageProps>) {
     const isLazyCreateAlias =
       project.id === NEW_PROJECT_ID &&
       (props.projectId === NEW_PROJECT_ID || props.projectId === createdProjectId)
-    if (project.id !== props.projectId && !isLazyCreateAlias) return null
+    if (project.id !== props.projectId && !isLazyCreateAlias) {
+      // In-place switch to another project: the stale project's landscape
+      // shell must not linger over the incoming one — reset to the default
+      // while the load is in flight (the new data re-syncs on render).
+      syncShellOrientation('portrait')
+      return null
+    }
 
     const exporting = exportState?.status === 'exporting'
     const overlayOpen = playing || exportState !== null || onboardingOpen

--- a/src/styles/editor.css
+++ b/src/styles/editor.css
@@ -867,3 +867,37 @@
 .editor-toolbar .btn {
   flex: 0 1 auto;
 }
+
+/* The landscape interface: with the project (and viewport) sideways there
+   is no room for a player stacked over a tall panel — the stage takes the
+   left, and the timeline/tools panel becomes a right-hand column. */
+@media (orientation: landscape) {
+  .orientation-landscape .editor-screen {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) minmax(320px, 44%);
+    grid-template-rows: auto minmax(0, 1fr);
+  }
+
+  .orientation-landscape .editor-top {
+    grid-column: 1 / -1;
+  }
+
+  .orientation-landscape .editor-stage {
+    grid-row: 2;
+    grid-column: 1;
+    margin: 2px 0 calc(12px + var(--safe-bottom)) 14px;
+  }
+
+  .orientation-landscape .editor-screen.is-trimming .editor-stage,
+  .orientation-landscape .editor-screen.is-audio-editing .editor-stage {
+    flex: none;
+  }
+
+  .orientation-landscape .editor-panel {
+    grid-row: 2;
+    grid-column: 2;
+    min-height: 0;
+    overflow-y: auto;
+    padding-right: calc(12px + env(safe-area-inset-right, 0px));
+  }
+}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -949,3 +949,21 @@ a {
     box-shadow: none;
   }
 }
+
+/* Landscape projects shift the whole shell, not just a page: the app frame
+   is phone-shaped (480px column) by default, so while a landscape project
+   is open the project page sets data-project-orientation on <html> and the
+   frame widens to the viewport (phones turned sideways) or to a wide
+   desktop frame. Must sit after the base #root / .app-shell rules AND the
+   min-width desktop block so it wins in both. */
+html[data-project-orientation='landscape'] #root,
+html[data-project-orientation='landscape'] .app-shell {
+  width: 100%;
+  max-width: none;
+}
+
+@media (min-width: 720px) {
+  html[data-project-orientation='landscape'] #root {
+    width: min(1280px, calc(100% - 48px));
+  }
+}

--- a/src/styles/record.css
+++ b/src/styles/record.css
@@ -417,6 +417,104 @@
   pointer-events: none;
 }
 
+/* Orientation toggle: the lock badge marks it as a Plus perk on the free
+   plan (tapping opens the upsell, like the editor's locked Add music). */
+.orientation-toggle {
+  position: relative;
+}
+
+.orientation-plus-lock {
+  position: absolute;
+  top: -4px;
+  right: -4px;
+  display: grid;
+  place-items: center;
+  width: 17px;
+  height: 17px;
+  border-radius: 50%;
+  color: var(--ink-strong);
+  background: var(--accent);
+}
+
+/* Landscape project held upright: the camera captures what the device
+   orientation gives it, so turning the phone IS the landscape switch.
+   Rendered only on landscape projects; shown only on portrait viewports. */
+.orientation-hint {
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  z-index: 2;
+  display: none;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  padding: 16px 22px;
+  border-radius: 18px;
+  color: #fff;
+  background: rgba(8, 12, 14, 0.66);
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  backdrop-filter: blur(10px);
+  box-shadow: 0 8px 28px rgba(0, 0, 0, 0.35);
+  text-align: center;
+  pointer-events: none;
+  max-width: min(300px, 84vw);
+}
+
+.orientation-hint strong {
+  font-family: var(--font-display);
+  font-size: 1.15rem;
+  line-height: 1.15;
+}
+
+.orientation-hint span {
+  font-size: 0.82rem;
+  opacity: 0.82;
+}
+
+@media (orientation: portrait) {
+  .orientation-hint {
+    display: flex;
+  }
+}
+
+/* The landscape interface: with the project (and viewport) sideways, the
+   dock leaves the bottom edge and becomes a right-hand rail — Go under the
+   thumb, tools stacked above it, native-camera style. The zoom cluster
+   drops to the freed bottom edge. */
+@media (orientation: landscape) {
+  .orientation-landscape .record-dock {
+    top: 0;
+    bottom: 0;
+    left: auto;
+    right: 0;
+    flex-direction: column;
+    justify-content: center;
+    gap: 16px;
+    padding: calc(16px + var(--safe-top)) calc(14px + env(safe-area-inset-right, 0px)) calc(16px + var(--safe-bottom)) 22px;
+    background: linear-gradient(
+      90deg,
+      transparent 0%,
+      rgba(0, 0, 0, 0.28) 35%,
+      rgba(0, 0, 0, 0.68) 100%
+    );
+  }
+
+  .orientation-landscape .record-tools {
+    flex-direction: column;
+    gap: 10px;
+  }
+
+  /* Keep the title/meta clear of the rail. */
+  .orientation-landscape .record-top {
+    right: 108px;
+  }
+
+  .orientation-landscape .record-zoom {
+    bottom: calc(16px + var(--safe-bottom));
+  }
+}
+
 /* Narrow phones: keep tools + Go on one row without overflow. */
 @media (max-width: 360px) {
   .record-tools {

--- a/tests/e2e/project-orientation.spec.ts
+++ b/tests/e2e/project-orientation.spec.ts
@@ -1,0 +1,170 @@
+import { test, expect, type Page } from '@playwright/test'
+import {
+  gotoHome,
+  recordClip,
+  seedProject,
+  unlockPlus,
+  waitForCameraReady,
+} from './helpers'
+
+/** The camera view's orientation toggle (locked or not). */
+function orientationToggle(page: Page) {
+  return page.getByRole('button', { name: /(landscape|portrait) project/i })
+}
+
+async function shellOrientation(page: Page): Promise<string | undefined> {
+  return page.evaluate(() => document.documentElement.dataset.projectOrientation)
+}
+
+test.describe('project orientation', () => {
+  test('free plan: the toggle is locked and opens the Plus upsell', async ({ page }) => {
+    const projectId = await seedProject(page, { clips: 1 })
+    await page.goto(`/project/${projectId}`)
+    await waitForCameraReady(page)
+
+    const toggle = orientationToggle(page)
+    await expect(toggle.locator('.orientation-plus-lock')).toBeVisible()
+    await toggle.click()
+
+    const upsell = page.locator('.sheet[aria-label="Kody Video Plus"]')
+    await expect(upsell).toBeVisible()
+    await expect(upsell).toContainText(/landscape projects/i)
+
+    // Nothing changed: the shell and the stored project stay portrait.
+    expect(await shellOrientation(page)).toBe('portrait')
+    const stored = await page.evaluate(async (id) => {
+      const storage = await import('/src/lib/storage.ts')
+      return (await storage.getProject(id))?.orientation
+    }, projectId)
+    expect(stored).toBeUndefined()
+  })
+
+  test('plus: landscape shifts the shell, persists, and hints until the device turns', async ({
+    page,
+  }) => {
+    const projectId = await seedProject(page, { clips: 2 })
+    await unlockPlus(page)
+    await page.goto(`/project/${projectId}`)
+    await waitForCameraReady(page)
+
+    await orientationToggle(page).click()
+
+    // The whole interface swings: document-level data attribute (widens the
+    // shell via CSS) + the page-level class.
+    await expect
+      .poll(() => shellOrientation(page))
+      .toBe('landscape')
+    await expect(page.locator('.project-screen.orientation-landscape')).toBeVisible()
+
+    // Held upright (portrait viewport), the app asks for a turn.
+    await expect(page.locator('.orientation-hint')).toBeVisible()
+    await expect(page.locator('.orientation-hint')).toContainText(/turn your device/i)
+
+    // Persisted on the project — a reload keeps the landscape interface.
+    await page.reload()
+    await waitForCameraReady(page)
+    await expect.poll(() => shellOrientation(page)).toBe('landscape')
+
+    // Turn the phone: the hint goes away and the dock becomes a right-hand
+    // rail (taller than wide, hugging the shell's right edge — at wide
+    // viewports the shell itself sits centered in the desktop frame).
+    const viewport = page.viewportSize()!
+    await page.setViewportSize({ width: viewport.height, height: viewport.width })
+    await expect(page.locator('.orientation-hint')).toBeHidden()
+    const dock = await page.locator('.record-dock').boundingBox()
+    const shell = await page.locator('.project-screen').boundingBox()
+    expect(dock).not.toBeNull()
+    expect(shell).not.toBeNull()
+    expect(dock!.height).toBeGreaterThan(dock!.width)
+    expect(dock!.x + dock!.width).toBeGreaterThan(shell!.x + shell!.width - 8)
+
+    // The editor, sideways, puts the player beside the panel. Polled: the
+    // stage mounts with a brief scale-in animation that inflates its
+    // bounding box until it settles.
+    await page.locator('[aria-label="Open editor"]').click()
+    await expect
+      .poll(async () => {
+        const stage = await page.locator('.editor-stage').boundingBox()
+        const panel = await page.locator('.editor-panel').boundingBox()
+        if (!stage || !panel) return false
+        return panel.x >= stage.x + stage.width - 2
+      })
+      .toBe(true)
+
+    // Back on the camera, switching to portrait restores everything and
+    // clears the stored field.
+    await page.locator('[aria-label="Back to camera"]').click()
+    await waitForCameraReady(page)
+    await orientationToggle(page).click()
+    await expect.poll(() => shellOrientation(page)).toBe('portrait')
+    const stored = await page.evaluate(async (id) => {
+      const storage = await import('/src/lib/storage.ts')
+      return (await storage.getProject(id))?.orientation
+    }, projectId)
+    expect(stored).toBeUndefined()
+  })
+
+  test('plus: orientation picked on a brand-new project survives the first clip', async ({
+    page,
+  }) => {
+    await gotoHome(page)
+    await unlockPlus(page)
+    await page.locator('.project-slot.empty').first().click()
+    await page.waitForURL(/\/project\//)
+    await waitForCameraReady(page)
+
+    // Nothing is persisted yet — the pick is pending on the lazy project.
+    await orientationToggle(page).click()
+    await expect.poll(() => shellOrientation(page)).toBe('landscape')
+    expect(
+      await page.evaluate(async () => {
+        const storage = await import('/src/lib/storage.ts')
+        return (await storage.listProjects()).length
+      }),
+    ).toBe(0)
+
+    // The first clip creates the project carrying the pending orientation.
+    await recordClip(page)
+    await expect
+      .poll(async () =>
+        page.evaluate(async () => {
+          const storage = await import('/src/lib/storage.ts')
+          return (await storage.listProjects())[0]?.orientation
+        }),
+      )
+      .toBe('landscape')
+  })
+
+  test('landscape projects export a landscape file from portrait clips', async ({ page }) => {
+    await gotoHome(page)
+    // Portrait fixture clips (320×568) forced landscape must come out
+    // 568×320 — the same cover-fit center crop the preview shows.
+    const dims = await page.evaluate(async () => {
+      const storage = await import('/src/lib/storage.ts')
+      const { exportProject } = await import('/src/lib/export/index.ts')
+      const { makeTestClipBlob } = await import('/src/lib/testing/make-test-clip.ts')
+      const project = await storage.createProject()
+      await storage.addClip({
+        projectId: project.id,
+        blob: await makeTestClipBlob(1200),
+        mimeType: 'video/webm',
+        durationMs: 1200,
+        width: 320,
+        height: 568,
+      })
+      const clips = await storage.getClipsForProject(project.id)
+      const result = await exportProject(clips, {
+        watermark: false,
+        orientation: 'landscape',
+      })
+      const video = document.createElement('video')
+      video.src = URL.createObjectURL(result.blob)
+      await new Promise((resolve, reject) => {
+        video.onloadedmetadata = () => resolve(null)
+        video.onerror = () => reject(new Error('exported file failed to load'))
+      })
+      return { width: video.videoWidth, height: video.videoHeight }
+    })
+    expect(dims).toEqual({ width: 568, height: 320 })
+  })
+})

--- a/tests/e2e/project-orientation.spec.ts
+++ b/tests/e2e/project-orientation.spec.ts
@@ -136,35 +136,43 @@ test.describe('project orientation', () => {
   })
 
   test('landscape projects export a landscape file from portrait clips', async ({ page }) => {
-    await gotoHome(page)
-    // Portrait fixture clips (320×568) forced landscape must come out
-    // 568×320 — the same cover-fit center crop the preview shows.
-    const dims = await page.evaluate(async () => {
+    // Through the real project boundary: a PERSISTED landscape project,
+    // exported with the Go button — portrait fixture clips (320×568) must
+    // come out 568×320 (the same cover-fit center crop the preview shows).
+    const projectId = await seedProject(page, { clips: 1 })
+    await unlockPlus(page)
+    await page.evaluate(async (id) => {
       const storage = await import('/src/lib/storage.ts')
-      const { exportProject } = await import('/src/lib/export/index.ts')
-      const { makeTestClipBlob } = await import('/src/lib/testing/make-test-clip.ts')
-      const project = await storage.createProject()
-      await storage.addClip({
-        projectId: project.id,
-        blob: await makeTestClipBlob(1200),
-        mimeType: 'video/webm',
-        durationMs: 1200,
-        width: 320,
-        height: 568,
-      })
-      const clips = await storage.getClipsForProject(project.id)
-      const result = await exportProject(clips, {
-        watermark: false,
-        orientation: 'landscape',
-      })
-      const video = document.createElement('video')
-      video.src = URL.createObjectURL(result.blob)
-      await new Promise((resolve, reject) => {
-        video.onloadedmetadata = () => resolve(null)
-        video.onerror = () => reject(new Error('exported file failed to load'))
-      })
-      return { width: video.videoWidth, height: video.videoHeight }
-    })
-    expect(dims).toEqual({ width: 568, height: 320 })
+      await storage.setProjectOrientation(id, 'landscape')
+    }, projectId)
+    await page.goto(`/project/${projectId}`)
+    await waitForCameraReady(page)
+
+    await page.locator('.go-button').click()
+    await expect(page.getByText('Done! Your video is ready')).toBeVisible({ timeout: 60_000 })
+
+    // The finished export persists (in the background) as the recoverable
+    // last export — measure that exact file.
+    await expect
+      .poll(
+        () =>
+          page.evaluate(async () => {
+            const storage = await import('/src/lib/storage.ts')
+            const opfs = await import('/src/lib/export/opfs.ts')
+            const last = (await storage.getSettings()).lastExport
+            if (!last) return null
+            const file = await opfs.readOpfsFile(last.opfsName)
+            if (!file || file.size === 0) return null
+            const video = document.createElement('video')
+            video.src = URL.createObjectURL(new Blob([file], { type: last.mimeType }))
+            await new Promise((resolve, reject) => {
+              video.onloadedmetadata = () => resolve(null)
+              video.onerror = () => reject(new Error('exported file failed to load'))
+            })
+            return { width: video.videoWidth, height: video.videoHeight }
+          }),
+        { timeout: 20_000 },
+      )
+      .toEqual({ width: 568, height: 320 })
   })
 })


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

A per-project **orientation** setting: projects can now be **landscape** instead of the default portrait. Landscape is a **Kody Video Plus** perk, gated exactly like background music (locked control opens the upsell; enforced again in storage).

Setting a project to landscape shifts the **entire interface**:

- The phone-shaped shell (480px column) widens to the viewport (or a wide desktop frame) via a document-level `data-project-orientation` attribute.
- The camera view asks the user to **turn the device sideways** while it's held upright (capture follows the physical device orientation, so turning the phone is what makes the footage landscape). Installed PWAs additionally get a best-effort `screen.orientation.lock('landscape')`.
- Sideways, the record controls become a **right-hand rail** (Go under the thumb, tools stacked above — native camera style) and the **editor** puts the player beside the timeline panel.
- **Exports are forced into the project's orientation**: output dimensions swap when the first clip mismatches, and every frame center-crops via the existing cover-fit draw. Portrait projects keep the legacy follow-the-first-clip behavior (desktop/screen recordings are landscape media in "portrait" projects — those must not crop).

## Details

- `Project.orientation?: 'portrait' | 'landscape'` — absent = portrait, so every existing project is untouched. Switching back to portrait deletes the field.
- Toggle lives in the camera view's top actions; on `/project/new` the pick is **pending** and persists with the lazy project creation on the first clip. An orientation-set project is no longer "pristine" (won't be silently auto-deleted).
- Backups carry the orientation (`KODYVID1` manifest field, ignored by older app versions); restoring on a free device keeps the clips as a portrait project, like the music-playlist precedent.
- `exportSignature` signs landscape only — portrait signatures stay byte-identical, so cached last-exports survive the update.
- Upsell copy, README, and manual-test-checklist updated.

## Testing

- `npm run lint` — clean.
- `npm test` — 285 passed (new: `projectOrientation`, `pickOutputSize` orientation swap, storage gating + pristine rules, backup round-trip incl. free-device downgrade, `exportSignature` stability).
- `npm run test:e2e` — 74 passed (new spec `tests/e2e/project-orientation.spec.ts`: free-plan lock → upsell, landscape shell shift + persistence + rotate hint + rail + side-by-side editor, pending orientation on `/project/new` surviving the first clip, and a real export of portrait 320×568 clips coming out **568×320**).
- `npm run test:smoke` — 32/32 (an earlier revision force-cropped portrait-default projects and this suite caught it; fixed so only explicit landscape forces the output).

![Landscape project held upright: rotate-device hint](https://cursor.com/artifacts/c/art-89ff9493-c70f-4312-a607-7382d6f59456)
![Landscape record interface with right-hand rail](https://cursor.com/artifacts/c/art-efadf296-dec7-4308-ae80-b08291f4fb6c)
![Landscape editor: player beside the timeline panel](https://cursor.com/artifacts/c/art-b454cb6c-f48e-4d6c-8eb4-a9356d99bba7)
![Free plan: locked toggle opens the Plus upsell](https://cursor.com/artifacts/c/art-946629ad-59ec-4bf4-9f8a-2ed318594453)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3e5e5a27-888a-4ee3-a56c-ddc583c2ebda?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3e5e5a27-888a-4ee3-a56c-ddc583c2ebda&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Plus now unlocks landscape projects with responsive recording and editing layouts.
  - Switch between portrait and landscape modes, with orientation guidance when needed.
  - Landscape settings persist across reloads and supported project backups.
- **Export Improvements**
  - Exports respect the selected orientation, dimensions, and portrait center-cropping behavior.
- **Bug Fixes**
  - Free plans remain in portrait mode and receive a clear Plus upgrade prompt.
- **Documentation & Tests**
  - Updated Plus feature documentation and expanded coverage for orientation, persistence, and exports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->