### PR TITLE
Orientation follows the device: the first take locks it (toggle removed)

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,8 @@ For a phone on the same network, use your machine’s LAN URL over HTTPS, or tun
   browser's volume ceiling in previews)
 - **Landscape projects** (Plus): no setting — rotate the phone. While a
   project has no clips its interface follows how the device is held, and
-  the **first take locks the orientation** for good. Landscape shifts the
+  the **first take locks the orientation** (emptying the project of clips
+  lets the next first take decide again). Landscape shifts the
   entire interface: the phone-shaped shell widens to the viewport, the
   record controls become a right-hand rail, the editor puts the player
   beside the timeline, and hints ask for a turn whenever the device

--- a/README.md
+++ b/README.md
@@ -57,13 +57,19 @@ For a phone on the same network, use your machine’s LAN URL over HTTPS, or tun
   editor's clip stage plays the music under the selected clip from its
   exact spot on the film's timeline (normalization boosts cap at the
   browser's volume ceiling in previews)
-- **Landscape projects** (Plus): a per-project orientation setting on the
-  camera view. Landscape shifts the entire interface — the phone-shaped
-  shell widens to the viewport, the record controls become a right-hand
-  rail, the editor puts the player beside the timeline, and a hint asks for
-  the device to be turned while it's still upright. Exports are forced into
-  the project's orientation (mismatched clips center-crop), and the setting
-  travels in backups. Default stays portrait; existing projects are untouched
+- **Landscape projects** (Plus): no setting — rotate the phone. While a
+  project has no clips its interface follows how the device is held, and
+  the **first take locks the orientation** for good. Landscape shifts the
+  entire interface: the phone-shaped shell widens to the viewport, the
+  record controls become a right-hand rail, the editor puts the player
+  beside the timeline, and hints ask for a turn whenever the device
+  mismatches the locked project. Exports are forced into a landscape
+  project's orientation (mismatched clips center-crop), and the lock
+  travels in backups. On the free plan, rotating an empty project previews
+  the landscape interface but the take that would lock it opens the Plus
+  upsell. Desktop is exempt (webcams and screen shares are landscape media
+  without that being a choice): its projects stay unlocked and exports
+  follow the clips, as always
 - Project preview playback: tap edges to skip clips, tap middle to stop
 - Up to **6** stable project slots (create / open / rename / delete, poster art from your clips)
 - Big Go CTA: on-device export to **one video file**, then Share (system sheet) or Save
@@ -213,8 +219,8 @@ The free plan includes one project, and exports carry a small Kody Video mark
 in the corner. Kody Video Plus — a one-time $0.99 Stripe Payment Link —
 removes the watermark, unlocks six project slots, background music, and
 landscape projects: the export sheet (or a locked home slot, the locked "Add
-music" button in the editor, or the locked orientation toggle on the camera
-view) links to checkout, Stripe redirects back to
+music" button in the editor, or rotating an empty project sideways on the
+free plan) links to checkout, Stripe redirects back to
 `/unlocked?session_id=…`, and a single Cloudflare Pages Function
 (`functions/api/verify-purchase.ts`) verifies the session server-side before
 the entitlement is stored in IndexedDB. 100%-off promotion codes (friends /

--- a/manual-test-checklist.md
+++ b/manual-test-checklist.md
@@ -24,13 +24,15 @@ npm test           # unit tests
   default-state project (no notification); free plan locks slots 2–6 behind
   the Plus upsell; Plus unlocks 6 and blocks the 7th; the upsell sheet copy
   and buttons
-- **Orientation (Plus)**: the camera-view toggle is locked (opens the upsell)
-  on the free plan; with Plus it flips the project to landscape — the shell
-  widens, a "turn your device" hint shows while upright, the record controls
-  become a right-hand rail sideways, and exports come out landscape (portrait
-  clips center-crop); the setting survives reload; toggling back to portrait
-  restores everything (backup/import round-trip of the setting is covered by
-  the unit suite)
+- **Orientation (Plus)**: an empty project's interface follows device
+  rotation (touch emulation) and the first take locks it — landscape locks
+  survive reload and keep the landscape interface (shell widens, right-hand
+  record rail, side-by-side editor, "turn your device" hint when held the
+  other way); on the free plan rotating an empty project opens the Plus
+  upsell and the landscape take is blocked until it's turned back; desktop
+  (fine-pointer) recording never locks; landscape projects export landscape
+  files (portrait clips center-crop; backup round-trip of the lock is
+  covered by the unit suite)
 - **Location**: toggle asks permission, `aria-pressed` reflects state, new
   clips carry exact coordinates, toasts confirm on/off
 - **Editor**: opens at the most recent clip; tap selects; tiles show

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -43,7 +43,15 @@ export default defineConfig({
         hasTouch: false,
         defaultBrowserType: 'chromium',
       },
-      testIgnore: /desktop-keyboard/,
+      testIgnore: [/desktop-keyboard/, /orientation-touch/],
+    },
+    {
+      // Real touch emulation (pointer: coarse): the rotate-to-choose
+      // orientation flow only exists on devices that are physically held.
+      // Input still drives through the mouse (pointer events fire the same).
+      name: 'touch',
+      use: { ...devices['Pixel 7'], defaultBrowserType: 'chromium' },
+      testMatch: /orientation-touch/,
     },
     {
       name: 'desktop',

--- a/src/components/record-screen.tsx
+++ b/src/components/record-screen.tsx
@@ -78,10 +78,13 @@ interface RecordScreenProps {
   locationTaggingEnabled?: boolean
   /** The film's orientation — landscape shifts the whole interface. */
   orientation: ProjectOrientation
+  /** True while no clip has locked the orientation yet: on phones/tablets
+   * the interface follows the device, and the first take decides. */
+  orientationUnlocked: boolean
   /** Kody Video Plus unlocked (landscape projects are a Plus perk). */
   plus: boolean
-  /** Change the project's orientation (the page owns gating + upsell). */
-  onSetOrientation: (orientation: ProjectOrientation) => void
+  /** Open the Plus upsell sheet (landscape takes on the free plan). */
+  onUpsell: () => void
   onOpenEditor: () => void
   onOpenExport: () => void
   onPlay: () => void
@@ -345,6 +348,13 @@ export function RecordScreen(handle: Handle<RecordScreenProps>) {
     })()
   }
 
+  /** Free plan, empty project, device held sideways: the landscape
+   * interface is on screen as a preview, but the take that would lock the
+   * project landscape is a Plus perk — recording waits for an upgrade (or
+   * for the device to turn back upright). */
+  const landscapeTakeGated = () =>
+    props.orientationUnlocked && props.orientation === 'landscape' && !props.plus
+
   const beginRecord = async (
     nextPointerId: number | null,
     nextRecordingMode: RecordingMode,
@@ -356,6 +366,10 @@ export function RecordScreen(handle: Handle<RecordScreenProps>) {
       props.interactionLocked ||
       countdown !== null
     ) {
+      return false
+    }
+    if (landscapeTakeGated()) {
+      props.onUpsell()
       return false
     }
     if (screenSession) {
@@ -544,6 +558,10 @@ export function RecordScreen(handle: Handle<RecordScreenProps>) {
   const startSelfTimer = () => {
     if (recording || props.interactionLocked || countdown !== null) return
     if (screenSession) return
+    if (landscapeTakeGated()) {
+      props.onUpsell()
+      return
+    }
     if (!camera.getStream() || !camera.isReady) {
       props.showToast('Camera not ready')
       return
@@ -1007,16 +1025,48 @@ export function RecordScreen(handle: Handle<RecordScreenProps>) {
             </div>
           ) : null}
 
-          {/* Landscape project on a portrait viewport: what the camera
-              captures follows how the device is held, so the one thing that
-              makes the footage landscape is turning the phone. Visibility is
-              CSS-driven (portrait viewports only). */}
-          {props.orientation === 'landscape' && !recording && !screenRecording ? (
+          {/* Locked projects are stuck with their first take's orientation;
+              when the device is held the other way, say so. Visibility is
+              CSS-driven (each hint shows only on the mismatching viewport,
+              and the portrait one only where rotating means anything —
+              coarse pointers). */}
+          {!props.orientationUnlocked &&
+          props.orientation === 'landscape' &&
+          !recording &&
+          !screenRecording ? (
             <div className="orientation-hint" role="status">
               <IconOrientation size={28} landscape />
               <strong>Turn your device sideways</strong>
               <span>this is a landscape project</span>
             </div>
+          ) : null}
+          {!props.orientationUnlocked &&
+          props.orientation === 'portrait' &&
+          !recording &&
+          !screenRecording ? (
+            <div className="orientation-hint orientation-hint-portrait" role="status">
+              <IconOrientation size={28} />
+              <strong>Turn your device upright</strong>
+              <span>this is a portrait project</span>
+            </div>
+          ) : null}
+
+          {/* The rotate-to-choose upsell: the free user is LOOKING at the
+              landscape interface — recording in it is the Plus perk. */}
+          {landscapeTakeGated() && !recording && !screenRecording && countdown === null ? (
+            <button
+              type="button"
+              className="orientation-gate-pill"
+              mix={[
+                // The stage records on pointerdown — the pill must not
+                // double as a (gated) hold-to-record press.
+                on('pointerdown', (event) => event.stopPropagation()),
+                on('click', () => props.onUpsell()),
+              ]}
+            >
+              <IconLock size={14} />
+              Landscape projects are a Plus perk — unlock to record
+            </button>
           ) : null}
 
           <div
@@ -1101,29 +1151,6 @@ export function RecordScreen(handle: Handle<RecordScreenProps>) {
             ) : null}
           </div>
           <div className="record-top-actions">
-            <button
-              type="button"
-              className={`btn-icon orientation-toggle${props.orientation === 'landscape' ? ' is-active' : ''}`}
-              aria-label={
-                props.orientation === 'landscape'
-                  ? 'Switch to a portrait project'
-                  : 'Switch to a landscape project (Kody Video Plus)'
-              }
-              aria-pressed={props.orientation === 'landscape'}
-              disabled={recording || screenRecording || countdown !== null}
-              mix={on('click', () => {
-                props.onSetOrientation(
-                  props.orientation === 'landscape' ? 'portrait' : 'landscape',
-                )
-              })}
-            >
-              <IconOrientation landscape={props.orientation === 'landscape'} />
-              {!props.plus ? (
-                <span className="orientation-plus-lock" aria-hidden="true">
-                  <IconLock size={11} />
-                </span>
-              ) : null}
-            </button>
             {screenRecordingSupported ? (
               <button
                 type="button"

--- a/src/components/record-screen.tsx
+++ b/src/components/record-screen.tsx
@@ -1018,7 +1018,13 @@ export function RecordScreen(handle: Handle<RecordScreenProps>) {
             </div>
           ) : null}
 
-          {!recording && !screenRecording && countdown === null && camera.isReady ? (
+          {/* The gate pill replaces the hold hint — "hold anywhere" would
+              contradict a blocked take. */}
+          {!recording &&
+          !screenRecording &&
+          countdown === null &&
+          camera.isReady &&
+          !landscapeTakeGated() ? (
             <div className={`hold-hint${clips.length > 0 ? ' hold-hint-subtle' : ''}`}>
               <strong>Hold anywhere</strong>
               <span>release to stop</span>

--- a/src/components/record-screen.tsx
+++ b/src/components/record-screen.tsx
@@ -328,6 +328,12 @@ export function RecordScreen(handle: Handle<RecordScreenProps>) {
       ) {
         return
       }
+      // Touch-primary devices with getDisplayMedia (ChromeOS tablets): a
+      // screen take is a first clip like any other — same landscape gate.
+      if (landscapeTakeGated()) {
+        props.onUpsell()
+        return
+      }
       screenBusy = true
       try {
         const session = await startScreenRecording()

--- a/src/lib/platform.ts
+++ b/src/lib/platform.ts
@@ -4,6 +4,37 @@ export function isMobileBrowser(): boolean {
   return /Android|iPhone|iPad|iPod|Mobile/i.test(navigator.userAgent)
 }
 
+interface PlatformOverrides {
+  coarsePointer?: boolean
+  viewportLandscape?: boolean
+}
+
+/** Test seam: headless Chromium always reports a fine pointer and a
+ * landscape window, so touch-device flows are unreachable without it. */
+let platformOverrides: PlatformOverrides = {}
+
+export function setPlatformOverridesForTests(overrides: PlatformOverrides): void {
+  platformOverrides = overrides
+}
+
+/**
+ * True on devices whose PRIMARY pointer is a finger (phones, tablets) —
+ * where physically rotating the device is a deliberate orientation choice.
+ * Touchscreen laptops report their mouse/trackpad as primary and stay fine.
+ */
+export function isCoarsePointerDevice(): boolean {
+  if (platformOverrides.coarsePointer !== undefined) return platformOverrides.coarsePointer
+  return typeof window !== 'undefined' && window.matchMedia('(pointer: coarse)').matches
+}
+
+/** How the device is currently held (viewport orientation). */
+export function viewportIsLandscape(): boolean {
+  if (platformOverrides.viewportLandscape !== undefined) {
+    return platformOverrides.viewportLandscape
+  }
+  return typeof window !== 'undefined' && window.matchMedia('(orientation: landscape)').matches
+}
+
 /** All iOS browsers share WebKit (and its quirks), whatever their brand. */
 export function isIosBrowser(): boolean {
   if (/iPhone|iPad|iPod/i.test(navigator.userAgent)) return true

--- a/src/lib/project-actions.test.ts
+++ b/src/lib/project-actions.test.ts
@@ -81,6 +81,10 @@ describe('appendRecording orientation lock', () => {
     const project = await createProject('Tall')
     const first = await record(project.id, 'wide-take')
     await deleteClip(first.id)
+    // Deleting the last clip deliberately KEEPS the stored lock: clearing it
+    // here would lose the orientation across a delete → undo cycle. An empty
+    // project is unlocked because the UI derives that from clip count, and
+    // the next first take overwrites the stale value (asserted below).
     expect((await getProject(project.id))?.orientation).toBe('landscape')
 
     // Emptied project: the next first take re-decides — now held upright.

--- a/src/lib/project-actions.test.ts
+++ b/src/lib/project-actions.test.ts
@@ -1,7 +1,8 @@
-import { beforeEach, describe, expect, it } from 'vitest'
-import { loadHomeProjects } from './project-actions'
-import { __resetDbForTests, addClip, createProject, deleteClip, listProjects, renameProject } from './storage'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { appendRecording, loadHomeProjects } from './project-actions'
+import { __resetDbForTests, addClip, createProject, deleteClip, getProject, listProjects, renameProject } from './storage'
 import { markWatermarkRemoved } from './entitlement'
+import { setPlatformOverridesForTests } from './platform'
 
 function fakeBlob(label: string): Blob {
   return new Blob([label], { type: 'video/webm' })
@@ -41,5 +42,72 @@ describe('loadHomeProjects', () => {
 
     expect(summaries.map((entry) => entry.id)).toEqual([project.id])
     expect(summaries[0]?.clipCount).toBe(0)
+  })
+})
+
+describe('appendRecording orientation lock', () => {
+  beforeEach(async () => {
+    await __resetDbForTests()
+  })
+
+  afterEach(() => {
+    setPlatformOverridesForTests({})
+  })
+
+  const record = (projectId: string, label: string) =>
+    appendRecording(projectId, {
+      blob: fakeBlob(label),
+      mimeType: 'video/webm',
+      durationMs: 900,
+    })
+
+  it('locks landscape from the first take on a sideways-held touch device', async () => {
+    await markWatermarkRemoved('cs_test_actions')
+    setPlatformOverridesForTests({ coarsePointer: true, viewportLandscape: true })
+    const project = await createProject('Wide')
+
+    await record(project.id, 'first')
+    expect((await getProject(project.id))?.orientation).toBe('landscape')
+
+    // Later takes never re-decide.
+    setPlatformOverridesForTests({ coarsePointer: true, viewportLandscape: false })
+    await record(project.id, 'second')
+    expect((await getProject(project.id))?.orientation).toBe('landscape')
+  })
+
+  it('locks portrait (clearing any stale lock) from an upright first take', async () => {
+    await markWatermarkRemoved('cs_test_actions')
+    setPlatformOverridesForTests({ coarsePointer: true, viewportLandscape: true })
+    const project = await createProject('Tall')
+    const first = await record(project.id, 'wide-take')
+    await deleteClip(first.id)
+    expect((await getProject(project.id))?.orientation).toBe('landscape')
+
+    // Emptied project: the next first take re-decides — now held upright.
+    setPlatformOverridesForTests({ coarsePointer: true, viewportLandscape: false })
+    await record(project.id, 'upright-take')
+    expect((await getProject(project.id))?.orientation).toBeUndefined()
+  })
+
+  it('never locks on fine-pointer (desktop) devices', async () => {
+    setPlatformOverridesForTests({ coarsePointer: false, viewportLandscape: true })
+    const project = await createProject('Desk')
+
+    await record(project.id, 'webcam')
+    expect((await getProject(project.id))?.orientation).toBeUndefined()
+  })
+
+  it('saves the take even when the landscape lock is entitlement-gated', async () => {
+    // Free plan: the record screen blocks landscape takes up front, but if
+    // one ever reaches the save path the clip must land and the project
+    // simply stays unlocked.
+    setPlatformOverridesForTests({ coarsePointer: true, viewportLandscape: true })
+    const project = await createProject('Free wide')
+
+    const clip = await record(project.id, 'take')
+    expect(clip.id).toBeTruthy()
+    const stored = await getProject(project.id)
+    expect(stored?.clipIds).toHaveLength(1)
+    expect(stored?.orientation).toBeUndefined()
   })
 })

--- a/src/lib/project-actions.ts
+++ b/src/lib/project-actions.ts
@@ -14,6 +14,7 @@ import {
   moveClip,
   removeProjectAudioTrack,
   setLastOpenedProjectId,
+  setProjectOrientation,
   undoDeleteLastClip,
   updateClipThumbs,
   updateClipTrim,
@@ -22,6 +23,7 @@ import {
   type ClipVolumeSettings,
   type ProjectAudioTrackSettings,
 } from './storage'
+import { isCoarsePointerDevice, viewportIsLandscape } from './platform'
 import { probeAudioFile } from './audio-import'
 import { estimateExportCacheBytes } from './export/export-cache'
 import { estimateStorageSpace, type StorageSpace } from './storage-space'
@@ -237,6 +239,14 @@ export async function appendRecording(
     capturedThumbs?: GeneratedThumbs | null
   },
 ): Promise<ClipRecord> {
+  // The FIRST recording locks the project's orientation to how the device
+  // is held — but only where holding it a way is a deliberate choice
+  // (phones/tablets). Desktop cameras and screen shares are landscape media
+  // regardless of intent, so desktop projects stay unlocked (their exports
+  // follow the clips, as always). Checked before the write so the lock
+  // below can never mistake this very clip for an existing one.
+  const project = await getProject(projectId)
+  const locksOrientation = project?.clipIds.length === 0 && isCoarsePointerDevice()
   const clip = await addClip({
     projectId,
     blob: input.blob,
@@ -249,6 +259,16 @@ export async function appendRecording(
     lng: input.lng,
     locationAccuracyM: input.locationAccuracyM,
   })
+  if (locksOrientation) {
+    // Best-effort, after the clip is safely stored: a lock failure (e.g.
+    // the landscape Plus gate racing an entitlement change — the record
+    // screen blocks free landscape takes before they start) must never
+    // lose a recorded take. An unlocked project just stays portrait.
+    await setProjectOrientation(
+      projectId,
+      viewportIsLandscape() ? 'landscape' : 'portrait',
+    ).catch(() => undefined)
+  }
   if (options?.capturedThumbs) {
     // Best-effort: on a (rare) persistence failure the loader backfill
     // still generates thumbs — one black flash beats missing artwork. The

--- a/src/lib/storage.test.ts
+++ b/src/lib/storage.test.ts
@@ -318,13 +318,15 @@ describe('storage layer', () => {
     expect((await listProjects())[0]?.orientation).toBe('landscape')
   })
 
-  it('deleteProjectIfPristine keeps landscape projects', async () => {
+  it('deleteProjectIfPristine drops an emptied project even when a lock was recorded', async () => {
+    // Orientation is derived from the first take, not a standalone choice —
+    // a project emptied of clips is back to its default state.
     await markWatermarkRemoved('cs_test_storage')
     const project = await createProject()
     await setProjectOrientation(project.id, 'landscape')
 
-    expect(await deleteProjectIfPristine(project.id)).toBe(false)
-    expect(await listProjects()).toHaveLength(1)
+    expect(await deleteProjectIfPristine(project.id)).toBe(true)
+    expect(await listProjects()).toHaveLength(0)
   })
 
   it('deleteProjectIfPristine keeps projects with background music', async () => {

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -341,11 +341,11 @@ function assertLandscapeAllowed(settings: Pick<AppMeta, 'watermarkRemoved'>): vo
 }
 
 /**
- * Set the project's orientation. Landscape requires the Plus entitlement
- * (enforced here so every path — toggle, import — hits the same gate);
- * switching back to portrait is always allowed and clears the stored field,
- * so a portrait project is indistinguishable from one made before the
- * setting existed.
+ * Set the project's orientation — the lock primitive behind the first-take
+ * rule (appendRecording) and backup restore. Landscape requires the Plus
+ * entitlement (enforced here so every path hits the same gate); portrait is
+ * always allowed and clears the stored field, so a portrait project is
+ * indistinguishable from one made before orientation existed.
  */
 export async function setProjectOrientation(
   id: ProjectId,
@@ -378,8 +378,7 @@ export async function deleteProject(id: ProjectId): Promise<void> {
 
 /**
  * Delete the project only when it is still indistinguishable from a freshly
- * created one: no clips, never renamed, default (portrait) orientation, no
- * background music. Exiting such a
+ * created one: no clips, never renamed, no background music. Exiting such a
  * project should leave nothing behind — deleting it changes nothing the user
  * can see, so it happens silently. Any leftover undo snapshot (last clip
  * deleted, never restored) goes with it. Returns true when it was deleted.
@@ -404,10 +403,12 @@ async function deleteProjectRecords(
     // delete (exiting right as a take persists) serializes against it, so a
     // fresh clip can never survive into a half-deleted project.
     const audio = await tx.objectStore('audio').get(id)
+    // Orientation deliberately does NOT block this: it is derived from the
+    // first take (not a standalone choice), so a project emptied of clips
+    // is back to its default state even when a lock was once recorded.
     const pristine =
       project.clipIds.length === 0 &&
       project.nameIsDefault === true &&
-      project.orientation === undefined &&
       (!audio || audio.tracks.length === 0)
     if (!pristine) {
       await tx.done

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -2,7 +2,8 @@ export type ProjectId = string
 export type ClipId = string
 
 /** The film's shape: portrait (the default, phone-style) or landscape.
- * Landscape is a Kody Video Plus perk. */
+ * Landscape is a Kody Video Plus perk. Chosen by how the device is held
+ * when the first clip is recorded (phones/tablets), not by a setting. */
 export type ProjectOrientation = 'portrait' | 'landscape'
 
 export interface Project {
@@ -15,8 +16,11 @@ export interface Project {
    * rename, and never set for caller-chosen names, so a deliberate name
    * (even one shaped like "Project 2") is never mistaken for the default. */
   nameIsDefault?: boolean
-  /** The film's orientation. Absent = portrait (every project made before
-   * this setting existed is a portrait project). */
+  /** The film's orientation, locked in by the first clip recorded on a
+   * touch device (how the device was held). Absent = portrait: projects
+   * made before this existed, desktop projects, and portrait locks all
+   * store nothing. A project with no clips is UNLOCKED — its interface
+   * follows the device until the first take decides. */
   orientation?: ProjectOrientation
 }
 

--- a/src/pages/project-page.tsx
+++ b/src/pages/project-page.tsx
@@ -24,14 +24,10 @@ import {
   shareFile,
   shareOrDownload,
 } from '../lib/media'
+import { isCoarsePointerDevice, viewportIsLandscape } from '../lib/platform'
 import { loadProjectPage, type ProjectLoaderData } from '../lib/project-actions'
 import { projectBackupFilename, serializeProject } from '../lib/project-transfer'
-import {
-  createProject,
-  setKeepWatermark,
-  setOnboardingDismissed,
-  setProjectOrientation,
-} from '../lib/storage'
+import { createProject, setKeepWatermark, setOnboardingDismissed } from '../lib/storage'
 import { formatBytes, requestPersistentStorage } from '../lib/storage-space'
 import { navigate } from '../router'
 import {
@@ -106,9 +102,6 @@ export function ProjectPage(handle: Handle<ProjectPageProps>) {
   let exportState: ExportUiState | null = null
   let restoring = false
   let upselling = false
-  /** Orientation chosen on a "/project/new" shell before anything is
-   * persisted — applied when the first clip creates the project. */
-  let pendingOrientation: ProjectOrientation | null = null
   /** In-flight share/save COUNT (concurrent actions must not clear each
    * other's busy state) — the export sheet must not dismiss while > 0. */
   let exportActionCount = 0
@@ -181,12 +174,25 @@ export function ProjectPage(handle: Handle<ProjectPageProps>) {
     }, 2600)
   }
 
-  /** The film's orientation this page renders for: the persisted project's
-   * setting, or the pending pick on a not-yet-persisted "/project/new". */
+  /** No clips yet = the orientation is still the device's to choose: the
+   * first recorded take locks it (touch devices only — see appendRecording). */
+  const orientationUnlocked = (): boolean => (data?.clips.length ?? 0) === 0
+
+  /**
+   * The film's orientation this page renders for. Locked projects (any with
+   * clips) are stuck with what their first take chose, wherever they open.
+   * Unlocked projects on phones/tablets follow how the device is held right
+   * now — rotating IS the orientation picker. Desktop keeps the classic
+   * column for unlocked projects (its cameras are landscape media without
+   * that being a choice).
+   */
   const effectiveOrientation = (): ProjectOrientation => {
     const project = data?.project
-    if (project && project.id !== NEW_PROJECT_ID) return projectOrientation(project)
-    return pendingOrientation ?? 'portrait'
+    if (!project) return 'portrait'
+    if (orientationUnlocked() && isCoarsePointerDevice()) {
+      return viewportIsLandscape() ? 'landscape' : 'portrait'
+    }
+    return projectOrientation(project)
   }
 
   /**
@@ -194,21 +200,26 @@ export function ProjectPage(handle: Handle<ProjectPageProps>) {
    * phone-shaped (480px column) by default, and the record/editor layouts
    * re-arrange for a wide viewport. Both hang off a document-level data
    * attribute so the CSS can reach the shell (#root) above the app tree.
-   * Installed PWAs additionally get a best-effort orientation lock — the
-   * manifest defaults the app to portrait, and an explicit lock is the only
-   * way a landscape project can rotate there. In a browser tab the lock
-   * rejects (fullscreen-only) and the user simply turns the phone.
+   * Installed PWAs additionally need explicit screen-orientation locks (the
+   * manifest pins the app portrait): a locked-landscape project locks the
+   * screen sideways, an UNLOCKED project frees rotation entirely so turning
+   * the phone can make the choice, and everything else returns to the
+   * manifest default. In a browser tab every lock call rejects silently and
+   * the OS's own auto-rotate does the job.
    */
-  let appliedShellOrientation: ProjectOrientation | null = null
-  const syncShellOrientation = (orientation: ProjectOrientation) => {
-    if (appliedShellOrientation === orientation) return
-    appliedShellOrientation = orientation
+  let appliedShellState: string | null = null
+  const syncShellOrientation = (orientation: ProjectOrientation, unlocked: boolean) => {
+    const nextState = `${orientation}:${unlocked}`
+    if (appliedShellState === nextState) return
+    appliedShellState = nextState
     document.documentElement.dataset.projectOrientation = orientation
     try {
       const lockable = screen.orientation as ScreenOrientation & {
         lock?: (lock: string) => Promise<void>
       }
-      if (orientation === 'landscape') {
+      if (unlocked && isCoarsePointerDevice()) {
+        void lockable.lock?.('any').catch(() => undefined)
+      } else if (orientation === 'landscape') {
         void lockable.lock?.('landscape').catch(() => undefined)
       } else {
         screen.orientation.unlock()
@@ -226,36 +237,27 @@ export function ProjectPage(handle: Handle<ProjectPageProps>) {
     }
   })
 
-  const setOrientation = (next: ProjectOrientation) => {
-    if (!data) return
-    if (next === 'landscape' && !data.watermarkRemoved) {
+  // Rotating the device re-renders (the unlocked layout follows it), and on
+  // the free plan, turning an unlocked project sideways is the moment to
+  // pitch Plus: the landscape interface is on screen — the gate (recording
+  // is blocked until upgrade or rotating back) needs explaining.
+  const landscapeMedia = window.matchMedia('(orientation: landscape)')
+  const onDeviceOrientationChange = () => {
+    if (
+      landscapeMedia.matches &&
+      isCoarsePointerDevice() &&
+      orientationUnlocked() &&
+      data &&
+      !data.watermarkRemoved
+    ) {
       upselling = true
-      void handle.update()
-      return
-    }
-    const project = data.project
-    if (!project || project.id === NEW_PROJECT_ID) {
-      pendingOrientation = next
-      void handle.update()
-      return
-    }
-    // Optimistic: the whole interface swings on this — the write's result
-    // is exactly this state, so only a failure needs a resync.
-    data = {
-      ...data,
-      project: {
-        ...project,
-        ...(next === 'landscape' ? { orientation: 'landscape' as const } : {}),
-        ...(next === 'portrait' ? { orientation: undefined } : {}),
-      },
     }
     void handle.update()
-    void setProjectOrientation(project.id, next).catch((err) => {
-      reportError(err, 'set-orientation')
-      showToast(err instanceof Error ? err.message : 'Could not switch orientation')
-      refresh()
-    })
   }
+  landscapeMedia.addEventListener('change', onDeviceOrientationChange)
+  handle.signal.addEventListener('abort', () => {
+    landscapeMedia.removeEventListener('change', onDeviceOrientationChange)
+  })
 
   // Lazy creation: a "/project/new" project is persisted only when the
   // first clip finishes recording. The promise is memoized so overlapping
@@ -270,9 +272,7 @@ export function ProjectPage(handle: Handle<ProjectPageProps>) {
     if (project && project.id !== NEW_PROJECT_ID) return Promise.resolve(project.id)
     ensureProjectPromise ??= (async () => {
       try {
-        const created = await createProject(undefined, {
-          orientation: pendingOrientation === 'landscape' ? 'landscape' : undefined,
-        })
+        const created = await createProject()
         createdProjectId = created.id
         // Their recordings should survive storage pressure.
         requestPersistentStorage()
@@ -517,7 +517,7 @@ export function ProjectPage(handle: Handle<ProjectPageProps>) {
 
     if (!project || data.error) {
       // Whatever project shaped the shell is gone — error UI is portrait.
-      syncShellOrientation('portrait')
+      syncShellOrientation('portrait', false)
       if (data.error === 'Project not found') {
         handle.queueTask(() => navigate('/', { replace: true }))
         return null
@@ -547,7 +547,7 @@ export function ProjectPage(handle: Handle<ProjectPageProps>) {
       // In-place switch to another project: the stale project's landscape
       // shell must not linger over the incoming one — reset to the default
       // while the load is in flight (the new data re-syncs on render).
-      syncShellOrientation('portrait')
+      syncShellOrientation('portrait', false)
       return null
     }
 
@@ -557,7 +557,8 @@ export function ProjectPage(handle: Handle<ProjectPageProps>) {
       ? projectFilename(project.name, exportState.result.fileExtension)
       : null
     const orientation = effectiveOrientation()
-    syncShellOrientation(orientation)
+    const unlocked = orientationUnlocked()
+    syncShellOrientation(orientation, unlocked)
 
     return (
       <div
@@ -576,8 +577,12 @@ export function ProjectPage(handle: Handle<ProjectPageProps>) {
             locationTaggingEnabled={data.locationTaggingEnabled}
             interactionLocked={overlayOpen}
             orientation={orientation}
+            orientationUnlocked={unlocked}
             plus={data.watermarkRemoved}
-            onSetOrientation={setOrientation}
+            onUpsell={() => {
+              upselling = true
+              void handle.update()
+            }}
             onOpenEditor={() => {
               mode = 'editor'
               void handle.update()

--- a/src/styles/record.css
+++ b/src/styles/record.css
@@ -417,28 +417,10 @@
   pointer-events: none;
 }
 
-/* Orientation toggle: the lock badge marks it as a Plus perk on the free
-   plan (tapping opens the upsell, like the editor's locked Add music). */
-.orientation-toggle {
-  position: relative;
-}
-
-.orientation-plus-lock {
-  position: absolute;
-  top: -4px;
-  right: -4px;
-  display: grid;
-  place-items: center;
-  width: 17px;
-  height: 17px;
-  border-radius: 50%;
-  color: var(--ink-strong);
-  background: var(--accent);
-}
-
-/* Landscape project held upright: the camera captures what the device
-   orientation gives it, so turning the phone IS the landscape switch.
-   Rendered only on landscape projects; shown only on portrait viewports. */
+/* Locked-project mismatch hints: a landscape project held upright (shown on
+   portrait viewports), and a portrait project held sideways (shown on
+   landscape viewports, coarse pointers only — desktop windows aren't
+   "held"). Each is rendered only on its project kind. */
 .orientation-hint {
   position: absolute;
   left: 50%;
@@ -476,6 +458,39 @@
   .orientation-hint {
     display: flex;
   }
+
+  .orientation-hint-portrait {
+    display: none;
+  }
+}
+
+@media (orientation: landscape) and (pointer: coarse) {
+  .orientation-hint-portrait {
+    display: flex;
+  }
+}
+
+/* Rotate-to-choose upsell (free plan, empty project, device sideways): the
+   landscape interface is visible as a preview; this explains why recording
+   waits. Sits where the hold-hint would be. */
+.orientation-gate-pill {
+  position: absolute;
+  left: 50%;
+  bottom: 22%;
+  transform: translateX(-50%);
+  z-index: 2;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 16px;
+  border-radius: 999px;
+  color: #10171a;
+  background: var(--accent);
+  border: 1px solid color-mix(in srgb, var(--accent) 65%, #fff);
+  font-weight: 700;
+  font-size: 0.85rem;
+  box-shadow: 0 8px 28px rgba(0, 0, 0, 0.35);
+  max-width: min(420px, 88vw);
 }
 
 /* The landscape interface: with the project (and viewport) sideways, the

--- a/tests/e2e/orientation-touch.spec.ts
+++ b/tests/e2e/orientation-touch.spec.ts
@@ -1,0 +1,105 @@
+import { test, expect, type Page } from '@playwright/test'
+import { openNewProject, recordClip, totalClipCount, unlockPlus } from './helpers'
+
+// Runs under the `touch` Playwright project (real touch emulation, so
+// `pointer: coarse` matches): the rotate-to-choose flow only exists on
+// devices that are physically held.
+
+async function shellOrientation(page: Page) {
+  return page.evaluate(() => document.documentElement.dataset.projectOrientation)
+}
+
+async function rotate(page: Page) {
+  const viewport = page.viewportSize()!
+  await page.setViewportSize({ width: viewport.height, height: viewport.width })
+}
+
+async function storedOrientation(page: Page) {
+  return page.evaluate(async () => {
+    const storage = await import('/src/lib/storage.ts')
+    return (await storage.listProjects())[0]?.orientation as string | undefined
+  })
+}
+
+test.describe('rotate-to-choose orientation (touch)', () => {
+  test('sanity: the touch project emulates a coarse pointer', async ({ page }) => {
+    await page.goto('/')
+    expect(await page.evaluate(() => matchMedia('(pointer: coarse)').matches)).toBe(true)
+  })
+
+  test('plus: an empty project follows rotation and the first take locks it', async ({
+    page,
+  }) => {
+    await page.goto('/')
+    await unlockPlus(page)
+    await openNewProject(page)
+
+    // Upright: portrait interface, nothing stored yet.
+    await expect.poll(() => shellOrientation(page)).toBe('portrait')
+
+    // Turn the phone: the interface follows (no upsell — Plus).
+    await rotate(page)
+    await expect.poll(() => shellOrientation(page)).toBe('landscape')
+    await expect(page.locator('.project-screen.orientation-landscape')).toBeVisible()
+    await expect(page.locator('.sheet[aria-label="Kody Video Plus"]')).toBeHidden()
+
+    // The first take decides: recording sideways locks the project landscape.
+    await recordClip(page)
+    await expect.poll(() => storedOrientation(page)).toBe('landscape')
+
+    // From now on the interface is stuck landscape — turning the phone back
+    // upright keeps the landscape layout and asks for a turn instead.
+    await rotate(page)
+    await expect.poll(() => shellOrientation(page)).toBe('landscape')
+    await expect(page.locator('.orientation-hint')).toBeVisible()
+    await expect(page.locator('.orientation-hint')).toContainText(/turn your device sideways/i)
+
+    // Survives a reload.
+    await page.reload()
+    await page.locator('.camera-video').waitFor()
+    await expect.poll(() => shellOrientation(page)).toBe('landscape')
+  })
+
+  test('free plan: rotating previews landscape but the take is gated behind Plus', async ({
+    page,
+  }) => {
+    await openNewProject(page)
+    await expect.poll(() => shellOrientation(page)).toBe('portrait')
+
+    // Turn the phone: the layout shifts (the preview IS the pitch) and the
+    // upsell opens to explain the gate.
+    await rotate(page)
+    await expect.poll(() => shellOrientation(page)).toBe('landscape')
+    const upsell = page.locator('.sheet[aria-label="Kody Video Plus"]')
+    await expect(upsell).toBeVisible()
+    await expect(upsell).toContainText(/landscape projects/i)
+    await upsell.getByRole('button', { name: 'Not now' }).click()
+    await expect(upsell).toBeHidden()
+
+    // The standing gate pill explains why recording waits; pressing the
+    // stage re-opens the upsell instead of starting a take.
+    await expect(page.locator('.orientation-gate-pill')).toBeVisible()
+    const stage = await page.locator('.record-stage').boundingBox()
+    await page.mouse.move(stage!.x + stage!.width / 2, stage!.y + stage!.height / 2)
+    await page.mouse.down()
+    await page.waitForTimeout(800)
+    await page.mouse.up()
+    await expect(upsell).toBeVisible()
+    expect(await totalClipCount(page)).toBe(0)
+    await upsell.getByRole('button', { name: 'Not now' }).click()
+
+    // Turning back upright: everything works free, and the first take locks
+    // portrait (stored as nothing — the default).
+    await rotate(page)
+    await expect.poll(() => shellOrientation(page)).toBe('portrait')
+    await expect(page.locator('.orientation-gate-pill')).toBeHidden()
+    await recordClip(page)
+    expect(await storedOrientation(page)).toBeUndefined()
+    expect(
+      await page.evaluate(async () => {
+        const storage = await import('/src/lib/storage.ts')
+        return (await storage.listProjects()).length
+      }),
+    ).toBe(1)
+  })
+})

--- a/tests/e2e/project-orientation.spec.ts
+++ b/tests/e2e/project-orientation.spec.ts
@@ -1,66 +1,43 @@
-import { test, expect, type Page } from '@playwright/test'
+import { test, expect } from '@playwright/test'
 import {
-  gotoHome,
+  openNewProject,
   recordClip,
   seedProject,
   unlockPlus,
   waitForCameraReady,
 } from './helpers'
 
-/** The camera view's orientation toggle (locked or not). */
-function orientationToggle(page: Page) {
-  return page.getByRole('button', { name: /(landscape|portrait) project/i })
-}
-
-async function shellOrientation(page: Page): Promise<string | undefined> {
+async function shellOrientation(page: import('@playwright/test').Page) {
   return page.evaluate(() => document.documentElement.dataset.projectOrientation)
 }
 
+// Rotate-to-choose (the touch flow: follow the device, lock on the first
+// take, free-plan gate) lives in orientation-touch.spec.ts under the touch
+// Playwright project. This file covers what locked projects do everywhere
+// and the fine-pointer (desktop-like) exemption.
 test.describe('project orientation', () => {
-  test('free plan: the toggle is locked and opens the Plus upsell', async ({ page }) => {
-    const projectId = await seedProject(page, { clips: 1 })
-    await page.goto(`/project/${projectId}`)
-    await waitForCameraReady(page)
-
-    const toggle = orientationToggle(page)
-    await expect(toggle.locator('.orientation-plus-lock')).toBeVisible()
-    await toggle.click()
-
-    const upsell = page.locator('.sheet[aria-label="Kody Video Plus"]')
-    await expect(upsell).toBeVisible()
-    await expect(upsell).toContainText(/landscape projects/i)
-
-    // Nothing changed: the shell and the stored project stay portrait.
-    expect(await shellOrientation(page)).toBe('portrait')
-    const stored = await page.evaluate(async (id) => {
-      const storage = await import('/src/lib/storage.ts')
-      return (await storage.getProject(id))?.orientation
-    }, projectId)
-    expect(stored).toBeUndefined()
-  })
-
-  test('plus: landscape shifts the shell, persists, and hints until the device turns', async ({
+  test('a locked landscape project shifts the shell, persists, and hints upright', async ({
     page,
   }) => {
     const projectId = await seedProject(page, { clips: 2 })
     await unlockPlus(page)
+    await page.evaluate(async (id) => {
+      const storage = await import('/src/lib/storage.ts')
+      await storage.setProjectOrientation(id, 'landscape')
+    }, projectId)
     await page.goto(`/project/${projectId}`)
     await waitForCameraReady(page)
 
-    await orientationToggle(page).click()
-
     // The whole interface swings: document-level data attribute (widens the
     // shell via CSS) + the page-level class.
-    await expect
-      .poll(() => shellOrientation(page))
-      .toBe('landscape')
+    await expect.poll(() => shellOrientation(page)).toBe('landscape')
     await expect(page.locator('.project-screen.orientation-landscape')).toBeVisible()
 
     // Held upright (portrait viewport), the app asks for a turn.
     await expect(page.locator('.orientation-hint')).toBeVisible()
     await expect(page.locator('.orientation-hint')).toContainText(/turn your device/i)
 
-    // Persisted on the project — a reload keeps the landscape interface.
+    // A reload keeps the landscape interface — the lock is on the project.
     await page.reload()
     await waitForCameraReady(page)
     await expect.poll(() => shellOrientation(page)).toBe('landscape')
@@ -90,53 +67,25 @@ test.describe('project orientation', () => {
         return panel.x >= stage.x + stage.width - 2
       })
       .toBe(true)
-
-    // Back on the camera, switching to portrait restores everything and
-    // clears the stored field.
-    await page.locator('[aria-label="Back to camera"]').click()
-    await waitForCameraReady(page)
-    await orientationToggle(page).click()
-    await expect.poll(() => shellOrientation(page)).toBe('portrait')
-    const stored = await page.evaluate(async (id) => {
-      const storage = await import('/src/lib/storage.ts')
-      return (await storage.getProject(id))?.orientation
-    }, projectId)
-    expect(stored).toBeUndefined()
   })
 
-  test('plus: orientation picked on a brand-new project survives the first clip', async ({
-    page,
-  }) => {
-    await gotoHome(page)
-    await unlockPlus(page)
-    await page.locator('.project-slot.empty').first().click()
-    await page.waitForURL(/\/project\//)
-    await waitForCameraReady(page)
+  test('fine-pointer (desktop-like) recording never locks an orientation', async ({ page }) => {
+    // Webcams and screen shares are landscape media without that being a
+    // choice — desktop projects stay unlocked and keep the classic column.
+    await openNewProject(page)
 
-    // Nothing is persisted yet — the pick is pending on the lazy project.
-    await orientationToggle(page).click()
-    await expect.poll(() => shellOrientation(page)).toBe('landscape')
-    expect(
-      await page.evaluate(async () => {
-        const storage = await import('/src/lib/storage.ts')
-        return (await storage.listProjects()).length
-      }),
-    ).toBe(0)
-
-    // The first clip creates the project carrying the pending orientation.
     await recordClip(page)
-    await expect
-      .poll(async () =>
-        page.evaluate(async () => {
-          const storage = await import('/src/lib/storage.ts')
-          return (await storage.listProjects())[0]?.orientation
-        }),
-      )
-      .toBe('landscape')
+
+    const orientation = await page.evaluate(async () => {
+      const storage = await import('/src/lib/storage.ts')
+      return (await storage.listProjects())[0]?.orientation
+    })
+    expect(orientation).toBeUndefined()
+    expect(await shellOrientation(page)).toBe('portrait')
   })
 
   test('landscape projects export a landscape file from portrait clips', async ({ page }) => {
-    // Through the real project boundary: a PERSISTED landscape project,
+    // Through the real project boundary: a locked landscape project,
     // exported with the Go button — portrait fixture clips (320×568) must
     // come out 568×320 (the same cover-fit center crop the preview shows).
     const projectId = await seedProject(page, { clips: 1 })


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Replaces the explicit orientation toggle from [#146](https://github.com/kentcdodds/kody-video/pull/146) with the inferred model: **there is no setting — rotate the phone**.

- While a project has **no clips**, its interface follows how the device is held (rotate → the whole landscape interface from #146 appears live).
- The **first recorded take locks the orientation** for good: from then on the project opens in that layout everywhere, with "turn your device" hints when the device mismatches.
- **Free plan**: rotating an empty project still shifts the layout (the preview is the pitch), the Plus upsell opens automatically, and a standing gate pill explains that the landscape take waits — recording is blocked until upgrade or rotating back upright. Portrait recording stays fully free.
- **Desktop is exempt** (per discussion): webcams/screen shares are landscape media without that being a choice, so fine-pointer devices never lock and keep the classic column + follow-the-clips exports.

## Mechanics

- Lock lives in `appendRecording`: first clip + coarse-pointer device → `setProjectOrientation` from the viewport orientation at save time. Best-effort after the clip is stored (a gate/entitlement race can never lose a take). Later takes never re-decide; emptying a project un-locks it (and the pristine cleanup treats orientation as derived, not deliberate, so emptied default projects still self-delete).
- Storage semantics unchanged: only `'landscape'` is ever stored (absent = portrait/legacy/desktop), so backups, export forcing, and the export-signature stability from #146 all carry over untouched.
- Installed PWAs: unlocked projects get a best-effort `screen.orientation.lock('any')` so rotation can actually happen despite the portrait manifest; locked-landscape projects lock sideways; everything else returns to the manifest default. Browser tabs fall back to OS auto-rotate.
- `src/lib/platform.ts` gains `isCoarsePointerDevice()` / `viewportIsLandscape()` with a test seam (headless Chromium always reports fine-pointer/landscape).

## Testing

- `npm run lint` — clean.
- `npm test` — 302 passed (new: first-take lock matrix — landscape lock, re-decide after emptying, desktop exemption, free-plan save-without-lock; pristine-cleanup inversion).
- `npm run test:e2e` — 75 passed, including a new **`touch` Playwright project** (real Pixel 7 touch emulation, `pointer: coarse` verified) running `tests/e2e/orientation-touch.spec.ts`: empty project follows rotation, first take locks landscape, layout stays stuck + hint after rotating back, reload persists; free plan gets the auto-upsell + gate pill and a blocked take (clip count stays 0), then records fine upright. Fine-pointer specs cover the desktop exemption and the Go-flow export still coming out 568×320 from portrait clips.
- `npm run test:smoke` — 32/32.

![Free plan: rotating an empty project opens the Plus upsell over the landscape interface](https://cursor.com/artifacts/c/art-bb581191-5371-4489-baab-5d9fdd28c0a9)
![Free plan: standing gate pill while the landscape take is blocked](https://cursor.com/artifacts/c/art-abb00d05-72fd-4b63-a4e1-24c31e0b4881)
![Plus: empty project follows the device into the landscape interface](https://cursor.com/artifacts/c/art-82d20d3d-bd2d-4dde-a8be-b5b3ac48556e)
![After the first landscape take: project locked, upright viewport asks for a turn](https://cursor.com/artifacts/c/art-b9ec8785-c2e4-4aec-93a7-a0d3f6ab59b5)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3e5e5a27-888a-4ee3-a56c-ddc583c2ebda?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3e5e5a27-888a-4ee3-a56c-ddc583c2ebda&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Touch-device projects follow device rotation until the first recording, then lock to that orientation.
  - Added orientation guidance and Plus upsell prompts when landscape recording is unavailable on the free plan.
  - Landscape and portrait projects now support orientation-aware recording and exports.
  - Desktop recording remains unaffected by orientation locking.

- **Bug Fixes**
  - Orientation state now persists across reloads and backup restoration.
  - Empty projects can be cleaned up correctly after recordings are removed.

- **Documentation**
  - Updated guidance for orientation behavior, plan restrictions, exports, and testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->