### PR TITLE
Landscape home/static layouts + PWA rotation (manifest orientation: any)

### DIFF
--- a/index.html
+++ b/index.html
@@ -234,12 +234,13 @@
     </style>
     <script>
       // Pre-paint shell layout: home and static pages adapt to landscape
-      // viewports; project pages manage their own width (set by the app once
-      // it knows the project's locked orientation). Runs before first paint
-      // so the frame never jumps; main.tsx keeps it synced on navigation.
-      if (!location.pathname.startsWith('/project/')) {
-        document.documentElement.dataset.shell = 'adaptive'
-      }
+      // viewports; project pages start on the narrow phone column and widen
+      // once the app knows the project is landscape-locked. Runs before
+      // first paint so the frame never jumps; main.tsx keeps it synced on
+      // navigation (must match syncRouteChrome there).
+      document.documentElement.dataset.shell = location.pathname.startsWith('/project/')
+        ? 'narrow'
+        : 'adaptive'
     </script>
     <script>
       // Fathom Analytics (cookieless, anonymous page-view counts). Loaded

--- a/index.html
+++ b/index.html
@@ -188,15 +188,17 @@
           max-width: none;
         }
       }
-      @media (min-width: 720px) and (orientation: landscape) {
+      @media (min-width: 720px) and (orientation: landscape) and (pointer: fine) {
         html[data-shell='adaptive'] #root,
         html[data-shell='wide'] #root {
           width: min(1200px, calc(100% - 48px));
         }
       }
       /* Desktop: SPA paints the hero. Reserve the phone-chrome frame here so
-         applying the full stylesheet does not shift the whole page (CLS). */
-      @media (min-width: 720px) {
+         applying the full stylesheet does not shift the whole page (CLS).
+         Fine pointers only — a phone turned sideways is also ≥720px wide,
+         and held devices must stay full-bleed (match global.css). */
+      @media (min-width: 720px) and (pointer: fine) {
         body {
           overflow: auto;
           /* Must match global.css: BFC keeps #root margins from collapsing
@@ -220,7 +222,7 @@
           overflow: hidden;
         }
       }
-      @media (min-width: 720px) and (prefers-color-scheme: light) {
+      @media (min-width: 720px) and (pointer: fine) and (prefers-color-scheme: light) {
         #root {
           border-color: rgba(26, 40, 36, 0.12);
         }

--- a/index.html
+++ b/index.html
@@ -166,6 +166,34 @@
       html[data-route='app'] #boot-hero {
         display: none;
       }
+      /* Landscape viewports (turned phones, desktop-ish windows): the SPA
+         paints the hero inside its two-pane home layout — the top-centered
+         boot hero would sit in the wrong place. */
+      @media (orientation: landscape) {
+        #boot-hero {
+          display: none;
+        }
+      }
+      /* Shell width by layout mode — must mirror global.css (the attribute
+         is set by the pre-paint script below, so the frame never jumps when
+         the full stylesheet arrives). 'adaptive' (home/static pages) widens
+         on landscape viewports; 'wide' (landscape projects) always. */
+      html[data-shell='wide'] #root {
+        width: 100%;
+        max-width: none;
+      }
+      @media (orientation: landscape) {
+        html[data-shell='adaptive'] #root {
+          width: 100%;
+          max-width: none;
+        }
+      }
+      @media (min-width: 720px) and (orientation: landscape) {
+        html[data-shell='adaptive'] #root,
+        html[data-shell='wide'] #root {
+          width: min(1200px, calc(100% - 48px));
+        }
+      }
       /* Desktop: SPA paints the hero. Reserve the phone-chrome frame here so
          applying the full stylesheet does not shift the whole page (CLS). */
       @media (min-width: 720px) {
@@ -202,6 +230,15 @@
         z-index: 1;
       }
     </style>
+    <script>
+      // Pre-paint shell layout: home and static pages adapt to landscape
+      // viewports; project pages manage their own width (set by the app once
+      // it knows the project's locked orientation). Runs before first paint
+      // so the frame never jumps; main.tsx keeps it synced on navigation.
+      if (!location.pathname.startsWith('/project/')) {
+        document.documentElement.dataset.shell = 'adaptive'
+      }
+    </script>
     <script>
       // Fathom Analytics (cookieless, anonymous page-view counts). Loaded
       // only on real deployments so dev servers and test runs stay out of

--- a/index.html
+++ b/index.html
@@ -178,12 +178,14 @@
          is set by the pre-paint script below, so the frame never jumps when
          the full stylesheet arrives). 'adaptive' (home/static pages) widens
          on landscape viewports; 'wide' (landscape projects) always. */
-      html[data-shell='wide'] #root {
+      html[data-shell='wide'] #root,
+      html[data-shell='wide'] .app-shell {
         width: 100%;
         max-width: none;
       }
       @media (orientation: landscape) {
-        html[data-shell='adaptive'] #root {
+        html[data-shell='adaptive'] #root,
+        html[data-shell='adaptive'] .app-shell {
           width: 100%;
           max-width: none;
         }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -15,10 +15,21 @@ void sweepExportCache().catch(() => undefined)
 const appEl = document.getElementById('app')
 if (!appEl) throw new Error('#app mount point missing')
 
-/** Hide the HTML boot hero on non-home routes (never touch it on home). */
-function syncBootHeroRoute(): void {
-  const home = window.location.pathname === '/' || window.location.pathname === ''
+/**
+ * Per-route document chrome: hide the HTML boot hero on non-home routes,
+ * and keep the shell-layout attribute (see index.html's pre-paint script)
+ * in step with navigation. Home and static pages are 'adaptive' (wide on
+ * landscape viewports); project pages own the attribute themselves — the
+ * width there depends on the project's locked orientation, which only the
+ * project page knows.
+ */
+function syncRouteChrome(): void {
+  const path = window.location.pathname
+  const home = path === '/' || path === ''
   document.documentElement.dataset.route = home ? 'home' : 'app'
+  if (!path.startsWith('/project/')) {
+    document.documentElement.dataset.shell = 'adaptive'
+  }
 }
 
 // Styles load before the first SPA paint so we do not flash an unstyled
@@ -33,8 +44,8 @@ root.addEventListener('error', (event) => {
 root.render(<App />)
 
 queueMicrotask(() => {
-  syncBootHeroRoute()
-  onNavigate({ signal: new AbortController().signal }, syncBootHeroRoute)
+  syncRouteChrome()
+  onNavigate({ signal: new AbortController().signal }, syncRouteChrome)
 })
 
 // Fonts after first paint so ~74KB of woff2 never contends with LCP.

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -27,9 +27,14 @@ function syncRouteChrome(): void {
   const path = window.location.pathname
   const home = path === '/' || path === ''
   document.documentElement.dataset.route = home ? 'home' : 'app'
-  if (!path.startsWith('/project/')) {
-    document.documentElement.dataset.shell = 'adaptive'
-  }
+  // Project routes start narrow — the phone-column default — so a wide
+  // adaptive page (landscape home) can't linger over a portrait project
+  // while its data loads. The project page upgrades to 'wide' as soon as it
+  // knows the project is landscape-locked (same brief narrow-first paint a
+  // hard reload of a landscape project has).
+  document.documentElement.dataset.shell = path.startsWith('/project/')
+    ? 'narrow'
+    : 'adaptive'
 }
 
 // Styles load before the first SPA paint so we do not flash an unstyled

--- a/src/pages/home-page.tsx
+++ b/src/pages/home-page.tsx
@@ -111,15 +111,23 @@ export function HomePage(handle: Handle) {
   const unsubscribeInstall = subscribeInstallPrompt(() => void handle.update())
   handle.signal.addEventListener('abort', unsubscribeInstall)
 
-  // Rotating swaps who paints the hero: portrait mobile shows the static
-  // #boot-hero over a same-size spacer (LCP), landscape/desktop render the
-  // real in-app hero inside the two-pane layout. The swap is a render-time
-  // decision, so a rotation must re-render.
-  const landscapeMedia = window.matchMedia('(orientation: landscape)')
-  const onOrientationChange = () => void handle.update()
-  landscapeMedia.addEventListener('change', onOrientationChange)
+  // Rotating (or resizing across the phone-width breakpoint) swaps who
+  // paints the hero: portrait mobile shows the static #boot-hero over a
+  // same-size spacer (LCP), landscape/desktop render the real in-app hero
+  // inside the two-pane layout. The swap is a render-time decision, so both
+  // media flips must re-render.
+  const heroMediaQueries = [
+    window.matchMedia('(orientation: landscape)'),
+    window.matchMedia('(max-width: 719px)'),
+  ]
+  const onHeroMediaChange = () => void handle.update()
+  for (const media of heroMediaQueries) {
+    media.addEventListener('change', onHeroMediaChange)
+  }
   handle.signal.addEventListener('abort', () => {
-    landscapeMedia.removeEventListener('change', onOrientationChange)
+    for (const media of heroMediaQueries) {
+      media.removeEventListener('change', onHeroMediaChange)
+    }
   })
 
   // Nothing is persisted until the first clip is recorded — backing out of

--- a/src/pages/home-page.tsx
+++ b/src/pages/home-page.tsx
@@ -111,6 +111,17 @@ export function HomePage(handle: Handle) {
   const unsubscribeInstall = subscribeInstallPrompt(() => void handle.update())
   handle.signal.addEventListener('abort', unsubscribeInstall)
 
+  // Rotating swaps who paints the hero: portrait mobile shows the static
+  // #boot-hero over a same-size spacer (LCP), landscape/desktop render the
+  // real in-app hero inside the two-pane layout. The swap is a render-time
+  // decision, so a rotation must re-render.
+  const landscapeMedia = window.matchMedia('(orientation: landscape)')
+  const onOrientationChange = () => void handle.update()
+  landscapeMedia.addEventListener('change', onOrientationChange)
+  handle.signal.addEventListener('abort', () => {
+    landscapeMedia.removeEventListener('change', onOrientationChange)
+  })
+
   // Nothing is persisted until the first clip is recorded — backing out of
   // an untouched new project leaves no empty project behind.
   const openNewProject = () => {
@@ -292,7 +303,10 @@ export function HomePage(handle: Handle) {
               size={96}
               className="brand-hero-art"
               variant="camera"
-              priority={typeof window !== 'undefined' && window.matchMedia('(max-width: 719px)').matches}
+              priority={
+                typeof window !== 'undefined' &&
+                window.matchMedia('(max-width: 719px) and (orientation: portrait)').matches
+              }
             />
           </div>
           <h1 className="brand">

--- a/src/pages/home-page.tsx
+++ b/src/pages/home-page.tsx
@@ -275,12 +275,17 @@ export function HomePage(handle: Handle) {
           <IconInfo />
         </a>
 
-        {/* On mobile, the visible brand/LCP hero lives in index.html
-            (#boot-hero) so first paint is not gated on JS — this block is a
-            layout spacer there. Desktop hides #boot-hero and shows this. */}
+        {/* On portrait mobile, the visible brand/LCP hero lives in
+            index.html (#boot-hero) so first paint is not gated on JS — this
+            block is a layout spacer there. Desktop and landscape viewports
+            hide #boot-hero and show this (it moves into the two-pane
+            layout's left column). */}
         <div
           className="home-hero home-hero-spacer"
-          aria-hidden={typeof window !== 'undefined' && window.matchMedia('(max-width: 719px)').matches}
+          aria-hidden={
+            typeof window !== 'undefined' &&
+            window.matchMedia('(max-width: 719px) and (orientation: portrait)').matches
+          }
         >
           <div className="home-hero-art">
             <BrandMark
@@ -296,195 +301,197 @@ export function HomePage(handle: Handle) {
           <p className="lede">Hold to record. Tap Go to share.</p>
         </div>
 
-        {isLegacyOrigin() ? (
-          <div className="home-migrate">
-            <strong>Kody Video has moved to <a href="https://kody.video">kody.video</a>.</strong>{' '}
-            Projects live in this browser per-site, so use ⋯ → Save backup here, then import them
-            over there (About → Import a backup). This address keeps working but won&rsquo;t get
-            updates.
-          </div>
-        ) : null}
+        <div className="home-main">
+          {isLegacyOrigin() ? (
+            <div className="home-migrate">
+              <strong>Kody Video has moved to <a href="https://kody.video">kody.video</a>.</strong>{' '}
+              Projects live in this browser per-site, so use ⋯ → Save backup here, then import them
+              over there (About → Import a backup). This address keeps working but won&rsquo;t get
+              updates.
+            </div>
+          ) : null}
 
-        {showcase && showShowcaseBanner ? (
-          <div className="home-migrate home-showcase" role="note">
-            <span>
-              <strong>
-                This is the {showcase.edition} showcase — the real app lives at{' '}
-                <a href="https://kody.video">kody.video</a>.
-              </strong>{' '}
-              Projects stay in this browser per-site, so record over there. Curious how this
-              edition came to be? Read the agent&rsquo;s analysis in{' '}
-              <a href={showcase.prUrl} target="_blank" rel="noreferrer noopener">
-                PR #{showcase.prNumber}
-              </a>
-              .
-            </span>
-            <button
-              type="button"
-              className="install-hint-dismiss"
-              aria-label="Dismiss showcase note"
-              mix={on('click', () => {
-                dismissShowcaseBanner()
-                showShowcaseBanner = false
-                void handle.update()
-              })}
-            >
-              <IconClose size={16} />
-            </button>
-          </div>
-        ) : null}
-
-        {error ? <div className="error-banner">{error}</div> : null}
-        {notice ? <p className="home-notice">{notice}</p> : null}
-
-        {storage && severity !== 'ok' ? (
-          <div
-            className={`storage-banner${severity === 'critical' ? ' is-critical' : ''}`}
-            role="alert"
-          >
-            <strong>
-              Device storage {formatStoragePercent(storage.ratio)} full
-              {severity === 'critical' ? ' — recordings may start failing' : ''}
-            </strong>
-            <span>
-              {formatBytes(storage.usedBytes)} of {formatBytes(storage.quotaBytes)} used.
-              {oldestProject
-                ? ` Free space fast: delete an old project (⋯ on “${oldestProject.name}”, then Delete).`
-                : ' Free space by clearing other site data or files on this device.'}
-            </span>
-            {exportCacheBytes > 0 ? (
-              <button
-                type="button"
-                className="btn btn-secondary storage-banner-action"
-                disabled={busy}
-                mix={on('click', onClearExportCache)}
-              >
-                Clear cached exports ({formatBytes(exportCacheBytes)})
-              </button>
-            ) : null}
-          </div>
-        ) : null}
-
-        {showInstallHint ? (
-          <div className="home-install-hint">
-            <span className="install-hint-icon" aria-hidden="true">
-              <IconShareIos size={18} />
-            </span>
-            <span>
-              Install Kody Video: tap <strong>Share</strong>, then{' '}
-              <strong>Add to Home Screen</strong> — full screen, and your clips are safer from
-              Safari&rsquo;s storage cleanup.
-            </span>
-            <button
-              type="button"
-              className="install-hint-dismiss"
-              aria-label="Dismiss install tip"
-              mix={on('click', () => {
-                dismissIosInstallHint()
-                showInstallHint = false
-                void handle.update()
-              })}
-            >
-              <IconClose size={16} />
-            </button>
-          </div>
-        ) : null}
-
-        {projects.length === 0 && !data.tourCardDismissed ? (
-          <TourCard
-            onDismiss={() => {
-              // Mutate the loaded data (it is also the module-level
-              // lastHomeData cache) so a remount before the async persist
-              // lands doesn't resurrect the card.
-              data!.tourCardDismissed = true
-              void setTourCardDismissed(true)
-              void handle.update()
-            }}
-          />
-        ) : null}
-
-        <section className="project-slots" aria-label="Kody Video projects">
-          {slots.map((project, index) =>
-            project ? (
-              <article
-                key={project.id}
-                className={
-                  project.posterThumb ? 'project-slot filled has-poster' : 'project-slot filled'
-                }
-              >
-                {project.posterThumb ? (
-                  <BlobImage
-                    blob={project.posterThumb}
-                    className="slot-poster"
-                    alt=""
-                    aria-hidden="true"
-                    draggable={false}
-                  />
-                ) : null}
-                <div className="slot-fade" aria-hidden="true" />
-                <a className="slot-open" href={`/project/${project.id}`}>
-                  <span className="slot-number">Slot {index + 1}</span>
-                  <strong>{project.name}</strong>
-                  <small>
-                    {project.clipCount} clip{project.clipCount === 1 ? '' : 's'} ·{' '}
-                    {formatDuration(project.durationMs)}
-                  </small>
+          {showcase && showShowcaseBanner ? (
+            <div className="home-migrate home-showcase" role="note">
+              <span>
+                <strong>
+                  This is the {showcase.edition} showcase — the real app lives at{' '}
+                  <a href="https://kody.video">kody.video</a>.
+                </strong>{' '}
+                Projects stay in this browser per-site, so record over there. Curious how this
+                edition came to be? Read the agent&rsquo;s analysis in{' '}
+                <a href={showcase.prUrl} target="_blank" rel="noreferrer noopener">
+                  PR #{showcase.prNumber}
                 </a>
-                <button
-                  type="button"
-                  className="slot-options"
-                  aria-label={`Options for ${project.name}`}
-                  mix={on('click', () => {
-                    prefetchedClips = {
-                      projectId: project.id,
-                      clips: getClipsForProject(project.id),
-                      audio: getProjectAudio(project.id),
-                    }
-                    menuProject = project
-                    void handle.update()
-                  })}
-                >
-                  <IconMore />
-                </button>
-              </article>
-            ) : index < projectLimit ? (
+                .
+              </span>
               <button
-                key={`empty-${index}`}
                 type="button"
-                className="project-slot empty"
-                disabled={busy}
-                mix={on('click', openNewProject)}
-              >
-                <span className="slot-plus" aria-hidden="true">
-                  <IconPlus size={26} />
-                </span>
-                <strong>New project</strong>
-                <small>{`Slot ${index + 1}`}</small>
-              </button>
-            ) : (
-              <button
-                key={`locked-${index}`}
-                type="button"
-                className="project-slot empty locked"
+                className="install-hint-dismiss"
+                aria-label="Dismiss showcase note"
                 mix={on('click', () => {
-                  upselling = true
+                  dismissShowcaseBanner()
+                  showShowcaseBanner = false
                   void handle.update()
                 })}
               >
-                <span className="slot-plus" aria-hidden="true">
-                  <IconLock size={22} />
-                </span>
-                <strong>Plus slot</strong>
-                <small>Unlock with Kody Video Plus</small>
+                <IconClose size={16} />
               </button>
-            ),
-          )}
-        </section>
+            </div>
+          ) : null}
 
-        <p className="home-privacy">
-          <span>Clips stay on this phone until you share.</span>
-          {storage ? <StorageMeter storage={storage} /> : null}
-        </p>
+          {error ? <div className="error-banner">{error}</div> : null}
+          {notice ? <p className="home-notice">{notice}</p> : null}
+
+          {storage && severity !== 'ok' ? (
+            <div
+              className={`storage-banner${severity === 'critical' ? ' is-critical' : ''}`}
+              role="alert"
+            >
+              <strong>
+                Device storage {formatStoragePercent(storage.ratio)} full
+                {severity === 'critical' ? ' — recordings may start failing' : ''}
+              </strong>
+              <span>
+                {formatBytes(storage.usedBytes)} of {formatBytes(storage.quotaBytes)} used.
+                {oldestProject
+                  ? ` Free space fast: delete an old project (⋯ on “${oldestProject.name}”, then Delete).`
+                  : ' Free space by clearing other site data or files on this device.'}
+              </span>
+              {exportCacheBytes > 0 ? (
+                <button
+                  type="button"
+                  className="btn btn-secondary storage-banner-action"
+                  disabled={busy}
+                  mix={on('click', onClearExportCache)}
+                >
+                  Clear cached exports ({formatBytes(exportCacheBytes)})
+                </button>
+              ) : null}
+            </div>
+          ) : null}
+
+          {showInstallHint ? (
+            <div className="home-install-hint">
+              <span className="install-hint-icon" aria-hidden="true">
+                <IconShareIos size={18} />
+              </span>
+              <span>
+                Install Kody Video: tap <strong>Share</strong>, then{' '}
+                <strong>Add to Home Screen</strong> — full screen, and your clips are safer from
+                Safari&rsquo;s storage cleanup.
+              </span>
+              <button
+                type="button"
+                className="install-hint-dismiss"
+                aria-label="Dismiss install tip"
+                mix={on('click', () => {
+                  dismissIosInstallHint()
+                  showInstallHint = false
+                  void handle.update()
+                })}
+              >
+                <IconClose size={16} />
+              </button>
+            </div>
+          ) : null}
+
+          {projects.length === 0 && !data.tourCardDismissed ? (
+            <TourCard
+              onDismiss={() => {
+                // Mutate the loaded data (it is also the module-level
+                // lastHomeData cache) so a remount before the async persist
+                // lands doesn't resurrect the card.
+                data!.tourCardDismissed = true
+                void setTourCardDismissed(true)
+                void handle.update()
+              }}
+            />
+          ) : null}
+
+          <section className="project-slots" aria-label="Kody Video projects">
+            {slots.map((project, index) =>
+              project ? (
+                <article
+                  key={project.id}
+                  className={
+                    project.posterThumb ? 'project-slot filled has-poster' : 'project-slot filled'
+                  }
+                >
+                  {project.posterThumb ? (
+                    <BlobImage
+                      blob={project.posterThumb}
+                      className="slot-poster"
+                      alt=""
+                      aria-hidden="true"
+                      draggable={false}
+                    />
+                  ) : null}
+                  <div className="slot-fade" aria-hidden="true" />
+                  <a className="slot-open" href={`/project/${project.id}`}>
+                    <span className="slot-number">Slot {index + 1}</span>
+                    <strong>{project.name}</strong>
+                    <small>
+                      {project.clipCount} clip{project.clipCount === 1 ? '' : 's'} ·{' '}
+                      {formatDuration(project.durationMs)}
+                    </small>
+                  </a>
+                  <button
+                    type="button"
+                    className="slot-options"
+                    aria-label={`Options for ${project.name}`}
+                    mix={on('click', () => {
+                      prefetchedClips = {
+                        projectId: project.id,
+                        clips: getClipsForProject(project.id),
+                        audio: getProjectAudio(project.id),
+                      }
+                      menuProject = project
+                      void handle.update()
+                    })}
+                  >
+                    <IconMore />
+                  </button>
+                </article>
+              ) : index < projectLimit ? (
+                <button
+                  key={`empty-${index}`}
+                  type="button"
+                  className="project-slot empty"
+                  disabled={busy}
+                  mix={on('click', openNewProject)}
+                >
+                  <span className="slot-plus" aria-hidden="true">
+                    <IconPlus size={26} />
+                  </span>
+                  <strong>New project</strong>
+                  <small>{`Slot ${index + 1}`}</small>
+                </button>
+              ) : (
+                <button
+                  key={`locked-${index}`}
+                  type="button"
+                  className="project-slot empty locked"
+                  mix={on('click', () => {
+                    upselling = true
+                    void handle.update()
+                  })}
+                >
+                  <span className="slot-plus" aria-hidden="true">
+                    <IconLock size={22} />
+                  </span>
+                  <strong>Plus slot</strong>
+                  <small>Unlock with Kody Video Plus</small>
+                </button>
+              ),
+            )}
+          </section>
+
+          <p className="home-privacy">
+            <span>Clips stay on this phone until you share.</span>
+            {storage ? <StorageMeter storage={storage} /> : null}
+          </p>
+        </div>
 
         {menuProject ? (
           <HomeOptionsSheet

--- a/src/pages/project-page.tsx
+++ b/src/pages/project-page.tsx
@@ -196,40 +196,41 @@ export function ProjectPage(handle: Handle<ProjectPageProps>) {
   }
 
   /**
-   * Landscape shifts the whole shell, not just this page: the app frame is
-   * phone-shaped (480px column) by default, and the record/editor layouts
-   * re-arrange for a wide viewport. Both hang off a document-level data
-   * attribute so the CSS can reach the shell (#root) above the app tree.
-   * Installed PWAs additionally need explicit screen-orientation locks (the
-   * manifest pins the app portrait): a locked-landscape project locks the
-   * screen sideways, an UNLOCKED project frees rotation entirely so turning
-   * the phone can make the choice, and everything else returns to the
-   * manifest default. In a browser tab every lock call rejects silently and
-   * the OS's own auto-rotate does the job.
+   * A landscape project shifts the whole shell, not just this page: the app
+   * frame is phone-shaped (480px column) by default, and the record/editor
+   * layouts re-arrange for a wide viewport. Both hang off the document-level
+   * data-shell attribute so the CSS can reach the shell (#root) above the
+   * app tree ('wide' vs 'narrow' — main.tsx resets it to 'adaptive' when
+   * navigating to non-project routes).
+   * Installed PWAs additionally get best-effort screen-orientation pins
+   * (the manifest allows every orientation so rotation can happen at all):
+   * a LOCKED project pins the screen to its orientation, native-camera
+   * style; an unlocked project frees rotation so turning the phone can make
+   * the choice. In a browser tab every lock call rejects silently and the
+   * OS's own auto-rotate does the job.
    */
   let appliedShellState: string | null = null
   const syncShellOrientation = (orientation: ProjectOrientation, unlocked: boolean) => {
     const nextState = `${orientation}:${unlocked}`
     if (appliedShellState === nextState) return
     appliedShellState = nextState
-    document.documentElement.dataset.projectOrientation = orientation
+    document.documentElement.dataset.shell = orientation === 'landscape' ? 'wide' : 'narrow'
     try {
       const lockable = screen.orientation as ScreenOrientation & {
         lock?: (lock: string) => Promise<void>
       }
-      if (unlocked && isCoarsePointerDevice()) {
-        void lockable.lock?.('any').catch(() => undefined)
-      } else if (orientation === 'landscape') {
-        void lockable.lock?.('landscape').catch(() => undefined)
-      } else {
+      if (unlocked) {
         screen.orientation.unlock()
+      } else {
+        void lockable.lock?.(orientation).catch(() => undefined)
       }
     } catch {
       // Orientation API missing or lock not allowed here — rotation stays manual.
     }
   }
   handle.signal.addEventListener('abort', () => {
-    delete document.documentElement.dataset.projectOrientation
+    // main.tsx owns data-shell for the route being navigated to; this page
+    // only needs to release any screen pin it took.
     try {
       screen.orientation.unlock()
     } catch {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -918,7 +918,11 @@ a {
   border: 0;
 }
 
-@media (min-width: 720px) {
+/* The framed "phone in a desktop window" chrome is for fine-pointer
+   machines only: a PHONE turned sideways is also ≥720px wide, and margins,
+   rounded corners, and a height cap there shrink the camera and push the
+   record rail off screen — held devices stay full-bleed. */
+@media (min-width: 720px) and (pointer: fine) {
   body {
     overflow: auto;
     /* BFC so #root's 24px margins can't collapse through the 100%-tall body
@@ -975,7 +979,7 @@ html[data-shell='wide'] .app-shell {
   }
 }
 
-@media (min-width: 720px) and (orientation: landscape) {
+@media (min-width: 720px) and (orientation: landscape) and (pointer: fine) {
   html[data-shell='adaptive'] #root,
   html[data-shell='wide'] #root {
     width: min(1200px, calc(100% - 48px));

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -950,20 +950,34 @@ a {
   }
 }
 
-/* Landscape projects shift the whole shell, not just a page: the app frame
-   is phone-shaped (480px column) by default, so while a landscape project
-   is open the project page sets data-project-orientation on <html> and the
-   frame widens to the viewport (phones turned sideways) or to a wide
-   desktop frame. Must sit after the base #root / .app-shell rules AND the
-   min-width desktop block so it wins in both. */
-html[data-project-orientation='landscape'] #root,
-html[data-project-orientation='landscape'] .app-shell {
+/* Shell width by layout mode (mirrored in index.html's critical CSS). The
+   app frame is a phone-shaped 480px column by default; <html data-shell>
+   picks the layout per page:
+   - 'adaptive' (home, about, privacy, terms, unlocked — set pre-paint in
+     index.html and on navigation in main.tsx): widens on landscape
+     viewports, which includes desktop windows by default.
+   - 'wide' (locked-landscape projects, set by the project page): always
+     widens — the layout is stuck sideways wherever it opens.
+   - 'narrow' / absent (portrait projects): the classic column.
+   Must sit after the base #root / .app-shell rules AND the min-width
+   desktop block so it wins in both. */
+html[data-shell='wide'] #root,
+html[data-shell='wide'] .app-shell {
   width: 100%;
   max-width: none;
 }
 
-@media (min-width: 720px) {
-  html[data-project-orientation='landscape'] #root {
-    width: min(1280px, calc(100% - 48px));
+@media (orientation: landscape) {
+  html[data-shell='adaptive'] #root,
+  html[data-shell='adaptive'] .app-shell {
+    width: 100%;
+    max-width: none;
+  }
+}
+
+@media (min-width: 720px) and (orientation: landscape) {
+  html[data-shell='adaptive'] #root,
+  html[data-shell='wide'] #root {
+    width: min(1200px, calc(100% - 48px));
   }
 }

--- a/src/styles/home.css
+++ b/src/styles/home.css
@@ -69,7 +69,10 @@
   visibility: hidden;
 }
 
-@media (min-width: 720px), (orientation: landscape) {
+/* Fine-pointer ≥720px (desktop) and any landscape viewport hide #boot-hero
+   and render this hero for real; portrait tablets keep the boot-hero LCP
+   path like phones do. */
+@media (min-width: 720px) and (pointer: fine), (orientation: landscape) {
   .home-hero-spacer {
     visibility: visible;
   }

--- a/src/styles/home.css
+++ b/src/styles/home.css
@@ -62,14 +62,81 @@
   flex: 0 0 auto;
 }
 
-/* Reserves home-hero space while #boot-hero paints the real brand/LCP. */
+/* Reserves home-hero space while #boot-hero paints the real brand/LCP —
+   portrait mobile only. Desktop and landscape viewports hide #boot-hero
+   (see index.html) and render this hero for real. */
 .home-hero-spacer {
   visibility: hidden;
 }
 
-@media (min-width: 720px) {
+@media (min-width: 720px), (orientation: landscape) {
   .home-hero-spacer {
     visibility: visible;
+  }
+}
+
+/* Portrait: .home-main is invisible to layout — its children stay direct
+   flex items of the .home-screen column, exactly the classic layout. */
+.home-main {
+  display: contents;
+}
+
+/* The landscape home: a deliberate two-pane layout instead of a squeezed
+   column — brand hero in its own left pane, everything else (banners,
+   slots, footer) in a column on the right. Landscape phones and desktop
+   windows (which are landscape-shaped) both get this. */
+@media (orientation: landscape) {
+  .home-screen {
+    display: grid;
+    grid-template-columns: minmax(220px, 34%) minmax(0, 1fr);
+    grid-template-rows: minmax(0, 1fr);
+    column-gap: clamp(18px, 4vw, 48px);
+    padding-left: clamp(16px, 4vw, 48px);
+    padding-right: clamp(16px, 4vw, 48px);
+  }
+
+  .home-hero {
+    grid-column: 1;
+    grid-row: 1;
+    align-self: center;
+    justify-self: center;
+    min-width: 0;
+  }
+
+  .home-hero .brand-hero-art {
+    width: 118px;
+    height: 118px;
+  }
+
+  .home-screen .brand {
+    font-size: clamp(1.8rem, 3.2vw, 2.4rem);
+  }
+
+  .home-screen .lede {
+    font-size: 0.92rem;
+  }
+
+  .home-main {
+    display: flex;
+    flex-direction: column;
+    grid-column: 2;
+    grid-row: 1;
+    min-height: 0;
+    min-width: 0;
+  }
+
+  /* Six slots read as 3×2 in a wide pane (2×3 is the portrait shape). */
+  .home-main .project-slots {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    grid-template-rows: repeat(2, minmax(0, 1fr));
+  }
+
+  /* Top-right would sit on the first slot row's ⋯ button; the install
+     button stays top-left over the hero pane (clear of the centered art,
+     and its popover still opens downward). */
+  .home-corner-right {
+    top: auto;
+    bottom: calc(14px + var(--safe-bottom));
   }
 }
 
@@ -536,6 +603,15 @@
 }
 
 /* About page */
+
+/* Landscape / desktop: the shell widens (data-shell='adaptive'), so prose
+   pages center themselves as a readable column instead of stretching. */
+@media (orientation: landscape) {
+  .about-screen {
+    width: min(760px, 100%);
+    margin-inline: auto;
+  }
+}
 
 .about-top {
   display: flex;

--- a/src/styles/record.css
+++ b/src/styles/record.css
@@ -504,9 +504,20 @@
     left: auto;
     right: 0;
     flex-direction: column;
-    justify-content: center;
-    gap: 16px;
-    padding: calc(16px + var(--safe-top)) calc(14px + env(safe-area-inset-right, 0px)) calc(16px + var(--safe-bottom)) 22px;
+    /* flex-start + auto margins on the ends, NOT justify-content: center —
+       a centered column that overflows a short viewport clips both of its
+       ends unreachably. Auto margins center while there is room and
+       collapse to 0 when there is not, and the rail scrolls. */
+    justify-content: flex-start;
+    overflow-y: auto;
+    scrollbar-width: none;
+    /* The rail owns its stripe (scroll needs real pointer events); the
+       stage stays fully holdable everywhere else, and active takes are
+       unaffected — the stage pointer-captures its holds. */
+    pointer-events: auto;
+    touch-action: pan-y;
+    gap: 12px;
+    padding: calc(12px + var(--safe-top)) calc(14px + env(safe-area-inset-right, 0px)) calc(12px + var(--safe-bottom)) 22px;
     background: linear-gradient(
       90deg,
       transparent 0%,
@@ -515,14 +526,32 @@
     );
   }
 
+  .orientation-landscape .record-dock::-webkit-scrollbar {
+    display: none;
+  }
+
   .orientation-landscape .record-tools {
     flex-direction: column;
     gap: 10px;
+    flex-shrink: 0;
+    margin-top: auto;
   }
 
-  /* Keep the title/meta clear of the rail. */
+  /* Compact Go so the whole rail fits common landscape phone heights. */
+  .orientation-landscape .record-dock .go-button {
+    width: 68px;
+    height: 68px;
+    min-width: 68px;
+    font-size: 1.3rem;
+    border-width: 3px;
+    margin-bottom: auto;
+  }
+
+  /* Keep the title/meta clear of the rail; pad the back button away from
+     the notch side. */
   .orientation-landscape .record-top {
     right: 108px;
+    padding-left: calc(12px + env(safe-area-inset-left, 0px));
   }
 
   .orientation-landscape .record-zoom {

--- a/src/styles/record.css
+++ b/src/styles/record.css
@@ -547,10 +547,10 @@
     margin-bottom: auto;
   }
 
-  /* Keep the title/meta clear of the rail; pad the back button away from
-     the notch side. */
+  /* Keep the title/meta clear of the rail (which grows with the right
+     inset); pad the back button away from the notch side. */
   .orientation-landscape .record-top {
-    right: 108px;
+    right: calc(108px + env(safe-area-inset-right, 0px));
     padding-left: calc(12px + env(safe-area-inset-left, 0px));
   }
 

--- a/tests/e2e/home.spec.ts
+++ b/tests/e2e/home.spec.ts
@@ -26,6 +26,10 @@ test.describe('home & app shell', () => {
     expect(hero).not.toBeNull()
     expect(slots).not.toBeNull()
     expect(slots!.x).toBeGreaterThan(hero!.x + hero!.width - 2)
+    // The REAL hero art must render here: portrait mobile shows a spacer
+    // (the static #boot-hero paints the LCP art), and rotating must swap in
+    // the in-app image — a stale spacer is a blank square.
+    await expect(page.locator('.home-hero img')).toBeVisible()
     expect((await page.locator('#root').boundingBox())!.width).toBeGreaterThan(600)
     const firstRow = await page.evaluate(() => {
       const tiles = [...document.querySelectorAll('.project-slot')]

--- a/tests/e2e/home.spec.ts
+++ b/tests/e2e/home.spec.ts
@@ -2,6 +2,45 @@ import { test, expect } from '@playwright/test'
 import { gotoHome, openNewProject, recordClip, unlockPlus } from './helpers'
 
 test.describe('home & app shell', () => {
+  test('landscape home is a deliberate two-pane layout; portrait keeps the column', async ({
+    page,
+  }) => {
+    await gotoHome(page)
+
+    // Portrait phone: classic column — hero above the 2-wide slot grid,
+    // phone-shaped shell.
+    const heroPortrait = await page.locator('.home-hero').boundingBox()
+    const slotsPortrait = await page.locator('.project-slots').boundingBox()
+    expect(heroPortrait).not.toBeNull()
+    expect(slotsPortrait).not.toBeNull()
+    expect(slotsPortrait!.y).toBeGreaterThan(heroPortrait!.y + heroPortrait!.height - 2)
+    expect(await page.evaluate(() => document.documentElement.dataset.shell)).toBe('adaptive')
+    expect((await page.locator('#root').boundingBox())!.width).toBeLessThanOrEqual(480)
+
+    // Turned sideways: the shell widens and the hero moves into its own
+    // left pane beside the slots (now 3 across).
+    const viewport = page.viewportSize()!
+    await page.setViewportSize({ width: viewport.height, height: viewport.width })
+    const hero = await page.locator('.home-hero').boundingBox()
+    const slots = await page.locator('.project-slots').boundingBox()
+    expect(hero).not.toBeNull()
+    expect(slots).not.toBeNull()
+    expect(slots!.x).toBeGreaterThan(hero!.x + hero!.width - 2)
+    expect((await page.locator('#root').boundingBox())!.width).toBeGreaterThan(600)
+    const firstRow = await page.evaluate(() => {
+      const tiles = [...document.querySelectorAll('.project-slot')]
+      const top = Math.min(...tiles.map((tile) => tile.getBoundingClientRect().top))
+      return tiles.filter((tile) => Math.abs(tile.getBoundingClientRect().top - top) < 2).length
+    })
+    expect(firstRow).toBe(3)
+
+    // Prose pages center a readable column inside the wide shell.
+    await page.goto('/about')
+    const about = await page.locator('.about-screen').boundingBox()
+    expect(about).not.toBeNull()
+    expect(about!.width).toBeLessThanOrEqual(760)
+  })
+
   test('onboarding shows on first camera open, dismisses for good', async ({ page }) => {
     await page.goto('/')
     await page.locator('.project-slot.empty').first().click()

--- a/tests/e2e/orientation-touch.spec.ts
+++ b/tests/e2e/orientation-touch.spec.ts
@@ -5,8 +5,8 @@ import { openNewProject, recordClip, totalClipCount, unlockPlus } from './helper
 // `pointer: coarse` matches): the rotate-to-choose flow only exists on
 // devices that are physically held.
 
-async function shellOrientation(page: Page) {
-  return page.evaluate(() => document.documentElement.dataset.projectOrientation)
+async function shellLayout(page: Page) {
+  return page.evaluate(() => document.documentElement.dataset.shell)
 }
 
 async function rotate(page: Page) {
@@ -35,11 +35,11 @@ test.describe('rotate-to-choose orientation (touch)', () => {
     await openNewProject(page)
 
     // Upright: portrait interface, nothing stored yet.
-    await expect.poll(() => shellOrientation(page)).toBe('portrait')
+    await expect.poll(() => shellLayout(page)).toBe('narrow')
 
     // Turn the phone: the interface follows (no upsell — Plus).
     await rotate(page)
-    await expect.poll(() => shellOrientation(page)).toBe('landscape')
+    await expect.poll(() => shellLayout(page)).toBe('wide')
     await expect(page.locator('.project-screen.orientation-landscape')).toBeVisible()
     await expect(page.locator('.sheet[aria-label="Kody Video Plus"]')).toBeHidden()
 
@@ -50,26 +50,26 @@ test.describe('rotate-to-choose orientation (touch)', () => {
     // From now on the interface is stuck landscape — turning the phone back
     // upright keeps the landscape layout and asks for a turn instead.
     await rotate(page)
-    await expect.poll(() => shellOrientation(page)).toBe('landscape')
+    await expect.poll(() => shellLayout(page)).toBe('wide')
     await expect(page.locator('.orientation-hint')).toBeVisible()
     await expect(page.locator('.orientation-hint')).toContainText(/turn your device sideways/i)
 
     // Survives a reload.
     await page.reload()
     await page.locator('.camera-video').waitFor()
-    await expect.poll(() => shellOrientation(page)).toBe('landscape')
+    await expect.poll(() => shellLayout(page)).toBe('wide')
   })
 
   test('free plan: rotating previews landscape but the take is gated behind Plus', async ({
     page,
   }) => {
     await openNewProject(page)
-    await expect.poll(() => shellOrientation(page)).toBe('portrait')
+    await expect.poll(() => shellLayout(page)).toBe('narrow')
 
     // Turn the phone: the layout shifts (the preview IS the pitch) and the
     // upsell opens to explain the gate.
     await rotate(page)
-    await expect.poll(() => shellOrientation(page)).toBe('landscape')
+    await expect.poll(() => shellLayout(page)).toBe('wide')
     const upsell = page.locator('.sheet[aria-label="Kody Video Plus"]')
     await expect(upsell).toBeVisible()
     await expect(upsell).toContainText(/landscape projects/i)
@@ -91,7 +91,7 @@ test.describe('rotate-to-choose orientation (touch)', () => {
     // Turning back upright: everything works free, and the first take locks
     // portrait (stored as nothing — the default).
     await rotate(page)
-    await expect.poll(() => shellOrientation(page)).toBe('portrait')
+    await expect.poll(() => shellLayout(page)).toBe('narrow')
     await expect(page.locator('.orientation-gate-pill')).toBeHidden()
     await recordClip(page)
     expect(await storedOrientation(page)).toBeUndefined()

--- a/tests/e2e/orientation-touch.spec.ts
+++ b/tests/e2e/orientation-touch.spec.ts
@@ -43,6 +43,31 @@ test.describe('rotate-to-choose orientation (touch)', () => {
     await expect(page.locator('.project-screen.orientation-landscape')).toBeVisible()
     await expect(page.locator('.sheet[aria-label="Kody Video Plus"]')).toBeHidden()
 
+    // On a held device the app is FULL-BLEED — no desktop frame margins
+    // shrinking the camera, even though a sideways phone is ≥720px wide.
+    const viewport = page.viewportSize()!
+    const root = await page.locator('#root').boundingBox()
+    expect(root!.x).toBe(0)
+    expect(root!.width).toBe(viewport.width)
+
+    // Every rail control is reachable: within the viewport on a normal
+    // landscape phone height…
+    for (const control of await page.locator('.record-dock button').all()) {
+      const box = await control.boundingBox()
+      expect(box).not.toBeNull()
+      expect(box!.y).toBeGreaterThanOrEqual(0)
+      expect(box!.y + box!.height).toBeLessThanOrEqual(viewport.height + 1)
+    }
+    // …and via rail scrolling on a very short one (a centered column would
+    // clip both ends unreachably).
+    await page.setViewportSize({ width: viewport.width, height: 300 })
+    const dock = page.locator('.record-dock')
+    expect(await dock.evaluate((el) => el.scrollHeight > el.clientHeight)).toBe(true)
+    await dock.evaluate((el) => el.scrollTo(0, el.scrollHeight))
+    const go = await page.locator('.record-dock .go-button').boundingBox()
+    expect(go!.y + go!.height).toBeLessThanOrEqual(301)
+    await page.setViewportSize({ width: viewport.width, height: viewport.height })
+
     // The first take decides: recording sideways locks the project landscape.
     await recordClip(page)
     await expect.poll(() => storedOrientation(page)).toBe('landscape')

--- a/tests/e2e/project-orientation.spec.ts
+++ b/tests/e2e/project-orientation.spec.ts
@@ -7,8 +7,8 @@ import {
   waitForCameraReady,
 } from './helpers'
 
-async function shellOrientation(page: import('@playwright/test').Page) {
-  return page.evaluate(() => document.documentElement.dataset.projectOrientation)
+async function shellLayout(page: import('@playwright/test').Page) {
+  return page.evaluate(() => document.documentElement.dataset.shell)
 }
 
 // Rotate-to-choose (the touch flow: follow the device, lock on the first
@@ -30,7 +30,7 @@ test.describe('project orientation', () => {
 
     // The whole interface swings: document-level data attribute (widens the
     // shell via CSS) + the page-level class.
-    await expect.poll(() => shellOrientation(page)).toBe('landscape')
+    await expect.poll(() => shellLayout(page)).toBe('wide')
     await expect(page.locator('.project-screen.orientation-landscape')).toBeVisible()
 
     // Held upright (portrait viewport), the app asks for a turn.
@@ -40,7 +40,7 @@ test.describe('project orientation', () => {
     // A reload keeps the landscape interface — the lock is on the project.
     await page.reload()
     await waitForCameraReady(page)
-    await expect.poll(() => shellOrientation(page)).toBe('landscape')
+    await expect.poll(() => shellLayout(page)).toBe('wide')
 
     // Turn the phone: the hint goes away and the dock becomes a right-hand
     // rail (taller than wide, hugging the shell's right edge — at wide
@@ -81,7 +81,7 @@ test.describe('project orientation', () => {
       return (await storage.listProjects())[0]?.orientation
     })
     expect(orientation).toBeUndefined()
-    expect(await shellOrientation(page)).toBe('portrait')
+    expect(await shellLayout(page)).toBe('narrow')
   })
 
   test('landscape projects export a landscape file from portrait clips', async ({ page }) => {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -135,7 +135,11 @@ export default defineConfig({
         theme_color: '#2F3E46',
         background_color: '#2F3E46',
         display: 'standalone',
-        orientation: 'portrait',
+        // 'any': installed apps must rotate — an empty project's interface
+        // follows the device (that's how orientation is chosen), and home /
+        // static pages have deliberate landscape layouts. Locked projects
+        // pin themselves with screen.orientation.lock() (best effort).
+        orientation: 'any',
         start_url: '/',
         icons: [
           {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Fixes the problems from testing the orientation feature on device:

**1. Installed PWA never rotated.** The web manifest pinned `orientation: 'portrait'`, which overrides everything in installed apps — no amount of `screen.orientation.lock()` from the page reliably frees it. The manifest is now `'any'`; locked projects pin themselves with best-effort `screen.orientation.lock('landscape' | 'portrait')` (native-camera style in installed apps; browser tabs fall back to OS auto-rotate, same as before). **Note: a reinstall of the PWA picks up the new manifest.**

**2. Landscape home (and prose pages) looked accidental.** They now have deliberate layouts, and desktop gets them by default:

- A document-level `data-shell` attribute picks the frame per page: `adaptive` (home/about/privacy/terms/unlocked — widens on landscape viewports, which includes desktop windows), `wide` (locked-landscape projects), `narrow`/absent (portrait projects). Set pre-paint by an inline script in `index.html`, kept in sync on navigation by `main.tsx`; project pages own it while mounted. The critical CSS mirrors the width rules so the frame never jumps.
- **Home in landscape** is a two-pane layout: brand hero in its own left pane, banners/slots/footer in a right column with the six slots as 3×2. Portrait keeps the classic column untouched (the new `.home-main` wrapper is `display: contents` there). The About corner button moves to the bottom-right in landscape (top-right would sit on the first slot row's ⋯ button).
- The static `#boot-hero` (portrait-mobile LCP) hides on landscape viewports and the in-app hero renders for real there — including a home re-render on rotation, since the spacer/real-art choice is made at render time (a stale spacer left a blank square).
- **About/privacy/terms** center themselves as a readable ≤760px column inside the wide shell; `/unlocked` already centers its card.

**3. On a real phone sideways, the camera didn't fill the screen and the record rail overflowed** (unreachable controls at both ends):

- The framed "phone in a desktop window" chrome (24px margins, rounded border, height cap) applied to any ≥720px viewport — which a sideways phone is. All those blocks are now qualified `and (pointer: fine)`: held devices stay **full-bleed**, desktops keep the frame.
- The rail was `justify-content: center`, which unreachably clips both ends when a short viewport overflows. It now centers with **auto margins** (collapse to 0 under overflow) inside a scrollable, scrollbar-less column, with a compact 68px Go and tighter spacing so common landscape phone heights fit without scrolling at all. The rail owns its stripe's pointer events (scrolling needs them); active takes are unaffected since the stage pointer-captures holds. The top bar also pads away from the notch (`safe-area-inset-left`).

## Testing

- `npm run lint` — clean; `npm test` — 302 passed; `npm run test:e2e` — 76 passed; `npm run test:smoke` — 32/32.
- New e2e: landscape home two-pane + real hero art after rotation + `/about` readable column (`home.spec.ts`); full-bleed `#root` on touch, every rail control within the viewport at phone heights, and rail scrollability on a 300px-tall viewport (`orientation-touch.spec.ts`).
- `npm run build` verified `dist/manifest.webmanifest` carries `"orientation":"any"`.

![Landscape record screen on a phone: full-bleed camera, whole rail reachable](https://cursor.com/artifacts/c/art-4a4ea056-f215-4c16-9ee2-3aafd99d6b36)
![Landscape home on a phone: hero pane beside a 3×2 slot grid](https://cursor.com/artifacts/c/art-fedab561-6a2d-40c8-9e15-76d06a4c8c11)
![Desktop home now gets the two-pane layout by default](https://cursor.com/artifacts/c/art-2e693cd3-3310-4335-af8d-cbadb40b2359)
![About page as a readable centered column in the wide shell](https://cursor.com/artifacts/c/art-2bc3a6d1-7fe3-4b4d-923a-fd6b6f2725de)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3e5e5a27-888a-4ee3-a56c-ddc583c2ebda?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3e5e5a27-888a-4ee3-a56c-ddc583c2ebda&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added responsive layouts that adapt between portrait and landscape orientations.
  - Project pages now use narrow or wide shells based on route and viewport.
  - Desktop framing is limited to fine-pointer devices, while touch devices use full-bleed layouts.
  - Landscape home pages display a two-column layout with a three-column project grid.
  - Recording controls now use an accessible, scrollable side rail.

- **Bug Fixes**
  - Improved orientation handling and screen-lock behavior across project views.
  - Enhanced responsive sizing and readability for About and home content.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->