### PR TITLE
Fix cut-off toasts and harden clip volume saves

### DIFF
--- a/src/lib/blob-url.test.ts
+++ b/src/lib/blob-url.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest'
+import { createBlobUrlBinder } from './blob-url'
+
+/** A revoked object URL is unfetchable — the observable half of revoke. */
+function canFetch(url: string): Promise<boolean> {
+  return fetch(url).then(
+    () => true,
+    () => false,
+  )
+}
+
+describe('createBlobUrlBinder', () => {
+  it('binds src to an object URL for the blob and revokes it on abort', async () => {
+    const blob = new Blob(['clip-bytes'], { type: 'video/webm' })
+    const binder = createBlobUrlBinder(() => blob)
+    const node = document.createElement('img')
+    const controller = new AbortController()
+
+    binder.attach(node, controller.signal)
+    const url = node.src
+    expect(url.startsWith('blob:')).toBe(true)
+    expect(await canFetch(url)).toBe(true)
+
+    controller.abort()
+    expect(await canFetch(url)).toBe(false)
+  })
+
+  it('re-binds when the blob identity changes between renders', async () => {
+    let blob = new Blob(['first'])
+    const binder = createBlobUrlBinder(() => blob)
+    const node = document.createElement('img')
+    const controller = new AbortController()
+
+    binder.attach(node, controller.signal)
+    const first = node.src
+
+    blob = new Blob(['second'])
+    binder.sync()
+    const second = node.src
+    expect(second).not.toBe(first)
+    expect(await canFetch(first)).toBe(false)
+    expect(await canFetch(second)).toBe(true)
+
+    controller.abort()
+    expect(await canFetch(second)).toBe(false)
+  })
+
+  it("keeps the URL alive when a stale teardown runs after a re-attach", async () => {
+    // A remount can attach the replacement node BEFORE the old node's abort
+    // fires. The stale teardown used to revoke the URL just handed to the
+    // new node — every filmstrip thumb and the preview died at once.
+    const blob = new Blob(['shared'])
+    const binder = createBlobUrlBinder(() => blob)
+
+    const oldNode = document.createElement('img')
+    const oldController = new AbortController()
+    binder.attach(oldNode, oldController.signal)
+
+    const newNode = document.createElement('img')
+    const newController = new AbortController()
+    binder.attach(newNode, newController.signal)
+    const url = newNode.src
+    expect(await canFetch(url)).toBe(true)
+
+    // The old node's teardown must now be a no-op.
+    oldController.abort()
+    expect(await canFetch(url)).toBe(true)
+
+    // The current owner still cleans up.
+    newController.abort()
+    expect(await canFetch(url)).toBe(false)
+  })
+})

--- a/src/lib/blob-url.test.ts
+++ b/src/lib/blob-url.test.ts
@@ -70,4 +70,27 @@ describe('createBlobUrlBinder', () => {
     newController.abort()
     expect(await canFetch(url)).toBe(false)
   })
+
+  it('keeps the URL alive when the SAME node re-attaches with a new signal', async () => {
+    // Ownership is decided by attachment order, not node identity — a
+    // reused node re-attached with a fresh signal must survive the old
+    // signal's late abort just like a replacement node does.
+    const blob = new Blob(['shared'])
+    const binder = createBlobUrlBinder(() => blob)
+    const node = document.createElement('img')
+
+    const oldController = new AbortController()
+    binder.attach(node, oldController.signal)
+
+    const newController = new AbortController()
+    binder.attach(node, newController.signal)
+    const url = node.src
+    expect(await canFetch(url)).toBe(true)
+
+    oldController.abort()
+    expect(await canFetch(url)).toBe(true)
+
+    newController.abort()
+    expect(await canFetch(url)).toBe(false)
+  })
 })

--- a/src/lib/blob-url.ts
+++ b/src/lib/blob-url.ts
@@ -11,6 +11,7 @@ export function createBlobUrlBinder<E extends HTMLElement & { src: string }>(
   let element: E | null = null
   let url: string | null = null
   let boundBlob: Blob | null = null
+  let attachToken = 0
 
   function sync(): void {
     if (!element) return
@@ -27,12 +28,15 @@ export function createBlobUrlBinder<E extends HTMLElement & { src: string }>(
 
   function attach(node: E, signal: AbortSignal): void {
     element = node
+    const token = ++attachToken
     sync()
     signal.addEventListener('abort', () => {
-      // A remount can attach the replacement node before the old node's
-      // teardown runs; by then the binder (and its URL) belong to the new
-      // node, and revoking here would kill the src just handed to it.
-      if (element !== node) return
+      // A remount can attach the replacement — possibly the SAME node with a
+      // new signal — before the old attachment's teardown runs; by then the
+      // binder (and its URL) belong to the newer attachment, and revoking
+      // here would kill the src just handed to it. The token, not node
+      // identity, decides ownership.
+      if (token !== attachToken) return
       if (url) URL.revokeObjectURL(url)
       element = null
       url = null

--- a/src/lib/blob-url.ts
+++ b/src/lib/blob-url.ts
@@ -29,6 +29,10 @@ export function createBlobUrlBinder<E extends HTMLElement & { src: string }>(
     element = node
     sync()
     signal.addEventListener('abort', () => {
+      // A remount can attach the replacement node before the old node's
+      // teardown runs; by then the binder (and its URL) belong to the new
+      // node, and revoking here would kill the src just handed to it.
+      if (element !== node) return
       if (url) URL.revokeObjectURL(url)
       element = null
       url = null

--- a/src/lib/storage.test.ts
+++ b/src/lib/storage.test.ts
@@ -17,6 +17,7 @@ import {
   getProjectAudio,
   getSettings,
   getUndoSnapshot,
+  isRetriableIdbFailure,
   isStaleConnectionError,
   listProjects,
   moveClip,
@@ -621,6 +622,84 @@ describe('storage layer', () => {
     expect(cleared?.clipVolume).toBeUndefined()
     expect(cleared && 'clipVolume' in cleared).toBe(false)
     expect(cleared && 'musicVolume' in cleared).toBe(false)
+  })
+
+  it('retries a volume write on a fresh connection when IDB dies mid-write', async () => {
+    const project = await createProject('Volume retry')
+    const clip = await addClip({
+      projectId: project.id,
+      blob: fakeBlob('volume-retry-bytes'),
+      mimeType: 'video/webm',
+      durationMs: 1000,
+    })
+
+    // Kill the connection at the exact moment of the clips write — after
+    // getDb()'s meta liveness probe passed — the way iOS Safari drops IDB
+    // under a slider commit.
+    const db = await getDb()
+    const originalTransaction = db.transaction.bind(db)
+    db.transaction = ((...args: Parameters<typeof db.transaction>) => {
+      const names = Array.isArray(args[0]) ? args[0] : [args[0]]
+      if (names.includes('clips') && args[1] === 'readwrite') {
+        db.close()
+      }
+      return originalTransaction(...args)
+    }) as typeof db.transaction
+
+    const meta = await updateClipVolumes(clip.id, { clipVolume: 0.4 })
+    expect(meta.clipVolume).toBe(0.4)
+
+    const stored = await getClip(clip.id)
+    expect(stored?.clipVolume).toBe(0.4)
+    // The retry re-materializes media blobs — the bytes must survive intact.
+    expect(await stored?.blob.text()).toBe('volume-retry-bytes')
+    expect(await getDb()).not.toBe(db)
+  })
+
+  it('skips the record rewrite when the committed volume is unchanged', async () => {
+    const project = await createProject('Volume no-op')
+    const clip = await addClip({
+      projectId: project.id,
+      blob: fakeBlob('v'),
+      mimeType: 'video/webm',
+      durationMs: 1000,
+    })
+
+    await updateClipVolumes(clip.id, { clipVolume: 0.4 })
+    const updatedAt = (await listProjects()).find((p) => p.id === project.id)!.updatedAt
+
+    // Releasing the slider on the value already stored (or clearing an
+    // override that never existed) must not rewrite the whole record.
+    await new Promise((resolve) => setTimeout(resolve, 5))
+    await updateClipVolumes(clip.id, { clipVolume: 0.4 })
+    await updateClipVolumes(clip.id, { musicVolume: 1 })
+    expect((await listProjects()).find((p) => p.id === project.id)!.updatedAt).toBe(updatedAt)
+
+    // A real change still lands and still bumps the project.
+    await updateClipVolumes(clip.id, { clipVolume: 0.7 })
+    expect((await getClip(clip.id))?.clipVolume).toBe(0.7)
+    expect(
+      (await listProjects()).find((p) => p.id === project.id)!.updatedAt,
+    ).toBeGreaterThan(updatedAt)
+  })
+
+  it('classifies environmental IDB failures as retriable', () => {
+    expect(
+      isRetriableIdbFailure(
+        new DOMException('The database connection is closing.', 'InvalidStateError'),
+      ),
+    ).toBe(true)
+    expect(
+      isRetriableIdbFailure(
+        new DOMException('Error preparing Blob/File data to be stored', 'UnknownError'),
+      ),
+    ).toBe(true)
+    expect(isRetriableIdbFailure(new DOMException('Transaction aborted', 'AbortError'))).toBe(true)
+    // Hard limits and caller mistakes are not retried.
+    expect(isRetriableIdbFailure(new DOMException('Quota exceeded', 'QuotaExceededError'))).toBe(
+      false,
+    )
+    expect(isRetriableIdbFailure(new Error('Clip not found'))).toBe(false)
   })
 
   it('persists the measured audio peak without touching updatedAt', async () => {

--- a/src/lib/storage.test.ts
+++ b/src/lib/storage.test.ts
@@ -31,6 +31,7 @@ import {
   toStoredBlob,
   undoDeleteLastClip,
   updateClipAudioPeak,
+  updateClipThumbs,
   updateClipVolumes,
   updateProjectAudioTrack,
   updateClipTrim,
@@ -632,6 +633,12 @@ describe('storage layer', () => {
       mimeType: 'video/webm',
       durationMs: 1000,
     })
+    await updateClipThumbs(clip.id, {
+      thumbs: [fakeBlob('thumb-one'), fakeBlob('thumb-two')],
+      poster: fakeBlob('poster'),
+      thumbWidth: 90,
+      thumbHeight: 160,
+    })
 
     // Kill the connection at the exact moment of the clips write — after
     // getDb()'s meta liveness probe passed — the way iOS Safari drops IDB
@@ -653,7 +660,41 @@ describe('storage layer', () => {
     expect(stored?.clipVolume).toBe(0.4)
     // The retry re-materializes media blobs — the bytes must survive intact.
     expect(await stored?.blob.text()).toBe('volume-retry-bytes')
+    expect(await Promise.all((stored?.thumbs ?? []).map((thumb) => thumb.text()))).toEqual([
+      'thumb-one',
+      'thumb-two',
+    ])
+    expect(await stored?.poster?.text()).toBe('poster')
     expect(await getDb()).not.toBe(db)
+  })
+
+  it('a stale retry never lands after a newer volume commit for the same clip', async () => {
+    const project = await createProject('Volume ordering')
+    const clip = await addClip({
+      projectId: project.id,
+      blob: fakeBlob('v'),
+      mimeType: 'video/webm',
+      durationMs: 1000,
+    })
+
+    // First commit hits a dead connection and takes the slow retry path
+    // (reopen + blob re-copy); the second commit follows right behind, the
+    // way a slider fires. The later value must win.
+    const db = await getDb()
+    const originalTransaction = db.transaction.bind(db)
+    db.transaction = ((...args: Parameters<typeof db.transaction>) => {
+      const names = Array.isArray(args[0]) ? args[0] : [args[0]]
+      if (names.includes('clips') && args[1] === 'readwrite') {
+        db.close()
+      }
+      return originalTransaction(...args)
+    }) as typeof db.transaction
+
+    const first = updateClipVolumes(clip.id, { clipVolume: 0.45 })
+    const second = updateClipVolumes(clip.id, { clipVolume: 0.3 })
+    await Promise.all([first, second])
+
+    expect((await getClip(clip.id))?.clipVolume).toBe(0.3)
   })
 
   it('skips the record rewrite when the committed volume is unchanged', async () => {

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -650,9 +650,31 @@ export interface ClipVolumeSettings {
   musicVolume?: number | null
 }
 
+/** In-flight volume writes per clip. Writes must apply in call order: a
+ * slow retry (fresh connection + blob re-copy) from an earlier commit must
+ * never land after — and silently undo — a newer slider commit. */
+const clipVolumeWrites = new Map<ClipId, Promise<unknown>>()
+
 /** Set a clip's volume levels. Full volume (1) is the default, so a value
  * of 1 or null clears the stored override. */
 export async function updateClipVolumes(
+  clipId: ClipId,
+  volumes: ClipVolumeSettings,
+): Promise<ClipMeta> {
+  const previous = clipVolumeWrites.get(clipId) ?? Promise.resolve()
+  const run = previous.then(
+    () => writeClipVolumesWithRetry(clipId, volumes),
+    () => writeClipVolumesWithRetry(clipId, volumes),
+  )
+  const tail = run.catch(() => undefined)
+  clipVolumeWrites.set(clipId, tail)
+  void tail.then(() => {
+    if (clipVolumeWrites.get(clipId) === tail) clipVolumeWrites.delete(clipId)
+  })
+  return run
+}
+
+async function writeClipVolumesWithRetry(
   clipId: ClipId,
   volumes: ClipVolumeSettings,
 ): Promise<ClipMeta> {
@@ -671,6 +693,19 @@ export async function updateClipVolumes(
   }
 }
 
+/** Same stored bytes, as far as a cheap check can tell — presence, size,
+ * and type. Blob identities never survive separate IDB reads, so this is
+ * the signal for "did someone else replace this media meanwhile". */
+function sameStoredBlob(a: Blob | undefined, b: Blob | undefined): boolean {
+  if (!a || !b) return !a && !b
+  return a.size === b.size && a.type === b.type
+}
+
+function sameStoredBlobList(a: Blob[] | undefined, b: Blob[] | undefined): boolean {
+  if (!a || !b) return !a && !b
+  return a.length === b.length && a.every((blob, i) => sameStoredBlob(blob, b[i]))
+}
+
 async function writeClipVolumes(
   clipId: ClipId,
   volumes: ClipVolumeSettings,
@@ -682,16 +717,22 @@ async function writeClipVolumes(
   // awaiting arrayBuffer() inside a tx would let it auto-commit, and the
   // whole point is to stop a possibly-poisoned stored Blob from failing
   // the put again.
-  let freshMedia: Partial<Pick<ClipRecord, 'blob' | 'thumbs' | 'poster'>> = {}
+  let fresh: {
+    snapshot: ClipRecord
+    blob: Blob
+    thumbs?: Blob[]
+    poster?: Blob
+  } | null = null
   if (options?.rematerializeBlobs) {
-    const current = await db.get('clips', clipId)
-    if (!current) throw new Error('Clip not found')
-    freshMedia = {
-      blob: await toStoredBlob(current.blob, current.mimeType),
-      ...(current.thumbs
-        ? { thumbs: await Promise.all(current.thumbs.map((thumb) => toStoredBlob(thumb))) }
-        : {}),
-      ...(current.poster ? { poster: await toStoredBlob(current.poster) } : {}),
+    const snapshot = await db.get('clips', clipId)
+    if (!snapshot) throw new Error('Clip not found')
+    fresh = {
+      snapshot,
+      blob: await toStoredBlob(snapshot.blob, snapshot.mimeType),
+      thumbs: snapshot.thumbs
+        ? await Promise.all(snapshot.thumbs.map((thumb) => toStoredBlob(thumb)))
+        : undefined,
+      poster: snapshot.poster ? await toStoredBlob(snapshot.poster) : undefined,
     }
   }
 
@@ -703,7 +744,19 @@ async function writeClipVolumes(
     await tx.done.catch(() => undefined)
     throw new Error('Clip not found')
   }
-  const updated: ClipRecord = { ...clip, ...freshMedia }
+  const updated: ClipRecord = { ...clip }
+  if (fresh) {
+    // Overlay a re-copied field only while the stored one still matches the
+    // snapshot it was copied from — a concurrent thumbs/poster/trim write
+    // that committed between the copy and this put must win over the copy.
+    if (sameStoredBlob(clip.blob, fresh.snapshot.blob)) updated.blob = fresh.blob
+    if (fresh.thumbs && sameStoredBlobList(clip.thumbs, fresh.snapshot.thumbs)) {
+      updated.thumbs = fresh.thumbs
+    }
+    if (fresh.poster && sameStoredBlob(clip.poster, fresh.snapshot.poster)) {
+      updated.poster = fresh.poster
+    }
+  }
   let changed = false
   const apply = (field: 'clipVolume' | 'musicVolume', value: number | null | undefined) => {
     if (value === undefined) return

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -102,6 +102,25 @@ export function isStaleConnectionError(error: unknown): boolean {
   return /database connection is (closing|closed)/i.test(error.message)
 }
 
+/**
+ * True when an IndexedDB failure looks environmental — the connection or the
+ * backing store gave out mid-operation (iOS Safari closing IDB under memory
+ * pressure, Chromium's "Error preparing Blob/File data to be stored") — so an
+ * idempotent write is worth one retry on a fresh connection. Caller mistakes
+ * and hard limits (QuotaExceededError, ConstraintError) are excluded: a retry
+ * would only repeat them.
+ */
+export function isRetriableIdbFailure(error: unknown): boolean {
+  if (isStaleConnectionError(error)) return true
+  if (!(error instanceof DOMException)) return false
+  return (
+    error.name === 'AbortError' ||
+    error.name === 'UnknownError' ||
+    error.name === 'InvalidStateError' ||
+    error.name === 'TransactionInactiveError'
+  )
+}
+
 function forgetCachedDb(closedDb?: IDBPDatabase<ClipsDB> | null): void {
   // Only clear when the terminating handle is still the active one (or no
   // handle was supplied). If activeDb is null, a reconnect may already be
@@ -637,7 +656,45 @@ export async function updateClipVolumes(
   clipId: ClipId,
   volumes: ClipVolumeSettings,
 ): Promise<ClipMeta> {
+  try {
+    return await writeClipVolumes(clipId, volumes)
+  } catch (error) {
+    if (!isRetriableIdbFailure(error)) throw error
+    // A volume write re-puts the whole clip record — video blob included —
+    // so it is the write most exposed to environmental IDB failures. Retry
+    // once on a fresh connection with re-copied media blobs: that covers
+    // both iOS Safari closing the connection under us and the engine
+    // refusing to re-store a Blob it itself returned. The write is
+    // idempotent, so a retry after an ambiguous failure is safe.
+    discardStaleDb(activeDb, dbPromise)
+    return await writeClipVolumes(clipId, volumes, { rematerializeBlobs: true })
+  }
+}
+
+async function writeClipVolumes(
+  clipId: ClipId,
+  volumes: ClipVolumeSettings,
+  options?: { rematerializeBlobs?: boolean },
+): Promise<ClipMeta> {
   const db = await getDb()
+
+  // Copy blob bytes into fresh Blobs before opening the transaction —
+  // awaiting arrayBuffer() inside a tx would let it auto-commit, and the
+  // whole point is to stop a possibly-poisoned stored Blob from failing
+  // the put again.
+  let freshMedia: Partial<Pick<ClipRecord, 'blob' | 'thumbs' | 'poster'>> = {}
+  if (options?.rematerializeBlobs) {
+    const current = await db.get('clips', clipId)
+    if (!current) throw new Error('Clip not found')
+    freshMedia = {
+      blob: await toStoredBlob(current.blob, current.mimeType),
+      ...(current.thumbs
+        ? { thumbs: await Promise.all(current.thumbs.map((thumb) => toStoredBlob(thumb))) }
+        : {}),
+      ...(current.poster ? { poster: await toStoredBlob(current.poster) } : {}),
+    }
+  }
+
   // Read + merge + write in one transaction so a concurrent clip mutation
   // (trim, thumbs) can never be clobbered by a stale snapshot.
   const tx = db.transaction('clips', 'readwrite')
@@ -646,18 +703,27 @@ export async function updateClipVolumes(
     await tx.done.catch(() => undefined)
     throw new Error('Clip not found')
   }
-  const updated: ClipRecord = { ...clip }
+  const updated: ClipRecord = { ...clip, ...freshMedia }
+  let changed = false
   const apply = (field: 'clipVolume' | 'musicVolume', value: number | null | undefined) => {
     if (value === undefined) return
     const clamped = value === null ? 1 : clampVolume(value)
     if (clamped >= 1) {
+      if (field in updated) changed = true
       delete updated[field]
     } else {
+      if (updated[field] !== clamped) changed = true
       updated[field] = clamped
     }
   }
   apply('clipVolume', volumes.clipVolume)
   apply('musicVolume', volumes.musicVolume)
+  // Re-committing the value already stored (a slider released twice on the
+  // same spot) must not rewrite the whole record's media blobs for nothing.
+  if (!changed && !options?.rematerializeBlobs) {
+    await tx.done
+    return toMeta(updated)
+  }
   await completeTransaction([tx.store.put(updated)], tx)
   await touchProject(clip.projectId)
   return toMeta(updated)

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -676,26 +676,35 @@ a {
 
 .toast {
   position: absolute;
-  left: 50%;
   bottom: calc(128px + var(--safe-bottom));
-  transform: translateX(-50%);
+  /* Center with left/right + max-content — not translateX(-50%) — so the
+     rise-in animation's transform cannot un-center the pill (it fills with
+     translateY(0), which replaced the centering translateX and left the
+     pill anchored at mid-screen, cut off by the right edge). Same fix as
+     .update-toast. */
+  left: 0;
+  right: 0;
+  width: max-content;
+  max-width: calc(100% - 24px);
+  margin-inline: auto;
   z-index: 7;
   display: flex;
   align-items: center;
   gap: 10px;
-  max-width: calc(100% - 24px);
   background: var(--toast-bg);
   border: 1px solid var(--line);
   color: var(--ink);
   padding: 10px 14px;
   border-radius: 999px;
   font-size: 0.9rem;
-  white-space: nowrap;
+  /* Messages longer than the viewport wrap instead of spilling past the pill. */
+  line-height: 1.35;
   animation: rise-in 220ms ease both;
   box-shadow: var(--shadow);
 }
 
 .toast button {
+  flex: 0 0 auto;
   color: var(--accent);
   font-weight: 700;
 }

--- a/tests/e2e/record.spec.ts
+++ b/tests/e2e/record.spec.ts
@@ -207,6 +207,31 @@ test.describe('camera & hold-to-record', () => {
     await context.close()
   })
 
+  test('long toasts stay on screen, centered and wrapped', async ({ page }) => {
+    // No geolocation permission granted: toggling location tagging surfaces
+    // the longest toast in the app ("Location unavailable — check the site's
+    // location permission"). It used to be anchored at mid-screen and cut
+    // off by the right viewport edge (the rise-in animation's transform
+    // replaced the centering translateX).
+    await openNewProject(page)
+    await page.getByRole('button', { name: 'Toggle location tagging' }).click()
+
+    const toast = page.locator('.toast')
+    await expect(toast).toContainText('Location unavailable')
+    const box = await toast.boundingBox()
+    const viewport = page.viewportSize()
+    expect(box).not.toBeNull()
+    expect(viewport).not.toBeNull()
+    expect(box!.x).toBeGreaterThanOrEqual(0)
+    expect(box!.x + box!.width).toBeLessThanOrEqual(viewport!.width)
+    // Centered in the screen it is positioned against (the viewport can be
+    // wider by a classic scrollbar in headless runs).
+    const screen = await page.locator('.project-screen').boundingBox()
+    expect(screen).not.toBeNull()
+    const offCenter = Math.abs(box!.x + box!.width / 2 - (screen!.x + screen!.width / 2))
+    expect(offCenter).toBeLessThanOrEqual(2)
+  })
+
   test('location tagging geotags new clips while on', async ({ context, page }) => {
     await context.grantPermissions(['camera', 'microphone', 'geolocation'])
     await context.setGeolocation({ latitude: 40.2338, longitude: -111.6585, accuracy: 12 })

--- a/tests/e2e/record.spec.ts
+++ b/tests/e2e/record.spec.ts
@@ -217,7 +217,20 @@ test.describe('camera & hold-to-record', () => {
     await page.getByRole('button', { name: 'Toggle location tagging' }).click()
 
     const toast = page.locator('.toast')
-    await expect(toast).toContainText('Location unavailable')
+    await expect(toast).toContainText(
+      "Location unavailable — check the site's location permission",
+    )
+    // The long message really wraps inside the pill instead of overflowing
+    // it on a single line: the message box is at least two line-heights tall.
+    // (getClientRects can't count line boxes here — a flex-item span is
+    // blockified and reports a single rect.)
+    const lines = await toast.locator('span').evaluate((el) => {
+      const lineHeight = Number.parseFloat(getComputedStyle(el).lineHeight)
+      return el.getBoundingClientRect().height / lineHeight
+    })
+    // ≥ 1.5 line-heights = wrapped (sub-pixel rounding keeps an exact two
+    //-line box a hair under 2.0).
+    expect(lines).toBeGreaterThan(1.5)
     const box = await toast.boundingBox()
     const viewport = page.viewportSize()
     expect(box).not.toBeNull()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Addresses the feedback in [Jake's post](https://x.com/JakeSaterlay/status/2086015852638322897): toast notifications get cut off at the right screen edge, and adjusting clip volumes can fail with "Could not save that change" and then break every filmstrip thumbnail and the preview.

## Toasts cut off (screenshot in the post)

`.toast` centered itself with `transform: translateX(-50%)`, but its `rise-in` animation also animates `transform` and fills forwards with `translateY(0)` — which replaces the centering translate and leaves the pill anchored at mid-screen, clipped by the right viewport edge. `.update-toast` was already migrated to `left/right + max-content + margin-inline: auto` centering for exactly this reason (its comment says so); this applies the same fix to the in-app `.toast`, and drops `white-space: nowrap` so messages longer than the viewport wrap inside the pill instead of spilling past it.

| Before | After |
| --- | --- |
| ![Toast cut off at the right edge](https://cursor.com/artifacts/c/art-099f6f77-003e-48b2-b9b6-5f313e6cedca) | ![Toast centered and wrapped](https://cursor.com/artifacts/c/art-119aaf72-9023-4c23-af22-558e39b0120c) |

A new e2e test triggers the longest toast in the app (the "Location unavailable" one from the screenshot) and asserts the pill stays on screen and centered.

## Volume save failure breaking the whole editor (video in the post)

In the video, releasing the clip-volume slider surfaces the "Could not save that change —" toast, and at that same moment every filmstrip thumbnail breaks and the preview goes black. Two things compound there:

- `updateClipVolumes` re-`put`s the entire clip record — multi-MB video blob and thumbs included — for a metadata-only change, making it the write most exposed to environmental IndexedDB failures (iOS Safari closing the connection under memory pressure, engine blob-store errors like Chromium's "Error preparing Blob/File data to be stored"). It now retries once on a fresh connection with re-materialized media blobs when the failure is environmental (`isRetriableIdbFailure`; quota/constraint errors are not retried), and skips the rewrite entirely when the committed value is unchanged (slider released on the same spot).
- `createBlobUrlBinder`'s teardown revoked the binder's current URL unconditionally. When a remount attaches the replacement node before the old node's abort runs, the stale teardown revoked the URL just handed to the new node — killing every thumb `<img>` and the preview `<video>` at once. The teardown is now a no-op when the binder has already been re-attached.

## Testing

- New unit tests: volume write retried across a killed IDB connection (blob bytes survive re-materialization), no-op commits skip the record rewrite and don't bump the project's `updatedAt`, retriable-failure classification, and blob-URL binder lifecycle including the re-attach race.
- `npm run lint` clean; `npm test` 308/308; `npm run test:e2e` 77/77 (includes the new toast layout test).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-62ec8a79-9e43-4086-befc-27862cc24fd7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-62ec8a79-9e43-4086-befc-27862cc24fd7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented replacement media URLs from being revoked when an earlier attachment is removed.
  * Improved IndexedDB recovery by retrying eligible storage failures without losing clip data.
  * Preserved concurrent clip updates and avoided unnecessary storage rewrites when volume values remain unchanged.
  * Fixed toast positioning and long-message wrapping to prevent viewport overflow.

* **Tests**
  * Added coverage for media URL lifecycle, storage recovery, volume updates, and responsive toast display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->