### PR TITLE
Fix InvalidStateError when tour dialog showModal runs twice

### DIFF
--- a/src/components/tour-card.test.ts
+++ b/src/components/tour-card.test.ts
@@ -1,0 +1,26 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { openTourFromGesture } from './tour-card'
+
+describe('openTourFromGesture', () => {
+  afterEach(() => {
+    document.body.replaceChildren()
+  })
+
+  it('opens a closed dialog and is safe to call again while open', () => {
+    const dialog = document.createElement('dialog')
+    const video = document.createElement('video')
+    dialog.append(video)
+    document.body.append(dialog)
+
+    openTourFromGesture(dialog, video)
+    expect(dialog.open).toBe(true)
+
+    // A double-tap / second click used to throw InvalidStateError here.
+    expect(() => openTourFromGesture(dialog, video)).not.toThrow()
+    expect(dialog.open).toBe(true)
+  })
+
+  it('no-ops when the dialog ref is missing', () => {
+    expect(() => openTourFromGesture(null, null)).not.toThrow()
+  })
+})

--- a/src/components/tour-card.tsx
+++ b/src/components/tour-card.tsx
@@ -15,6 +15,21 @@ interface TourCardProps {
 }
 
 /**
+ * Open the tour dialog from a user gesture and start playback.
+ * Idempotent: a second tap while already open must not call `showModal()`
+ * again — that throws `InvalidStateError` (seen on Safari/iOS double-taps).
+ */
+export function openTourFromGesture(
+  dialog: HTMLDialogElement | null,
+  video: HTMLVideoElement | null,
+): void {
+  if (dialog && !dialog.open) {
+    dialog.showModal()
+  }
+  void video?.play().catch(() => {})
+}
+
+/**
  * First-timer home card: the teaser opens the tour in a native `<dialog>`
  * (top layer — the page layout underneath never reflows) with a persistent
  * dismiss on the card itself.
@@ -33,8 +48,7 @@ export function TourCard(handle: Handle<TourCardProps>) {
           // re-render to appear, and mobile autoplay policies require the
           // unmuted play() to run inside the gesture. If play() still
           // rejects, the controls are right there.
-          dialog?.showModal()
-          void video?.play().catch(() => {})
+          openTourFromGesture(dialog, video)
         })}
       >
         <img src={TOUR_POSTER_URL} alt="" width={44} height={78} />

--- a/tests/e2e/home.spec.ts
+++ b/tests/e2e/home.spec.ts
@@ -72,9 +72,13 @@ test.describe('home & app shell', () => {
     const slotsBox = await slots.boundingBox()
     expect(slotsBox).not.toBeNull()
     const teaser = card.getByRole('button', { name: /watch the tour/i })
-    await teaser.click()
+    const pageErrors: string[] = []
+    page.on('pageerror', (err) => pageErrors.push(err.message))
+    // Double-tap: a second showModal() while open used to throw InvalidStateError.
+    await teaser.dblclick()
     const dialog = page.locator('dialog.tour-dialog')
     await expect(dialog).toBeVisible()
+    expect(pageErrors.filter((m) => /showModal|InvalidStateError/i.test(m))).toEqual([])
     const video = dialog.locator('video.tour-dialog-video')
     await expect(video).toHaveAttribute('src', /^https:\/\/media\.kody\.video\//)
     // The tap itself must start playback (in-gesture play() is what mobile


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Sentry

- Issue: https://sentry.io/organizations/kent-c-dodds-tech-llc/issues/7660583768/
- Production event on Safari/iOS: `InvalidStateError: Failed to execute 'showModal' on 'HTMLDialogElement': The element already has an 'open' attribute…`
- Stack: `src/components/tour-card.tsx` teaser click → `dialog.showModal()`

## Root cause

The first-timer tour teaser always called `dialog.showModal()` on click. A double-tap (common on iOS) fires a second click after the dialog already has the `open` attribute, which throws `InvalidStateError` per the HTML dialog spec.

## Fix

- Extract `openTourFromGesture()` that only calls `showModal()` when `!dialog.open`, then always attempts `video.play()` inside the gesture.
- Unit test: second call while open does not throw.
- E2E: double-click the teaser and assert no `showModal`/`InvalidStateError` page errors.

## Risk

Low — isolated client guard on one click path; no auth/billing/storage changes.

## Testing

- `npm run build`
- `npx vitest run`
- `node scripts/manual-smoke.mjs` (after Chromium install)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c82c85bf-8992-4006-b790-913d55f39503?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c82c85bf-8992-4006-b790-913d55f39503&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tour teaser interactions so repeated clicks safely open the tour dialog without errors.
  * Tour videos now begin playback reliably, while gracefully handling unavailable playback.

* **Tests**
  * Added coverage for opening tours from gestures, repeated activation, and missing media elements.
  * Expanded end-to-end checks to verify dialog behavior, playback, dismissal, layout, and persistence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->