### PR TITLE
Add Plus location controls for safer exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,13 +113,14 @@ src/
 
 MP4 exports carry **chapter markers** at every clip boundary (Nero `chpl`,
 injected post-mux by `lib/export/mp4-metadata.ts`), titled with each clip's
-recording time. With the opt-in **location tagging** toggle on the record
-screen, clips store device coordinates (kept in IndexedDB alongside the clip,
-never inside the MediaRecorder blob), chapter titles include them, and the
-file gets a `©xyz` geotag — derived by averaging the majority cluster of clip
-locations (within 5 km), falling back to the first located clip. WebM exports
-skip both (the WebM subset of Matroska excludes chapters). Clips recorded
-before this feature simply lack the data and degrade gracefully.
+recording time. Kody Video Plus users can opt into **location tagging** on the
+record screen; clips then store device coordinates in IndexedDB alongside the
+clip, never inside the MediaRecorder blob. Exports omit those coordinates by
+default. A separate Plus-only export toggle adds them to chapter titles and a
+`©xyz` geotag derived by averaging the majority cluster of clip locations
+(within 5 km), falling back to the first located clip. WebM exports skip both
+(the WebM subset of Matroska excludes chapters). Clips recorded before this
+feature simply lack the data and degrade gracefully.
 
 ### Export pipeline
 

--- a/manual-test-checklist.md
+++ b/manual-test-checklist.md
@@ -33,8 +33,9 @@ npm test           # unit tests
   (fine-pointer) recording never locks; landscape projects export landscape
   files (portrait clips center-crop; backup round-trip of the lock is
   covered by the unit suite)
-- **Location**: toggle asks permission, `aria-pressed` reflects state, new
-  clips carry exact coordinates, toasts confirm on/off
+- **Location (Plus)**: capture toggle asks permission, `aria-pressed` reflects
+  state, new clips carry exact coordinates, toasts confirm on/off; export
+  toggle is off by default and hidden on the free plan
 - **Editor**: opens at the most recent clip; tap selects; tiles show
   filmstrip thumbnails; duplicate inserts the copy right after the selection;
   delete offers Undo; trim strip opens, dragging the end handle + Done
@@ -135,9 +136,9 @@ see the README) — plain `http://<lan-ip>` fails in most browsers.
   clips with no clicks at joints, smooth frame rate
 - [ ] Watermark (before purchase): small Kody mark + domain bottom-right at
   50% opacity; gone after purchase
-- [ ] MP4 chapters at clip boundaries in VLC/mpv; with tagged clips,
-  VLC/exiftool show the ©xyz geotag; old projects without location still
-  export (chapters only)
+- [ ] MP4 chapters at clip boundaries in VLC/mpv; tagged clips export as
+  chapters only by default, while enabling export location adds coordinates
+  to chapter titles and a ©xyz geotag
 - [ ] Share opens the system share sheet (fresh tap, no silent failure)
 - [ ] Export failure path offers "Save clips instead"
 

--- a/scripts/manual-smoke.mjs
+++ b/scripts/manual-smoke.mjs
@@ -274,11 +274,15 @@ try {
     (await page.getByRole('button', { name: /get plus — \$0\.99/i }).count()) === 0
   if (upsellGone) pass('purchase removes the watermark upsell')
   else fail('purchase removes the watermark upsell', `exported=${unlockedExport}`)
-  await page
-    .getByRole('dialog', { name: /share project/i })
-    .getByRole('button', { name: /done|close/i })
-    .first()
-    .click()
+  const unlockedDialog = page.getByRole('dialog', { name: /share project/i })
+  const locationExportToggle = unlockedDialog.getByRole('checkbox', {
+    name: /include clip locations/i,
+  })
+  const locationExportSafe =
+    (await locationExportToggle.count()) === 1 && !(await locationExportToggle.isChecked())
+  if (locationExportSafe) pass('Plus location export toggle defaults off')
+  else fail('Plus location export toggle defaults off')
+  await unlockedDialog.getByRole('button', { name: /done|close/i }).first().click()
   await page.unroute('**/api/verify-purchase*')
 
   // --- Playback preview overlay ---

--- a/src/components/export-sheet.tsx
+++ b/src/components/export-sheet.tsx
@@ -24,6 +24,12 @@ interface ExportSheetProps {
   purchased: boolean
   /** Plus opt-in: keep stamping the mark on future exports. */
   keepWatermark: boolean
+  /** Plus opt-in: include captured coordinates in future MP4 exports. */
+  includeLocation: boolean
+  /** Whether THIS exported file contains captured coordinates. */
+  locationIncluded: boolean
+  /** Whether any clip in the current project carries captured coordinates. */
+  hasTaggedClips: boolean
   /**
    * True when this run used the realtime canvas fallback. Shows a dismissible
    * backup / try-elsewhere hint (session-only; resets on the next export).
@@ -32,6 +38,7 @@ interface ExportSheetProps {
   /** A share/save is in flight — dismissal would drop its result notice. */
   busy: boolean
   onKeepWatermarkChange: (keep: boolean) => void
+  onIncludeLocationChange: (include: boolean) => void
   onShare: () => void
   onSave: () => void
   onSaveClips: () => void
@@ -64,9 +71,13 @@ export function ExportSheet(handle: Handle<ExportSheetProps>) {
       watermarked,
       purchased,
       keepWatermark,
+      includeLocation,
+      locationIncluded,
+      hasTaggedClips,
       usedFallback,
       busy,
       onKeepWatermarkChange,
+      onIncludeLocationChange,
       onShare,
       onSave,
       onSaveClips,
@@ -185,8 +196,8 @@ export function ExportSheet(handle: Handle<ExportSheetProps>) {
                 </p>
               ) : null}
               {purchased ? (
-                <div className="watermark-prefs">
-                  <label className="watermark-keep-toggle">
+                <div className="export-prefs">
+                  <label className="export-pref-toggle">
                     <input
                       type="checkbox"
                       checked={keepWatermark}
@@ -197,17 +208,47 @@ export function ExportSheet(handle: Handle<ExportSheetProps>) {
                     />
                     Keep the Kody mark on exports
                   </label>
+                  <label className="export-pref-toggle">
+                    <input
+                      type="checkbox"
+                      checked={includeLocation}
+                      disabled={busy}
+                      mix={on('change', (event) => {
+                        onIncludeLocationChange(
+                          (event.currentTarget as HTMLInputElement).checked,
+                        )
+                      })}
+                    />
+                    Include clip locations in MP4 exports
+                  </label>
                   {watermarked && !keepWatermark ? (
-                    <p className="watermark-note">
+                    <p className="export-pref-note">
                       This video still includes the Kody mark — tap Re-export from scratch for a
                       clean export.
                     </p>
                   ) : null}
                   {!watermarked && keepWatermark ? (
-                    <p className="watermark-note">
+                    <p className="export-pref-note">
                       Tap Re-export from scratch to stamp the Kody mark on this video.
                     </p>
                   ) : null}
+                  {locationIncluded && !includeLocation ? (
+                    <p className="export-pref-note">
+                      This video still includes clip locations — tap Re-export from scratch to
+                      remove them.
+                    </p>
+                  ) : null}
+                  {!locationIncluded &&
+                  includeLocation &&
+                  hasTaggedClips &&
+                  fileExtension === 'mp4' ? (
+                    <p className="export-pref-note">
+                      Tap Re-export from scratch to include clip locations in this video.
+                    </p>
+                  ) : null}
+                  <p className="export-location-note">
+                    Location is off by default. Chapter markers stay in the video either way.
+                  </p>
                 </div>
               ) : null}
             </>

--- a/src/components/record-screen.tsx
+++ b/src/components/record-screen.tsx
@@ -141,7 +141,7 @@ export function RecordScreen(handle: Handle<RecordScreenProps>) {
   let micSilent = false
   /** Bottom sheet for choosing which microphone records takes. */
   let micPickerOpen = false
-  let locationTagging = props.locationTaggingEnabled ?? false
+  let locationTagging = props.plus && (props.locationTaggingEnabled ?? false)
 
   const screenRecordingSupported = isScreenRecordingSupported()
 
@@ -424,7 +424,7 @@ export function RecordScreen(handle: Handle<RecordScreenProps>) {
       }
       // Fire-and-forget GPS for this take — must not delay recording start.
       pendingFix = null
-      if (locationTagging) {
+      if (props.plus && locationTagging) {
         pendingFix = getLocationFix()
       }
       startThumbMirror(stream)
@@ -1308,16 +1308,18 @@ export function RecordScreen(handle: Handle<RecordScreenProps>) {
             >
               <IconTimer />
             </button>
-            <button
-              type="button"
-              className={`btn-icon${locationTagging ? ' is-active' : ''}`}
-              aria-label="Toggle location tagging"
-              aria-pressed={locationTagging}
-              disabled={recording || countdown !== null}
-              mix={on('click', toggleLocationTagging)}
-            >
-              <IconLocation />
-            </button>
+            {props.plus ? (
+              <button
+                type="button"
+                className={`btn-icon${locationTagging ? ' is-active' : ''}`}
+                aria-label="Toggle location tagging"
+                aria-pressed={locationTagging}
+                disabled={recording || countdown !== null}
+                mix={on('click', toggleLocationTagging)}
+              >
+                <IconLocation />
+              </button>
+            ) : null}
             <button
               type="button"
               className="btn-icon"

--- a/src/components/upsell-sheet.tsx
+++ b/src/components/upsell-sheet.tsx
@@ -10,7 +10,7 @@ interface UpsellSheetProps {
   onRestore: () => void
 }
 
-/** The one-time Kody Video Plus purchase: watermark removal + more projects. */
+/** The one-time Kody Video Plus purchase and its creation/export perks. */
 export function UpsellSheet(handle: Handle<UpsellSheetProps>) {
   return () => {
     const { onClose, onRestore } = handle.props
@@ -31,8 +31,9 @@ export function UpsellSheet(handle: Handle<UpsellSheetProps>) {
           <h3>Kody Video Plus</h3>
           <p className="sheet-copy">
             The free plan includes 1 project. Plus is a one-time $0.99 purchase that unlocks{' '}
-            {MAX_PROJECTS} project slots, background music, landscape projects, and removes the
-            watermark from exports — forever, on this device and any device you restore it on.
+            {MAX_PROJECTS} project slots, background music, landscape projects, optional location
+            tagging, and removes the watermark from exports — forever, on this device and any
+            device you restore it on.
           </p>
           <div className="sheet-actions">
             <button type="button" className="btn btn-ghost" mix={on('click', () => onClose())}>

--- a/src/lib/export/encode-realtime.ts
+++ b/src/lib/export/encode-realtime.ts
@@ -396,6 +396,7 @@ export async function exportRealtime(
     blob,
     mimeType: blob.type || 'video/webm',
     fileExtension: isMp4 ? 'mp4' : 'webm',
+    locationIncluded: false,
     engine: 'realtime',
   }
   } finally {

--- a/src/lib/export/encode-webcodecs.ts
+++ b/src/lib/export/encode-webcodecs.ts
@@ -16,7 +16,6 @@ import {
   type AudioCodec,
   type VideoCodec,
 } from 'mediabunny'
-import { deriveProjectLocation } from '../geo'
 import { isIosBrowser } from '../platform'
 import {
   clipMusicVolume,
@@ -54,6 +53,11 @@ import {
   seekTo,
   type ExportResult,
 } from './shared'
+import {
+  clipsSpanMultipleDays,
+  formatChapterTitle,
+  locationForExport,
+} from './mp4-export-metadata'
 
 const FPS = 30
 const AUDIO_SAMPLE_RATE = 48000
@@ -133,6 +137,7 @@ export async function exportWithWebCodecs(
   watermarkImage?: HTMLImageElement | null,
   background?: BackgroundAudio | null,
   orientation?: ProjectOrientation,
+  includeLocation = false,
 ): Promise<ExportResult> {
   if (!supportsWebCodecsExport()) {
     throw new Error('WebCodecs is not available')
@@ -337,7 +342,7 @@ export async function exportWithWebCodecs(
         if (choice.container === 'mp4') {
           chapters.push({
             startMs: Math.round(state.outputOffsetSec * 1000),
-            title: formatChapterTitle(segment.clip, multiDay),
+            title: formatChapterTitle(segment.clip, multiDay, includeLocation),
           })
         }
 
@@ -502,7 +507,13 @@ export async function exportWithWebCodecs(
   }
   const diskBlob = blob
   if (choice.container === 'mp4') {
-    blob = await injectMetadataBestEffort(blob, mimeType, chapters, clipsInPlan)
+    blob = await injectMetadataBestEffort(
+      blob,
+      mimeType,
+      chapters,
+      clipsInPlan,
+      includeLocation,
+    )
   }
   return {
     blob,
@@ -530,12 +541,13 @@ async function injectMetadataBestEffort(
   mimeType: string,
   chapters: Mp4Chapter[],
   clipsInPlan: ClipRecord[],
+  includeLocation: boolean,
 ): Promise<Blob> {
   if (blob.size > METADATA_INJECT_LIMIT_BYTES) return blob
   try {
     const injected = injectMp4Metadata(await blob.arrayBuffer(), {
       chapters,
-      location: deriveProjectLocation(clipsInPlan),
+      location: locationForExport(clipsInPlan, includeLocation),
     })
     return new Blob([injected], { type: mimeType })
   } catch {
@@ -576,37 +588,6 @@ async function probeOutputSize(
   }
 }
 
-/** Recording start ≈ createdAt − durationMs (wall-clock capture window). */
-function clipRecordingStartMs(clip: Pick<ClipRecord, 'createdAt' | 'durationMs'>): number {
-  return clip.createdAt - clip.durationMs
-}
-
-function clipsSpanMultipleDays(clips: Pick<ClipRecord, 'createdAt' | 'durationMs'>[]): boolean {
-  if (clips.length <= 1) return false
-  const days = new Set<string>()
-  for (const clip of clips) {
-    const d = new Date(clipRecordingStartMs(clip))
-    days.add(`${d.getFullYear()}-${d.getMonth()}-${d.getDate()}`)
-    if (days.size > 1) return true
-  }
-  return false
-}
-
-function formatChapterTitle(
-  clip: Pick<ClipRecord, 'createdAt' | 'durationMs' | 'lat' | 'lng'>,
-  includeDate: boolean,
-): string {
-  const start = new Date(clipRecordingStartMs(clip))
-  const time = start.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' })
-  const datePrefix = includeDate
-    ? `${start.toLocaleDateString([], { month: 'short', day: 'numeric' })} `
-    : ''
-  let title = `${datePrefix}${time}`
-  if (typeof clip.lat === 'number' && typeof clip.lng === 'number') {
-    title += ` · ${clip.lat.toFixed(4)},${clip.lng.toFixed(4)}`
-  }
-  return title
-}
 
 interface PumpState {
   lastVideoTsSec: number

--- a/src/lib/export/encode-webcodecs.ts
+++ b/src/lib/export/encode-webcodecs.ts
@@ -506,19 +506,23 @@ export async function exportWithWebCodecs(
     blob = new Blob([buffer], { type: mimeType })
   }
   const diskBlob = blob
+  let locationIncluded = false
   if (choice.container === 'mp4') {
-    blob = await injectMetadataBestEffort(
+    const metadata = await injectMetadataBestEffort(
       blob,
       mimeType,
       chapters,
       clipsInPlan,
       includeLocation,
     )
+    blob = metadata.blob
+    locationIncluded = metadata.locationIncluded
   }
   return {
     blob,
     mimeType,
     fileExtension: choice.container,
+    locationIncluded,
     engine: 'webcodecs',
     opfsName: opfs?.name,
     // Metadata injection returns a NEW in-memory blob; when it ran, the
@@ -542,16 +546,23 @@ async function injectMetadataBestEffort(
   chapters: Mp4Chapter[],
   clipsInPlan: ClipRecord[],
   includeLocation: boolean,
-): Promise<Blob> {
-  if (blob.size > METADATA_INJECT_LIMIT_BYTES) return blob
+): Promise<{ blob: Blob; locationIncluded: boolean }> {
+  if (blob.size > METADATA_INJECT_LIMIT_BYTES) {
+    return { blob, locationIncluded: false }
+  }
   try {
-    const injected = injectMp4Metadata(await blob.arrayBuffer(), {
+    const location = locationForExport(clipsInPlan, includeLocation)
+    const source = await blob.arrayBuffer()
+    const injected = injectMp4Metadata(source, {
       chapters,
-      location: locationForExport(clipsInPlan, includeLocation),
+      location,
     })
-    return new Blob([injected], { type: mimeType })
+    return {
+      blob: new Blob([injected], { type: mimeType }),
+      locationIncluded: location !== null && injected !== source,
+    }
   } catch {
-    return blob
+    return { blob, locationIncluded: false }
   }
 }
 

--- a/src/lib/export/index.test.ts
+++ b/src/lib/export/index.test.ts
@@ -6,6 +6,7 @@ vi.mock('./encode-realtime', () => ({
     blob: new Blob([new Uint8Array(2048)], { type: 'video/webm' }),
     mimeType: 'video/webm',
     fileExtension: 'webm' as const,
+    locationIncluded: false,
     engine: 'realtime' as const,
   })),
 }))
@@ -51,6 +52,7 @@ describe('exportProject fallback signaling', () => {
     expect(exportWithWebCodecs).not.toHaveBeenCalled()
     expect(exportRealtime).toHaveBeenCalledTimes(1)
     expect(result.engine).toBe('realtime')
+    expect(result.locationIncluded).toBe(false)
   })
 
   it('calls onFallback after WebCodecs fails', async () => {
@@ -73,6 +75,7 @@ describe('exportProject fallback signaling', () => {
       blob: new Blob([new Uint8Array(2048)], { type: 'video/mp4' }),
       mimeType: 'video/mp4',
       fileExtension: 'mp4',
+      locationIncluded: true,
       engine: 'webcodecs',
     })
     // Silence verification needs no audible input peak — leave diagnostics empty.
@@ -84,5 +87,6 @@ describe('exportProject fallback signaling', () => {
     expect(onFallback).not.toHaveBeenCalled()
     expect(exportRealtime).not.toHaveBeenCalled()
     expect(result.engine).toBe('webcodecs')
+    expect(result.locationIncluded).toBe(true)
   })
 })

--- a/src/lib/export/index.ts
+++ b/src/lib/export/index.ts
@@ -36,6 +36,12 @@ export interface ExportOptions {
   getPreviewCanvas?: () => HTMLCanvasElement | null
   /** Stamp the Kody Video mark on frames (default true; off after purchase). */
   watermark?: boolean
+  /**
+   * Include captured coordinates in MP4 metadata and chapter titles.
+   * Default false so exports do not disclose location without an explicit
+   * Plus-user opt-in.
+   */
+  includeLocation?: boolean
   /** Background-music playlist mixed under the clips at their per-clip
    * volumes; tracks play one after the other until the film ends. */
   background?: BackgroundAudio | null
@@ -93,6 +99,7 @@ async function runExport(
         watermarkImage,
         options.background,
         options.orientation,
+        options.includeLocation === true,
       )
       reportSilentExportAudio({ engine: 'webcodecs', outputMime: result.mimeType })
       reportBlackExportVideo({ engine: 'webcodecs', outputMime: result.mimeType })

--- a/src/lib/export/last-export.test.ts
+++ b/src/lib/export/last-export.test.ts
@@ -16,11 +16,8 @@ function fakeClip(id: string): ClipRecord {
 }
 
 describe('exportSignature', () => {
-  it('signs portrait projects identically to before the orientation setting', () => {
+  it('signs absent and portrait orientations identically', () => {
     const clips = [fakeClip('clip_a')]
-    // Cached exports from app versions without the setting must survive the
-    // update: absent and explicit-portrait orientations both sign like the
-    // old three-argument call.
     expect(exportSignature(clips, true, null, 'portrait')).toBe(
       exportSignature(clips, true, null),
     )
@@ -33,6 +30,13 @@ describe('exportSignature', () => {
     const clips = [fakeClip('clip_a')]
     expect(exportSignature(clips, true, null, 'landscape')).not.toBe(
       exportSignature(clips, true, null, 'portrait'),
+    )
+  })
+
+  it('signs location inclusion differently so a cached geotag is never reused', () => {
+    const clips = [fakeClip('clip_a')]
+    expect(exportSignature(clips, false, null, 'portrait', true)).not.toBe(
+      exportSignature(clips, false, null, 'portrait', false),
     )
   })
 })

--- a/src/lib/export/last-export.ts
+++ b/src/lib/export/last-export.ts
@@ -28,12 +28,14 @@ export function exportSignature(
   watermarked: boolean,
   audio?: Pick<ProjectAudioRecord, 'tracks' | 'fadeIn' | 'fadeOut'> | null,
   orientation?: ProjectOrientation,
+  includeLocation = false,
 ): string {
   return JSON.stringify({
     watermarked,
-    // Only landscape signs (JSON drops undefined): every portrait project's
-    // signature stays byte-identical to before the setting existed, so
-    // cached exports survive the app update.
+    // Sign explicitly, including false, to invalidate legacy cached exports
+    // that may contain location metadata before this privacy control existed.
+    includeLocation,
+    // Only landscape signs (JSON drops undefined).
     orientation: orientation === 'landscape' ? 'landscape' : undefined,
     clips: clips.map((clip) => [
       clip.id,

--- a/src/lib/export/last-export.ts
+++ b/src/lib/export/last-export.ts
@@ -136,6 +136,7 @@ async function persistLastExportInner(args: {
       createdAt: Date.now(),
       signature,
       watermarked,
+      locationIncluded: result.locationIncluded,
     },
   })
   if (previousName && previousName !== opfsName) {
@@ -167,6 +168,7 @@ export async function loadMatchingExport(
       blob: new Blob([file], { type: last.mimeType }),
       mimeType: last.mimeType,
       fileExtension: last.fileExtension,
+      locationIncluded: last.locationIncluded === true,
     },
     watermarked: last.watermarked,
     createdAt: last.createdAt,

--- a/src/lib/export/mp4-export-metadata.test.ts
+++ b/src/lib/export/mp4-export-metadata.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest'
+import type { ClipRecord } from '../types'
+import { formatChapterTitle, locationForExport } from './mp4-export-metadata'
+
+function locatedClip(): Pick<ClipRecord, 'createdAt' | 'durationMs' | 'lat' | 'lng'> {
+  return {
+    createdAt: new Date(2026, 7, 8, 14, 30).getTime() + 2_000,
+    durationMs: 2_000,
+    lat: 40.41791,
+    lng: -111.81496,
+  }
+}
+
+describe('MP4 export location metadata', () => {
+  it('keeps chapter times while omitting coordinates by default', () => {
+    const clip = locatedClip()
+    const title = formatChapterTitle(clip, false, false)
+
+    expect(title).toMatch(/\d/)
+    expect(title).not.toContain(clip.lat!.toFixed(4))
+    expect(title).not.toContain(clip.lng!.toFixed(4))
+    expect(locationForExport([clip], false)).toBeNull()
+  })
+
+  it('includes chapter coordinates and a project geotag when opted in', () => {
+    const clip = locatedClip()
+    const title = formatChapterTitle(clip, false, true)
+
+    expect(title).toContain(`${clip.lat!.toFixed(4)},${clip.lng!.toFixed(4)}`)
+    expect(locationForExport([clip], true)).toEqual({
+      lat: clip.lat,
+      lng: clip.lng,
+    })
+  })
+})

--- a/src/lib/export/mp4-export-metadata.test.ts
+++ b/src/lib/export/mp4-export-metadata.test.ts
@@ -32,4 +32,13 @@ describe('MP4 export location metadata', () => {
       lng: clip.lng,
     })
   })
+
+  it('omits malformed non-finite coordinates from opted-in chapter titles', () => {
+    const clip = locatedClip()
+
+    expect(formatChapterTitle({ ...clip, lat: Number.NaN }, false, true)).not.toContain('NaN')
+    expect(
+      formatChapterTitle({ ...clip, lng: Number.POSITIVE_INFINITY }, false, true),
+    ).not.toContain('Infinity')
+  })
 })

--- a/src/lib/export/mp4-export-metadata.ts
+++ b/src/lib/export/mp4-export-metadata.ts
@@ -33,7 +33,13 @@ export function formatChapterTitle(
     ? `${start.toLocaleDateString([], { month: 'short', day: 'numeric' })} `
     : ''
   let title = `${datePrefix}${time}`
-  if (includeLocation && typeof clip.lat === 'number' && typeof clip.lng === 'number') {
+  if (
+    includeLocation &&
+    typeof clip.lat === 'number' &&
+    Number.isFinite(clip.lat) &&
+    typeof clip.lng === 'number' &&
+    Number.isFinite(clip.lng)
+  ) {
     title += ` · ${clip.lat.toFixed(4)},${clip.lng.toFixed(4)}`
   }
   return title

--- a/src/lib/export/mp4-export-metadata.ts
+++ b/src/lib/export/mp4-export-metadata.ts
@@ -1,0 +1,47 @@
+import { deriveProjectLocation } from '../geo'
+import type { ClipRecord } from '../types'
+
+type ChapterClip = Pick<ClipRecord, 'createdAt' | 'durationMs' | 'lat' | 'lng'>
+type LocatedClip = Pick<ClipRecord, 'lat' | 'lng'>
+
+/** Recording start ≈ createdAt − durationMs (wall-clock capture window). */
+function clipRecordingStartMs(clip: Pick<ClipRecord, 'createdAt' | 'durationMs'>): number {
+  return clip.createdAt - clip.durationMs
+}
+
+export function clipsSpanMultipleDays(
+  clips: Pick<ClipRecord, 'createdAt' | 'durationMs'>[],
+): boolean {
+  if (clips.length <= 1) return false
+  const days = new Set<string>()
+  for (const clip of clips) {
+    const date = new Date(clipRecordingStartMs(clip))
+    days.add(`${date.getFullYear()}-${date.getMonth()}-${date.getDate()}`)
+    if (days.size > 1) return true
+  }
+  return false
+}
+
+export function formatChapterTitle(
+  clip: ChapterClip,
+  includeDate: boolean,
+  includeLocation: boolean,
+): string {
+  const start = new Date(clipRecordingStartMs(clip))
+  const time = start.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' })
+  const datePrefix = includeDate
+    ? `${start.toLocaleDateString([], { month: 'short', day: 'numeric' })} `
+    : ''
+  let title = `${datePrefix}${time}`
+  if (includeLocation && typeof clip.lat === 'number' && typeof clip.lng === 'number') {
+    title += ` · ${clip.lat.toFixed(4)},${clip.lng.toFixed(4)}`
+  }
+  return title
+}
+
+export function locationForExport(
+  clips: LocatedClip[],
+  includeLocation: boolean,
+): { lat: number; lng: number } | null {
+  return includeLocation ? deriveProjectLocation(clips) : null
+}

--- a/src/lib/export/shared.ts
+++ b/src/lib/export/shared.ts
@@ -974,6 +974,8 @@ export interface ExportResult {
   blob: Blob
   mimeType: string
   fileExtension: 'mp4' | 'webm'
+  /** True only when this file actually contains clip-location metadata. */
+  locationIncluded: boolean
   /** Which stitcher produced this file. Omitted on recovered cache hits. */
   engine?: ExportEngine
   /** Name of the OPFS exports-directory file this export streamed into. */

--- a/src/lib/project-actions.ts
+++ b/src/lib/project-actions.ts
@@ -58,6 +58,8 @@ export interface ProjectLoaderData {
    * Plus opt-in: keep the Kody mark on exports after purchase (default off).
    */
   keepWatermark: boolean
+  /** Plus opt-in: include captured coordinates in MP4 exports (default off). */
+  includeLocationInExports: boolean
   /** Device storage estimate (null when the API is unavailable). */
   storage: StorageSpace | null
   /** Opt-in: tag new clips with device location. */
@@ -148,8 +150,11 @@ export async function loadProjectPage(projectId: ProjectId): Promise<ProjectLoad
         onboardingDismissed: settings.onboardingDismissed,
         watermarkRemoved: settings.watermarkRemoved === true,
         keepWatermark: settings.keepWatermark === true,
+        includeLocationInExports:
+          settings.watermarkRemoved === true && settings.includeLocationInExports === true,
         storage,
-        locationTaggingEnabled: settings.locationTaggingEnabled === true,
+        locationTaggingEnabled:
+          settings.watermarkRemoved === true && settings.locationTaggingEnabled === true,
         error: null,
       }
     }
@@ -171,8 +176,11 @@ export async function loadProjectPage(projectId: ProjectId): Promise<ProjectLoad
         onboardingDismissed: settings.onboardingDismissed,
         watermarkRemoved: settings.watermarkRemoved === true,
         keepWatermark: settings.keepWatermark === true,
+        includeLocationInExports:
+          settings.watermarkRemoved === true && settings.includeLocationInExports === true,
         storage,
-        locationTaggingEnabled: settings.locationTaggingEnabled === true,
+        locationTaggingEnabled:
+          settings.watermarkRemoved === true && settings.locationTaggingEnabled === true,
         error: 'Project not found',
       }
     }
@@ -197,8 +205,11 @@ export async function loadProjectPage(projectId: ProjectId): Promise<ProjectLoad
       onboardingDismissed: settings.onboardingDismissed,
       watermarkRemoved: settings.watermarkRemoved === true,
       keepWatermark: settings.keepWatermark === true,
+      includeLocationInExports:
+        settings.watermarkRemoved === true && settings.includeLocationInExports === true,
       storage,
-      locationTaggingEnabled: settings.locationTaggingEnabled === true,
+      locationTaggingEnabled:
+        settings.watermarkRemoved === true && settings.locationTaggingEnabled === true,
       error: null,
     }
   } catch (err) {
@@ -210,6 +221,7 @@ export async function loadProjectPage(projectId: ProjectId): Promise<ProjectLoad
       onboardingDismissed: true,
       watermarkRemoved: false,
       keepWatermark: false,
+      includeLocationInExports: false,
       storage: null,
       locationTaggingEnabled: false,
       error: err instanceof Error ? err.message : 'Failed to load project',

--- a/src/lib/storage.test.ts
+++ b/src/lib/storage.test.ts
@@ -24,6 +24,8 @@ import {
   PlusRequiredError,
   removeProjectAudioTrack,
   renameProject,
+  setIncludeLocationInExports,
+  setLocationTaggingEnabled,
   setOnboardingDismissed,
   setProjectOrientation,
   setTourCardDismissed,
@@ -174,6 +176,26 @@ describe('storage layer', () => {
     expect((await getSettings()).keepWatermark).toBe(true)
     await setKeepWatermark(false)
     expect((await getSettings()).keepWatermark).toBe(false)
+  })
+
+  it('gates location capture and export preferences behind Plus', async () => {
+    await expect(setLocationTaggingEnabled(true)).rejects.toBeInstanceOf(PlusRequiredError)
+    await expect(setIncludeLocationInExports(true)).rejects.toBeInstanceOf(PlusRequiredError)
+
+    await markWatermarkRemoved('cs_test_location')
+    await setLocationTaggingEnabled(true)
+    await setIncludeLocationInExports(true)
+    expect(await getSettings()).toMatchObject({
+      locationTaggingEnabled: true,
+      includeLocationInExports: true,
+    })
+
+    await setLocationTaggingEnabled(false)
+    await setIncludeLocationInExports(false)
+    expect(await getSettings()).toMatchObject({
+      locationTaggingEnabled: false,
+      includeLocationInExports: false,
+    })
   })
 
   it('gates the second project behind the Plus purchase', async () => {

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -259,6 +259,9 @@ export async function setTourCardDismissed(tourCardDismissed: boolean): Promise<
 export async function setLocationTaggingEnabled(locationTaggingEnabled: boolean): Promise<void> {
   const db = await getDb()
   const settings = await getSettings()
+  if (locationTaggingEnabled && settings.watermarkRemoved !== true) {
+    throw new PlusRequiredError('Location tagging is a Kody Video Plus perk.')
+  }
   await db.put('meta', { ...settings, locationTaggingEnabled })
 }
 
@@ -266,6 +269,17 @@ export async function setKeepWatermark(keepWatermark: boolean): Promise<void> {
   const db = await getDb()
   const settings = await getSettings()
   await db.put('meta', { ...settings, keepWatermark })
+}
+
+export async function setIncludeLocationInExports(
+  includeLocationInExports: boolean,
+): Promise<void> {
+  const db = await getDb()
+  const settings = await getSettings()
+  if (includeLocationInExports && settings.watermarkRemoved !== true) {
+    throw new PlusRequiredError('Location export is a Kody Video Plus perk.')
+  }
+  await db.put('meta', { ...settings, includeLocationInExports })
 }
 
 export async function listProjects(): Promise<Project[]> {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -229,6 +229,8 @@ export interface AppMeta {
      * that produced the file — any difference means a fresh export is needed. */
     signature: string
     watermarked: boolean
+    /** Whether the cached file actually contains clip-location metadata. */
+    locationIncluded?: boolean
   } | null
 }
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -209,6 +209,12 @@ export interface AppMeta {
    * Default off — Plus removes the watermark unless the user chooses this.
    */
   keepWatermark?: boolean
+  /**
+   * Plus opt-in: include captured clip coordinates in MP4 metadata and
+   * chapter titles. Default off so a share cannot disclose location unless
+   * the user explicitly enables it.
+   */
+  includeLocationInExports?: boolean
   /** Opt-in: tag new clips with device location. */
   locationTaggingEnabled?: boolean
   /** The persisted last export (OPFS-backed), recoverable after the share
@@ -219,8 +225,8 @@ export interface AppMeta {
     mimeType: string
     fileExtension: 'mp4' | 'webm'
     createdAt: number
-    /** Fingerprint of the clips (ids + trims) and watermark state that
-     * produced the file — any difference means a fresh export is needed. */
+    /** Fingerprint of clips, render settings, and export metadata choices
+     * that produced the file — any difference means a fresh export is needed. */
     signature: string
     watermarked: boolean
   } | null

--- a/src/pages/privacy-page.tsx
+++ b/src/pages/privacy-page.tsx
@@ -62,12 +62,12 @@ export function PrivacyPage() {
         <section className="about-section">
           <h2>Optional location tagging</h2>
           <p>
-            Location tagging is off by default. You can opt in with a button, which asks the
-            browser for permission. When it&rsquo;s on, each new clip stores device coordinates
-            locally, and exported videos embed that location in their metadata and chapter titles.
-            Sharing such a video shares those coordinates. You can turn location tagging off anytime;
-            existing clips keep whatever they already captured, and deleting a clip deletes its
-            location data with it.
+            Location tagging is an optional Kody Video Plus feature and is off by default. You can
+            opt in with a button, which asks the browser for permission. When it&rsquo;s on, each
+            new clip stores device coordinates locally. Exported videos omit location by default;
+            Plus users can explicitly include it in MP4 metadata and chapter titles from the export
+            sheet. You can turn location tagging off anytime; existing clips keep whatever they
+            already captured, and deleting a clip deletes its location data with it.
           </p>
         </section>
 

--- a/src/pages/project-page.tsx
+++ b/src/pages/project-page.tsx
@@ -27,7 +27,12 @@ import {
 import { isCoarsePointerDevice, viewportIsLandscape } from '../lib/platform'
 import { loadProjectPage, type ProjectLoaderData } from '../lib/project-actions'
 import { projectBackupFilename, serializeProject } from '../lib/project-transfer'
-import { createProject, setKeepWatermark, setOnboardingDismissed } from '../lib/storage'
+import {
+  createProject,
+  setIncludeLocationInExports,
+  setKeepWatermark,
+  setOnboardingDismissed,
+} from '../lib/storage'
 import { formatBytes, requestPersistentStorage } from '../lib/storage-space'
 import { navigate } from '../router'
 import {
@@ -68,6 +73,8 @@ interface ExportUiState {
   notice: string | null
   /** Whether THIS export was stamped (entitlement can change mid-sheet). */
   watermarked: boolean
+  /** Whether THIS MP4 export contains captured clip coordinates. */
+  locationIncluded: boolean
   /** True once this run entered the realtime canvas fallback. */
   usedFallback: boolean
 }
@@ -142,6 +149,7 @@ export function ProjectPage(handle: Handle<ProjectPageProps>) {
           onboardingDismissed: true,
           watermarkRemoved: false,
           keepWatermark: false,
+          includeLocationInExports: false,
           storage: null,
           locationTaggingEnabled: false,
           error: err instanceof Error ? err.message : 'Could not load this project.',
@@ -316,12 +324,17 @@ export function ProjectPage(handle: Handle<ProjectPageProps>) {
     }
 
     const watermarked = shouldWatermarkExports(data)
+    const hasLocation = clips.some(
+      (clip) => typeof clip.lat === 'number' && typeof clip.lng === 'number',
+    )
+    const includeLocation =
+      data.watermarkRemoved && data.includeLocationInExports && hasLocation
     // Only an explicit landscape choice forces the output shape; portrait
     // projects keep following their first clip (desktop and screen
     // recordings are landscape media in "portrait" projects — cropping
     // those would be a regression, not a feature).
     const orientation = effectiveOrientation() === 'landscape' ? 'landscape' : undefined
-    const signature = exportSignature(clips, watermarked, audio, orientation)
+    const signature = exportSignature(clips, watermarked, audio, orientation, includeLocation)
     // Stop camera/mic immediately rather than waiting on record-screen
     // unmount. On iOS the combined mic+camera session can hold decoder
     // slots past the first paints, and WebKit reports that race as
@@ -334,6 +347,7 @@ export function ProjectPage(handle: Handle<ProjectPageProps>) {
       error: null,
       notice: null,
       watermarked,
+      locationIncluded: includeLocation,
       usedFallback: false,
     })
     // Long exports must survive the screen dimming: without a wake lock the
@@ -376,6 +390,8 @@ export function ProjectPage(handle: Handle<ProjectPageProps>) {
               error: null,
               notice: 'Restored your last export — nothing changed since. Retry re-renders.',
               watermarked: recovered.watermarked,
+              locationIncluded:
+                includeLocation && recovered.result.fileExtension === 'mp4',
               usedFallback: false,
             })
             return
@@ -401,6 +417,7 @@ export function ProjectPage(handle: Handle<ProjectPageProps>) {
         const result = await exportProject(clips, {
           audioContext,
           watermark: watermarked,
+          includeLocation,
           orientation,
           background:
             audio && audio.tracks.length > 0
@@ -452,6 +469,7 @@ export function ProjectPage(handle: Handle<ProjectPageProps>) {
           error: null,
           notice: null,
           watermarked,
+          locationIncluded: includeLocation && result.fileExtension === 'mp4',
           usedFallback: result.engine === 'realtime' || (exportState?.usedFallback ?? false),
         })
       } catch (err) {
@@ -478,6 +496,7 @@ export function ProjectPage(handle: Handle<ProjectPageProps>) {
           error: err instanceof Error ? err.message : 'Export failed.',
           notice: null,
           watermarked,
+          locationIncluded: false,
           usedFallback: exportState?.usedFallback ?? false,
         })
       } finally {
@@ -653,12 +672,24 @@ export function ProjectPage(handle: Handle<ProjectPageProps>) {
             usedFallback={exportState.usedFallback}
             purchased={data.watermarkRemoved}
             keepWatermark={data.keepWatermark}
+            includeLocation={data.includeLocationInExports}
+            locationIncluded={exportState.locationIncluded}
+            hasTaggedClips={clips.some(
+              (clip) => typeof clip.lat === 'number' && typeof clip.lng === 'number',
+            )}
             busy={exportActionCount > 0}
             onKeepWatermarkChange={(keep) => {
               data = { ...data!, keepWatermark: keep }
               void handle.update()
               void setKeepWatermark(keep).catch((err) => {
                 reportError(err, 'keep-watermark')
+              })
+            }}
+            onIncludeLocationChange={(include) => {
+              data = { ...data!, includeLocationInExports: include }
+              void handle.update()
+              void setIncludeLocationInExports(include).catch((err) => {
+                reportError(err, 'include-location')
               })
             }}
             onRemoveWatermark={() => {

--- a/src/pages/project-page.tsx
+++ b/src/pages/project-page.tsx
@@ -347,7 +347,7 @@ export function ProjectPage(handle: Handle<ProjectPageProps>) {
       error: null,
       notice: null,
       watermarked,
-      locationIncluded: includeLocation,
+      locationIncluded: false,
       usedFallback: false,
     })
     // Long exports must survive the screen dimming: without a wake lock the
@@ -390,8 +390,7 @@ export function ProjectPage(handle: Handle<ProjectPageProps>) {
               error: null,
               notice: 'Restored your last export — nothing changed since. Retry re-renders.',
               watermarked: recovered.watermarked,
-              locationIncluded:
-                includeLocation && recovered.result.fileExtension === 'mp4',
+              locationIncluded: recovered.result.locationIncluded,
               usedFallback: false,
             })
             return
@@ -469,7 +468,7 @@ export function ProjectPage(handle: Handle<ProjectPageProps>) {
           error: null,
           notice: null,
           watermarked,
-          locationIncluded: includeLocation && result.fileExtension === 'mp4',
+          locationIncluded: result.locationIncluded,
           usedFallback: result.engine === 'realtime' || (exportState?.usedFallback ?? false),
         })
       } catch (err) {

--- a/src/pages/terms-page.tsx
+++ b/src/pages/terms-page.tsx
@@ -35,11 +35,12 @@ export function TermsPage() {
         <section className="about-section">
           <h2>Kody Video Plus</h2>
           <p>
-            Kody Video Plus is a one-time $0.99 purchase that unlocks watermark-free exports and
-            up to six project slots (the free plan includes one project) for the browser profile
-            where it&rsquo;s verified. You can restore the purchase on another device via the
-            Stripe receipt link. Payments are handled by Stripe. For refunds or purchase trouble,
-            email <a href="mailto:team@kody.video">team@kody.video</a>.
+            Kody Video Plus is a one-time $0.99 purchase that unlocks watermark-free exports,
+            optional location tagging, and up to six project slots (the free plan includes one
+            project) for the browser profile where it&rsquo;s verified. You can restore the
+            purchase on another device via the Stripe receipt link. Payments are handled by Stripe.
+            For refunds or purchase trouble, email{' '}
+            <a href="mailto:team@kody.video">team@kody.video</a>.
           </p>
         </section>
 

--- a/src/pages/unlocked-page.tsx
+++ b/src/pages/unlocked-page.tsx
@@ -39,8 +39,9 @@ export function UnlockedPage(handle: Handle) {
             <h1>Kody Video Plus unlocked! 🎉</h1>
             <p className="muted">
               Thank you for supporting Kody Video. Every export from this device is now
-              watermark-free and all six project slots are open. Keep your Stripe receipt email —
-              its link restores the purchase on another device.
+              watermark-free, all six project slots are open, and optional location tagging is
+              available. Keep your Stripe receipt email — its link restores the purchase on another
+              device.
             </p>
           </>
         ) : (

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -419,7 +419,7 @@ a {
   line-height: 1.5;
 }
 
-.watermark-prefs {
+.export-prefs {
   margin-top: 14px;
   display: flex;
   flex-direction: column;
@@ -427,7 +427,7 @@ a {
   gap: 8px;
 }
 
-.watermark-keep-toggle {
+.export-pref-toggle {
   display: inline-flex;
   align-items: center;
   gap: 8px;
@@ -437,16 +437,25 @@ a {
   cursor: pointer;
 }
 
-.watermark-keep-toggle input[type='checkbox'] {
+.export-pref-toggle input[type='checkbox'] {
   width: 16px;
   height: 16px;
   accent-color: var(--accent);
   margin: 0;
 }
 
-.watermark-prefs .watermark-note {
+.export-pref-note,
+.export-location-note {
   margin: 0;
   text-align: center;
+  font-size: 0.85rem;
+  line-height: 1.5;
+  color: var(--ink-muted);
+}
+
+.export-location-note {
+  max-width: 30rem;
+  font-size: 0.78rem;
 }
 
 .link-button {

--- a/tests/e2e/export.spec.ts
+++ b/tests/e2e/export.spec.ts
@@ -1,5 +1,11 @@
 import { test, expect, type Page } from '@playwright/test'
-import { gotoHome, openSeededProject, waitForCameraReady } from './helpers'
+import {
+  gotoHome,
+  openSeededProject,
+  seedProject,
+  unlockPlus,
+  waitForCameraReady,
+} from './helpers'
 
 async function exportReady(page: Page): Promise<void> {
   await expect(page.getByText('Done! Your video is ready')).toBeVisible({ timeout: 60_000 })
@@ -29,6 +35,9 @@ test.describe('Go / export', () => {
     await expect(sheet).toContainText(/(MP4|WebM) · .+MB/i)
     // Watermark upsell shows before purchase.
     await expect(sheet).toContainText(/Get Plus/)
+    await expect(
+      sheet.getByRole('checkbox', { name: /Include clip locations/ }),
+    ).toHaveCount(0)
 
     // Save stores the file locally.
     const downloadPromise = page.waitForEvent('download')
@@ -106,6 +115,31 @@ test.describe('Go / export', () => {
       return names
     })
     expect(cacheEntries).toHaveLength(1)
+  })
+
+  test('Plus users can opt location metadata into future MP4 exports', async ({ page }) => {
+    const projectId = await seedProject(page, {
+      clips: 1,
+      clipMs: 800,
+      location: { lat: 40.41791, lng: -111.81496 },
+    })
+    await unlockPlus(page)
+    await page.goto(`/project/${projectId}`)
+    await waitForCameraReady(page)
+
+    await page.locator('.go-button').click()
+    await exportReady(page)
+
+    const sheet = page.locator('.export-sheet')
+    const locationToggle = sheet.getByRole('checkbox', {
+      name: 'Include clip locations in MP4 exports',
+    })
+    await expect(locationToggle).toBeVisible()
+    await expect(locationToggle).not.toBeChecked()
+    await expect(sheet).toContainText('Location is off by default')
+
+    await locationToggle.check()
+    await expect(locationToggle).toBeChecked()
   })
 
   test('adjacent clips crossfade audio at the joint instead of dipping to silence', async ({

--- a/tests/e2e/helpers.ts
+++ b/tests/e2e/helpers.ts
@@ -19,6 +19,15 @@ export async function openNewProject(page: Page): Promise<void> {
   await waitForCameraReady(page)
 }
 
+/** Home → Plus unlock → empty project camera. */
+export async function openNewPlusProject(page: Page): Promise<void> {
+  await gotoHome(page)
+  await unlockPlus(page)
+  await page.locator('.project-slot.empty').first().click()
+  await page.waitForURL(/\/project\//)
+  await waitForCameraReady(page)
+}
+
 export async function waitForCameraReady(page: Page): Promise<void> {
   const video = page.locator('.camera-video')
   await video.waitFor()
@@ -102,11 +111,16 @@ export async function recordClip(page: Page, holdMs = 1200): Promise<void> {
  */
 export async function seedProject(
   page: Page,
-  options: { clips: number; clipMs?: number; name?: string } = { clips: 1 },
+  options: {
+    clips: number
+    clipMs?: number
+    name?: string
+    location?: { lat: number; lng: number }
+  } = { clips: 1 },
 ): Promise<string> {
   await gotoHome(page)
   const projectId = await page.evaluate(
-    async ({ clips, clipMs, name }) => {
+    async ({ clips, clipMs, name, location }) => {
       const storage = await import('/src/lib/storage.ts')
       const thumbs = await import('/src/lib/thumbs.ts')
       const { makeTestClipBlob } = await import('/src/lib/testing/make-test-clip.ts')
@@ -120,13 +134,20 @@ export async function seedProject(
           durationMs: clipMs,
           width: 320,
           height: 568,
+          lat: location?.lat,
+          lng: location?.lng,
         })
         // Thumbs/posters are generated at record time in the real flow.
         await thumbs.ensureClipThumbs(clip)
       }
       return project.id
     },
-    { clips: options.clips, clipMs: options.clipMs ?? 1500, name: options.name },
+    {
+      clips: options.clips,
+      clipMs: options.clipMs ?? 1500,
+      name: options.name,
+      location: options.location,
+    },
   )
   return projectId
 }

--- a/tests/e2e/record.spec.ts
+++ b/tests/e2e/record.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect, type Page } from '@playwright/test'
 import {
   openNewProject,
+  openNewPlusProject,
   pressStageUntilRecording,
   recordClip,
   totalClipCount,
@@ -213,7 +214,7 @@ test.describe('camera & hold-to-record', () => {
     // location permission"). It used to be anchored at mid-screen and cut
     // off by the right viewport edge (the rise-in animation's transform
     // replaced the centering translateX).
-    await openNewProject(page)
+    await openNewPlusProject(page)
     await page.getByRole('button', { name: 'Toggle location tagging' }).click()
 
     const toast = page.locator('.toast')
@@ -248,7 +249,7 @@ test.describe('camera & hold-to-record', () => {
   test('location tagging geotags new clips while on', async ({ context, page }) => {
     await context.grantPermissions(['camera', 'microphone', 'geolocation'])
     await context.setGeolocation({ latitude: 40.2338, longitude: -111.6585, accuracy: 12 })
-    await openNewProject(page)
+    await openNewPlusProject(page)
     const toggle = page.getByRole('button', { name: 'Toggle location tagging' })
     await toggle.click()
     await expect(page.locator('.toast')).toContainText('Location tagging on')
@@ -271,6 +272,11 @@ test.describe('camera & hold-to-record', () => {
         { timeout: 15_000 },
       )
       .toEqual({ lat: 40.2338, lng: -111.6585 })
+  })
+
+  test('location tagging is hidden without Kody Video Plus', async ({ page }) => {
+    await openNewProject(page)
+    await expect(page.getByRole('button', { name: 'Toggle location tagging' })).toHaveCount(0)
   })
 })
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add a Plus-only export preference for including clip locations in MP4 metadata
- default location export to off while preserving chapter markers without coordinates
- gate location capture behind Kody Video Plus and force free exports to omit existing geotags
- invalidate legacy export caches so previously geotagged files are not silently reused
- report actual metadata injection success through fresh and recovered exports
- reject malformed non-finite coordinates in chapter titles
- update product/privacy copy and automated coverage

## Verification
- `npm run lint`
- `npm test` — 315 passed
- `npm run build`
- `npx playwright test tests/e2e/record.spec.ts tests/e2e/export.spec.ts` — 16 passed
- manual mobile walkthrough: checkbox transitions unchecked → checked → unchecked, ending in the safe default state

<a href="https://cursor.com/agents/bc-40699292-b2dc-464e-bbe9-ef8eeb2378e5/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Flocation-export-toggle-demo.mp4"><img src="https://cursor.com/artifacts/c/art-26d0f1cc-facb-428f-bd28-4768dbe93dca" alt="location-export-toggle-demo.mp4" /></a>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-40699292-b2dc-464e-bbe9-ef8eeb2378e5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-40699292-b2dc-464e-bbe9-ef8eeb2378e5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Plus users can optionally tag clips with location data.
  - MP4 exports offer an “Include clip locations” option, disabled by default.
  - When enabled, coordinates appear in chapter titles and MP4 geotags; WebM exports omit them.
  - Non-Plus users cannot access location tagging or export-location settings.

- **Documentation**
  - Updated privacy policy, terms, Plus messaging, and export guidance to explain location behavior.

- **Bug Fixes**
  - Export history now detects location-preference changes and requests re-exporting when needed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->