### PR TITLE
Harden tour dialog tests after CodeRabbit review

### DIFF
--- a/src/components/tour-card.test.ts
+++ b/src/components/tour-card.test.ts
@@ -1,23 +1,40 @@
-import { afterEach, describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import { openTourFromGesture } from './tour-card'
 
 describe('openTourFromGesture', () => {
   afterEach(() => {
     document.body.replaceChildren()
+    vi.restoreAllMocks()
   })
 
-  it('opens a closed dialog and is safe to call again while open', () => {
+  it('opens a closed dialog, plays on every call, and is safe while open', () => {
     const dialog = document.createElement('dialog')
     const video = document.createElement('video')
     dialog.append(video)
     document.body.append(dialog)
+    const play = vi.spyOn(video, 'play').mockResolvedValue(undefined)
 
     openTourFromGesture(dialog, video)
     expect(dialog.open).toBe(true)
+    expect(play).toHaveBeenCalledTimes(1)
 
     // A double-tap / second click used to throw InvalidStateError here.
     expect(() => openTourFromGesture(dialog, video)).not.toThrow()
     expect(dialog.open).toBe(true)
+    expect(play).toHaveBeenCalledTimes(2)
+  })
+
+  it('swallows rejected play() promises', async () => {
+    const dialog = document.createElement('dialog')
+    const video = document.createElement('video')
+    dialog.append(video)
+    document.body.append(dialog)
+    vi.spyOn(video, 'play').mockRejectedValue(new Error('autoplay blocked'))
+
+    expect(() => openTourFromGesture(dialog, video)).not.toThrow()
+    expect(dialog.open).toBe(true)
+    // Flush the rejected play() so an unhandled rejection would fail the test.
+    await Promise.resolve()
   })
 
   it('no-ops when the dialog ref is missing', () => {

--- a/src/components/tour-card.test.ts
+++ b/src/components/tour-card.test.ts
@@ -29,10 +29,11 @@ describe('openTourFromGesture', () => {
     const video = document.createElement('video')
     dialog.append(video)
     document.body.append(dialog)
-    vi.spyOn(video, 'play').mockRejectedValue(new Error('autoplay blocked'))
+    const play = vi.spyOn(video, 'play').mockRejectedValue(new Error('autoplay blocked'))
 
     expect(() => openTourFromGesture(dialog, video)).not.toThrow()
     expect(dialog.open).toBe(true)
+    expect(play).toHaveBeenCalledTimes(1)
     // Flush the rejected play() so an unhandled rejection would fail the test.
     await Promise.resolve()
   })

--- a/tests/e2e/home.spec.ts
+++ b/tests/e2e/home.spec.ts
@@ -74,9 +74,12 @@ test.describe('home & app shell', () => {
     const teaser = card.getByRole('button', { name: /watch the tour/i })
     const pageErrors: string[] = []
     page.on('pageerror', (err) => pageErrors.push(err.message))
-    // Double-tap: a second showModal() while open used to throw InvalidStateError.
-    await teaser.dblclick()
+    await teaser.click()
     const dialog = page.locator('dialog.tour-dialog')
+    await expect(dialog).toBeVisible()
+    // Second activation while open: dispatch on the teaser so we don't hit
+    // the modal backdrop (a physical dblclick can after showModal() inerting).
+    await teaser.dispatchEvent('click')
     await expect(dialog).toBeVisible()
     expect(pageErrors.filter((m) => /showModal|InvalidStateError/i.test(m))).toEqual([])
     const video = dialog.locator('video.tour-dialog-video')


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

Follow-up to #150. CodeRabbit reviewed after merge with two valid test findings:

1. Unit test didn’t assert the `video.play()` contract (including rejected promises).
2. E2E `dblclick()` can hit the modal backdrop after `showModal()` inerting, so the second activation wasn’t deterministic.

No production code change — test hardening only.

## Changes

- Stub `video.play()` and assert it’s called on every `openTourFromGesture` invocation; cover rejected-play swallow (including that `play()` is still invoked on that path).
- Open with one click, then `teaser.dispatchEvent('click')` for the second activation while asserting no `showModal`/`InvalidStateError` page errors.

## Risk

Low — tests only.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c82c85bf-8992-4006-b790-913d55f39503?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c82c85bf-8992-4006-b790-913d55f39503&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Expanded coverage for tour dialog interactions, including repeated teaser clicks while the dialog is open.
  - Verified that repeated interactions do not cause dialog errors or close the dialog unexpectedly.
  - Confirmed tour video playback is attempted consistently and playback failures are handled without uncaught errors.
  - Added end-to-end validation for stable dialog behavior during repeated user interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->