### PR TITLE
Eliminate per-frame main-thread work while recording

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ feature simply lack the data and degrade gracefully.
 
 - Phones prefer **hardware H.264** (`video/mp4`/`h264` MediaRecorder types) over software VP9 — software encoding is what makes previews and clips drop frames on Android.
 - Clip duration is measured from the encoded media after stop (wall-clock time includes encoder startup latency and corrupts trim/export math).
-- The elapsed timer is a leaf component writing `textContent` from a 10Hz boundary-aligned timer (a per-frame rAF loop would force 60 main-thread frames/s); nothing else re-renders during capture.
+- The elapsed timer is a leaf component mutating its text node directly from a 10Hz boundary-aligned timer (a per-frame rAF loop would force 60 main-thread frames/s), so the ticking readout never re-renders the page during capture.
 - A screen wake lock is held while recording.
 
 ### Remix data flow (explicit updates, no hooks)

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ feature simply lack the data and degrade gracefully.
 
 - Phones prefer **hardware H.264** (`video/mp4`/`h264` MediaRecorder types) over software VP9 — software encoding is what makes previews and clips drop frames on Android.
 - Clip duration is measured from the encoded media after stop (wall-clock time includes encoder startup latency and corrupts trim/export math).
-- The elapsed timer is a leaf component writing `textContent` from rAF; nothing else re-renders during capture.
+- The elapsed timer is a leaf component writing `textContent` from a 10Hz boundary-aligned timer (a per-frame rAF loop would force 60 main-thread frames/s); nothing else re-renders during capture.
 - A screen wake lock is held while recording.
 
 ### Remix data flow (explicit updates, no hooks)

--- a/src/components/record-screen.tsx
+++ b/src/components/record-screen.tsx
@@ -996,11 +996,14 @@ export function RecordScreen(handle: Handle<RecordScreenProps>) {
             mix={ref((node, signal) => bindCameraVideo(node as HTMLVideoElement, signal))}
           />
 
+          {/* aria-live sits on the LABEL, not the pill: the elapsed readout
+              rewrites its text 10×/s, and a live region around it would make
+              screen readers re-announce (and recompute) every tick. */}
           {recording ? (
             <div className="record-overlay">
-              <div className="record-pill" aria-live="polite">
+              <div className="record-pill">
                 <span className="record-dot" />
-                <span className="record-pill-label">
+                <span className="record-pill-label" aria-live="polite">
                   {recordingMode === 'hands-free' ? 'TAP TO STOP' : 'REC'}
                 </span>
                 <RecordTimer startedAt={recordStartedAt} className="record-elapsed" />
@@ -1010,9 +1013,11 @@ export function RecordScreen(handle: Handle<RecordScreenProps>) {
 
           {screenRecording ? (
             <div className="record-overlay">
-              <div className="record-pill" aria-live="polite">
+              <div className="record-pill">
                 <span className="record-dot" />
-                <span className="record-pill-label">SCREEN — TAP TO STOP</span>
+                <span className="record-pill-label" aria-live="polite">
+                  SCREEN — TAP TO STOP
+                </span>
                 <RecordTimer startedAt={screenRecordStartedAt} className="record-elapsed" />
               </div>
             </div>

--- a/src/components/record-timer.tsx
+++ b/src/components/record-timer.tsx
@@ -9,11 +9,20 @@ interface RecordTimerProps {
 }
 
 /**
- * Self-updating elapsed readout. Writes the text node directly from rAF so
- * the rest of the page never re-renders while recording — re-rendering the
- * whole screen 60×/s is what made the camera preview and encoder drop frames.
+ * Self-updating elapsed readout. Writes the text node directly from a
+ * coarse timer so the rest of the page never re-renders while recording —
+ * re-rendering the whole screen per tick is what made the camera preview
+ * and encoder drop frames.
  *
- * The readout is rendered as a real (vdom-owned) text child and the rAF loop
+ * Scheduling: the readout has 0.1s resolution, so it ticks ~10×/s from a
+ * setTimeout aligned just past the next tenth boundary — NOT from
+ * requestAnimationFrame. A per-frame rAF loop (even one that skips
+ * redundant writes) forces the main thread to produce a frame 60×/s for
+ * the whole take, and every one of those frames also re-evaluates the
+ * record pill's (compositor-run) pulse animations — profiled as ~60/s
+ * style recalcs + prepaints competing with the preview and encoder.
+ *
+ * The readout is rendered as a real (vdom-owned) text child and the timer
  * mutates that same node's data. Rendering the span EMPTY and relying on
  * textContent alone looks equivalent, but the reconciler bulk-clears the
  * children of any element whose vnode has none — so every mid-take re-render
@@ -21,20 +30,18 @@ interface RecordTimerProps {
  * the pill visibly collapsed/re-expanded: the "recording counter jitter".
  */
 export function RecordTimer(handle: Handle<RecordTimerProps>) {
-  const elapsedText = () =>
-    formatDuration(Math.max(0, performance.now() - handle.props.startedAt))
+  const elapsedMs = () => Math.max(0, performance.now() - handle.props.startedAt)
 
   return () => (
     <span
       className={handle.props.className}
       mix={ref((node, signal) => {
-        let raf = 0
+        let timer = 0
         let lastText = ''
         const tick = () => {
-          const text = elapsedText()
-          // The readout has 0.1s resolution, so ~5 of 6 frames would write
-          // the same string — and every text write dirties layout.
-          // Skipping no-ops keeps recording free of per-frame layout work.
+          const text = formatDuration(elapsedMs())
+          // A tick can land twice in the same tenth under load — and every
+          // text write dirties layout, so skip no-op writes.
           if (text !== lastText) {
             lastText = text
             // Mutate the existing text node (never replace it): the vdom
@@ -44,13 +51,14 @@ export function RecordTimer(handle: Handle<RecordTimerProps>) {
             if (textNode) textNode.nodeValue = text
             else node.textContent = text
           }
-          raf = requestAnimationFrame(tick)
+          // Land ~5ms past the next 0.1s boundary so every tenth renders.
+          timer = window.setTimeout(tick, 105 - (elapsedMs() % 100))
         }
         tick()
-        signal.addEventListener('abort', () => cancelAnimationFrame(raf))
+        signal.addEventListener('abort', () => window.clearTimeout(timer))
       })}
     >
-      {elapsedText()}
+      {formatDuration(elapsedMs())}
     </span>
   )
 }

--- a/src/components/record-timer.tsx
+++ b/src/components/record-timer.tsx
@@ -10,9 +10,10 @@ interface RecordTimerProps {
 
 /**
  * Self-updating elapsed readout. Writes the text node directly from a
- * coarse timer so the rest of the page never re-renders while recording —
- * re-rendering the whole screen per tick is what made the camera preview
- * and encoder drop frames.
+ * coarse timer so the ticking readout never triggers a component
+ * re-render — re-rendering the whole screen per tick is what made the
+ * camera preview and encoder drop frames. (Other state changes, like the
+ * mic-silent warning, may still re-render the screen mid-take.)
  *
  * Scheduling: the readout has 0.1s resolution, so it ticks ~10×/s from a
  * setTimeout aligned just past the next tenth boundary — NOT from

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -180,15 +180,32 @@ a {
   }
 }
 
+/* Recording pulse, split into two compositor-only animations: the pill
+   breathes with transform, and the expanding halo is a pseudo-element
+   (.record-pill::before) animating transform + opacity over a STATIC
+   border. The previous single animation tweened box-shadow — a paint
+   property — so the pill repainted and re-rasterized on the main thread
+   every frame for the whole take, right while it competed with the live
+   camera preview and the encoder (the record-start jank). */
 @keyframes pulse-record {
   0%,
   100% {
-    box-shadow: 0 0 0 0 rgba(240, 79, 58, 0.55);
     transform: scale(1);
   }
   50% {
-    box-shadow: 0 0 0 18px rgba(240, 79, 58, 0);
     transform: scale(1.03);
+  }
+}
+
+@keyframes pulse-record-ring {
+  0%,
+  100% {
+    opacity: 0.55;
+    transform: scale(0.98);
+  }
+  50% {
+    opacity: 0;
+    transform: scale(1.2);
   }
 }
 

--- a/src/styles/record.css
+++ b/src/styles/record.css
@@ -147,20 +147,41 @@
 }
 
 .record-pill {
+  position: relative;
   display: inline-flex;
   align-items: center;
   gap: 10px;
   padding: 10px 18px;
   border-radius: 999px;
-  background: rgba(8, 12, 14, 0.72);
+  /* Slightly more opaque than the old backdrop-blurred look: blurring the
+     LIVE camera video behind the pill re-sampled the backdrop on the GPU
+     every frame of the whole take — measurable contention with the
+     preview and encoder on phones, for a subtle frost. */
+  background: rgba(8, 12, 14, 0.8);
   border: 1px solid color-mix(in srgb, var(--danger) 70%, transparent);
   color: #fff;
   font-variant-numeric: tabular-nums;
   font-weight: 700;
   letter-spacing: 0.04em;
-  backdrop-filter: blur(10px);
   box-shadow: 0 8px 28px rgba(0, 0, 0, 0.35);
+  /* The elapsed readout rewrites its text 10×/s; layout containment keeps
+     those relayouts scoped to the pill instead of the record screen. */
+  contain: layout;
   animation: pulse-record 1.1s ease-in-out infinite;
+}
+
+/* Expanding pulse halo: a static border whose layer animates only
+   transform + opacity (compositor-driven, no per-frame paint) — the
+   replacement for the old box-shadow tween (see the pulse-record
+   keyframes in global.css). */
+.record-pill::before {
+  content: '';
+  position: absolute;
+  inset: -2px;
+  border-radius: 999px;
+  border: 3px solid color-mix(in srgb, var(--danger) 60%, transparent);
+  pointer-events: none;
+  animation: pulse-record-ring 1.1s ease-in-out infinite;
 }
 
 .record-pill-label {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Performance audit of the record screen: the UI janks when recording starts. A DevTools trace of a hold-to-record take (fake camera, `/project/new`) showed the page entering a full per-frame rendering pipeline the moment recording starts — while the main thread is competing with the live camera preview and the hardware encoder:

| Recording phase (3s hold) | Before | After |
|---|---|---|
| Paint | 121/s | 23/s |
| Rasterization | 61/s | 12/s |
| Style recalc | 61/s | 13/s |
| rAF main frames | 60/s | 0/s |
| Total main-thread task time | ~135ms | ~47ms |

Idle phase was near-silent in both traces — all of this work starts exactly when the REC pill appears.

## Causes and fixes

1. **REC pill pulse animated `box-shadow`** — a paint property, so the pill repainted and re-rasterized every frame for the whole take. Split into compositor-only halves: a transform-only breathe on the pill plus an expanding halo pseudo-element (`.record-pill::before`) animating only `transform` + `opacity` over a static border.
2. **REC pill `backdrop-filter: blur(10px)`** — blurring the live camera video behind the pill re-samples the backdrop on the GPU every frame of the take. Replaced with a slightly more opaque background.
3. **`RecordTimer` ticked from a per-frame rAF loop** for a 0.1s-resolution readout. Even with no-op writes skipped, the loop forces the main thread to produce a frame 60×/s, and each of those frames also re-evaluates the pill's (compositor-run) animations — this was the residual 60/s style recalc after fixing the keyframes. It now ticks ~10×/s from a `setTimeout` aligned just past the next tenth boundary.
4. **Layout containment** on the pill scopes the 10Hz text relayouts to the pill instead of the record screen.
5. **`aria-live` moved from the pill to its label** — the pill was a live region containing text that rewrites 10×/s, so screen readers re-announced (and recomputed) every tick.

## Testing

- Before/after CDP traces driving a real hold-to-record take (numbers above), including a CSS-override bisection to isolate each cause.
- `npm run lint` clean, `npm test` 318/318, `npm run test:e2e` 79/79, `npm run test:smoke` 33/33.
- Manual demo in real Chrome (fake camera): hold-to-record take with the new pulse halo, ticking counter, clean take end, and total duration updating.

## Demo

<a href="https://cursor.com/agents/bc-95fbfba6-e41b-4968-afe9-c43f8fb8275b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhold_to_record_rec_pill_demo.mp4"><img src="https://cursor.com/artifacts/c/art-751314b7-19a8-4c14-8d79-f41fc667725e" alt="hold_to_record_rec_pill_demo.mp4" /></a>

![REC pill with the new compositor-driven pulse halo mid-fade](https://cursor.com/artifacts/c/art-90d10d14-8641-49c2-a13c-596c6cd1f104)

(The "Mic isn't picking up sound" warning in the demo is the expected fake-mic behavior in the headless VM, per `docs/contribute/manual-camera-testing.md`.)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-95fbfba6-e41b-4968-afe9-c43f8fb8275b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-95fbfba6-e41b-4968-afe9-c43f8fb8275b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Improved screen-reader announcements for changing recording status text without repeatedly announcing the entire recording control.

* **Performance**
  * Updated elapsed-time display behavior for smoother, more efficient timer updates.
  * Reduced unnecessary visual and text updates while recording.

* **Visual Updates**
  * Refined the recording indicator with a clearer pulse and animated halo effect.
  * Improved recording-pill styling and layout stability.

* **Documentation**
  * Updated recording-quality documentation to reflect the timer behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->