### PR TITLE
Add photos to the timeline with a lengthenable Duration strip

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,16 @@ For a phone on the same network, use your machine’s LAN URL over HTTPS, or tun
 - Hold-to-record anywhere on the preview; drag up/down while holding to zoom
 - Self-timer for hands-free takes (tap to stop)
 - Recording feedback (REC pill + elapsed) with a page that does **not** re-render per frame — capture stays smooth
-- Editor: filmstrip timeline (thumbnails, width ∝ duration), drag to reorder, duplicate, delete w/ undo, **in-timeline trim with drag handles**, **add clips from your device/gallery**
+- Editor: filmstrip timeline (thumbnails, width ∝ duration), drag to reorder, duplicate, delete w/ undo, **in-timeline trim with drag handles**, **add clips and photos from your device/gallery**
+- **Photos on the timeline**: a picked image becomes a still clip (3s by
+  default) that plays in previews and exports like any other clip — silent,
+  with a small camera badge on its tile. Instead of the trim strip, photos
+  open a **Duration** strip: because a still has no media length to trim
+  within, its on-screen time is a free choice that can grow as well as
+  shrink — drag the handle across a 0–30s scale, tap a preset (1/2/3/5/10s),
+  or nudge with ±0.5s steppers to land the exact length, with the precise
+  readout always visible. Photos travel in backups and duplicate/reorder
+  like clips
 - **Per-clip audio levels**: every clip's audio is **peak-normalized** as a
   post-recording step (measured once, persisted on the clip, backfilled
   automatically when an older project loads), so takes recorded at

--- a/manual-test-checklist.md
+++ b/manual-test-checklist.md
@@ -41,6 +41,11 @@ npm test           # unit tests
   delete offers Undo; trim strip opens, dragging the end handle + Done
   persists `trimEndMs` and updates the tile duration; **Add** imports a
   video from the device onto the timeline
+- **Photos on the timeline**: a picked image lands as a 3s still with a
+  camera badge; the Duration strip (photo counterpart of Trim) lengthens as
+  well as shortens via drag handle, presets, and ±0.5s steppers; the project
+  preview shows the still for its wall-clock duration; a photo + video
+  project exports at the summed duration
 - **Playback**: whole cut with segmented progress; edge taps skip
   next/previous; middle tap stops; auto-closes at the end of the cut
 - **Go / export**: full export to a ready sheet with format + size; Save

--- a/src/components/audio-strip.tsx
+++ b/src/components/audio-strip.tsx
@@ -13,6 +13,7 @@ import {
   clipMusicVolume,
   clipSoundVolume,
   formatDuration,
+  isImageClip,
   projectAudioTotalDurationMs,
   type ClipId,
   type ClipRecord,
@@ -190,8 +191,10 @@ export function AudioStrip(handle: Handle<AudioStripProps>) {
       : 1
 
     // The clip's own sound volume applies with or without music (and on
-    // the free plan) — it is about the clip, not the playlist.
-    const clipSoundRow = selectedClip ? (
+    // the free plan) — it is about the clip, not the playlist. Photos are
+    // silent by construction, so they get no sound dial (the music dial
+    // below still applies — ducking music under a photo is meaningful).
+    const clipSoundRow = selectedClip && !isImageClip(selectedClip) ? (
       <VolumeRow
         label={`Clip ${selectedIndex + 1} sound`}
         ariaLabel={`Clip ${selectedIndex + 1} sound volume`}

--- a/src/components/editor-clip-preview.tsx
+++ b/src/components/editor-clip-preview.tsx
@@ -15,11 +15,13 @@ import {
   trackMediaSec,
   trackMusicGain,
 } from '../lib/preview-music-bed'
+import { BlobImage } from './blob-image'
 import { BlobVideo } from './blob-video'
 import { IconPause, IconPlay } from './icons'
 import {
   clipMusicVolume,
   clipSoundVolume,
+  isImageClip,
   type ClipRecord,
   type ProjectAudioRecord,
 } from '../lib/types'
@@ -62,6 +64,34 @@ function nudgeFrame(video: HTMLVideoElement): void {
  */
 export function EditorClipPreview(handle: Handle<EditorClipPreviewProps>) {
   const { props } = handle
+
+  // Photos have nothing to play or seek in the single-clip stage — show
+  // the still and satisfy the imperative handle with no-ops. The stage is
+  // keyed by clip id, so an instance's kind never changes.
+  if (isImageClip(props.clip)) {
+    const bindImage = (_node: Element, signal: AbortSignal) => {
+      const apiRef = props.apiRef
+      if (!apiRef) return
+      const api = { seekToMs: () => undefined, pause: () => undefined }
+      apiRef.current = api
+      signal.addEventListener('abort', () => {
+        // A remount may bind the replacement before this abort runs —
+        // never null out a live binding that is not ours.
+        if (apiRef.current === api) apiRef.current = null
+      })
+    }
+    return () => (
+      <div className="editor-clip-preview-wrap">
+        <BlobImage
+          blob={props.clip.blob}
+          className="editor-clip-preview editor-clip-preview-image"
+          alt="Selected photo"
+          mix={ref(bindImage)}
+        />
+      </div>
+    )
+  }
+
   let media: HTMLVideoElement | null = null
   let playing = false
   /** An explicit seek before loadeddata must not be snapped back to the trim

--- a/src/components/editor-screen.tsx
+++ b/src/components/editor-screen.tsx
@@ -8,12 +8,14 @@ import {
   moveSelectedClip,
   removeClip,
   setAudioTrackSettings,
+  setClipDuration,
   trimClip,
   undoLastDelete,
 } from '../lib/project-actions'
 import {
   effectiveDurationMs,
   formatDuration,
+  isImageClip,
   type ClipId,
   type ClipRecord,
   type Project,
@@ -34,6 +36,7 @@ import {
   IconTrim,
   IconUndo,
 } from './icons'
+import { ImageDurationStrip } from './image-duration-strip'
 import { Timeline } from './timeline'
 import { TrimStrip } from './trim-strip'
 import type { ToastAction } from './record-screen'
@@ -146,8 +149,11 @@ export function EditorScreen(handle: Handle<EditorScreenProps>) {
     editingTrackId = null
     // Seek after the commit: entering trim can remount the preview (the trim
     // override changes its remount key), and the seek must land on the new
-    // element so the stage opens on the trim-start frame.
-    handle.queueTask(() => previewApi.current?.seekToMs(clip.trimStartMs))
+    // element so the stage opens on the trim-start frame. Photos open the
+    // duration strip instead — the stage already shows the whole still.
+    if (!isImageClip(clip)) {
+      handle.queueTask(() => previewApi.current?.seekToMs(clip.trimStartMs))
+    }
     void handle.update()
   }
 
@@ -265,6 +271,8 @@ export function EditorScreen(handle: Handle<EditorScreenProps>) {
       if (!ids.has(id)) refineAttempted.delete(id)
     }
     const pending = props.clips.filter((clip) => {
+      // A photo's single frame IS its finished filmstrip.
+      if (isImageClip(clip)) return false
       const count = clip.thumbs?.length ?? 0
       return count > 0 && count < THUMB_COUNT && !refineAttempted.has(clip.id)
     })
@@ -383,7 +391,18 @@ export function EditorScreen(handle: Handle<EditorScreenProps>) {
         </div>
 
         <div className="editor-panel">
-          {trimming && selected ? (
+          {trimming && selected && isImageClip(selected) ? (
+            <ImageDurationStrip
+              key={selected.id}
+              clip={selected}
+              onCancel={() => setTrimming(false)}
+              onDone={async (durationMs) => {
+                await setClipDuration(selected.id, durationMs)
+                props.refresh()
+                setTrimming(false)
+              }}
+            />
+          ) : trimming && selected ? (
             <TrimStrip
               key={selected.id}
               clip={selected}
@@ -473,7 +492,10 @@ export function EditorScreen(handle: Handle<EditorScreenProps>) {
                 icon={<IconDuplicate />}
               />
               <ActionButton
-                label="Trim"
+                label={selected && isImageClip(selected) ? 'Duration' : 'Trim'}
+                ariaLabel={
+                  selected && isImageClip(selected) ? 'Set photo duration' : 'Trim clip'
+                }
                 disabled={!selected || importing}
                 prominent
                 onClick={() => {

--- a/src/components/icons.tsx
+++ b/src/components/icons.tsx
@@ -208,6 +208,16 @@ export function IconShareIos(handle: Handle<IconProps>) {
   )
 }
 
+export function IconPhoto(handle: Handle<IconProps>) {
+  return () => (
+    <svg {...baseProps(handle.props.size ?? 22)}>
+      <rect x="3" y="4.5" width="18" height="15" rx="2.5" />
+      <circle cx="9" cy="10" r="1.6" />
+      <path d="M21 16.5l-4.8-4.8-4.2 4.2-2.2-2.2L3 20" />
+    </svg>
+  )
+}
+
 export function IconMusic(handle: Handle<IconProps>) {
   return () => (
     <svg {...baseProps(handle.props.size ?? 22)}>

--- a/src/components/image-duration-strip.tsx
+++ b/src/components/image-duration-strip.tsx
@@ -12,6 +12,10 @@ import { TimelineThumbImage } from './timeline-thumb-image'
 /** Steppers move in half-second increments — coarse enough to feel, fine
  * enough to land an exact value after a rough drag. */
 const STEP_MS = 500
+/** Arrow keys on the duration handle nudge by one tenth (the snap unit). */
+const KEY_FINE_MS = 100
+/** PageUp/PageDown jump a full second. */
+const KEY_COARSE_MS = 1000
 /** One-tap durations covering the common "how long should this show" answers. */
 const PRESETS_MS = [1000, 2000, 3000, 5000, 10_000]
 
@@ -124,9 +128,36 @@ export function ImageDurationStrip(handle: Handle<ImageDurationStripProps>) {
             type="button"
             className={`trim-handle trim-handle-right${dragging ? ' active' : ''}`}
             style={{ left: `${pct}%` }}
+            role="slider"
             aria-label="Photo duration handle"
+            aria-valuemin={MIN_IMAGE_DURATION_MS / 1000}
+            aria-valuemax={MAX_IMAGE_DURATION_MS / 1000}
+            aria-valuenow={durationMs / 1000}
             aria-valuetext={formatDuration(durationMs)}
-            mix={on('pointerdown', (event) => startHandleDrag(event))}
+            mix={[
+              on('pointerdown', (event) => startHandleDrag(event)),
+              on('keydown', (event) => {
+                if (event.key === 'ArrowLeft' || event.key === 'ArrowDown') {
+                  event.preventDefault()
+                  setDuration(durationMs - KEY_FINE_MS)
+                } else if (event.key === 'ArrowRight' || event.key === 'ArrowUp') {
+                  event.preventDefault()
+                  setDuration(durationMs + KEY_FINE_MS)
+                } else if (event.key === 'PageDown') {
+                  event.preventDefault()
+                  setDuration(durationMs - KEY_COARSE_MS)
+                } else if (event.key === 'PageUp') {
+                  event.preventDefault()
+                  setDuration(durationMs + KEY_COARSE_MS)
+                } else if (event.key === 'Home') {
+                  event.preventDefault()
+                  setDuration(MIN_IMAGE_DURATION_MS)
+                } else if (event.key === 'End') {
+                  event.preventDefault()
+                  setDuration(MAX_IMAGE_DURATION_MS)
+                }
+              }),
+            ]}
           />
         </div>
 

--- a/src/components/image-duration-strip.tsx
+++ b/src/components/image-duration-strip.tsx
@@ -1,0 +1,193 @@
+import type { Handle } from 'remix/ui'
+import { on } from 'remix/ui'
+import {
+  MAX_IMAGE_DURATION_MS,
+  MIN_IMAGE_DURATION_MS,
+  clampImageDurationMs,
+  formatDuration,
+  type ClipRecord,
+} from '../lib/types'
+import { TimelineThumbImage } from './timeline-thumb-image'
+
+/** Steppers move in half-second increments — coarse enough to feel, fine
+ * enough to land an exact value after a rough drag. */
+const STEP_MS = 500
+/** One-tap durations covering the common "how long should this show" answers. */
+const PRESETS_MS = [1000, 2000, 3000, 5000, 10_000]
+
+interface ImageDurationStripProps {
+  clip: ClipRecord
+  onDone: (durationMs: number) => Promise<void>
+  onCancel: () => void
+}
+
+/**
+ * The photo counterpart of TrimStrip. A still has no media length to trim
+ * within — its duration is a free choice that can grow as well as shrink,
+ * so instead of two handles over a fixed filmstrip this strip is a scale
+ * from 0 to the maximum: drag the single handle to any length, tap a
+ * preset, or nudge by half-seconds for an exact value. The readout always
+ * shows the precise result.
+ */
+export function ImageDurationStrip(handle: Handle<ImageDurationStripProps>) {
+  const { props } = handle
+  let durationMs = clampImageDurationMs(props.clip.durationMs)
+  let saving = false
+  let error: string | null = null
+  let dragging = false
+
+  const setDuration = (nextMs: number) => {
+    durationMs = clampImageDurationMs(nextMs)
+    void handle.update()
+  }
+
+  const msFromClientX = (clientX: number, strip: HTMLElement) => {
+    const rect = strip.getBoundingClientRect()
+    if (rect.width <= 0) return durationMs
+    const ratio = Math.min(1, Math.max(0, (clientX - rect.left) / rect.width))
+    return ratio * MAX_IMAGE_DURATION_MS
+  }
+
+  const startHandleDrag = (event: PointerEvent) => {
+    if (event.button !== 0) return
+    event.preventDefault()
+    event.stopPropagation()
+    const dragHandle = event.currentTarget as HTMLButtonElement
+    const strip = dragHandle.closest('.trim-strip-track') as HTMLElement | null
+    if (!strip) return
+
+    dragHandle.setPointerCapture(event.pointerId)
+    dragging = true
+    void handle.update()
+
+    const onMove = (ev: PointerEvent) => {
+      setDuration(msFromClientX(ev.clientX, strip))
+    }
+    const onUp = (ev: PointerEvent) => {
+      try {
+        dragHandle.releasePointerCapture(ev.pointerId)
+      } catch {
+        /* already released */
+      }
+      dragHandle.removeEventListener('pointermove', onMove)
+      dragHandle.removeEventListener('pointerup', onUp)
+      dragHandle.removeEventListener('pointercancel', onUp)
+      dragging = false
+      void handle.update()
+    }
+
+    dragHandle.addEventListener('pointermove', onMove)
+    dragHandle.addEventListener('pointerup', onUp)
+    dragHandle.addEventListener('pointercancel', onUp)
+  }
+
+  const onDoneClick = () => {
+    void (async () => {
+      saving = true
+      error = null
+      void handle.update()
+      try {
+        await props.onDone(clampImageDurationMs(durationMs))
+      } catch (err) {
+        error = err instanceof Error ? err.message : 'Could not save duration'
+        saving = false
+        void handle.update()
+      }
+    })()
+  }
+
+  return () => {
+    const clip = props.clip
+    const thumb = clip.thumbs?.find(Boolean) ?? clip.poster ?? null
+    const pct = (durationMs / MAX_IMAGE_DURATION_MS) * 100
+
+    return (
+      <div className="trim-strip image-duration-strip" role="group" aria-label="Photo duration">
+        <div className="trim-strip-meta">
+          <span className="trim-kept-label">{formatDuration(durationMs)} on screen</span>
+          {error ? <span className="trim-error">{error}</span> : null}
+        </div>
+
+        <div className="trim-strip-track">
+          <div className="trim-strip-filmstrip" aria-hidden>
+            {thumb ? (
+              <TimelineThumbImage blob={thumb} className="trim-strip-frame" alt="" />
+            ) : (
+              <div className="clip-filmstrip-placeholder" />
+            )}
+          </div>
+
+          <div className="trim-dim trim-dim-right" style={{ width: `${100 - pct}%` }} aria-hidden />
+          <div className="trim-selection" style={{ left: '0%', width: `${pct}%` }} aria-hidden />
+
+          <button
+            type="button"
+            className={`trim-handle trim-handle-right${dragging ? ' active' : ''}`}
+            style={{ left: `${pct}%` }}
+            aria-label="Photo duration handle"
+            aria-valuetext={formatDuration(durationMs)}
+            mix={on('pointerdown', (event) => startHandleDrag(event))}
+          />
+        </div>
+
+        <div className="image-duration-controls">
+          <div className="image-duration-steppers" role="group" aria-label="Adjust duration">
+            <button
+              type="button"
+              className="btn btn-ghost image-duration-step"
+              aria-label="Shorten by half a second"
+              disabled={saving || durationMs <= MIN_IMAGE_DURATION_MS}
+              mix={on('click', () => setDuration(durationMs - STEP_MS))}
+            >
+              −0.5s
+            </button>
+            <span className="image-duration-value" aria-live="polite">
+              {formatDuration(durationMs)}
+            </span>
+            <button
+              type="button"
+              className="btn btn-ghost image-duration-step"
+              aria-label="Lengthen by half a second"
+              disabled={saving || durationMs >= MAX_IMAGE_DURATION_MS}
+              mix={on('click', () => setDuration(durationMs + STEP_MS))}
+            >
+              +0.5s
+            </button>
+          </div>
+          <div className="image-duration-presets" role="group" aria-label="Duration presets">
+            {PRESETS_MS.map((presetMs) => (
+              <button
+                key={presetMs}
+                type="button"
+                className={`image-duration-preset${durationMs === presetMs ? ' active' : ''}`}
+                disabled={saving}
+                mix={on('click', () => setDuration(presetMs))}
+              >
+                {presetMs / 1000}s
+              </button>
+            ))}
+          </div>
+        </div>
+
+        <div className="trim-strip-actions">
+          <button
+            type="button"
+            className="btn btn-ghost"
+            disabled={saving}
+            mix={on('click', () => props.onCancel())}
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            className="btn btn-primary"
+            disabled={saving}
+            mix={on('click', onDoneClick)}
+          >
+            {saving ? 'Saving…' : 'Done'}
+          </button>
+        </div>
+      </div>
+    )
+  }
+}

--- a/src/components/playback-overlay.tsx
+++ b/src/components/playback-overlay.tsx
@@ -19,9 +19,11 @@ import {
 import {
   clipMusicVolume,
   clipSoundVolume,
+  isImageClip,
   type ClipRecord,
   type ProjectAudioRecord,
 } from '../lib/types'
+import { BlobImage } from './blob-image'
 import { IconPlay } from './icons'
 import { isInteractiveTarget } from '../lib/keyboard'
 
@@ -65,6 +67,16 @@ export function PlaybackOverlay(handle: Handle<PlaybackOverlayProps>) {
   /** Index whose media has actually loaded — gates stale timeupdate/ended
    * events from the previous clip that fire before the new source is ready. */
   let loadedIndex = -1
+
+  // Photo segments have no media clock — a wall-clock timer drives their
+  // progress, their music position, and the advance to the next segment.
+  /** Segment index the photo clock belongs to (-1 = none started). */
+  let imageFor = -1
+  /** Elapsed ms accumulated across pauses. */
+  let imageElapsedMs = 0
+  /** performance.now() of the live run, null while paused. */
+  let imageRunStartedAt: number | null = null
+  let imageRaf = 0
 
   // Background music: one audio element under the whole preview, playing
   // the playlist's tracks one after the other (nothing loops — when the
@@ -144,10 +156,23 @@ export function PlaybackOverlay(handle: Handle<PlaybackOverlayProps>) {
   const fadeOutScale = () =>
     props.audio ? playlistFadeOutScale(props.audio, timelinePositionMs(), filmTotalMs()) : 1
 
+  const currentIsImage = () => {
+    const segment = currentSegment()
+    return segment !== null && isImageClip(segment.clip)
+  }
+
+  /** The photo clock's position inside the current segment, in ms. */
+  const imagePositionMs = () =>
+    imageElapsedMs + (imageRunStartedAt !== null ? performance.now() - imageRunStartedAt : 0)
+
   /** Playhead position on the output timeline, in ms. */
   const timelinePositionMs = () => {
     const segment = currentSegment()
     if (!segment) return 0
+    if (isImageClip(segment.clip)) {
+      const total = segment.endMs - segment.startMs
+      return segment.offsetMs + Math.min(imageFor === index ? imagePositionMs() : 0, total)
+    }
     const elapsedSec = videoEl ? Math.max(0, videoEl.currentTime - segment.startMs / 1000) : 0
     return segment.offsetMs + elapsedSec * 1000
   }
@@ -272,7 +297,10 @@ export function PlaybackOverlay(handle: Handle<PlaybackOverlayProps>) {
     void (async () => {
       const blobs = [
         ...track.tracks.map((t) => t.blob),
-        ...resolveSegments().map((segment) => segment.clip.blob),
+        // Photos are silent by construction — no audio to measure.
+        ...resolveSegments()
+          .filter((segment) => !isImageClip(segment.clip))
+          .map((segment) => segment.clip.blob),
       ]
       for (const blob of blobs) {
         if (audioEl !== el) return
@@ -374,13 +402,68 @@ export function PlaybackOverlay(handle: Handle<PlaybackOverlayProps>) {
     })
   }
 
+  const stopImageClock = () => {
+    cancelAnimationFrame(imageRaf)
+    imageRaf = 0
+  }
+
+  /** Freeze the photo clock (Space pause) — music pauses with it. */
+  const pauseImage = () => {
+    if (imageRunStartedAt !== null) {
+      imageElapsedMs += performance.now() - imageRunStartedAt
+      imageRunStartedAt = null
+    }
+    stopImageClock()
+    pauseMusic()
+  }
+
+  /** Start (or resume) the current photo segment's clock and its music. */
+  const startImage = () => {
+    const segment = currentSegment()
+    if (!segment || !isImageClip(segment.clip)) return
+    if (imageFor !== index) {
+      imageFor = index
+      imageElapsedMs = 0
+    }
+    const total = segment.endMs - segment.startMs
+    // Replaying a finished photo starts it over (same as goTo on a video).
+    if (imageElapsedMs >= total) imageElapsedMs = 0
+    imageRunStartedAt = performance.now()
+    needsTap = false
+    playMusic()
+    stopImageClock()
+    const tick = () => {
+      const elapsed = imagePositionMs()
+      segmentProgress = total > 0 ? Math.min(1, elapsed / total) : 1
+      void handle.update()
+      if (elapsed >= total) {
+        imageElapsedMs = total
+        imageRunStartedAt = null
+        stopImageClock()
+        advance()
+        return
+      }
+      imageRaf = requestAnimationFrame(tick)
+    }
+    imageRaf = requestAnimationFrame(tick)
+  }
+
+  /** Drop the photo clock when the playhead leaves its segment. */
+  const resetImageClock = () => {
+    stopImageClock()
+    imageFor = -1
+    imageElapsedMs = 0
+    imageRunStartedAt = null
+  }
+
   /** Bind the current segment's blob to the persistent video element.
    * Returns whether a new source was assigned (i.e. `loadedmetadata` will
-   * fire and drive playback). */
+   * fire and drive playback). Photo segments never touch the video source —
+   * they render through their own <img>. */
   const syncVideoSrc = (): boolean => {
     const el = videoEl
     const segment = currentSegment()
-    if (!el || !segment) return false
+    if (!el || !segment || isImageClip(segment.clip)) return false
     if (urlState.blob !== segment.clip.blob) {
       if (urlState.url) URL.revokeObjectURL(urlState.url)
       urlState.url = URL.createObjectURL(segment.clip.blob)
@@ -396,6 +479,14 @@ export function PlaybackOverlay(handle: Handle<PlaybackOverlayProps>) {
     segmentProgress = 0
     needsTap = false
     if (nextIndex === index) {
+      if (currentIsImage()) {
+        // Restart the photo from its first moment, like the video seek.
+        imageElapsedMs = 0
+        imageRunStartedAt = null
+        startImage()
+        void handle.update()
+        return
+      }
       const video = videoEl
       if (video) {
         // Without music there is no per-frame tick — apply the clip's own
@@ -415,6 +506,7 @@ export function PlaybackOverlay(handle: Handle<PlaybackOverlayProps>) {
       return
     }
     index = Math.max(0, Math.min(resolveSegments().length - 1, nextIndex))
+    resetImageClock()
     // Jump the music to the new position now — waiting for the next clip's
     // metadata would leave the old position playing through the load gap.
     syncMusicPosition()
@@ -430,6 +522,7 @@ export function PlaybackOverlay(handle: Handle<PlaybackOverlayProps>) {
     }
     segmentProgress = 0
     index = index + 1
+    resetImageClock()
     // Positionally a no-op (segments abut on the timeline), but keeps the
     // playlist hand-off logic on one path with manual skips.
     syncMusicPosition()
@@ -476,6 +569,11 @@ export function PlaybackOverlay(handle: Handle<PlaybackOverlayProps>) {
         event.preventDefault()
         // Auto-repeat while held must not rapid-toggle pause/resume.
         if (event.repeat) return
+        if (currentIsImage()) {
+          if (imageRunStartedAt !== null) pauseImage()
+          else startImage()
+          return
+        }
         const video = videoEl
         if (!video) return
         if (video.paused) {
@@ -506,6 +604,10 @@ export function PlaybackOverlay(handle: Handle<PlaybackOverlayProps>) {
     window.addEventListener('keydown', onWindowKeyDown)
     signal.addEventListener('abort', () => {
       window.removeEventListener('keydown', onWindowKeyDown)
+      // The photo clock must not keep ticking (and updating a torn-down
+      // handle) after the overlay closes.
+      stopImageClock()
+      imageRunStartedAt = null
     })
   }
 
@@ -545,10 +647,18 @@ export function PlaybackOverlay(handle: Handle<PlaybackOverlayProps>) {
       )
     }
 
-    // Same blob as the previous segment = no new source, so `loadedmetadata`
-    // never re-fires (adjacent duplicated clips) — start this segment
-    // directly. Still-loading media (readyState 0) is left to loadedmetadata.
-    if (!syncVideoSrc() && videoEl && videoEl.readyState >= 1 && loadedIndex !== index) {
+    const isPhoto = isImageClip(segment.clip)
+    if (isPhoto) {
+      // Photos start their own clock; the persistent video element keeps
+      // its previous source but must stop sounding under the still.
+      if (imageFor !== index) {
+        videoEl?.pause()
+        startImage()
+      }
+    } else if (!syncVideoSrc() && videoEl && videoEl.readyState >= 1 && loadedIndex !== index) {
+      // Same blob as the previous segment = no new source, so `loadedmetadata`
+      // never re-fires (adjacent duplicated clips) — start this segment
+      // directly. Still-loading media (readyState 0) is left to loadedmetadata.
       loadedIndex = index
       startPlayback(videoEl)
     }
@@ -593,8 +703,17 @@ export function PlaybackOverlay(handle: Handle<PlaybackOverlayProps>) {
           />
         ) : null}
 
+        {isPhoto ? (
+          <BlobImage
+            key={`${segment.clip.id}:${index}`}
+            blob={segment.clip.blob}
+            className="playback-image"
+            alt=""
+          />
+        ) : null}
+
         <video
-          className="playback-video"
+          className={`playback-video${isPhoto ? ' is-hidden' : ''}`}
           playsInline
           preload="auto"
           mix={[

--- a/src/components/playback-overlay.tsx
+++ b/src/components/playback-overlay.tsx
@@ -264,7 +264,12 @@ export function PlaybackOverlay(handle: Handle<PlaybackOverlayProps>) {
     musicTrackIndex = next
     audio.src = urlForTrack(next)
     audio.currentTime = trackMediaSec(props.audio!, next, 0)
-    if (videoEl && !videoEl.paused) void audio.play().catch(() => undefined)
+    // Resume when a video is playing *or* a photo clock is running —
+    // during a still the video element is paused/hidden, so gating on
+    // video alone would leave the bed silent for the rest of the photo.
+    if ((videoEl && !videoEl.paused) || imageRunStartedAt !== null) {
+      void audio.play().catch(() => undefined)
+    }
   }
 
   const playMusic = () => {
@@ -400,6 +405,11 @@ export function PlaybackOverlay(handle: Handle<PlaybackOverlayProps>) {
       trackUrls.clear()
       musicTrackIndex = -1
     })
+
+    // Photo-first films call startImage() (and playMusic()) during render,
+    // before this <audio> ref exists. Once the element binds, kick the
+    // bed if the photo clock is already running for the current segment.
+    if (imageRunStartedAt !== null && currentIsImage()) playMusic()
   }
 
   const stopImageClock = () => {

--- a/src/components/timeline.tsx
+++ b/src/components/timeline.tsx
@@ -6,10 +6,12 @@ import {
   clipSoundVolume,
   effectiveDurationMs,
   formatDuration,
+  isImageClip,
   type ClipId,
   type ClipRecord,
   type ProjectId,
 } from '../lib/types'
+import { IconPhoto } from './icons'
 import { TimelineThumbImage } from './timeline-thumb-image'
 
 const PX_PER_SECOND = 26
@@ -328,16 +330,17 @@ export function Timeline(handle: Handle<TimelineProps>) {
           const thumbs = clip.thumbs?.filter(Boolean) ?? []
           const isDragging = draggingId === clip.id
           const showDropBefore = draggingId !== null && gapIndex === index
+          const isPhoto = isImageClip(clip)
 
           return (
             <div key={clip.id} className="timeline-slot">
               {showDropBefore ? <div className="timeline-drop-indicator" aria-hidden /> : null}
               <button
                 type="button"
-                className={`clip-thumb${selected ? ' selected' : ''}${isDragging ? ' lifting' : ''}`}
+                className={`clip-thumb${selected ? ' selected' : ''}${isDragging ? ' lifting' : ''}${isPhoto ? ' is-photo' : ''}`}
                 role="option"
                 aria-selected={selected}
-                aria-label={`Clip ${index + 1}, ${formatDuration(effectiveDurationMs(clip))}${
+                aria-label={`${isPhoto ? 'Photo' : 'Clip'} ${index + 1}, ${formatDuration(effectiveDurationMs(clip))}${
                   // Presence checks stay on the raw fields (override vs
                   // default); displayed values go through the clamped
                   // accessors playback uses.
@@ -387,6 +390,11 @@ export function Timeline(handle: Handle<TimelineProps>) {
                   )}
                 </div>
                 <span className="clip-dur">{formatDuration(effectiveDurationMs(clip))}</span>
+                {isPhoto ? (
+                  <span className="clip-photo-badge" aria-hidden="true">
+                    <IconPhoto size={12} />
+                  </span>
+                ) : null}
                 {props.showAudioBadges && clip.musicVolume !== undefined ? (
                   <span className="clip-audio-badge" aria-hidden="true">
                     ♪ {Math.round(clipMusicVolume(clip) * 100)}%

--- a/src/lib/clip-audio-peak.ts
+++ b/src/lib/clip-audio-peak.ts
@@ -1,7 +1,7 @@
 import { channelPeak } from './export/background-audio'
 import { decodeBlobAudio } from './export/shared'
 import { updateClipAudioPeak } from './storage'
-import type { ClipRecord } from './types'
+import { isImageClip, type ClipRecord } from './types'
 
 /**
  * Post-recording audio normalization measurement: every clip's whole-file
@@ -38,7 +38,9 @@ export async function measureClipAudioPeak(blob: Blob): Promise<number> {
  * next load retries the write. */
 export async function ensureClipAudioPeak(clip: ClipRecord): Promise<ClipRecord> {
   if (clip.audioPeak !== undefined) return clip
-  const audioPeak = await measureClipAudioPeak(clip.blob)
+  // Photos are silent by construction — persist the zero without wasting
+  // an audio-decode attempt on image bytes.
+  const audioPeak = isImageClip(clip) ? 0 : await measureClipAudioPeak(clip.blob)
   await updateClipAudioPeak(clip.id, audioPeak).catch(() => undefined)
   return { ...clip, audioPeak }
 }

--- a/src/lib/clips-zip.ts
+++ b/src/lib/clips-zip.ts
@@ -12,6 +12,8 @@ import { streamToOpfsFile } from './export/opfs'
 import type { ClipRecord } from './types'
 
 function extensionFor(mimeType: string): string {
+  const image = /^image\/(\w+)/i.exec(mimeType)
+  if (image) return image[1]!.toLowerCase() === 'jpeg' ? 'jpg' : image[1]!.toLowerCase()
   return /mp4/i.test(mimeType) ? 'mp4' : 'webm'
 }
 

--- a/src/lib/export/encode-realtime.ts
+++ b/src/lib/export/encode-realtime.ts
@@ -3,6 +3,7 @@ import { isIosBrowser } from '../platform'
 import {
   clipMusicVolume,
   clipSoundVolume,
+  isImageClip,
   resolveAudioTrackPlayback,
   type ProjectOrientation,
 } from '../types'
@@ -21,7 +22,9 @@ import {
   decodeBackgroundAudio,
   decodeClipAudio,
   drawCover,
+  drawCoverFrom,
   drawWatermark,
+  loadClipImage,
   loadClipVideo,
   noteEncodeCanvasKind,
   pickOutputSize,
@@ -64,13 +67,19 @@ export async function exportRealtime(
   let width: number
   let height: number
   try {
-    const probe = await loadClipVideo(probeClip.blob, 8000, probeClip.mimeType)
-    ;({ width, height } = pickOutputSize(
-      probe.video.videoWidth,
-      probe.video.videoHeight,
-      options.orientation,
-    ))
-    probe.release()
+    if (isImageClip(probeClip)) {
+      const bitmap = await loadClipImage(probeClip.blob)
+      ;({ width, height } = pickOutputSize(bitmap.width, bitmap.height, options.orientation))
+      bitmap.close()
+    } else {
+      const probe = await loadClipVideo(probeClip.blob, 8000, probeClip.mimeType)
+      ;({ width, height } = pickOutputSize(
+        probe.video.videoWidth,
+        probe.video.videoHeight,
+        options.orientation,
+      ))
+      probe.release()
+    }
   } catch (error) {
     // Probing is not worth dying over: recorded clips carry their capture
     // dimensions, and pickOutputSize has sane defaults for the rest.
@@ -279,20 +288,27 @@ export async function exportRealtime(
   const frameCounter = { count: 0 }
   try {
     for (const [segmentIndex, segment] of plan.segments.entries()) {
-      let loaded: Awaited<ReturnType<typeof loadClipVideo>>
-      try {
-        loaded = await loadClipVideo(segment.clip.blob, 8000, segment.clip.mimeType)
-      } catch (error) {
-        // The realtime engine plays clips through elements — this clip is
-        // genuinely unopenable here. Tag which one for the error report.
-        throw tagExportError(error, {
-          engine: 'realtime',
-          where: 'segment-load',
-          clipIndex: segmentIndex,
-        })
+      const isImage = isImageClip(segment.clip)
+      let loaded: Awaited<ReturnType<typeof loadClipVideo>> | null = null
+      if (!isImage) {
+        try {
+          loaded = await loadClipVideo(segment.clip.blob, 8000, segment.clip.mimeType)
+        } catch (error) {
+          // The realtime engine plays clips through elements — this clip is
+          // genuinely unopenable here. Tag which one for the error report.
+          throw tagExportError(error, {
+            engine: 'realtime',
+            where: 'segment-load',
+            clipIndex: segmentIndex,
+          })
+        }
       }
       try {
-        const clamped = clampSegmentToMedia(segment, loaded.mediaDurationMs)
+        // A photo has no media length to clamp against — its chosen
+        // duration is exact by definition.
+        const clamped = loaded
+          ? clampSegmentToMedia(segment, loaded.mediaDurationMs)
+          : { startMs: segment.startMs, endMs: segment.endMs }
         if (!clamped) continue
         if (audioContext) {
           const now = audioContext.currentTime
@@ -334,32 +350,45 @@ export async function exportRealtime(
             }
           }
         }
-        const paintedMs = await paintSegment({
-          video: loaded.video,
-          blob: segment.clip.blob,
+        const paintShared = {
           startSec: clamped.startMs / 1000,
           endSec: clamped.endMs / 1000,
           canvas,
           ctx,
-          audioContext,
-          // Clip audio joins the graph through the clip-volume gain and
-          // gets peak-normalized on the way in (music or not).
-          clipDestination: clipMixGain ?? dest,
-          normalizeClip: clipMixGain !== null,
           frameCounter,
           // No mirroring needed when the encode canvas is the preview.
           getPreviewCanvas: encodingIntoPreview ? undefined : options.getPreviewCanvas,
           watermarkImage: options.watermarkImage ?? null,
-          onElapsedMs: (elapsed) => {
+          onElapsedMs: (elapsed: number) => {
             if (plan.totalMs > 0) {
               options.onProgress?.(Math.min(1, (paintedTotalMs + elapsed) / plan.totalMs))
             }
           },
-        })
+        }
+        const paintedMs = loaded
+          ? await paintSegment({
+              video: loaded.video,
+              blob: segment.clip.blob,
+              audioContext,
+              // Clip audio joins the graph through the clip-volume gain and
+              // gets peak-normalized on the way in (music or not).
+              clipDestination: clipMixGain ?? dest,
+              normalizeClip: clipMixGain !== null,
+              ...paintShared,
+            })
+          : await paintImageSegment({ blob: segment.clip.blob, ...paintShared }).catch(
+              (error) => {
+                throw tagExportError(error, {
+                  engine: 'realtime',
+                  where: 'image-paint',
+                  clipIndex: segmentIndex,
+                })
+              },
+            )
         paintedTotalMs += paintedMs
         options.onProgress?.(plan.totalMs > 0 ? Math.min(1, paintedTotalMs / plan.totalMs) : 1)
       } finally {
-        loaded.release()
+        loaded?.release()
       }
     }
 
@@ -404,23 +433,91 @@ export async function exportRealtime(
   }
 }
 
-interface PaintSegmentArgs {
-  video: HTMLVideoElement
-  blob: Blob
+interface PaintSharedArgs {
   startSec: number
   endSec: number
   canvas: HTMLCanvasElement
   ctx: CanvasRenderingContext2D
+  frameCounter: { count: number }
+  getPreviewCanvas?: () => HTMLCanvasElement | null
+  watermarkImage: HTMLImageElement | null
+  onElapsedMs: (elapsedMs: number) => void
+}
+
+interface PaintSegmentArgs extends PaintSharedArgs {
+  video: HTMLVideoElement
+  blob: Blob
   audioContext: AudioContext | null
   /** Where the clip's own audio joins the recording graph (the clip-volume
    * gain when the graph exists, else the mux destination). */
   clipDestination: AudioNode | null
   /** Peak-normalize the clip audio (on whenever the graph exists). */
   normalizeClip: boolean
-  frameCounter: { count: number }
-  getPreviewCanvas?: () => HTMLCanvasElement | null
-  watermarkImage: HTMLImageElement | null
-  onElapsedMs: (elapsedMs: number) => void
+}
+
+interface PaintImageSegmentArgs extends PaintSharedArgs {
+  blob: Blob
+}
+
+/**
+ * Photo painter: this engine records a LIVE canvas capture, so the still is
+ * repainted every animation frame for its wall-clock duration (a static
+ * canvas would starve MediaRecorder of frames on some platforms). Photos
+ * contribute no audio — the music bed, when present, keeps playing on its
+ * own scheduled sources.
+ *
+ * @returns painted duration in ms (0 when the segment had nothing to show)
+ */
+async function paintImageSegment({
+  blob,
+  startSec,
+  endSec,
+  canvas,
+  ctx,
+  frameCounter,
+  getPreviewCanvas,
+  watermarkImage,
+  onElapsedMs,
+}: PaintImageSegmentArgs): Promise<number> {
+  const segmentSec = endSec - startSec
+  if (segmentSec <= 0.04) return 0
+
+  const bitmap = await loadClipImage(blob)
+  try {
+    const paintFrame = () => {
+      drawCoverFrom(ctx, bitmap, bitmap.width, bitmap.height, canvas.width, canvas.height)
+      if (watermarkImage) {
+        drawWatermark(ctx, watermarkImage, canvas.width, canvas.height)
+      }
+    }
+    paintFrame()
+    const startedAt = performance.now()
+    await new Promise<void>((resolve) => {
+      let raf = 0
+      const draw = () => {
+        const elapsedSec = (performance.now() - startedAt) / 1000
+        paintFrame()
+        if (elapsedSec >= segmentSec - 0.03) {
+          cancelAnimationFrame(raf)
+          resolve()
+          return
+        }
+        if (frameCounter.count % PREVIEW_EVERY_N_FRAMES === 0) {
+          blitPreview(canvas, getPreviewCanvas?.())
+        }
+        if (frameCounter.count % 30 === 0) {
+          recordVideoLumaSample(canvas)
+        }
+        frameCounter.count += 1
+        onElapsedMs(Math.min(segmentSec, elapsedSec) * 1000)
+        raf = requestAnimationFrame(draw)
+      }
+      raf = requestAnimationFrame(draw)
+    })
+    return Math.round(segmentSec * 1000)
+  } finally {
+    bitmap.close()
+  }
 }
 
 /** @returns painted duration in ms (0 when the segment had nothing to show) */

--- a/src/lib/export/encode-webcodecs.ts
+++ b/src/lib/export/encode-webcodecs.ts
@@ -20,6 +20,7 @@ import { isIosBrowser } from '../platform'
 import {
   clipMusicVolume,
   clipSoundVolume,
+  isImageClip,
   resolveAudioTrackPlayback,
   type ClipRecord,
   type ProjectOrientation,
@@ -43,7 +44,9 @@ import {
   blitPreview,
   decodeBackgroundAudio,
   decodeClipAudio,
+  drawCoverFrom,
   drawWatermark,
+  loadClipImage,
   loadClipVideo,
   tagExportError,
   pickOutputSize,
@@ -298,35 +301,45 @@ export async function exportWithWebCodecs(
 
   try {
     for (const [segmentIndex, segment] of plan.segments.entries()) {
-      const input = new Input({
-        source: new BlobSource(segment.clip.blob),
-        formats: ALL_FORMATS,
-      })
+      const isImage = isImageClip(segment.clip)
+      const input = isImage
+        ? null
+        : new Input({
+            source: new BlobSource(segment.clip.blob),
+            formats: ALL_FORMATS,
+          })
 
       let loaded: Awaited<ReturnType<typeof loadClipVideo>> | null = null
       try {
-        const mediaDurationMs = await input
-          .computeDuration()
-          .then((seconds) => Math.round(seconds * 1000))
-          .catch(() => 0)
-        let clamped = mediaDurationMs > 0 ? clampSegmentToMedia(segment, mediaDurationMs) : null
-        if (!clamped) {
-          try {
-            loaded = await loadClipVideo(segment.clip.blob, 8000, segment.clip.mimeType)
-            clamped = clampSegmentToMedia(segment, loaded.mediaDurationMs)
-          } catch (error) {
-            // A stubborn element load (iOS WebKit can refuse a blob it
-            // recorded itself — KODY-VIDEO-A) must not kill the export when
-            // it was only measuring duration: the recorder already measured
-            // this clip's real media duration at capture time. Only the
-            // element PUMP truly needs the element.
-            clamped = clampSegmentToMedia(segment, segment.clip.durationMs)
-            if (!clamped) {
-              throw tagExportError(error, {
-                engine: 'webcodecs',
-                where: 'clip-duration',
-                clipIndex: segmentIndex,
-              })
+        let clamped: { startMs: number; endMs: number } | null
+        if (isImage || !input) {
+          // A photo has no media length to clamp against — its chosen
+          // duration is exact by definition.
+          clamped = { startMs: segment.startMs, endMs: segment.endMs }
+        } else {
+          const mediaDurationMs = await input
+            .computeDuration()
+            .then((seconds) => Math.round(seconds * 1000))
+            .catch(() => 0)
+          clamped = mediaDurationMs > 0 ? clampSegmentToMedia(segment, mediaDurationMs) : null
+          if (!clamped) {
+            try {
+              loaded = await loadClipVideo(segment.clip.blob, 8000, segment.clip.mimeType)
+              clamped = clampSegmentToMedia(segment, loaded.mediaDurationMs)
+            } catch (error) {
+              // A stubborn element load (iOS WebKit can refuse a blob it
+              // recorded itself — KODY-VIDEO-A) must not kill the export when
+              // it was only measuring duration: the recorder already measured
+              // this clip's real media duration at capture time. Only the
+              // element PUMP truly needs the element.
+              clamped = clampSegmentToMedia(segment, segment.clip.durationMs)
+              if (!clamped) {
+                throw tagExportError(error, {
+                  engine: 'webcodecs',
+                  where: 'clip-duration',
+                  clipIndex: segmentIndex,
+                })
+              }
             }
           }
         }
@@ -351,7 +364,11 @@ export async function exportWithWebCodecs(
         // by position, so segments can never drift. Adjacent segments
         // CROSSFADE at the joint: the previous slice withheld its tail, and
         // this slice mixes it into its own head (see segment-audio.ts).
-        const buffer = await decodeClipAudio(segment.clip.blob, AUDIO_SAMPLE_RATE)
+        // Photos are silent by construction — a null source slices to
+        // silence without attempting an audio decode on image bytes.
+        const buffer = isImage
+          ? null
+          : await decodeClipAudio(segment.clip.blob, AUDIO_SAMPLE_RATE)
         const sourceChannels = buffer
           ? Array.from({ length: buffer.numberOfChannels }, (_, ch) =>
               buffer.getChannelData(ch),
@@ -447,23 +464,35 @@ export async function exportWithWebCodecs(
           },
         }
 
-        let pumped = false
-        const outcome = await pumpSegmentVideoDecoded({ input, ...pumpShared })
-        pumped = outcome === 'done'
-        if (!pumped) {
-          // Per-clip fallback: undecodable/unsupported clips play through a
-          // video element like before (realtime-paced, but correct).
-          console.info('[export] segment video path: element (realtime-paced)')
+        if (isImage || !input) {
           try {
-            loaded ??= await loadClipVideo(segment.clip.blob, 8000, segment.clip.mimeType)
+            await pumpSegmentImage({ blob: segment.clip.blob, ...pumpShared })
           } catch (error) {
             throw tagExportError(error, {
               engine: 'webcodecs',
-              where: 'element-pump',
+              where: 'image-pump',
               clipIndex: segmentIndex,
             })
           }
-          await pumpSegmentVideo({ video: loaded.video, ...pumpShared })
+        } else {
+          let pumped = false
+          const outcome = await pumpSegmentVideoDecoded({ input, ...pumpShared })
+          pumped = outcome === 'done'
+          if (!pumped) {
+            // Per-clip fallback: undecodable/unsupported clips play through a
+            // video element like before (realtime-paced, but correct).
+            console.info('[export] segment video path: element (realtime-paced)')
+            try {
+              loaded ??= await loadClipVideo(segment.clip.blob, 8000, segment.clip.mimeType)
+            } catch (error) {
+              throw tagExportError(error, {
+                engine: 'webcodecs',
+                where: 'element-pump',
+                clipIndex: segmentIndex,
+              })
+            }
+            await pumpSegmentVideo({ video: loaded.video, ...pumpShared })
+          }
         }
 
         state.outputOffsetSec += (segmentMs - headChopMs - tailChopMs) / 1000
@@ -573,6 +602,22 @@ async function probeOutputSize(
   orientation?: ProjectOrientation,
 ): Promise<{ width: number; height: number }> {
   const clip = plan.segments[0]!.clip
+  if (isImageClip(clip)) {
+    // Photos store their pixel size at import; a decode is the fallback.
+    if ((clip.width ?? 0) > 0 && (clip.height ?? 0) > 0) {
+      return pickOutputSize(clip.width!, clip.height!, orientation)
+    }
+    try {
+      const bitmap = await loadClipImage(clip.blob)
+      try {
+        return pickOutputSize(bitmap.width, bitmap.height, orientation)
+      } finally {
+        bitmap.close()
+      }
+    } catch (error) {
+      throw tagExportError(error, { engine: 'webcodecs', where: 'probe-size', clipIndex: 0 })
+    }
+  }
   try {
     const input = new Input({ source: new BlobSource(clip.blob), formats: ALL_FORMATS })
     const track = await input.getPrimaryVideoTrack()
@@ -739,6 +784,35 @@ async function pumpSegmentVideoDecoded(
 
   if (framesEmitted === 0) return 'unsupported'
   return 'done'
+}
+
+interface ImagePumpArgs extends PumpSharedArgs {
+  blob: Blob
+}
+
+/**
+ * Photo pump: decode the still once and emit it on every 30fps output tick
+ * across the segment — the encoder sees a regular constant-rate stream, so
+ * photos and videos concatenate seamlessly. Runs at hardware speed (the
+ * only per-frame cost is the canvas draw + encode).
+ */
+async function pumpSegmentImage({ blob, ...shared }: ImagePumpArgs): Promise<void> {
+  const { startSec, endSec, onElapsedMs } = shared
+  const emit = makeFrameSink(shared)
+  const bitmap = await loadClipImage(blob)
+  try {
+    const draw = (ctx: CanvasRenderingContext2D, width: number, height: number) =>
+      drawCoverFrom(ctx, bitmap, bitmap.width, bitmap.height, width, height)
+    // The epsilon keeps float accumulation from emitting one tick past the
+    // segment's end (the sink would clamp it onto the same timestamp).
+    for (let tsSec = startSec, first = true; tsSec < endSec - 1e-6; tsSec += FRAME_INTERVAL_SEC) {
+      await emit(draw, tsSec, { force: first })
+      first = false
+      onElapsedMs((tsSec - startSec) * 1000)
+    }
+  } finally {
+    bitmap.close()
+  }
 }
 
 interface PumpArgs extends PumpSharedArgs {

--- a/src/lib/export/plan.test.ts
+++ b/src/lib/export/plan.test.ts
@@ -44,6 +44,24 @@ describe('planExport', () => {
     expect(plan.totalMs).toBe(1000)
   })
 
+  it('plans photo clips as full-duration segments alongside videos', () => {
+    const plan = planExport([
+      clip({ id: 'video', durationMs: 2000, trimEndMs: 2000 }),
+      clip({
+        id: 'photo',
+        kind: 'image',
+        mimeType: 'image/png',
+        blob: new Blob(['png'], { type: 'image/png' }),
+        durationMs: 7000,
+        trimStartMs: 0,
+        trimEndMs: 7000,
+      }),
+    ])
+    expect(plan.segments).toHaveLength(2)
+    expect(plan.segments[1]).toMatchObject({ startMs: 0, endMs: 7000, offsetMs: 2000 })
+    expect(plan.totalMs).toBe(9000)
+  })
+
   it('returns an empty plan for no clips', () => {
     const plan = planExport([])
     expect(plan.segments).toHaveLength(0)

--- a/src/lib/export/shared.ts
+++ b/src/lib/export/shared.ts
@@ -140,6 +140,20 @@ async function loadClipVideoOnce(blob: Blob, timeoutMs: number): Promise<LoadedC
   }
 }
 
+/**
+ * Decode a photo clip's blob for export drawing. ImageBitmap is preferred
+ * (decodes off the main thread, honors EXIF orientation in every current
+ * browser); the caller must close() it.
+ */
+export async function loadClipImage(blob: Blob): Promise<ImageBitmap> {
+  const bitmap = await createImageBitmap(blob)
+  if (bitmap.width <= 0 || bitmap.height <= 0) {
+    bitmap.close()
+    throw new Error('Could not decode photo')
+  }
+  return bitmap
+}
+
 export function waitForMediaEvent(
   target: HTMLMediaElement,
   event: string,

--- a/src/lib/import-device-clips.test.ts
+++ b/src/lib/import-device-clips.test.ts
@@ -1,11 +1,35 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 import {
   importDeviceClips,
+  isLikelyImageFile,
   isLikelyVideoFile,
   mimeTypeForDeviceFile,
+  mimeTypeForDeviceImage,
   probeDeviceClip,
+  probeDeviceImage,
 } from './import-device-clips'
 import { __resetDbForTests, createProject, getClipsForProject } from './storage'
+import { DEFAULT_IMAGE_DURATION_MS } from './types'
+
+/** A real decodable PNG File, drawn in-page (browser-mode tests). */
+async function makeTestImageFile(
+  name = 'photo.png',
+  width = 64,
+  height = 48,
+): Promise<File> {
+  const canvas = document.createElement('canvas')
+  canvas.width = width
+  canvas.height = height
+  const ctx = canvas.getContext('2d')
+  if (!ctx) throw new Error('Canvas not available')
+  ctx.fillStyle = '#3aa76d'
+  ctx.fillRect(0, 0, width, height)
+  const blob = await new Promise<Blob | null>((resolve) => {
+    canvas.toBlob((b) => resolve(b), 'image/png')
+  })
+  if (!blob) throw new Error('Could not encode test image')
+  return new File([blob], name, { type: 'image/png' })
+}
 
 describe('mimeTypeForDeviceFile', () => {
   it('prefers an explicit video MIME type', () => {
@@ -41,18 +65,70 @@ describe('isLikelyVideoFile', () => {
   })
 })
 
+describe('isLikelyImageFile / mimeTypeForDeviceImage', () => {
+  it('accepts image/* types and image extensions with empty types', () => {
+    expect(isLikelyImageFile({ name: 'a.bin', type: 'image/png' })).toBe(true)
+    expect(isLikelyImageFile({ name: 'photo.JPG', type: '' })).toBe(true)
+    expect(isLikelyImageFile({ name: 'photo.webp', type: 'application/octet-stream' })).toBe(true)
+  })
+
+  it('rejects videos and extension-less ambiguous picks (video path decides those)', () => {
+    expect(isLikelyImageFile({ name: 'clip.mp4', type: 'video/mp4' })).toBe(false)
+    expect(isLikelyImageFile({ name: 'content', type: '' })).toBe(false)
+    expect(isLikelyImageFile({ name: 'notes.txt', type: 'text/plain' })).toBe(false)
+  })
+
+  it('infers image MIME types from extensions when the type is empty', () => {
+    expect(mimeTypeForDeviceImage({ name: 'a.PNG', type: '' })).toBe('image/png')
+    expect(mimeTypeForDeviceImage({ name: 'a.webp', type: '' })).toBe('image/webp')
+    expect(mimeTypeForDeviceImage({ name: 'a.jpg', type: '' })).toBe('image/jpeg')
+    expect(mimeTypeForDeviceImage({ name: 'a.jpeg', type: 'image/jpeg' })).toBe('image/jpeg')
+  })
+})
+
 describe('probeDeviceClip / importDeviceClips', () => {
   beforeEach(async () => {
     await __resetDbForTests()
   })
 
-  it('rejects empty and non-video picks before probing', async () => {
+  it('rejects empty and unreadable picks before probing', async () => {
     await expect(probeDeviceClip(new File([], 'empty.mp4', { type: 'video/mp4' }))).rejects.toThrow(
       /empty/i,
     )
+    // Image-typed picks take the photo path; junk bytes fail its decode.
     await expect(
-      probeDeviceClip(new File(['not-video'], 'photo.jpg', { type: 'image/jpeg' })),
-    ).rejects.toThrow(/video/i)
+      probeDeviceClip(new File(['not-an-image'], 'photo.jpg', { type: 'image/jpeg' })),
+    ).rejects.toThrow(/photo/i)
+    await expect(
+      probeDeviceClip(new File(['not-video'], 'notes.txt', { type: 'text/plain' })),
+    ).rejects.toThrow(/video or photo/i)
+  })
+
+  it('probes a photo pick as an image clip with the default duration', async () => {
+    const probed = await probeDeviceImage(await makeTestImageFile('photo.png', 64, 48))
+    expect(probed.kind).toBe('image')
+    expect(probed.mimeType).toBe('image/png')
+    expect(probed.durationMs).toBe(DEFAULT_IMAGE_DURATION_MS)
+    expect(probed.width).toBe(64)
+    expect(probed.height).toBe(48)
+  })
+
+  it('imports photos into the timeline as image clips', async () => {
+    const project = await createProject('Photo import')
+    const result = await importDeviceClips([await makeTestImageFile()], {
+      ensureProjectId: async () => project.id,
+    })
+    expect(result.failed).toHaveLength(0)
+    expect(result.added).toHaveLength(1)
+    const clips = await getClipsForProject(project.id)
+    expect(clips).toHaveLength(1)
+    expect(clips[0]!.kind).toBe('image')
+    expect(clips[0]!.durationMs).toBe(DEFAULT_IMAGE_DURATION_MS)
+    expect(clips[0]!.trimStartMs).toBe(0)
+    expect(clips[0]!.trimEndMs).toBe(DEFAULT_IMAGE_DURATION_MS)
+    // Photos are silent by construction — the zero peak is persisted so the
+    // loader backfill never attempts an audio decode on image bytes.
+    expect(clips[0]!.audioPeak).toBe(0)
   })
 
   it('collects per-file failures without aborting the batch', async () => {

--- a/src/lib/import-device-clips.test.ts
+++ b/src/lib/import-device-clips.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 import {
+  DEVICE_CLIP_ACCEPT,
   importDeviceClips,
   isLikelyImageFile,
   isLikelyVideoFile,
@@ -83,6 +84,15 @@ describe('isLikelyImageFile / mimeTypeForDeviceImage', () => {
     expect(mimeTypeForDeviceImage({ name: 'a.webp', type: '' })).toBe('image/webp')
     expect(mimeTypeForDeviceImage({ name: 'a.jpg', type: '' })).toBe('image/jpeg')
     expect(mimeTypeForDeviceImage({ name: 'a.jpeg', type: 'image/jpeg' })).toBe('image/jpeg')
+    expect(mimeTypeForDeviceImage({ name: 'scan.bmp', type: '' })).toBe('image/bmp')
+    expect(mimeTypeForDeviceImage({ name: 'IMG_0001.HEIC', type: '' })).toBe('image/heic')
+    expect(mimeTypeForDeviceImage({ name: 'photo.heif', type: '' })).toBe('image/heif')
+  })
+
+  it('lists .bmp/.heic/.heif in the device picker accept string', () => {
+    expect(DEVICE_CLIP_ACCEPT).toContain('.bmp')
+    expect(DEVICE_CLIP_ACCEPT).toContain('.heic')
+    expect(DEVICE_CLIP_ACCEPT).toContain('.heif')
   })
 })
 

--- a/src/lib/import-device-clips.ts
+++ b/src/lib/import-device-clips.ts
@@ -1,13 +1,17 @@
 import { addClip, clearUndo } from './storage'
-import type { ClipRecord, ProjectId } from './types'
+import { DEFAULT_IMAGE_DURATION_MS, type ClipKind, type ClipRecord, type ProjectId } from './types'
 
-/** Accept string for `<input type="file">` — common phone/desktop video types. */
+/** Accept string for `<input type="file">` — common phone/desktop video
+ * types, plus photos (added to the timeline as stills with a chosen
+ * on-screen duration). */
 export const DEVICE_CLIP_ACCEPT =
-  'video/*,video/mp4,video/webm,video/quicktime,video/x-matroska,.mp4,.m4v,.webm,.mov,.mkv'
+  'video/*,video/mp4,video/webm,video/quicktime,video/x-matroska,.mp4,.m4v,.webm,.mov,.mkv,' +
+  'image/*,image/jpeg,image/png,image/webp,image/gif,image/avif,.jpg,.jpeg,.png,.webp,.gif,.avif'
 
 export interface DeviceClipProbe {
   blob: Blob
   mimeType: string
+  kind?: ClipKind
   durationMs: number
   width?: number
   height?: number
@@ -52,6 +56,34 @@ export function isLikelyVideoFile(file: Pick<File, 'name' | 'type'>): boolean {
   return true
 }
 
+const IMAGE_EXTENSIONS = /\.(jpe?g|png|webp|gif|avif|bmp|heic|heif)$/
+
+/**
+ * Infer a MIME type for a picked photo. Like videos, empty `File.type` is
+ * common for Android content URIs — fall back to the extension.
+ */
+export function mimeTypeForDeviceImage(file: Pick<File, 'name' | 'type'>): string {
+  const typed = (file.type || '').trim().toLowerCase()
+  if (typed.startsWith('image/')) return typed
+  const name = file.name.toLowerCase()
+  if (name.endsWith('.png')) return 'image/png'
+  if (name.endsWith('.webp')) return 'image/webp'
+  if (name.endsWith('.gif')) return 'image/gif'
+  if (name.endsWith('.avif')) return 'image/avif'
+  if (name.endsWith('.bmp')) return 'image/bmp'
+  if (name.endsWith('.heic') || name.endsWith('.heif')) return 'image/heic'
+  return 'image/jpeg'
+}
+
+/** True when a pick should take the photo import path (checked before the
+ * video path — an image type or extension is unambiguous). */
+export function isLikelyImageFile(file: Pick<File, 'name' | 'type'>): boolean {
+  const typed = (file.type || '').trim().toLowerCase()
+  if (typed.startsWith('image/')) return true
+  if (typed && !typed.startsWith('application/octet-stream')) return false
+  return IMAGE_EXTENSIONS.test(file.name.toLowerCase())
+}
+
 async function demuxClipMeta(
   blob: Blob,
   timeoutMs: number,
@@ -87,6 +119,48 @@ async function demuxClipMeta(
 }
 
 /**
+ * Materialize a picked photo's bytes and prove this browser can decode it
+ * (an undecodable format must fail the pick, not the export). Stills enter
+ * the timeline with the default on-screen duration — the editor's duration
+ * strip adjusts it afterward.
+ */
+export async function probeDeviceImage(file: File): Promise<DeviceClipProbe> {
+  if (file.size <= 0) {
+    throw new Error('That file is empty')
+  }
+  const mimeType = mimeTypeForDeviceImage(file)
+  const bytes = await file.arrayBuffer()
+  const blob = new Blob([bytes], { type: mimeType })
+  const createdAt =
+    Number.isFinite(file.lastModified) && file.lastModified > 0
+      ? file.lastModified
+      : Date.now()
+
+  let bitmap: ImageBitmap
+  try {
+    bitmap = await createImageBitmap(blob)
+  } catch {
+    throw new Error('This browser cannot read that photo format')
+  }
+  try {
+    if (bitmap.width <= 0 || bitmap.height <= 0) {
+      throw new Error('This browser cannot read that photo format')
+    }
+    return {
+      blob,
+      mimeType,
+      kind: 'image',
+      durationMs: DEFAULT_IMAGE_DURATION_MS,
+      width: bitmap.width,
+      height: bitmap.height,
+      createdAt,
+    }
+  } finally {
+    bitmap.close()
+  }
+}
+
+/**
  * Materialize bytes and resolve duration/dimensions. File-backed blobs from
  * the picker must be copied before IndexedDB persistence — Chromium stores
  * references to the underlying file (esp. Android content URIs), which go
@@ -103,8 +177,11 @@ export async function probeDeviceClip(
   if (file.size <= 0) {
     throw new Error('That file is empty')
   }
+  if (isLikelyImageFile(file)) {
+    return probeDeviceImage(file)
+  }
   if (!isLikelyVideoFile(file)) {
-    throw new Error('Pick a video file')
+    throw new Error('Pick a video or photo file')
   }
 
   const mimeType = mimeTypeForDeviceFile(file)
@@ -160,15 +237,26 @@ export async function importDeviceClip(
   file: File,
 ): Promise<ClipRecord> {
   const probed = await probeDeviceClip(file)
-  return addClip({
+  return addClip(addClipInputFor(projectId, probed))
+}
+
+function addClipInputFor(
+  projectId: ProjectId,
+  probed: DeviceClipProbe,
+): Parameters<typeof addClip>[0] {
+  return {
     projectId,
     blob: probed.blob,
     mimeType: probed.mimeType,
+    kind: probed.kind,
     durationMs: probed.durationMs,
     width: probed.width,
     height: probed.height,
     createdAt: probed.createdAt,
-  })
+    // Photos are silent by construction — persist the zero measurement so
+    // the loader backfill never attempts an audio decode on them.
+    ...(probed.kind === 'image' ? { audioPeak: 0 } : {}),
+  }
 }
 
 export interface ImportDeviceClipsOptions {
@@ -199,17 +287,7 @@ export async function importDeviceClips(
     try {
       const probed = await probeDeviceClip(file)
       projectId ??= await options.ensureProjectId()
-      added.push(
-        await addClip({
-          projectId,
-          blob: probed.blob,
-          mimeType: probed.mimeType,
-          durationMs: probed.durationMs,
-          width: probed.width,
-          height: probed.height,
-          createdAt: probed.createdAt,
-        }),
-      )
+      added.push(await addClip(addClipInputFor(projectId, probed)))
     } catch (error) {
       failed.push({
         name: file.name || 'clip',

--- a/src/lib/import-device-clips.ts
+++ b/src/lib/import-device-clips.ts
@@ -6,7 +6,7 @@ import { DEFAULT_IMAGE_DURATION_MS, type ClipKind, type ClipRecord, type Project
  * on-screen duration). */
 export const DEVICE_CLIP_ACCEPT =
   'video/*,video/mp4,video/webm,video/quicktime,video/x-matroska,.mp4,.m4v,.webm,.mov,.mkv,' +
-  'image/*,image/jpeg,image/png,image/webp,image/gif,image/avif,.jpg,.jpeg,.png,.webp,.gif,.avif'
+  'image/*,image/jpeg,image/png,image/webp,image/gif,image/avif,.jpg,.jpeg,.png,.webp,.gif,.avif,.bmp,.heic,.heif'
 
 export interface DeviceClipProbe {
   blob: Blob
@@ -71,7 +71,8 @@ export function mimeTypeForDeviceImage(file: Pick<File, 'name' | 'type'>): strin
   if (name.endsWith('.gif')) return 'image/gif'
   if (name.endsWith('.avif')) return 'image/avif'
   if (name.endsWith('.bmp')) return 'image/bmp'
-  if (name.endsWith('.heic') || name.endsWith('.heif')) return 'image/heic'
+  if (name.endsWith('.heic')) return 'image/heic'
+  if (name.endsWith('.heif')) return 'image/heif'
   return 'image/jpeg'
 }
 

--- a/src/lib/project-actions.ts
+++ b/src/lib/project-actions.ts
@@ -16,6 +16,7 @@ import {
   setLastOpenedProjectId,
   setProjectOrientation,
   undoDeleteLastClip,
+  updateClipDuration,
   updateClipThumbs,
   updateClipTrim,
   updateClipVolumes,
@@ -320,6 +321,11 @@ export async function trimClip(
   trimEndMs: number,
 ): Promise<void> {
   await updateClipTrim(clipId, trimStartMs, trimEndMs)
+}
+
+/** Set a photo clip's on-screen duration (can grow as well as shrink). */
+export async function setClipDuration(clipId: ClipId, durationMs: number): Promise<void> {
+  await updateClipDuration(clipId, durationMs)
 }
 
 /** Append a picked audio file to the project's background-music playlist. */

--- a/src/lib/project-transfer.test.ts
+++ b/src/lib/project-transfer.test.ts
@@ -96,6 +96,37 @@ describe('project backup round trip', () => {
     expect(await clips[0].blob.text()).toBe('MEDIA')
   })
 
+  it('round-trips photo clips with their on-screen duration', async () => {
+    const photo = fakeClip('clip_a', 'PNGBYTES', {
+      kind: 'image',
+      blob: new Blob(['PNGBYTES'], { type: 'image/png' }),
+      mimeType: 'image/png',
+      durationMs: 7000,
+      trimStartMs: 0,
+      trimEndMs: 7000,
+      lat: undefined,
+      lng: undefined,
+      locationAccuracyM: undefined,
+      audioPeak: 0,
+    })
+    const backup = serializeProject(fakeProject('With photo'), [photo])
+
+    const parsed = await parseProjectBackup(backup)
+    expect(parsed.clips[0].kind).toBe('image')
+    expect(parsed.clips[0].durationMs).toBe(7000)
+    expect(parsed.clips[0].blob.type).toBe('image/png')
+
+    const project = await importProjectBackup(parsed)
+    const clips = await getClipsForProject(project.id)
+    expect(clips).toHaveLength(1)
+    expect(clips[0].kind).toBe('image')
+    expect(clips[0].durationMs).toBe(7000)
+    expect(clips[0].trimStartMs).toBe(0)
+    expect(clips[0].trimEndMs).toBe(7000)
+    expect(clips[0].audioPeak).toBe(0)
+    expect(await clips[0].blob.text()).toBe('PNGBYTES')
+  })
+
   it('parses backups without music with audio: null (older backups)', async () => {
     const backup = serializeProject(fakeProject(), [fakeClip('clip_a', 'AAAA')])
     const parsed = await parseProjectBackup(backup)

--- a/src/lib/project-transfer.ts
+++ b/src/lib/project-transfer.ts
@@ -8,7 +8,13 @@ import {
   updateProjectAudioTrack,
 } from './storage'
 import { requestPersistentStorage } from './storage-space'
-import type { ClipRecord, Project, ProjectAudioRecord, ProjectOrientation } from './types'
+import {
+  clampImageDurationMs,
+  type ClipRecord,
+  type Project,
+  type ProjectAudioRecord,
+  type ProjectOrientation,
+} from './types'
 
 /**
  * Single-file project backup, used both as a safety net and to move a
@@ -27,6 +33,10 @@ const MAGIC_BYTES = new TextEncoder().encode(MAGIC)
 
 interface ManifestClip {
   mimeType: string
+  /** 'image' for a still photo shown for durationMs (absent = video).
+   * Older app versions ignore this field; the media bytes then fail their
+   * video probe on playback rather than corrupting the import. */
+  kind?: 'image'
   durationMs: number
   trimStartMs: number
   trimEndMs: number
@@ -126,6 +136,7 @@ export function serializeProject(
     ...(project.orientation === 'landscape' ? { orientation: 'landscape' as const } : {}),
     clips: clips.map((clip) => ({
       mimeType: clip.mimeType,
+      ...(clip.kind === 'image' ? { kind: 'image' as const } : {}),
       durationMs: clip.durationMs,
       trimStartMs: clip.trimStartMs,
       trimEndMs: clip.trimEndMs,
@@ -242,6 +253,7 @@ export async function parseProjectBackup(file: Blob): Promise<ParsedBackup> {
     const mimeType = typeof clip.mimeType === 'string' ? clip.mimeType : 'video/webm'
     clips.push({
       mimeType,
+      ...(clip.kind === 'image' ? { kind: 'image' as const } : {}),
       durationMs: clip.durationMs,
       trimStartMs: clip.trimStartMs,
       trimEndMs: clip.trimEndMs,
@@ -383,11 +395,14 @@ async function persistImportedProject(
       // Android content URIs) and leaves clips unreadable. Reading it here
       // both copies the bytes and proves the file is intact.
       const bytes = await clip.blob.arrayBuffer()
+      const isImage = clip.kind === 'image'
       const added = await addClip({
         projectId: project.id,
         blob: new Blob([bytes], { type: clip.mimeType }),
         mimeType: clip.mimeType,
-        durationMs: clip.durationMs,
+        kind: clip.kind,
+        // Photo durations re-clamp into the supported range on the way in.
+        durationMs: isImage ? clampImageDurationMs(clip.durationMs) : clip.durationMs,
         // Keep the original capture time so chapter titles stay truthful.
         createdAt: clip.createdAt,
         width: clip.width,
@@ -397,10 +412,14 @@ async function persistImportedProject(
         locationAccuracyM: clip.locationAccuracyM,
         clipVolume: clip.clipVolume,
         musicVolume: clip.musicVolume,
-        audioPeak: clip.audioPeak,
+        // Photos are silent by construction.
+        audioPeak: isImage ? (clip.audioPeak ?? 0) : clip.audioPeak,
       })
-      // Restore trims (addClip resets them to the full clip).
-      const trimmed = await updateClipTrim(added.id, clip.trimStartMs, clip.trimEndMs)
+      // Restore trims (addClip resets them to the full clip). A photo shows
+      // in full by definition — its trim window IS its duration.
+      const trimmed = isImage
+        ? added
+        : await updateClipTrim(added.id, clip.trimStartMs, clip.trimEndMs)
       // Generate thumbnails now so the slot poster shows right away and the
       // first open doesn't pay the backfill cost. Lazy import keeps mediabunny
       // out of the home-shell graph until an import actually runs.

--- a/src/lib/storage.test.ts
+++ b/src/lib/storage.test.ts
@@ -454,6 +454,33 @@ describe('storage layer', () => {
     expect(photo.trimStartMs).toBe(0)
     expect(photo.trimEndMs).toBe(3000)
 
+    // addClip itself is the storage gate: out-of-range durations clamp and
+    // any supplied trim window is ignored in favor of 0..durationMs.
+    const clampedIn = await addClip({
+      projectId: project.id,
+      blob: new Blob(['png-bytes'], { type: 'image/png' }),
+      mimeType: 'image/png',
+      kind: 'image',
+      durationMs: 1,
+      trimEndMs: 250,
+      audioPeak: 0,
+    })
+    expect(clampedIn.durationMs).toBe(MIN_IMAGE_DURATION_MS)
+    expect(clampedIn.trimStartMs).toBe(0)
+    expect(clampedIn.trimEndMs).toBe(MIN_IMAGE_DURATION_MS)
+
+    const clampedOut = await addClip({
+      projectId: project.id,
+      blob: new Blob(['png-bytes'], { type: 'image/png' }),
+      mimeType: 'image/png',
+      kind: 'image',
+      durationMs: 10 * 60_000,
+      trimEndMs: 12_000,
+      audioPeak: 0,
+    })
+    expect(clampedOut.durationMs).toBe(MAX_IMAGE_DURATION_MS)
+    expect(clampedOut.trimEndMs).toBe(MAX_IMAGE_DURATION_MS)
+
     // Lengthen well past the original duration — a photo has no media
     // length to trim within, so the duration is a free (clamped) choice.
     const longer = await updateClipDuration(photo.id, 12_000)

--- a/src/lib/storage.test.ts
+++ b/src/lib/storage.test.ts
@@ -33,13 +33,19 @@ import {
   toStoredBlob,
   undoDeleteLastClip,
   updateClipAudioPeak,
+  updateClipDuration,
   updateClipThumbs,
   updateClipVolumes,
   updateProjectAudioTrack,
   updateClipTrim,
 } from './storage'
 import { markWatermarkRemoved } from './entitlement'
-import { MAX_PROJECTS, effectiveDurationMs } from './types'
+import {
+  MAX_IMAGE_DURATION_MS,
+  MAX_PROJECTS,
+  MIN_IMAGE_DURATION_MS,
+  effectiveDurationMs,
+} from './types'
 
 function fakeBlob(label: string): Blob {
   return new Blob([label], { type: 'video/webm' })
@@ -432,6 +438,49 @@ describe('storage layer', () => {
     expect(await getClip(copy.id)).toBeTruthy()
     clips = await getClipsForProject(project.id)
     expect(clips.map((c) => c.id)).toEqual([c2.id, copy.id, c1.id])
+  })
+
+  it('stores photo clips and sets their duration (grow and shrink, clamped)', async () => {
+    const project = await createProject('Photos')
+    const photo = await addClip({
+      projectId: project.id,
+      blob: new Blob(['png-bytes'], { type: 'image/png' }),
+      mimeType: 'image/png',
+      kind: 'image',
+      durationMs: 3000,
+      audioPeak: 0,
+    })
+    expect(photo.kind).toBe('image')
+    expect(photo.trimStartMs).toBe(0)
+    expect(photo.trimEndMs).toBe(3000)
+
+    // Lengthen well past the original duration — a photo has no media
+    // length to trim within, so the duration is a free (clamped) choice.
+    const longer = await updateClipDuration(photo.id, 12_000)
+    expect(longer.durationMs).toBe(12_000)
+    expect(longer.trimStartMs).toBe(0)
+    expect(longer.trimEndMs).toBe(12_000)
+    expect(effectiveDurationMs(longer)).toBe(12_000)
+
+    const shorter = await updateClipDuration(photo.id, 900)
+    expect(shorter.durationMs).toBe(900)
+    expect(shorter.trimEndMs).toBe(900)
+
+    // Out-of-range and unsnapped requests clamp into the supported range.
+    expect((await updateClipDuration(photo.id, 1)).durationMs).toBe(MIN_IMAGE_DURATION_MS)
+    expect((await updateClipDuration(photo.id, 10 * 60_000)).durationMs).toBe(
+      MAX_IMAGE_DURATION_MS,
+    )
+    expect((await updateClipDuration(photo.id, 2_222)).durationMs).toBe(2_200)
+
+    // Videos keep their media-bound trim semantics.
+    const video = await addClip({
+      projectId: project.id,
+      blob: fakeBlob('video'),
+      mimeType: 'video/webm',
+      durationMs: 2000,
+    })
+    await expect(updateClipDuration(video.id, 5000)).rejects.toThrow(/photo/i)
   })
 
   it('delete removes blob storage permanently when not undone', async () => {

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -3,10 +3,12 @@ import { removeExportEntry } from './export/opfs'
 import {
   FREE_PROJECTS,
   MAX_PROJECTS,
+  clampImageDurationMs,
   clampVolume,
   newId,
   type AppMeta,
   type ClipId,
+  type ClipKind,
   type ClipMeta,
   type ClipRecord,
   type DeletedClipSnapshot,
@@ -518,6 +520,8 @@ export interface AddClipInput {
   projectId: ProjectId
   blob: Blob
   mimeType: string
+  /** 'image' for a still photo shown for `durationMs`; omit for video. */
+  kind?: ClipKind
   durationMs: number
   /** Default trim-out point; recordings pass the release point so the
    * stop-grace tail (real media past the finger-lift) starts trimmed off. */
@@ -569,6 +573,7 @@ export async function addClip(input: AddClipInput): Promise<ClipRecord> {
     trimStartMs: 0,
     trimEndMs: Math.max(0, Math.min(input.trimEndMs ?? input.durationMs, input.durationMs)),
     createdAt: input.createdAt ?? now,
+    ...(input.kind === 'image' ? { kind: 'image' as const } : {}),
     width: input.width,
     height: input.height,
     lat: input.lat,
@@ -653,6 +658,39 @@ export async function updateClipTrim(
   const end = Math.max(start, Math.min(trimEndMs, clip.durationMs))
   const updated: ClipRecord = { ...clip, trimStartMs: start, trimEndMs: end }
   await db.put('clips', updated)
+  await touchProject(clip.projectId)
+  return toMeta(updated)
+}
+
+/**
+ * Set a photo clip's on-screen duration. Unlike a video trim, a photo has
+ * no media length to clamp against — the duration IS the clip's length, so
+ * it can grow as well as shrink. The trim window follows (0..duration): a
+ * photo always shows in full, and every consumer of trims keeps working.
+ */
+export async function updateClipDuration(
+  clipId: ClipId,
+  durationMs: number,
+): Promise<ClipMeta> {
+  const clamped = clampImageDurationMs(durationMs)
+  const db = await getDb()
+  const tx = db.transaction('clips', 'readwrite')
+  const clip = await tx.store.get(clipId)
+  if (!clip) {
+    await tx.done.catch(() => undefined)
+    throw new Error('Clip not found')
+  }
+  if (clip.kind !== 'image') {
+    await tx.done
+    throw new Error('Only photos can change duration — trim videos instead')
+  }
+  const updated: ClipRecord = {
+    ...clip,
+    durationMs: clamped,
+    trimStartMs: 0,
+    trimEndMs: clamped,
+  }
+  await completeTransaction([tx.store.put(updated)], tx)
   await touchProject(clip.projectId)
   return toMeta(updated)
 }

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -558,6 +558,13 @@ export async function toStoredBlob(blob: Blob, mimeType?: string): Promise<Blob>
 
 export async function addClip(input: AddClipInput): Promise<ClipRecord> {
   const db = await getDb()
+  const isImage = input.kind === 'image'
+  // Photos: clamp duration and pin the trim window at the storage gate so
+  // a direct caller cannot bypass the import/backup clamps with an
+  // out-of-range duration or a partial trim window.
+  const durationMs = isImage
+    ? clampImageDurationMs(input.durationMs)
+    : input.durationMs
   // Materialize before opening the transaction — awaiting inside a tx lets
   // IndexedDB auto-commit and abort subsequent puts. Re-read the project
   // inside the tx so overlapping saves cannot clobber fresher clipIds.
@@ -569,11 +576,13 @@ export async function addClip(input: AddClipInput): Promise<ClipRecord> {
     projectId: input.projectId,
     blob: durableBlob,
     mimeType: input.mimeType,
-    durationMs: input.durationMs,
+    durationMs,
     trimStartMs: 0,
-    trimEndMs: Math.max(0, Math.min(input.trimEndMs ?? input.durationMs, input.durationMs)),
+    trimEndMs: isImage
+      ? durationMs
+      : Math.max(0, Math.min(input.trimEndMs ?? durationMs, durationMs)),
     createdAt: input.createdAt ?? now,
-    ...(input.kind === 'image' ? { kind: 'image' as const } : {}),
+    ...(isImage ? { kind: 'image' as const } : {}),
     width: input.width,
     height: input.height,
     lat: input.lat,

--- a/src/lib/testing/make-test-image.ts
+++ b/src/lib/testing/make-test-image.ts
@@ -1,0 +1,25 @@
+/**
+ * Deterministic fixture photo for the e2e suite (imported in-page through
+ * the vite dev server; never referenced by app code, so it ships nowhere).
+ */
+export async function makeTestImageBlob(
+  width = 320,
+  height = 568,
+  color = '#3aa76d',
+): Promise<Blob> {
+  const canvas = document.createElement('canvas')
+  canvas.width = width
+  canvas.height = height
+  const ctx = canvas.getContext('2d')
+  if (!ctx) throw new Error('Canvas not available')
+  ctx.fillStyle = color
+  ctx.fillRect(0, 0, width, height)
+  ctx.fillStyle = '#fff'
+  ctx.font = '48px sans-serif'
+  ctx.fillText('photo', 24, 64)
+  const blob = await new Promise<Blob | null>((resolve) => {
+    canvas.toBlob((b) => resolve(b), 'image/png')
+  })
+  if (!blob) throw new Error('Test image encode produced no bytes')
+  return blob
+}

--- a/src/lib/thumbs.ts
+++ b/src/lib/thumbs.ts
@@ -1,6 +1,6 @@
 import { loadClipVideo, seekTo } from './export/shared'
 import { updateClipThumbs } from './storage'
-import type { ClipRecord } from './types'
+import { isImageClip, type ClipRecord } from './types'
 
 /** Filmstrip frame height: timeline tiles are 72 CSS px on up-to-3× screens. */
 export const THUMB_HEIGHT = 216
@@ -89,6 +89,53 @@ function canvasToBlob(canvas: HTMLCanvasElement, quality: number): Promise<Blob 
 }
 
 /**
+ * Thumbnails for a photo clip: one filmstrip frame (a still has no moments
+ * to strip through — the single frame stretches across the tile) plus the
+ * high-res poster, both drawn from one decode.
+ */
+export async function generateImageThumbs(blob: Blob): Promise<GeneratedThumbs> {
+  const bitmap = await createImageBitmap(blob)
+  try {
+    if (bitmap.width <= 0 || bitmap.height <= 0) {
+      throw new Error('Could not read photo')
+    }
+    const aspect = bitmap.width / bitmap.height
+    const thumbHeight = THUMB_HEIGHT
+    const thumbWidth = Math.max(2, Math.round(thumbHeight * aspect))
+    const canvas = document.createElement('canvas')
+    canvas.width = thumbWidth
+    canvas.height = thumbHeight
+    const ctx = canvas.getContext('2d', { alpha: false })
+
+    const posterHeight = Math.min(POSTER_HEIGHT, bitmap.height)
+    const posterWidth = Math.max(2, Math.round(posterHeight * aspect))
+    const posterCanvas = document.createElement('canvas')
+    posterCanvas.width = posterWidth
+    posterCanvas.height = posterHeight
+    const posterCtx = posterCanvas.getContext('2d', { alpha: false })
+    if (!ctx || !posterCtx) throw new Error('Canvas not available')
+
+    posterCtx.drawImage(bitmap, 0, 0, posterWidth, posterHeight)
+    ctx.drawImage(posterCanvas, 0, 0, thumbWidth, thumbHeight)
+    const [thumb, poster] = await Promise.all([
+      canvasToBlob(canvas, 0.72),
+      canvasToBlob(posterCanvas, 0.82),
+    ])
+    if (!thumb) throw new Error('Could not capture photo thumbnail')
+    return {
+      thumbs: [thumb],
+      poster: poster ?? thumb,
+      thumbWidth,
+      thumbHeight,
+      videoWidth: bitmap.width,
+      videoHeight: bitmap.height,
+    }
+  } finally {
+    bitmap.close()
+  }
+}
+
+/**
  * Capture a poster + single filmstrip frame straight off the LIVE camera
  * preview at take end. Zero decoder cost: decoding the fresh blob in a
  * hidden <video> while the preview runs blanks the preview on many Androids
@@ -150,6 +197,8 @@ const refineInFlight = new Map<string, Promise<void>>()
  * black flash the live capture avoids.
  */
 export function refineClipFilmstrip(clip: ClipRecord): Promise<void> {
+  // A photo's single frame IS its finished filmstrip — nothing to refine.
+  if (isImageClip(clip)) return Promise.resolve()
   const count = clip.thumbs?.length ?? 0
   if (count === 0 || count >= THUMB_COUNT) return Promise.resolve()
   if (failedThisSession.has(clip.id)) return Promise.resolve()
@@ -200,7 +249,9 @@ export function ensureClipThumbs(clip: ClipRecord): Promise<ClipRecord> {
     try {
       let generated: GeneratedThumbs
       try {
-        generated = await generateClipThumbs(clip.blob)
+        generated = isImageClip(clip)
+          ? await generateImageThumbs(clip.blob)
+          : await generateClipThumbs(clip.blob)
       } catch {
         // Unreadable/undecodable media — retrying costs an 8s timeout every
         // load, so skip this clip for the rest of the session.

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -31,9 +31,15 @@ export function projectOrientation(
   return project.orientation === 'landscape' ? 'landscape' : 'portrait'
 }
 
+/** What a timeline clip is made of. Absent = 'video' (every clip recorded
+ * or imported before photos existed stores nothing). */
+export type ClipKind = 'video' | 'image'
+
 export interface ClipMeta {
   id: ClipId
   projectId: ProjectId
+  /** 'image' for a still photo shown for `durationMs`; absent = video. */
+  kind?: ClipKind
   mimeType: string
   durationMs: number
   trimStartMs: number
@@ -242,6 +248,29 @@ export const FREE_PROJECTS = 1
 /** Route id for a project that exists only as a URL until the first clip is
  * recorded — backing out of an empty "new project" leaves nothing behind. */
 export const NEW_PROJECT_ID: ProjectId = 'new'
+
+/** True when the clip is a still photo shown for its duration. */
+export function isImageClip(clip: Pick<ClipMeta, 'kind'>): boolean {
+  return clip.kind === 'image'
+}
+
+/** How long a photo shows by default — long enough to read, short enough
+ * to keep the film moving. */
+export const DEFAULT_IMAGE_DURATION_MS = 3_000
+/** Photo on-screen time bounds. The floor keeps a photo visible (and its
+ * export segment above MIN_SEGMENT_MS); the ceiling keeps the duration
+ * strip's drag scale useful. */
+export const MIN_IMAGE_DURATION_MS = 500
+export const MAX_IMAGE_DURATION_MS = 30_000
+
+/** Clamp a requested photo duration into the supported range, snapped to
+ * whole tenths of a second (the resolution the UI shows). Non-finite
+ * requests fall back to the default. */
+export function clampImageDurationMs(durationMs: number): number {
+  if (!Number.isFinite(durationMs)) return DEFAULT_IMAGE_DURATION_MS
+  const snapped = Math.round(durationMs / 100) * 100
+  return Math.max(MIN_IMAGE_DURATION_MS, Math.min(MAX_IMAGE_DURATION_MS, snapped))
+}
 
 export function effectiveDurationMs(clip: Pick<ClipMeta, 'durationMs' | 'trimStartMs' | 'trimEndMs'>): number {
   const end = Math.min(clip.trimEndMs, clip.durationMs)

--- a/src/styles/editor.css
+++ b/src/styles/editor.css
@@ -105,6 +105,10 @@
   pointer-events: auto;
 }
 
+.editor-clip-preview-image {
+  object-fit: contain;
+}
+
 .editor-empty-preview {
   width: 100%;
   height: 100%;
@@ -292,6 +296,21 @@
   pointer-events: none;
 }
 
+/* Photo tiles carry a small camera badge so stills read at a glance. */
+.clip-thumb .clip-photo-badge {
+  position: absolute;
+  left: 4px;
+  bottom: 4px;
+  display: grid;
+  place-items: center;
+  width: 18px;
+  height: 18px;
+  border-radius: 6px;
+  color: #fff;
+  background: rgba(0, 0, 0, 0.55);
+  pointer-events: none;
+}
+
 /* In-timeline trim mode */
 .trim-strip {
   display: flex;
@@ -419,6 +438,62 @@
 
 .trim-handle.active {
   transform: translateX(-50%) scale(1.06);
+}
+
+/* Photo duration mode — the trim strip's still-image counterpart: one
+   handle over a 0→max scale, plus exact-value steppers and presets. */
+.image-duration-controls {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  flex-wrap: wrap;
+  min-height: 30px;
+}
+
+.image-duration-steppers {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  flex: 0 0 auto;
+}
+
+.image-duration-step {
+  min-height: 30px;
+  padding: 0 10px;
+  font-size: 0.78rem;
+  font-variant-numeric: tabular-nums;
+}
+
+.image-duration-value {
+  min-width: 52px;
+  text-align: center;
+  font-size: 0.92rem;
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+  color: var(--ink);
+}
+
+.image-duration-presets {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  flex-wrap: wrap;
+}
+
+.image-duration-preset {
+  min-height: 26px;
+  padding: 2px 10px;
+  border-radius: 999px;
+  font-size: 0.74rem;
+  font-weight: 600;
+  color: var(--accent);
+  background: color-mix(in srgb, var(--accent) 14%, transparent);
+}
+
+.image-duration-preset.active {
+  color: var(--ink-strong);
+  background: var(--accent);
 }
 
 .trim-strip-actions {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -846,6 +846,19 @@ a {
   background: #000;
 }
 
+/* Photo segments show through their own <img>; the persistent video
+   element stays mounted (unmuted-playback allowance) but out of sight. */
+.playback-video.is-hidden {
+  display: none;
+}
+
+.playback-image {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+  background: #000;
+}
+
 .playback-progress {
   position: absolute;
   top: calc(10px + var(--safe-top));

--- a/tests/e2e/photo-clips.spec.ts
+++ b/tests/e2e/photo-clips.spec.ts
@@ -1,0 +1,210 @@
+import { test, expect, type Page } from '@playwright/test'
+import { gotoHome, openSeededProject, waitForCameraReady } from './helpers'
+
+/** 1×1 red PNG — enough for the picker import path (decode + thumbs). */
+const TINY_PNG = Buffer.from(
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==',
+  'base64',
+)
+
+/** Seed a project with one photo clip (in-page canvas PNG) and open it. */
+async function seedPhotoProject(
+  page: Page,
+  options: { durationMs?: number; videoClips?: number } = {},
+): Promise<string> {
+  await gotoHome(page)
+  const projectId = await page.evaluate(
+    async ({ durationMs, videoClips }) => {
+      const storage = await import('/src/lib/storage.ts')
+      const thumbs = await import('/src/lib/thumbs.ts')
+      const { makeTestImageBlob } = await import('/src/lib/testing/make-test-image.ts')
+      const project = await storage.createProject('Photo project')
+      if (videoClips > 0) {
+        const { makeTestClipBlob } = await import('/src/lib/testing/make-test-clip.ts')
+        const blob = await makeTestClipBlob(1500)
+        for (let i = 0; i < videoClips; i += 1) {
+          const clip = await storage.addClip({
+            projectId: project.id,
+            blob,
+            mimeType: 'video/webm',
+            durationMs: 1500,
+            width: 320,
+            height: 568,
+          })
+          await thumbs.ensureClipThumbs(clip)
+        }
+      }
+      const photo = await storage.addClip({
+        projectId: project.id,
+        blob: await makeTestImageBlob(),
+        mimeType: 'image/png',
+        kind: 'image',
+        durationMs,
+        width: 320,
+        height: 568,
+        audioPeak: 0,
+      })
+      await thumbs.ensureClipThumbs(photo)
+      return project.id
+    },
+    { durationMs: options.durationMs ?? 3000, videoClips: options.videoClips ?? 0 },
+  )
+  await page.goto(`/project/${projectId}`)
+  await waitForCameraReady(page)
+  return projectId
+}
+
+test.describe('photo clips on the timeline', () => {
+  test('a picked photo lands on the timeline as a 3s still with a badge', async ({ page }) => {
+    await openSeededProject(page, { clips: 1 })
+    await page.getByRole('button', { name: 'Open editor' }).click()
+    await expect(page.locator('.editor-screen')).toBeVisible()
+
+    await page
+      .locator('.editor-screen input[type="file"]')
+      .setInputFiles({ name: 'vacation.png', mimeType: 'image/png', buffer: TINY_PNG })
+
+    await expect(page.locator('.toast')).toContainText('Clip added')
+    const tiles = page.locator('.clip-thumb')
+    await expect(tiles).toHaveCount(2)
+    const photoTile = page.locator('.clip-thumb.is-photo')
+    await expect(photoTile).toHaveCount(1)
+    await expect(photoTile.locator('.clip-photo-badge')).toBeVisible()
+    await expect(photoTile.locator('.clip-dur')).toHaveText('3.0s')
+
+    const stored = await page.evaluate(async () => {
+      const storage = await import('/src/lib/storage.ts')
+      const projects = await storage.listProjects()
+      const clips = await storage.getClipMetasForProject(projects[0]!.id)
+      const photo = clips.find((clip: { kind?: string }) => clip.kind === 'image')
+      return photo
+        ? { durationMs: photo.durationMs, trimEndMs: photo.trimEndMs, audioPeak: photo.audioPeak }
+        : null
+    })
+    expect(stored).toEqual({ durationMs: 3000, trimEndMs: 3000, audioPeak: 0 })
+  })
+
+  test('the duration strip sets an exact on-screen time (lengthen past the original)', async ({
+    page,
+  }) => {
+    await seedPhotoProject(page, { durationMs: 3000 })
+    await page.getByRole('button', { name: 'Open editor' }).click()
+    await expect(page.locator('.editor-screen')).toBeVisible()
+
+    // The photo is selected (most recent) — the trim action reads Duration.
+    await page.getByRole('button', { name: 'Set photo duration' }).click()
+    const strip = page.locator('.image-duration-strip')
+    await expect(strip).toBeVisible()
+    await expect(strip).toContainText('3.0s on screen')
+
+    // Preset for speed, steppers for exactness: 5s + 0.5 + 0.5 = 6.0s —
+    // twice the original duration, something a video trim can never do.
+    await strip.getByRole('button', { name: '5s', exact: true }).click()
+    await strip.getByRole('button', { name: 'Lengthen by half a second' }).click()
+    await strip.getByRole('button', { name: 'Lengthen by half a second' }).click()
+    await expect(strip).toContainText('6.0s on screen')
+    await strip.getByRole('button', { name: 'Done' }).click()
+    await expect(strip).toBeHidden()
+
+    await expect(page.locator('.clip-thumb .clip-dur').first()).toHaveText('6.0s')
+    const stored = await page.evaluate(async () => {
+      const storage = await import('/src/lib/storage.ts')
+      const projects = await storage.listProjects()
+      const clips = await storage.getClipMetasForProject(projects[0]!.id)
+      return { durationMs: clips[0]!.durationMs, trimEndMs: clips[0]!.trimEndMs }
+    })
+    expect(stored).toEqual({ durationMs: 6000, trimEndMs: 6000 })
+  })
+
+  test('the duration handle drags to lengthen and shorten', async ({ page }) => {
+    await seedPhotoProject(page, { durationMs: 3000 })
+    await page.getByRole('button', { name: 'Open editor' }).click()
+    await page.getByRole('button', { name: 'Set photo duration' }).click()
+    const strip = page.locator('.image-duration-strip')
+    await expect(strip).toBeVisible()
+
+    // The track is a 0→30s scale; drag the handle to ~50% ≈ 15s.
+    const handle = strip.locator('.trim-handle-right')
+    const handleBox = await handle.boundingBox()
+    const trackBox = await strip.locator('.trim-strip-track').boundingBox()
+    if (!handleBox || !trackBox) throw new Error('duration geometry unavailable')
+    const y = handleBox.y + handleBox.height / 2
+    await page.mouse.move(handleBox.x + handleBox.width / 2, y)
+    await page.mouse.down()
+    await page.mouse.move(trackBox.x + trackBox.width * 0.5, y, { steps: 8 })
+    await page.mouse.up()
+    await strip.getByRole('button', { name: 'Done' }).click()
+
+    const durationMs = await page.evaluate(async () => {
+      const storage = await import('/src/lib/storage.ts')
+      const projects = await storage.listProjects()
+      const clips = await storage.getClipMetasForProject(projects[0]!.id)
+      return clips[0]!.durationMs
+    })
+    expect(durationMs).toBeGreaterThan(12_000)
+    expect(durationMs).toBeLessThan(18_000)
+  })
+
+  test('project preview shows the photo for its duration, then finishes', async ({ page }) => {
+    await seedPhotoProject(page, { durationMs: 1000 })
+    await page.getByRole('button', { name: 'Open editor' }).click()
+    await page.getByRole('button', { name: 'Play project preview' }).click()
+
+    const overlay = page.locator('.playback-overlay')
+    await expect(overlay).toBeVisible()
+    await expect(page.locator('.playback-image')).toBeVisible()
+    // The photo plays out on its wall-clock timer and the preview closes.
+    await expect(overlay).toBeHidden({ timeout: 10_000 })
+  })
+
+  test('photos export into the stitched film at their chosen duration', async ({ page }) => {
+    test.slow()
+    await gotoHome(page)
+
+    const measured = await page.evaluate(async () => {
+      const storage = await import('/src/lib/storage.ts')
+      const { exportProject } = await import('/src/lib/export/index.ts')
+      const { makeTestClipBlob } = await import('/src/lib/testing/make-test-clip.ts')
+      const { makeTestImageBlob } = await import('/src/lib/testing/make-test-image.ts')
+
+      const project = await storage.createProject()
+      await storage.addClip({
+        projectId: project.id,
+        blob: await makeTestClipBlob(1500),
+        mimeType: 'video/webm',
+        durationMs: 1500,
+        width: 320,
+        height: 568,
+      })
+      await storage.addClip({
+        projectId: project.id,
+        blob: await makeTestImageBlob(320, 568, '#c0396f'),
+        mimeType: 'image/png',
+        kind: 'image',
+        durationMs: 2000,
+        width: 320,
+        height: 568,
+        audioPeak: 0,
+      })
+      const clips = await storage.getClipsForProject(project.id)
+      const result = await exportProject(clips, { watermark: false })
+
+      // The exported audio track spans the whole film (photos contribute
+      // silence), so its decoded length measures the output duration.
+      const { decodeBackgroundAudio } = await import('/src/lib/export/shared.ts')
+      const decoded = await decodeBackgroundAudio(result.blob, 48000)
+      return {
+        durationSec: decoded ? decoded.duration : null,
+        mimeType: result.mimeType,
+        bytes: result.blob.size,
+      }
+    })
+
+    expect(measured.bytes).toBeGreaterThan(8_000)
+    // 1.5s video + 2s photo ≈ 3.5s film (codec padding keeps this a sanity
+    // bound, not an exact one).
+    expect(measured.durationSec).not.toBeNull()
+    expect(measured.durationSec!).toBeGreaterThan(3.3)
+    expect(measured.durationSec!).toBeLessThan(3.8)
+  })
+})

--- a/tests/e2e/photo-clips.spec.ts
+++ b/tests/e2e/photo-clips.spec.ts
@@ -1,5 +1,30 @@
 import { test, expect, type Page } from '@playwright/test'
-import { gotoHome, openSeededProject, waitForCameraReady } from './helpers'
+import { gotoHome, openSeededProject, unlockPlus, waitForCameraReady } from './helpers'
+
+/** Tiny mono 16-bit PCM WAV for music-bed regression coverage. */
+function makeWavFile(name: string, durationSec = 4) {
+  const rate = 8000
+  const samples = Math.round(durationSec * rate)
+  const dataSize = samples * 2
+  const buffer = Buffer.alloc(44 + dataSize)
+  buffer.write('RIFF', 0)
+  buffer.writeUInt32LE(36 + dataSize, 4)
+  buffer.write('WAVE', 8)
+  buffer.write('fmt ', 12)
+  buffer.writeUInt32LE(16, 16)
+  buffer.writeUInt16LE(1, 20)
+  buffer.writeUInt16LE(1, 22)
+  buffer.writeUInt32LE(rate, 24)
+  buffer.writeUInt32LE(rate * 2, 28)
+  buffer.writeUInt16LE(2, 32)
+  buffer.writeUInt16LE(16, 34)
+  buffer.write('data', 36)
+  buffer.writeUInt32LE(dataSize, 40)
+  for (let i = 0; i < samples; i += 1) {
+    buffer.writeInt16LE(Math.round(Math.sin((2 * Math.PI * 440 * i) / rate) * 12000), 44 + i * 2)
+  }
+  return { name, mimeType: 'audio/wav', buffer }
+}
 
 /** 1×1 red PNG — enough for the picker import path (decode + thumbs). */
 const TINY_PNG = Buffer.from(
@@ -124,7 +149,7 @@ test.describe('photo clips on the timeline', () => {
     await expect(strip).toBeVisible()
 
     // The track is a 0→30s scale; drag the handle to ~50% ≈ 15s.
-    const handle = strip.locator('.trim-handle-right')
+    const handle = strip.getByRole('slider', { name: 'Photo duration handle' })
     const handleBox = await handle.boundingBox()
     const trackBox = await strip.locator('.trim-strip-track').boundingBox()
     if (!handleBox || !trackBox) throw new Error('duration geometry unavailable')
@@ -143,6 +168,56 @@ test.describe('photo clips on the timeline', () => {
     })
     expect(durationMs).toBeGreaterThan(12_000)
     expect(durationMs).toBeLessThan(18_000)
+  })
+
+  test('the duration handle is a keyboard-controllable slider', async ({ page }) => {
+    await seedPhotoProject(page, { durationMs: 3000 })
+    await page.getByRole('button', { name: 'Open editor' }).click()
+    await page.getByRole('button', { name: 'Set photo duration' }).click()
+    const strip = page.locator('.image-duration-strip')
+    const handle = strip.getByRole('slider', { name: 'Photo duration handle' })
+    await expect(handle).toHaveAttribute('aria-valuenow', '3')
+    await handle.focus()
+    await page.keyboard.press('ArrowRight')
+    await expect(strip).toContainText('3.1s on screen')
+    await page.keyboard.press('PageUp')
+    await expect(strip).toContainText('4.1s on screen')
+    await page.keyboard.press('Home')
+    await expect(strip).toContainText('0.5s on screen')
+    await page.keyboard.press('End')
+    await expect(strip).toContainText('30.0s on screen')
+  })
+
+  test('photo-first preview starts the music bed once the audio element binds', async ({
+    page,
+  }) => {
+    // Regression: startImage() used to call playMusic() before the <audio>
+    // ref existed, so a film that opens on a photo stayed silent.
+    await seedPhotoProject(page, { durationMs: 5000 })
+    await unlockPlus(page)
+    await page.getByRole('button', { name: 'Open editor' }).click()
+    await expect(page.locator('.editor-screen')).toBeVisible()
+
+    const chooserPromise = page.waitForEvent('filechooser')
+    await page.getByRole('button', { name: 'Add background music' }).click()
+    const chooser = await chooserPromise
+    await chooser.setFiles(makeWavFile('photo-bed.wav', 8))
+    await expect(page.locator('.audio-track-name').filter({ hasText: 'photo-bed.wav' })).toBeVisible(
+      { timeout: 15_000 },
+    )
+
+    await page.getByRole('button', { name: 'Play project preview' }).click()
+    const overlay = page.locator('.playback-overlay')
+    await expect(overlay).toBeVisible()
+    await expect(page.locator('.playback-image')).toBeVisible()
+    const music = overlay.locator('audio')
+    await expect(music).toHaveCount(1)
+    await expect
+      .poll(() => music.evaluate((el) => !(el as HTMLAudioElement).paused), { timeout: 10_000 })
+      .toBe(true)
+
+    await overlay.getByRole('button', { name: 'Stop preview' }).click()
+    await expect(overlay).toBeHidden()
   })
 
   test('project preview shows the photo for its duration, then finishes', async ({ page }) => {

--- a/tests/e2e/photo-clips.spec.ts
+++ b/tests/e2e/photo-clips.spec.ts
@@ -193,8 +193,12 @@ test.describe('photo clips on the timeline', () => {
   }) => {
     // Regression: startImage() used to call playMusic() before the <audio>
     // ref existed, so a film that opens on a photo stayed silent.
-    await seedPhotoProject(page, { durationMs: 5000 })
+    const projectId = await seedPhotoProject(page, { durationMs: 5000 })
+    // Unlock before re-entering the project so the editor renders the
+    // unlocked Add music control (not the Plus upsell button).
     await unlockPlus(page)
+    await page.goto(`/project/${projectId}`)
+    await waitForCameraReady(page)
     await page.getByRole('button', { name: 'Open editor' }).click()
     await expect(page.locator('.editor-screen')).toBeVisible()
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Picked images now land on the filmstrip timeline as still clips that preview, play, and export like any other clip.

- **Import**: the device picker accepts `image/*`; photos are decoded/probed via `createImageBitmap`, stored as `kind: 'image'` clips (default 3s), and are silent by construction (`audioPeak: 0` persisted, so the loader backfill never attempts an audio decode on image bytes).
- **Duration instead of Trim**: a still has no media length to trim within — its on-screen time is a free choice that can **grow as well as shrink**. Selecting a photo turns the Trim action into **Duration**, which opens a duration strip: one drag handle over a 0–30s scale, presets (1/2/3/5/10s), and ±0.5s steppers, with the exact readout (`N.Ns on screen`) always visible. Values snap to tenths; storage clamps to 0.5–30s and keeps the trim window pinned to `0..durationMs` so every existing trim consumer keeps working.
- **Editor**: photo tiles carry a camera badge and `Photo N` aria labels; the stage shows the still (no play affordance); photos get no clip-sound dial (the music-duck dial stays — ducking music under a photo is meaningful).
- **Project preview**: photo segments run on a wall-clock timer that drives the progress bar, the music bed position, Space pause/resume, and auto-advance; the persistent video element stays mounted but hidden.
- **Export**: the WebCodecs engine gets an image pump that decodes the still once and emits it on every 30fps output tick (hardware-speed, seamless concatenation with video segments); the realtime fallback paints it for its wall-clock duration; photo segments slice to silence without an audio-decode attempt; output-size probing reads the photo's stored dimensions.
- **Round-trips**: `.kodyvideo` backups carry `kind` + duration (with clamping on import); the clips ZIP keeps image extensions; duplicate/reorder/delete/undo work by construction.

## Why this UX

Trim implies shortening within recorded media. For a still there is no media length, so the same two-handle strip would be misleading and could never lengthen. The duration strip keeps the trim strip's visual language (same track, same handle) but makes the scale absolute (0–30s), and pairs the fast drag with presets and ±0.5s steppers so users can land **exactly** the on-screen time they want — the precise readout confirms it.

## Screenshots

![Photo tile on the timeline with camera badge and Duration action](https://cursor.com/artifacts/c/art-9f654108-7bbb-4b5e-bf0d-b4b85aae3c8b)
![Duration strip: drag handle on a 0–30s scale, presets, and half-second steppers](https://cursor.com/artifacts/c/art-38b5848d-36ea-402c-a688-4631a249884d)

## Testing

- `npm run lint` — clean
- `npm test` — 326 unit tests pass (new: photo import probing/MIME inference, `updateClipDuration` clamp + video guard, backup round-trip of `kind`/duration, photo export planning)
- `npm run test:e2e` — 84 tests pass (new `tests/e2e/photo-clips.spec.ts`: picker import lands a 3s still with badge; duration strip presets + steppers persist an exact 6.0s; drag handle lengthens to ~15s; project preview shows the photo then finishes; a photo + video project exports at the summed duration, verified by decoding the output)
- `npm run build` — clean

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c0d2bf1e-76ba-42bf-8e23-bcc00f61d15d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c0d2bf1e-76ba-42bf-8e23-bcc00f61d15d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Import photos from a device or gallery as silent 3-second timeline clips with thumbnails and camera badges.
  * Preview, play back, export, duplicate, reorder, and preserve photos in project backups.
  * Adjust photo duration from 0.5 to 30 seconds using presets, steppers, keyboard controls, or dragging.
  * Photos contribute their full configured duration to playback and exported projects.

* **Bug Fixes**
  * Improved photo thumbnail generation, audio handling, playback timing, and project transfer reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->