### PR TITLE
Survive iOS muted play() blocks during export (KODY-VIDEO-W)

### DIFF
--- a/scripts/manual-smoke.mjs
+++ b/scripts/manual-smoke.mjs
@@ -177,7 +177,8 @@ try {
   else fail('timeline filmstrip thumbnails render', 'no <img> frames found')
   await shot(page, '05-editor')
 
-  await page.getByRole('button', { name: /^trim$/i }).click()
+  // Accessible name is "Trim clip" (aria-label); visible label stays "Trim".
+  await page.getByRole('button', { name: /^trim(?: clip)?$/i }).click()
   const trimStrip = page.getByRole('group', { name: /trim clip/i })
   if (await trimStrip.count()) pass('in-timeline trim mode opens')
   else fail('in-timeline trim mode opens')

--- a/src/lib/export/encode-realtime.ts
+++ b/src/lib/export/encode-realtime.ts
@@ -30,6 +30,7 @@ import {
   pickOutputSize,
   recordVideoLumaSample,
   resolveEncodeCanvas,
+  playExportVideo,
   seekTo,
   tagExportError,
   wait,
@@ -546,9 +547,14 @@ async function paintSegment({
   const audioBuffer = audioContext && clipDestination ? await decodeClipAudio(blob) : null
 
   try {
-    video.muted = true
-    await video.play()
-    await waitForPlaybackStart(video, startSec)
+    // iOS Safari (esp. installed PWA + Low Power Mode) can reject muted
+    // play() once the export tap's user-activation has expired across the
+    // awaits before we get here (KODY-VIDEO-W). Scrub via currentTime so
+    // the MediaRecorder canvas path still paints wall-clock frames.
+    const playback = await playExportVideo(video)
+    if (playback === 'playing') {
+      await waitForPlaybackStart(video, startSec)
+    }
 
     const paintFrame = () => {
       drawCover(ctx, video, canvas.width, canvas.height)
@@ -589,6 +595,7 @@ async function paintSegment({
       }
     }
 
+    const wallStartedAt = performance.now()
     await new Promise<void>((resolve, reject) => {
       let raf = 0
       let lastFrameAt = performance.now()
@@ -603,19 +610,36 @@ async function paintSegment({
 
       const draw = () => {
         const now = performance.now()
-        const elapsed = Math.max(0, video.currentTime - startSec)
-        if (video.ended || video.currentTime >= endSec - 0.04 || elapsed >= segmentSec - 0.03) {
-          finish()
-          return
-        }
-        if (video.currentTime > lastVideoTime + 0.001) {
-          lastVideoTime = video.currentTime
-          lastFrameAt = now
-        } else if (now - lastFrameAt > 8000) {
-          cancelAnimationFrame(raf)
-          video.pause()
-          reject(new Error('Clip playback stalled during export'))
-          return
+        let elapsed: number
+        if (playback === 'playing') {
+          elapsed = Math.max(0, video.currentTime - startSec)
+          if (video.ended || video.currentTime >= endSec - 0.04 || elapsed >= segmentSec - 0.03) {
+            finish()
+            return
+          }
+          if (video.currentTime > lastVideoTime + 0.001) {
+            lastVideoTime = video.currentTime
+            lastFrameAt = now
+          } else if (now - lastFrameAt > 8000) {
+            cancelAnimationFrame(raf)
+            video.pause()
+            reject(new Error('Clip playback stalled during export'))
+            return
+          }
+        } else {
+          // Autoplay blocked: advance the element on the wall clock and
+          // paint whatever frame WebKit has decoded. Do not await seeked —
+          // MediaRecorder is wall-clock paced and must keep receiving
+          // canvas frames in realtime.
+          elapsed = (now - wallStartedAt) / 1000
+          if (elapsed >= segmentSec - 0.03) {
+            finish()
+            return
+          }
+          const target = Math.min(endSec - 0.001, startSec + elapsed)
+          if (Math.abs(video.currentTime - target) > 0.02) {
+            video.currentTime = target
+          }
         }
         paintFrame()
         if (frameCounter.count % PREVIEW_EVERY_N_FRAMES === 0) {

--- a/src/lib/export/encode-webcodecs.ts
+++ b/src/lib/export/encode-webcodecs.ts
@@ -48,6 +48,7 @@ import {
   drawWatermark,
   loadClipImage,
   loadClipVideo,
+  playExportVideo,
   tagExportError,
   pickOutputSize,
   noteEncodeCanvasKind,
@@ -859,8 +860,24 @@ async function pumpSegmentVideo({
   await emitAt(startSec, { force: true })
 
   const supportsRvfc = typeof video.requestVideoFrameCallback === 'function'
+  const playback = await playExportVideo(video)
 
-  await video.play()
+  // Autoplay blocked (iOS Low Power Mode / expired gesture): scrub by seek.
+  // This path is offline-paced, so awaiting seeked is fine and keeps frames
+  // timestamp-accurate (unlike the realtime MediaRecorder painter).
+  if (playback === 'blocked') {
+    for (
+      let tsSec = startSec + FRAME_INTERVAL_SEC;
+      tsSec < endSec - 1e-6;
+      tsSec += FRAME_INTERVAL_SEC
+    ) {
+      await seekTo(video, tsSec)
+      await emitAt(tsSec)
+      onElapsedMs((tsSec - startSec) * 1000)
+    }
+    video.pause()
+    return
+  }
 
   try {
     await new Promise<void>((resolve, reject) => {

--- a/src/lib/export/index.test.ts
+++ b/src/lib/export/index.test.ts
@@ -37,9 +37,17 @@ function clip(): ClipRecord {
 
 describe('exportProject fallback signaling', () => {
   beforeEach(() => {
-    vi.mocked(supportsWebCodecsExport).mockReturnValue(false)
+    // Prefer mockReset over mockClear: in Vitest browser mode, restoreAllMocks
+    // from another file can leave a fn without mockClear until it is re-armed.
+    vi.mocked(supportsWebCodecsExport).mockReset().mockReturnValue(false)
     vi.mocked(exportWithWebCodecs).mockReset()
-    vi.mocked(exportRealtime).mockClear()
+    vi.mocked(exportRealtime).mockReset().mockImplementation(async () => ({
+      blob: new Blob([new Uint8Array(2048)], { type: 'video/webm' }),
+      mimeType: 'video/webm',
+      fileExtension: 'webm' as const,
+      locationIncluded: false,
+      engine: 'realtime' as const,
+    }))
   })
 
   it('calls onFallback once when WebCodecs is unavailable', async () => {

--- a/src/lib/export/shared.test.ts
+++ b/src/lib/export/shared.test.ts
@@ -375,7 +375,7 @@ describe('export muted play helpers (KODY-VIDEO-W)', () => {
   })
 
   it('unlockExportMediaPlayback primes play/pause from a clip blob', async () => {
-    const blob = await makeTestClipBlob()
+    const blob = await makeTestClipBlob(200)
     const play = vi
       .spyOn(HTMLMediaElement.prototype, 'play')
       .mockResolvedValue(undefined)
@@ -393,7 +393,7 @@ describe('export muted play helpers (KODY-VIDEO-W)', () => {
     const play = vi.spyOn(HTMLMediaElement.prototype, 'play')
     unlockExportMediaPlayback(null)
     unlockExportMediaPlayback(undefined)
-    unlockExportMediaPlayback(new Blob())
+    unlockExportMediaPlayback(new Blob([]))
     expect(play).not.toHaveBeenCalled()
   })
 })

--- a/src/lib/export/shared.test.ts
+++ b/src/lib/export/shared.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import { makeTestClipBlob } from '../testing/make-test-clip'
 import {
   __isAudioDecodeFailureReportArmedForTests,
@@ -11,11 +11,15 @@ import {
   decodeBlobAudio,
   decodeBlobAudioViaWebAudio,
   decodeClipAudio,
+  isAutoplayBlockedError,
   isWebKitAudioDecoderNotFoundError,
   pickOutputSize,
+  playExportVideo,
+  prepareExportVideoElement,
   resampleAudioBuffer,
   resetAudioDiagnostics,
   resolveEncodeCanvas,
+  unlockExportMediaPlayback,
   waitForPreviewCanvas,
 } from './shared'
 
@@ -310,5 +314,86 @@ describe('waitForPreviewCanvas / resolveEncodeCanvas', () => {
     expect(resolved.kind).toBe('detached')
     expect(resolved.canvas.isConnected).toBe(false)
     resolved.release()
+  })
+})
+
+describe('export muted play helpers (KODY-VIDEO-W)', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('detects autoplay NotAllowedError and ignores unrelated failures', () => {
+    expect(
+      isAutoplayBlockedError(
+        new DOMException(
+          'The request is not allowed by the user agent or the platform in the current context, possibly because the user denied permission.',
+          'NotAllowedError',
+        ),
+      ),
+    ).toBe(true)
+    expect(isAutoplayBlockedError(new DOMException('Permission denied', 'NotAllowedError'))).toBe(
+      true,
+    )
+    expect(isAutoplayBlockedError(new DOMException('aborted', 'AbortError'))).toBe(false)
+    expect(isAutoplayBlockedError(new Error('NotAllowedError'))).toBe(false)
+  })
+
+  it('sets Safari-load-bearing muted / playsinline attributes', () => {
+    const video = document.createElement('video')
+    prepareExportVideoElement(video)
+    expect(video.muted).toBe(true)
+    expect(video.defaultMuted).toBe(true)
+    expect(video.playsInline).toBe(true)
+    expect(video.getAttribute('muted')).toBe('')
+    expect(video.getAttribute('playsinline')).toBe('true')
+    expect(video.getAttribute('webkit-playsinline')).toBe('true')
+  })
+
+  it('playExportVideo returns playing when play() resolves', async () => {
+    const video = document.createElement('video')
+    const play = vi.spyOn(video, 'play').mockResolvedValue(undefined)
+    await expect(playExportVideo(video)).resolves.toBe('playing')
+    expect(play).toHaveBeenCalledTimes(1)
+    expect(video.muted).toBe(true)
+  })
+
+  it('playExportVideo returns blocked on NotAllowedError instead of throwing', async () => {
+    const video = document.createElement('video')
+    vi.spyOn(video, 'play').mockRejectedValue(
+      new DOMException(
+        'The request is not allowed by the user agent or the platform in the current context, possibly because the user denied permission.',
+        'NotAllowedError',
+      ),
+    )
+    await expect(playExportVideo(video)).resolves.toBe('blocked')
+  })
+
+  it('playExportVideo rethrows non-autoplay failures', async () => {
+    const video = document.createElement('video')
+    vi.spyOn(video, 'play').mockRejectedValue(new DOMException('aborted', 'AbortError'))
+    await expect(playExportVideo(video)).rejects.toMatchObject({ name: 'AbortError' })
+  })
+
+  it('unlockExportMediaPlayback primes play/pause from a clip blob', async () => {
+    const blob = await makeTestClipBlob()
+    const play = vi
+      .spyOn(HTMLMediaElement.prototype, 'play')
+      .mockResolvedValue(undefined)
+    const pause = vi.spyOn(HTMLMediaElement.prototype, 'pause').mockImplementation(() => undefined)
+
+    unlockExportMediaPlayback(blob)
+    expect(play).toHaveBeenCalled()
+    // Flush the play().then(pause) microtask.
+    await Promise.resolve()
+    await Promise.resolve()
+    expect(pause).toHaveBeenCalled()
+  })
+
+  it('unlockExportMediaPlayback no-ops without a blob', () => {
+    const play = vi.spyOn(HTMLMediaElement.prototype, 'play')
+    unlockExportMediaPlayback(null)
+    unlockExportMediaPlayback(undefined)
+    unlockExportMediaPlayback(new Blob())
+    expect(play).not.toHaveBeenCalled()
   })
 })

--- a/src/lib/export/shared.test.ts
+++ b/src/lib/export/shared.test.ts
@@ -376,24 +376,32 @@ describe('export muted play helpers (KODY-VIDEO-W)', () => {
 
   it('unlockExportMediaPlayback primes play/pause from a clip blob', async () => {
     const blob = await makeTestClipBlob(200)
+    // Spy on the prototype only for this test — browser-mode files share a
+    // page, so leave nothing restored late for sibling suites.
     const play = vi
       .spyOn(HTMLMediaElement.prototype, 'play')
       .mockResolvedValue(undefined)
     const pause = vi.spyOn(HTMLMediaElement.prototype, 'pause').mockImplementation(() => undefined)
-
-    unlockExportMediaPlayback(blob)
-    expect(play).toHaveBeenCalled()
-    // Flush the play().then(pause) microtask.
-    await Promise.resolve()
-    await Promise.resolve()
-    expect(pause).toHaveBeenCalled()
+    try {
+      unlockExportMediaPlayback(blob)
+      expect(play).toHaveBeenCalled()
+      // Flush the play().then(pause) microtask.
+      await Promise.resolve()
+      await Promise.resolve()
+      expect(pause).toHaveBeenCalled()
+    } finally {
+      play.mockRestore()
+      pause.mockRestore()
+    }
   })
 
   it('unlockExportMediaPlayback no-ops without a blob', () => {
-    const play = vi.spyOn(HTMLMediaElement.prototype, 'play')
+    const create = vi.spyOn(document, 'createElement')
     unlockExportMediaPlayback(null)
     unlockExportMediaPlayback(undefined)
     unlockExportMediaPlayback(new Blob([]))
-    expect(play).not.toHaveBeenCalled()
+    // No media element is created when there is nothing to prime.
+    expect(create).not.toHaveBeenCalled()
+    create.mockRestore()
   })
 })

--- a/src/lib/export/shared.ts
+++ b/src/lib/export/shared.ts
@@ -88,9 +88,7 @@ async function loadClipVideoOnce(blob: Blob, timeoutMs: number): Promise<LoadedC
   const url = URL.createObjectURL(blob)
   const video = document.createElement('video')
   video.preload = 'auto'
-  video.muted = true
-  video.playsInline = true
-  video.setAttribute('playsinline', 'true')
+  prepareExportVideoElement(video)
 
   const release = () => {
     try {
@@ -211,6 +209,87 @@ export async function seekTo(video: HTMLVideoElement, sec: number, timeoutMs = 2
   const seeked = waitForMediaEvent(video, 'seeked', timeoutMs).catch(() => undefined)
   video.currentTime = sec
   await seeked
+}
+
+/**
+ * Autoplay-policy / Low Power Mode rejection from HTMLMediaElement.play().
+ * Same DOMException name as getUserMedia permission denial — callers must
+ * only use this on a play() rejection, never on a camera error.
+ */
+export function isAutoplayBlockedError(error: unknown): boolean {
+  return error instanceof DOMException && error.name === 'NotAllowedError'
+}
+
+/**
+ * Safari/iOS treats the muted *attribute* and playsinline flag as load-bearing
+ * for muted autoplay; the JS properties alone are not always enough.
+ */
+export function prepareExportVideoElement(video: HTMLVideoElement): void {
+  video.muted = true
+  video.defaultMuted = true
+  video.playsInline = true
+  video.setAttribute('muted', '')
+  video.setAttribute('playsinline', 'true')
+  video.setAttribute('webkit-playsinline', 'true')
+}
+
+/**
+ * Start muted playback for an export painter. Returns `blocked` when the
+ * user agent refuses play() (iOS Low Power Mode / expired user activation)
+ * so callers can scrub frames via seek instead of failing the export
+ * (KODY-VIDEO-W).
+ */
+export async function playExportVideo(
+  video: HTMLVideoElement,
+): Promise<'playing' | 'blocked'> {
+  prepareExportVideoElement(video)
+  try {
+    await video.play()
+    return 'playing'
+  } catch (error) {
+    if (isAutoplayBlockedError(error)) return 'blocked'
+    throw error
+  }
+}
+
+/**
+ * Soften iOS autoplay / Low Power Mode blocks for later muted export plays.
+ * Must run from the export tap (same reason we unlock AudioContext): play
+ * then pause a muted element while the gesture token is still alive so
+ * subsequent detached muted play() calls are more likely to succeed after
+ * the many awaits that precede paintSegment.
+ */
+export function unlockExportMediaPlayback(sourceBlob?: Blob | null): void {
+  if (typeof document === 'undefined') return
+  if (!sourceBlob || sourceBlob.size <= 0) return
+
+  const video = document.createElement('video')
+  prepareExportVideoElement(video)
+  const objectUrl = URL.createObjectURL(sourceBlob)
+  const release = () => {
+    try {
+      video.pause()
+    } catch {
+      // already released
+    }
+    video.removeAttribute('src')
+    video.load()
+    URL.revokeObjectURL(objectUrl)
+  }
+
+  video.preload = 'auto'
+  video.src = objectUrl
+  // load() during the gesture helps WebKit accept a delayed play() later.
+  video.load()
+  void video
+    .play()
+    .then(() => {
+      video.pause()
+      release()
+    })
+    .catch(() => {
+      release()
+    })
 }
 
 /** Draw the video into the canvas with cover fit (center crop, no bars). */

--- a/src/pages/project-page.tsx
+++ b/src/pages/project-page.tsx
@@ -15,7 +15,7 @@ import { clearExportMarker, markExportStarted, reportError } from '../lib/error-
 import { exportProject, type ExportResult } from '../lib/export'
 import { exportSignature, loadMatchingExport, persistLastExport } from '../lib/export/last-export'
 import { MediaElementFailureError } from '../lib/export/media-error'
-import { wait } from '../lib/export/shared'
+import { unlockExportMediaPlayback, wait } from '../lib/export/shared'
 import {
   canShareFile,
   downloadBlob,
@@ -37,6 +37,7 @@ import { formatBytes, requestPersistentStorage } from '../lib/storage-space'
 import { navigate } from '../router'
 import {
   NEW_PROJECT_ID,
+  isImageClip,
   projectOrientation,
   type ProjectId,
   type ProjectOrientation,
@@ -322,6 +323,12 @@ export function ProjectPage(handle: Handle<ProjectPageProps>) {
     } catch {
       audioContext = undefined
     }
+
+    // Same gesture window: prime muted video playback so iOS (Low Power Mode
+    // / installed PWA) is less likely to reject later detached play() calls
+    // once activation has expired across the export awaits (KODY-VIDEO-W).
+    const unlockClip = clips.find((clip) => !isImageClip(clip))
+    unlockExportMediaPlayback(unlockClip?.blob)
 
     const watermarked = shouldWatermarkExports(data)
     const hasLocation = clips.some(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes [KODY-VIDEO-W](https://kent-c-dodds-tech-llc.sentry.io/issues/7664543941/): on Safari iOS (installed PWA), realtime export failed in `paintSegment` when muted `video.play()` threw `NotAllowedError` after the export tap’s user activation expired (Low Power Mode / delayed play).

## Changes

- Prime muted video playback from the export tap (alongside the existing AudioContext unlock).
- Shared `playExportVideo` helper: ensure Safari muted/playsinline attributes, return `blocked` on autoplay `NotAllowedError` instead of failing the export.
- Realtime painter: wall-clock seek-scrub when play is blocked (MediaRecorder stays realtime-paced; clip audio already comes from Web Audio).
- WebCodecs element-pump fallback: seek frame-by-frame when play is blocked.
- Unit tests for the autoplay helpers.
- Smoke: match the editor’s `Trim clip` accessible name (pre-existing mismatch after photo-duration work).

## Risk

**Low** — isolated export path hardening with tests; no auth/billing/storage surface.

## Sentry

- Issue: KODY-VIDEO-W / `7664543941`
- No sibling unresolved `NotAllowedError` issues

## Test plan

- [x] `npm run build`
- [x] `npx vitest run`
- [x] `node scripts/manual-smoke.mjs`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-36a178e0-fc96-42a4-935c-507b200c0193?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-36a178e0-fc96-42a4-935c-507b200c0193&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved video export reliability when browser autoplay is blocked.
  * Added frame-by-frame fallback processing so exports can continue without normal playback.
  * Improved export playback setup and readiness for supported video clips.
  * Preserved error handling for unrelated playback failures.
* **Tests**
  * Expanded coverage for blocked playback, autoplay detection, browser compatibility, cleanup, and playback unlocking.
* **Chores**
  * Updated smoke-test coverage to recognize both “Trim clip” and “Trim” labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->