### PR TITLE
Stop export to change mark/location; insert and follow clips on the timeline

### DIFF
--- a/src/components/editor-screen.tsx
+++ b/src/components/editor-screen.tsx
@@ -133,7 +133,9 @@ export function EditorScreen(handle: Handle<EditorScreenProps>) {
         trimming = false
         if (result.added.length > 0) {
           await props.refresh()
-          optimisticAdds = []
+          optimisticAdds = optimisticAdds.filter(
+            (extra) => !props.clips.some((clip) => clip.id === extra.clip.id),
+          )
         }
         if (result.added.length === 0 && result.failed.length > 0) {
           props.showToast(result.failed[0]?.reason || 'Could not add that clip')

--- a/src/components/editor-screen.tsx
+++ b/src/components/editor-screen.tsx
@@ -74,8 +74,25 @@ export function EditorScreen(handle: Handle<EditorScreenProps>) {
    * counterpart of `trimming`. */
   let editingTrackId: string | null = null
   let importing = false
+  /** Clips persisted but not yet in props.clips (refresh still in flight). */
+  let optimisticAdds: { clip: ClipRecord; afterId: ClipId | null }[] = []
+  let pendingGhostCount = 0
+  let ghostAfterId: ClipId | null = null
   const fileInputRef: { current: HTMLInputElement | null } = { current: null }
   const previewApi: { current: EditorClipPreviewHandle | null } = { current: null }
+
+  const visibleClips = (loaded: ClipRecord[]): ClipRecord[] => {
+    let next = loaded
+    for (const extra of optimisticAdds) {
+      if (next.some((clip) => clip.id === extra.clip.id)) continue
+      const index = extra.afterId ? next.findIndex((clip) => clip.id === extra.afterId) : -1
+      next =
+        index >= 0
+          ? [...next.slice(0, index + 1), extra.clip, ...next.slice(index + 1)]
+          : [...next, extra.clip]
+    }
+    return next
+  }
 
   const openDevicePicker = () => {
     if (importing || props.interactionLocked) return
@@ -85,6 +102,10 @@ export function EditorScreen(handle: Handle<EditorScreenProps>) {
   const importFromDevice = (files: File[]) => {
     if (files.length === 0 || importing) return
     importing = true
+    const afterId = resolveSelectedId()
+    ghostAfterId = afterId
+    pendingGhostCount = files.length
+    optimisticAdds = []
     void handle.update()
     void (async () => {
       try {
@@ -92,6 +113,15 @@ export function EditorScreen(handle: Handle<EditorScreenProps>) {
         // — a bad pick on /project/new must not create an empty project.
         const result = await importDeviceClips(files, {
           ensureProjectId: props.ensureProjectId,
+          afterClipId: afterId,
+          onAdded: (clip) => {
+            optimisticAdds = [...optimisticAdds, { clip, afterId: ghostAfterId }]
+            ghostAfterId = clip.id
+            pendingGhostCount = Math.max(0, pendingGhostCount - 1)
+            selectedClipId = clip.id
+            trimming = false
+            void handle.update()
+          },
           onProgress: (done, total) => {
             if (total > 1) {
               props.showToast(`Adding clip ${Math.min(done + 1, total)} of ${total}…`)
@@ -118,16 +148,19 @@ export function EditorScreen(handle: Handle<EditorScreenProps>) {
         props.showToast(err instanceof Error ? err.message : 'Could not add clips')
       } finally {
         importing = false
+        pendingGhostCount = 0
         void handle.update()
       }
     })()
   }
 
-  // Derive a valid selection from the loaded clips (no state syncing).
-  const resolveSelectedId = (): ClipId | null =>
-    selectedClipId && props.clips.some((c) => c.id === selectedClipId)
+  // Derive a valid selection from the visible clips (loaded + optimistic).
+  const resolveSelectedId = (clips?: ClipRecord[]): ClipId | null => {
+    const list = clips ?? visibleClips(props.clips)
+    return selectedClipId && list.some((c) => c.id === selectedClipId)
       ? selectedClipId
-      : (props.clips.at(-1)?.id ?? null)
+      : (list.at(-1)?.id ?? null)
+  }
 
   const setSelectedClipId = (id: ClipId | null) => {
     selectedClipId = id
@@ -291,9 +324,14 @@ export function EditorScreen(handle: Handle<EditorScreenProps>) {
   }
 
   return () => {
-    const { project, clips, canUndo, onOpenCamera, onOpenExport, onPlay } = props
+    const { project, canUndo, onOpenCamera, onOpenExport, onPlay } = props
+    const loadedIds = new Set(props.clips.map((clip) => clip.id))
+    if (optimisticAdds.some((extra) => loadedIds.has(extra.clip.id))) {
+      optimisticAdds = optimisticAdds.filter((extra) => !loadedIds.has(extra.clip.id))
+    }
+    const clips = visibleClips(props.clips)
     const totalDurationMs = clips.reduce((sum, clip) => sum + effectiveDurationMs(clip), 0)
-    const resolvedSelectedId = resolveSelectedId()
+    const resolvedSelectedId = resolveSelectedId(clips)
     const selected = clips.find((c) => c.id === resolvedSelectedId) ?? null
     const selectedIndex = selected ? clips.findIndex((c) => c.id === selected.id) : -1
     // Derive the edited track from the loaded audio (no state syncing) —
@@ -443,6 +481,8 @@ export function EditorScreen(handle: Handle<EditorScreenProps>) {
               }}
               onAddFromDevice={openDevicePicker}
               addingFromDevice={importing}
+              pendingGhostCount={pendingGhostCount}
+              pendingGhostAfterId={ghostAfterId}
               showAudioBadges={props.audio !== null}
               refresh={props.refresh}
             />

--- a/src/components/editor-screen.tsx
+++ b/src/components/editor-screen.tsx
@@ -63,7 +63,7 @@ interface EditorScreenProps {
   onOpenExport: () => void
   onPlay: () => void
   showToast: (message: string, action?: ToastAction) => void
-  refresh: () => void
+  refresh: () => void | Promise<void>
 }
 
 export function EditorScreen(handle: Handle<EditorScreenProps>) {
@@ -131,7 +131,10 @@ export function EditorScreen(handle: Handle<EditorScreenProps>) {
         const last = result.added.at(-1)
         if (last) selectedClipId = last.id
         trimming = false
-        if (result.added.length > 0) props.refresh()
+        if (result.added.length > 0) {
+          await props.refresh()
+          optimisticAdds = []
+        }
         if (result.added.length === 0 && result.failed.length > 0) {
           props.showToast(result.failed[0]?.reason || 'Could not add that clip')
         } else if (result.failed.length > 0) {

--- a/src/components/export-overlay.tsx
+++ b/src/components/export-overlay.tsx
@@ -10,13 +10,23 @@ interface ExportOverlayProps {
    * preview matches the final video.
    */
   watermarked: boolean
+  /** True when this run will write captured coordinates into the MP4. */
+  locationIncluded: boolean
   /**
    * True once this run entered the realtime canvas + MediaRecorder path.
    * Shows a dismissible compatibility notice (session-only; resets next export).
    */
   usedFallback: boolean
+  /** Plus unlocked — mark/location prefs can change mid-export. */
+  purchased: boolean
+  keepWatermark: boolean
+  includeLocation: boolean
+  hasTaggedClips: boolean
   /** Bound to the canvas the export engines mirror sampled frames onto. */
   bindPreviewCanvas: (canvas: HTMLCanvasElement | null) => void
+  onStop: () => void
+  onKeepWatermarkChange: (keep: boolean) => void
+  onIncludeLocationChange: (include: boolean) => void
 }
 
 /**
@@ -28,11 +38,44 @@ export function ExportOverlay(handle: Handle<ExportOverlayProps>) {
   let fallbackNoticeDismissed = false
 
   return () => {
-    const { projectName, progress, watermarked, usedFallback } = handle.props
+    const {
+      projectName,
+      progress,
+      watermarked,
+      locationIncluded,
+      usedFallback,
+      purchased,
+      keepWatermark,
+      includeLocation,
+      hasTaggedClips,
+      onStop,
+      onKeepWatermarkChange,
+      onIncludeLocationChange,
+    } = handle.props
     const percent = Math.round(progress * 100)
     const showFallbackNotice = usedFallback && !fallbackNoticeDismissed
+    const statusBits = [
+      watermarked ? 'includes the Kody mark' : null,
+      locationIncluded ? 'includes clip locations' : null,
+    ].filter((bit): bit is string => bit !== null)
     return (
-      <div className="export-overlay" role="dialog" aria-label="Exporting video">
+      <div
+        className="export-overlay"
+        role="dialog"
+        aria-label="Exporting video"
+        mix={ref((_node, signal) => {
+          const onKey = (event: KeyboardEvent) => {
+            if (event.code === 'Escape') {
+              event.preventDefault()
+              handle.props.onStop()
+            }
+          }
+          window.addEventListener('keydown', onKey)
+          signal.addEventListener('abort', () => {
+            window.removeEventListener('keydown', onKey)
+          })
+        })}
+      >
         <div className="export-overlay-stage">
           <canvas
             className="export-preview-canvas"
@@ -65,7 +108,7 @@ export function ExportOverlay(handle: Handle<ExportOverlayProps>) {
           <h2>Exporting your video…</h2>
           <p className="muted">
             {projectName} — keep the app open
-            {watermarked ? ' · includes the Kody mark' : ''}
+            {statusBits.length > 0 ? ` · ${statusBits.join(' · ')}` : ''}
           </p>
           <div className="progress-bar" aria-label="Export progress">
             <span style={{ width: `${percent}%` }} />
@@ -73,6 +116,47 @@ export function ExportOverlay(handle: Handle<ExportOverlayProps>) {
           <p className="export-percent" aria-live="polite">
             {percent}%
           </p>
+          {purchased ? (
+            <div className="export-overlay-prefs">
+              <label className="export-pref-toggle">
+                <input
+                  type="checkbox"
+                  checked={keepWatermark}
+                  mix={on('change', (event) => {
+                    onKeepWatermarkChange((event.currentTarget as HTMLInputElement).checked)
+                  })}
+                />
+                Keep the Kody mark on exports
+              </label>
+              <label className="export-pref-toggle">
+                <input
+                  type="checkbox"
+                  checked={includeLocation}
+                  mix={on('change', (event) => {
+                    onIncludeLocationChange((event.currentTarget as HTMLInputElement).checked)
+                  })}
+                />
+                Include clip locations in MP4 exports
+              </label>
+              {hasTaggedClips ? (
+                <p className="export-overlay-pref-hint muted">
+                  Changing a setting stops this export and starts a new one.
+                </p>
+              ) : (
+                <p className="export-overlay-pref-hint muted">
+                  Changing the mark setting stops this export and starts a new one.
+                </p>
+              )}
+            </div>
+          ) : null}
+          <button
+            type="button"
+            className="btn btn-secondary export-overlay-stop"
+            aria-label="Stop export"
+            mix={on('click', () => onStop())}
+          >
+            Stop
+          </button>
         </div>
       </div>
     )

--- a/src/components/timeline.tsx
+++ b/src/components/timeline.tsx
@@ -77,10 +77,23 @@ export function Timeline(handle: Handle<TimelineProps>) {
    * already positions the strip) and follow later moves/selection changes. */
   let followKey: string | null = null
 
+  const scrollSelectedIntoView = (clipId: ClipId) => {
+    const track = trackEl
+    const el = tileRefs.get(clipId)
+    if (!track || !el) return
+    const tile = el.getBoundingClientRect()
+    const strip = track.getBoundingClientRect()
+    const pad = 12
+    if (tile.left < strip.left + pad) {
+      track.scrollLeft += tile.left - strip.left - pad
+    } else if (tile.right > strip.right - pad) {
+      track.scrollLeft += tile.right - strip.right + pad
+    }
+  }
+
   const selectClip = (id: ClipId) => {
     props.onSelect(id)
-    const el = tileRefs.get(id)
-    el?.scrollIntoView({ behavior: 'smooth', inline: 'nearest', block: 'nearest' })
+    scrollSelectedIntoView(id)
   }
 
   /**
@@ -295,12 +308,9 @@ export function Timeline(handle: Handle<TimelineProps>) {
     const isFirst = followKey === null
     followKey = key
     if (isFirst) return
-    queueMicrotask(() => {
-      tileRefs.get(clipId)?.scrollIntoView({
-        behavior: 'smooth',
-        inline: 'nearest',
-        block: 'nearest',
-      })
+    // After a reorder the tiles have not been laid out yet — wait for paint.
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => scrollSelectedIntoView(clipId))
     })
   }
 

--- a/src/components/timeline.tsx
+++ b/src/components/timeline.tsx
@@ -36,6 +36,9 @@ interface TimelineProps {
   /** Open the device file picker to append gallery videos. */
   onAddFromDevice?: () => void
   addingFromDevice?: boolean
+  /** Placeholder tiles for files still probing (shown after this clip). */
+  pendingGhostCount?: number
+  pendingGhostAfterId?: ClipId | null
   /** Show per-clip music-volume badges (project has a background track). */
   showAudioBadges?: boolean
   refresh: () => void
@@ -70,6 +73,9 @@ export function Timeline(handle: Handle<TimelineProps>) {
   const tileRefs = new Map<ClipId, HTMLButtonElement>()
   let flingRaf = 0
   let drag: DragState | null = null
+  /** Last selected id+index we scrolled to — skip the first paint (bindTrack
+   * already positions the strip) and follow later moves/selection changes. */
+  let followKey: string | null = null
 
   const selectClip = (id: ClipId) => {
     props.onSelect(id)
@@ -282,10 +288,60 @@ export function Timeline(handle: Handle<TimelineProps>) {
     void reorderClips(props.projectId, nextIds).then(() => props.refresh())
   }
 
-  return () => {
-    const { clips, selectedClipId, onAddFromDevice, addingFromDevice } = props
+  const followSelected = (clipId: ClipId | null, index: number) => {
+    if (!clipId || index < 0) return
+    const key = `${clipId}:${index}`
+    if (key === followKey) return
+    const isFirst = followKey === null
+    followKey = key
+    if (isFirst) return
+    queueMicrotask(() => {
+      tileRefs.get(clipId)?.scrollIntoView({
+        behavior: 'smooth',
+        inline: 'nearest',
+        block: 'nearest',
+      })
+    })
+  }
 
-    if (clips.length === 0) {
+  const ghostTile = (ghostIndex: number) => (
+    <div
+      key={`ghost-${ghostIndex}`}
+      className="clip-thumb is-ghost"
+      style={{ width: `${MIN_TILE_WIDTH}px` }}
+      aria-hidden="true"
+    >
+      <div className="clip-filmstrip">
+        <div className="clip-filmstrip-placeholder" />
+      </div>
+    </div>
+  )
+
+  const renderGhostSlots = (count: number) =>
+    Array.from({ length: count }, (_, ghostIndex) => (
+      <div key={`ghost-slot-${ghostIndex}`} className="timeline-slot">
+        {ghostTile(ghostIndex)}
+      </div>
+    ))
+
+  return () => {
+    const {
+      clips,
+      selectedClipId,
+      onAddFromDevice,
+      addingFromDevice,
+      pendingGhostCount = 0,
+      pendingGhostAfterId = null,
+    } = props
+    const selectedIndex = selectedClipId
+      ? clips.findIndex((clip) => clip.id === selectedClipId)
+      : -1
+    followSelected(selectedClipId, selectedIndex)
+    const ghostAfterIndex = pendingGhostAfterId
+      ? clips.findIndex((clip) => clip.id === pendingGhostAfterId)
+      : -1
+
+    if (clips.length === 0 && pendingGhostCount === 0) {
       return (
         <div key="timeline-empty" className="timeline" aria-label="Timeline empty">
           {onAddFromDevice ? (
@@ -331,8 +387,12 @@ export function Timeline(handle: Handle<TimelineProps>) {
           const isDragging = draggingId === clip.id
           const showDropBefore = draggingId !== null && gapIndex === index
           const isPhoto = isImageClip(clip)
+          const showGhostsAfter =
+            pendingGhostCount > 0 &&
+            draggingId === null &&
+            ghostAfterIndex === index
 
-          return (
+          const tile = (
             <div key={clip.id} className="timeline-slot">
               {showDropBefore ? <div className="timeline-drop-indicator" aria-hidden /> : null}
               <button
@@ -408,7 +468,11 @@ export function Timeline(handle: Handle<TimelineProps>) {
               </button>
             </div>
           )
+          return showGhostsAfter ? [tile, ...renderGhostSlots(pendingGhostCount)] : tile
         })}
+        {pendingGhostCount > 0 && draggingId === null && ghostAfterIndex < 0
+          ? renderGhostSlots(pendingGhostCount)
+          : null}
         {draggingId !== null && gapIndex === clips.length ? (
           <div className="timeline-drop-indicator timeline-drop-trailing" aria-hidden />
         ) : null}

--- a/src/lib/export/cancelled.test.ts
+++ b/src/lib/export/cancelled.test.ts
@@ -22,8 +22,18 @@ describe('export cancellation', () => {
     expect(() => decodedPumpFailure(new Error('stalled'), 2)).toThrow(/stalled/)
   })
 
-  it('recognizes AbortError as a cancel', () => {
-    expect(isExportCancelled(new DOMException('aborted', 'AbortError'))).toBe(true)
+  it('treats a decoder AbortError as a cancel only when the export signal aborted', () => {
+    const controller = new AbortController()
+    expect(decodedPumpFailure(new DOMException('aborted', 'AbortError'), 0)).toBe('unsupported')
+    controller.abort()
+    expect(() =>
+      decodedPumpFailure(new DOMException('aborted', 'AbortError'), 0, controller.signal),
+    ).toThrow(ExportCancelledError)
+  })
+
+  it('does not treat a generic AbortError as a user cancel', () => {
+    expect(isExportCancelled(new DOMException('aborted', 'AbortError'))).toBe(false)
+    expect(isExportCancelled(new ExportCancelledError())).toBe(true)
     expect(isExportCancelled(new Error('nope'))).toBe(false)
   })
 })

--- a/src/lib/export/cancelled.test.ts
+++ b/src/lib/export/cancelled.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest'
+import {
+  ExportCancelledError,
+  decodedPumpFailure,
+  isExportCancelled,
+  throwIfExportAborted,
+} from './cancelled'
+
+describe('export cancellation', () => {
+  it('throwIfExportAborted only throws when the signal is aborted', () => {
+    const live = new AbortController()
+    expect(() => throwIfExportAborted(live.signal)).not.toThrow()
+    expect(() => throwIfExportAborted(undefined)).not.toThrow()
+    live.abort()
+    expect(() => throwIfExportAborted(live.signal)).toThrow(ExportCancelledError)
+  })
+
+  it('does not treat a pre-first-frame cancel as an unsupported codec', () => {
+    expect(() => decodedPumpFailure(new ExportCancelledError(), 0)).toThrow(ExportCancelledError)
+    expect(() => decodedPumpFailure(new ExportCancelledError(), 4)).toThrow(ExportCancelledError)
+    expect(decodedPumpFailure(new Error('no track'), 0)).toBe('unsupported')
+    expect(() => decodedPumpFailure(new Error('stalled'), 2)).toThrow(/stalled/)
+  })
+
+  it('recognizes AbortError as a cancel', () => {
+    expect(isExportCancelled(new DOMException('aborted', 'AbortError'))).toBe(true)
+    expect(isExportCancelled(new Error('nope'))).toBe(false)
+  })
+})

--- a/src/lib/export/cancelled.ts
+++ b/src/lib/export/cancelled.ts
@@ -1,0 +1,17 @@
+/** Thrown when the user stops an in-flight export (mark/location change or Stop). */
+export class ExportCancelledError extends Error {
+  constructor() {
+    super('Export cancelled')
+    this.name = 'ExportCancelledError'
+  }
+}
+
+export function isExportCancelled(error: unknown): boolean {
+  if (error instanceof ExportCancelledError) return true
+  if (error instanceof DOMException && error.name === 'AbortError') return true
+  return error instanceof Error && error.name === 'ExportCancelledError'
+}
+
+export function throwIfExportAborted(signal?: AbortSignal): void {
+  if (signal?.aborted) throw new ExportCancelledError()
+}

--- a/src/lib/export/cancelled.ts
+++ b/src/lib/export/cancelled.ts
@@ -15,3 +15,20 @@ export function isExportCancelled(error: unknown): boolean {
 export function throwIfExportAborted(signal?: AbortSignal): void {
   if (signal?.aborted) throw new ExportCancelledError()
 }
+
+/**
+ * Decode-pump catch policy: a cancel before the first frame must not look
+ * like "unsupported codec" (that would start the realtime fallback).
+ */
+export function decodedPumpFailure(
+  error: unknown,
+  framesEmitted: number,
+): 'unsupported' {
+  if (isExportCancelled(error)) {
+    throw error instanceof ExportCancelledError ? error : new ExportCancelledError()
+  }
+  if (framesEmitted > 0) {
+    throw error instanceof Error ? error : new Error('Decoded video pump failed')
+  }
+  return 'unsupported'
+}

--- a/src/lib/export/cancelled.ts
+++ b/src/lib/export/cancelled.ts
@@ -7,9 +7,10 @@ export class ExportCancelledError extends Error {
 }
 
 export function isExportCancelled(error: unknown): boolean {
-  if (error instanceof ExportCancelledError) return true
-  if (error instanceof DOMException && error.name === 'AbortError') return true
-  return error instanceof Error && error.name === 'ExportCancelledError'
+  return (
+    error instanceof ExportCancelledError ||
+    (error instanceof Error && error.name === 'ExportCancelledError')
+  )
 }
 
 export function throwIfExportAborted(signal?: AbortSignal): void {
@@ -23,8 +24,9 @@ export function throwIfExportAborted(signal?: AbortSignal): void {
 export function decodedPumpFailure(
   error: unknown,
   framesEmitted: number,
+  signal?: AbortSignal,
 ): 'unsupported' {
-  if (isExportCancelled(error)) {
+  if (isExportCancelled(error) || signal?.aborted) {
     throw error instanceof ExportCancelledError ? error : new ExportCancelledError()
   }
   if (framesEmitted > 0) {

--- a/src/lib/export/encode-realtime.ts
+++ b/src/lib/export/encode-realtime.ts
@@ -36,6 +36,7 @@ import {
   wait,
   type ExportResult,
 } from './shared'
+import { ExportCancelledError, throwIfExportAborted } from './cancelled'
 
 export interface RealtimeExportOptions {
   /**
@@ -53,6 +54,8 @@ export interface RealtimeExportOptions {
   /** Force the output into the project's orientation (absent = follow the
    * first clip). */
   orientation?: ProjectOrientation
+  /** Stop the stitcher as soon as the user cancels (Stop or a pref change). */
+  signal?: AbortSignal
 }
 
 /**
@@ -289,6 +292,7 @@ export async function exportRealtime(
   const frameCounter = { count: 0 }
   try {
     for (const [segmentIndex, segment] of plan.segments.entries()) {
+      throwIfExportAborted(options.signal)
       const isImage = isImageClip(segment.clip)
       let loaded: Awaited<ReturnType<typeof loadClipVideo>> | null = null
       if (!isImage) {
@@ -360,7 +364,9 @@ export async function exportRealtime(
           // No mirroring needed when the encode canvas is the preview.
           getPreviewCanvas: encodingIntoPreview ? undefined : options.getPreviewCanvas,
           watermarkImage: options.watermarkImage ?? null,
+          signal: options.signal,
           onElapsedMs: (elapsed: number) => {
+            throwIfExportAborted(options.signal)
             if (plan.totalMs > 0) {
               options.onProgress?.(Math.min(1, (paintedTotalMs + elapsed) / plan.totalMs))
             }
@@ -417,6 +423,7 @@ export async function exportRealtime(
     }
   }
 
+  throwIfExportAborted(options.signal)
   const blob = await stopped
   if (blob.size < 8_000) {
     throw new Error('Export produced an unusable file')
@@ -442,6 +449,7 @@ interface PaintSharedArgs {
   frameCounter: { count: number }
   getPreviewCanvas?: () => HTMLCanvasElement | null
   watermarkImage: HTMLImageElement | null
+  signal?: AbortSignal
   onElapsedMs: (elapsedMs: number) => void
 }
 
@@ -478,6 +486,7 @@ async function paintImageSegment({
   frameCounter,
   getPreviewCanvas,
   watermarkImage,
+  signal,
   onElapsedMs,
 }: PaintImageSegmentArgs): Promise<number> {
   const segmentSec = endSec - startSec
@@ -496,6 +505,11 @@ async function paintImageSegment({
     await new Promise<void>((resolve) => {
       let raf = 0
       const draw = () => {
+        if (signal?.aborted) {
+          cancelAnimationFrame(raf)
+          resolve()
+          return
+        }
         const elapsedSec = (performance.now() - startedAt) / 1000
         paintFrame()
         if (elapsedSec >= segmentSec - 0.03) {
@@ -535,6 +549,7 @@ async function paintSegment({
   frameCounter,
   getPreviewCanvas,
   watermarkImage,
+  signal,
   onElapsedMs,
 }: PaintSegmentArgs): Promise<number> {
   const segmentSec = endSec - startSec
@@ -609,6 +624,12 @@ async function paintSegment({
       }
 
       const draw = () => {
+        if (signal?.aborted) {
+          cancelAnimationFrame(raf)
+          video.pause()
+          reject(new ExportCancelledError())
+          return
+        }
         const now = performance.now()
         let elapsed: number
         if (playback === 'playing') {

--- a/src/lib/export/encode-realtime.ts
+++ b/src/lib/export/encode-realtime.ts
@@ -366,7 +366,6 @@ export async function exportRealtime(
           watermarkImage: options.watermarkImage ?? null,
           signal: options.signal,
           onElapsedMs: (elapsed: number) => {
-            throwIfExportAborted(options.signal)
             if (plan.totalMs > 0) {
               options.onProgress?.(Math.min(1, (paintedTotalMs + elapsed) / plan.totalMs))
             }
@@ -502,12 +501,12 @@ async function paintImageSegment({
     }
     paintFrame()
     const startedAt = performance.now()
-    await new Promise<void>((resolve) => {
+    await new Promise<void>((resolve, reject) => {
       let raf = 0
       const draw = () => {
         if (signal?.aborted) {
           cancelAnimationFrame(raf)
-          resolve()
+          reject(new ExportCancelledError())
           return
         }
         const elapsedSec = (performance.now() - startedAt) / 1000

--- a/src/lib/export/encode-webcodecs.ts
+++ b/src/lib/export/encode-webcodecs.ts
@@ -784,7 +784,7 @@ async function pumpSegmentVideoDecoded(
       onElapsedMs((Math.min(wrapped.timestamp, endSec) - startSec) * 1000)
     }
   } catch (err) {
-    return decodedPumpFailure(err, framesEmitted)
+    return decodedPumpFailure(err, framesEmitted, args.signal)
   }
 
   if (framesEmitted === 0) return 'unsupported'

--- a/src/lib/export/encode-webcodecs.ts
+++ b/src/lib/export/encode-webcodecs.ts
@@ -62,6 +62,7 @@ import {
   formatChapterTitle,
   locationForExport,
 } from './mp4-export-metadata'
+import { throwIfExportAborted } from './cancelled'
 
 const FPS = 30
 const AUDIO_SAMPLE_RATE = 48000
@@ -142,6 +143,7 @@ export async function exportWithWebCodecs(
   background?: BackgroundAudio | null,
   orientation?: ProjectOrientation,
   includeLocation = false,
+  signal?: AbortSignal,
 ): Promise<ExportResult> {
   if (!supportsWebCodecsExport()) {
     throw new Error('WebCodecs is not available')
@@ -302,6 +304,7 @@ export async function exportWithWebCodecs(
 
   try {
     for (const [segmentIndex, segment] of plan.segments.entries()) {
+      throwIfExportAborted(signal)
       const isImage = isImageClip(segment.clip)
       const input = isImage
         ? null
@@ -458,7 +461,9 @@ export async function exportWithWebCodecs(
           // No mirroring needed when the encode canvas is the preview.
           getPreviewCanvas: encodingIntoPreview ? undefined : getPreviewCanvas,
           watermarkImage,
+          signal,
           onElapsedMs: (elapsed: number) => {
+            throwIfExportAborted(signal)
             if (plan.totalMs > 0) {
               onProgress?.(Math.min(1, (state.doneMs + elapsed) / plan.totalMs))
             }
@@ -665,6 +670,7 @@ interface PumpSharedArgs {
   state: PumpState
   getPreviewCanvas?: () => HTMLCanvasElement | null
   watermarkImage?: HTMLImageElement | null
+  signal?: AbortSignal
   onElapsedMs: (elapsedMs: number) => void
 }
 
@@ -680,12 +686,14 @@ function makeFrameSink({
   state,
   getPreviewCanvas,
   watermarkImage,
+  signal,
 }: PumpSharedArgs) {
   return (
     draw: (ctx: CanvasRenderingContext2D, width: number, height: number) => void,
     mediaTimeSec: number,
     options?: { force?: boolean },
   ): Promise<void> => {
+    throwIfExportAborted(signal)
     const clampedSec = Math.min(Math.max(mediaTimeSec, startSec), endSec)
     let tsSec = state.outputOffsetSec + (clampedSec - startSec)
     // Decimate against the output clock: emit one frame per 30fps tick and

--- a/src/lib/export/encode-webcodecs.ts
+++ b/src/lib/export/encode-webcodecs.ts
@@ -62,7 +62,7 @@ import {
   formatChapterTitle,
   locationForExport,
 } from './mp4-export-metadata'
-import { throwIfExportAborted } from './cancelled'
+import { ExportCancelledError, decodedPumpFailure, throwIfExportAborted } from './cancelled'
 
 const FPS = 30
 const AUDIO_SAMPLE_RATE = 48000
@@ -463,7 +463,6 @@ export async function exportWithWebCodecs(
           watermarkImage,
           signal,
           onElapsedMs: (elapsed: number) => {
-            throwIfExportAborted(signal)
             if (plan.totalMs > 0) {
               onProgress?.(Math.min(1, (state.doneMs + elapsed) / plan.totalMs))
             }
@@ -785,10 +784,7 @@ async function pumpSegmentVideoDecoded(
       onElapsedMs((Math.min(wrapped.timestamp, endSec) - startSec) * 1000)
     }
   } catch (err) {
-    if (framesEmitted > 0) {
-      throw err instanceof Error ? err : new Error('Decoded video pump failed')
-    }
-    return 'unsupported'
+    return decodedPumpFailure(err, framesEmitted)
   }
 
   if (framesEmitted === 0) return 'unsupported'
@@ -914,6 +910,10 @@ async function pumpSegmentVideo({
 
       const handleFrame = (mediaTimeSec: number) => {
         if (finished) return
+        if (shared.signal?.aborted) {
+          abort(new ExportCancelledError())
+          return
+        }
         if (mediaTimeSec > lastMediaTime + 0.001) {
           lastMediaTime = mediaTimeSec
           lastProgressAt = performance.now()

--- a/src/lib/export/index.test.ts
+++ b/src/lib/export/index.test.ts
@@ -18,7 +18,7 @@ vi.mock('./encode-webcodecs', () => ({
 
 import { exportRealtime } from './encode-realtime'
 import { exportWithWebCodecs, supportsWebCodecsExport } from './encode-webcodecs'
-import { exportProject } from './index'
+import { ExportCancelledError, exportProject } from './index'
 
 function clip(): ClipRecord {
   return {
@@ -96,5 +96,34 @@ describe('exportProject fallback signaling', () => {
     expect(exportRealtime).not.toHaveBeenCalled()
     expect(result.engine).toBe('webcodecs')
     expect(result.locationIncluded).toBe(true)
+  })
+
+  it('throws immediately when the signal is already aborted', async () => {
+    const controller = new AbortController()
+    controller.abort()
+    await expect(
+      exportProject([clip()], { watermark: false, signal: controller.signal }),
+    ).rejects.toBeInstanceOf(ExportCancelledError)
+    expect(exportWithWebCodecs).not.toHaveBeenCalled()
+    expect(exportRealtime).not.toHaveBeenCalled()
+  })
+
+  it('does not fall back to realtime when WebCodecs is cancelled', async () => {
+    vi.mocked(supportsWebCodecsExport).mockReturnValue(true)
+    vi.mocked(exportWithWebCodecs).mockImplementation(async (...args) => {
+      const signal = args[7] as AbortSignal | undefined
+      if (signal?.aborted) throw new ExportCancelledError()
+      await new Promise<void>((_, reject) => {
+        signal?.addEventListener('abort', () => reject(new ExportCancelledError()), {
+          once: true,
+        })
+      })
+      throw new Error('unreachable')
+    })
+    const controller = new AbortController()
+    const pending = exportProject([clip()], { watermark: false, signal: controller.signal })
+    controller.abort()
+    await expect(pending).rejects.toBeInstanceOf(ExportCancelledError)
+    expect(exportRealtime).not.toHaveBeenCalled()
   })
 })

--- a/src/lib/export/index.ts
+++ b/src/lib/export/index.ts
@@ -1,6 +1,7 @@
 import { reportError } from '../error-reporting'
 import type { ClipRecord, ProjectOrientation } from '../types'
 import type { BackgroundAudio } from './background-audio'
+import { ExportCancelledError, isExportCancelled, throwIfExportAborted } from './cancelled'
 import { exportRealtime } from './encode-realtime'
 import { exportWithWebCodecs, supportsWebCodecsExport } from './encode-webcodecs'
 import { sweepExportCache, withExportCacheReserved } from './export-cache'
@@ -20,6 +21,7 @@ import {
 
 export type { ExportResult } from './shared'
 export { planExport, type ExportPlan, type PlannedSegment } from './plan'
+export { ExportCancelledError, isExportCancelled } from './cancelled'
 
 export interface ExportOptions {
   onProgress?: (ratio: number) => void
@@ -54,6 +56,8 @@ export interface ExportOptions {
    * try-elsewhere hint without waiting for the finished file.
    */
   onFallback?: () => void
+  /** Abort the in-flight encode (Stop, or a mark/location change). */
+  signal?: AbortSignal
 }
 
 /**
@@ -70,7 +74,9 @@ export async function exportProject(
     throw new Error('Nothing to export yet — record a clip first')
   }
 
+  throwIfExportAborted(options.signal)
   const watermarkImage = options.watermark === false ? null : await loadWatermarkImage()
+  throwIfExportAborted(options.signal)
 
   // Reclaim stale cache (old temp files, the clips zip, an orphaned last
   // export) before writing a new potentially-huge file. The current last
@@ -100,6 +106,7 @@ async function runExport(
         options.background,
         options.orientation,
         options.includeLocation === true,
+        options.signal,
       )
       reportSilentExportAudio({ engine: 'webcodecs', outputMime: result.mimeType })
       reportBlackExportVideo({ engine: 'webcodecs', outputMime: result.mimeType })
@@ -114,6 +121,9 @@ async function runExport(
       }
       return result
     } catch (error) {
+      if (isExportCancelled(error) || options.signal?.aborted) {
+        throw error instanceof ExportCancelledError ? error : new ExportCancelledError()
+      }
       console.warn('WebCodecs export failed; falling back to realtime stitcher', error)
       // Keep the decode-failure report gate: both engines share decodeClipAudio,
       // and a second Sentry event for the same export is just noise (Bugbot).
@@ -122,6 +132,7 @@ async function runExport(
     }
   }
 
+  throwIfExportAborted(options.signal)
   options.onFallback?.()
   const result = await exportRealtime(plan, {
     audioContext: options.audioContext,
@@ -130,6 +141,7 @@ async function runExport(
     watermarkImage,
     background: options.background,
     orientation: options.orientation,
+    signal: options.signal,
   })
   reportSilentExportAudio({ engine: 'realtime', outputMime: result.mimeType })
   reportBlackExportVideo({ engine: 'realtime', outputMime: result.mimeType })

--- a/src/lib/import-device-clips.test.ts
+++ b/src/lib/import-device-clips.test.ts
@@ -9,7 +9,7 @@ import {
   probeDeviceClip,
   probeDeviceImage,
 } from './import-device-clips'
-import { __resetDbForTests, createProject, getClipsForProject } from './storage'
+import { __resetDbForTests, addClip, createProject, getClipsForProject } from './storage'
 import { DEFAULT_IMAGE_DURATION_MS } from './types'
 
 /** A real decodable PNG File, drawn in-page (browser-mode tests). */
@@ -162,5 +162,42 @@ describe('probeDeviceClip / importDeviceClips', () => {
     expect(result.failed[1]?.name).toBe('notes.txt')
     expect(ensureCalls).toBe(0)
     expect(await getClipsForProject(project.id)).toHaveLength(0)
+  })
+
+  it('inserts imported clips after the selected neighbor and reports each add', async () => {
+    const project = await createProject('Insert import')
+    const first = await addClip({
+      projectId: project.id,
+      blob: new Blob(['a'], { type: 'video/webm' }),
+      mimeType: 'video/webm',
+      durationMs: 800,
+    })
+    const last = await addClip({
+      projectId: project.id,
+      blob: new Blob(['b'], { type: 'video/webm' }),
+      mimeType: 'video/webm',
+      durationMs: 800,
+    })
+    const addedIds: string[] = []
+    const result = await importDeviceClips(
+      [await makeTestImageFile('one.png'), await makeTestImageFile('two.png')],
+      {
+        ensureProjectId: async () => project.id,
+        afterClipId: first.id,
+        onAdded: (clip) => {
+          addedIds.push(clip.id)
+        },
+      },
+    )
+    expect(result.failed).toHaveLength(0)
+    expect(result.added).toHaveLength(2)
+    expect(addedIds).toEqual(result.added.map((clip) => clip.id))
+    const clips = await getClipsForProject(project.id)
+    expect(clips.map((clip) => clip.id)).toEqual([
+      first.id,
+      result.added[0]!.id,
+      result.added[1]!.id,
+      last.id,
+    ])
   })
 })

--- a/src/lib/import-device-clips.ts
+++ b/src/lib/import-device-clips.ts
@@ -1,5 +1,11 @@
 import { addClip, clearUndo } from './storage'
-import { DEFAULT_IMAGE_DURATION_MS, type ClipKind, type ClipRecord, type ProjectId } from './types'
+import {
+  DEFAULT_IMAGE_DURATION_MS,
+  type ClipId,
+  type ClipKind,
+  type ClipRecord,
+  type ProjectId,
+} from './types'
 
 /** Accept string for `<input type="file">` — common phone/desktop video
  * types, plus photos (added to the timeline as stills with a chosen
@@ -236,14 +242,16 @@ export async function probeDeviceClip(
 export async function importDeviceClip(
   projectId: ProjectId,
   file: File,
+  afterClipId?: ClipId | null,
 ): Promise<ClipRecord> {
   const probed = await probeDeviceClip(file)
-  return addClip(addClipInputFor(projectId, probed))
+  return addClip(addClipInputFor(projectId, probed, afterClipId))
 }
 
 function addClipInputFor(
   projectId: ProjectId,
   probed: DeviceClipProbe,
+  afterClipId?: ClipId | null,
 ): Parameters<typeof addClip>[0] {
   return {
     projectId,
@@ -254,6 +262,7 @@ function addClipInputFor(
     width: probed.width,
     height: probed.height,
     createdAt: probed.createdAt,
+    ...(afterClipId ? { afterClipId } : {}),
     // Photos are silent by construction — persist the zero measurement so
     // the loader backfill never attempts an audio decode on them.
     ...(probed.kind === 'image' ? { audioPeak: 0 } : {}),
@@ -265,6 +274,10 @@ export interface ImportDeviceClipsOptions {
    * so a failed pick on `/project/new` does not burn a free project slot. */
   ensureProjectId: () => Promise<ProjectId>
   onProgress?: (done: number, total: number) => void
+  /** Insert each new clip after this one (then after the last added). */
+  afterClipId?: ClipId | null
+  /** Fired after each successful persist so the timeline can show the clip. */
+  onAdded?: (clip: ClipRecord) => void
 }
 
 /**
@@ -281,6 +294,7 @@ export async function importDeviceClips(
   const added: ClipRecord[] = []
   const failed: DeviceClipImportFailure[] = []
   let projectId: ProjectId | null = null
+  let afterClipId = options.afterClipId ?? null
   options.onProgress?.(0, list.length)
 
   for (let i = 0; i < list.length; i += 1) {
@@ -288,7 +302,10 @@ export async function importDeviceClips(
     try {
       const probed = await probeDeviceClip(file)
       projectId ??= await options.ensureProjectId()
-      added.push(await addClip(addClipInputFor(projectId, probed)))
+      const clip = await addClip(addClipInputFor(projectId, probed, afterClipId))
+      added.push(clip)
+      afterClipId = clip.id
+      options.onAdded?.(clip)
     } catch (error) {
       failed.push({
         name: file.name || 'clip',

--- a/src/lib/project-actions.ts
+++ b/src/lib/project-actions.ts
@@ -186,21 +186,12 @@ export async function loadProjectPage(projectId: ProjectId): Promise<ProjectLoad
       }
     }
     await setLastOpenedProjectId(projectId)
-    // Backfill filmstrip thumbnails and the persisted audio-normalization
-    // measurement for clips that lack them. Serially — Android caps
-    // concurrent video decoders hard, and this normally touches at most
-    // the clip that was just recorded.
-    // Lazy: thumbs / clip-audio-peak → export/shared → mediabunny. Home
-    // never hits this path.
-    const { ensureClipThumbs } = await import('./thumbs')
-    const { ensureClipAudioPeak } = await import('./clip-audio-peak')
-    const hydrated: ClipRecord[] = []
-    for (const clip of clips) {
-      hydrated.push(await ensureClipAudioPeak(await ensureClipThumbs(clip)))
-    }
+    // Return stored clips immediately so the timeline can paint. Thumb and
+    // audio-peak backfill runs after first paint (hydrateProjectClips) —
+    // waiting here is what made "Clip added" land before the tile appeared.
     return {
       project,
-      clips: hydrated,
+      clips,
       audio: audio ?? null,
       canUndo: !!undo,
       onboardingDismissed: settings.onboardingDismissed,
@@ -228,6 +219,20 @@ export async function loadProjectPage(projectId: ProjectId): Promise<ProjectLoad
       error: err instanceof Error ? err.message : 'Failed to load project',
     }
   }
+}
+
+/** Generate missing filmstrip thumbs and audio-peak measurements. Serial
+ * because Android caps concurrent video decoders. Safe to call after the
+ * first paint — tiles already render with placeholders. */
+export async function hydrateProjectClips(clips: ClipRecord[]): Promise<ClipRecord[]> {
+  if (clips.length === 0) return clips
+  const { ensureClipThumbs } = await import('./thumbs')
+  const { ensureClipAudioPeak } = await import('./clip-audio-peak')
+  const hydrated: ClipRecord[] = []
+  for (const clip of clips) {
+    hydrated.push(await ensureClipAudioPeak(await ensureClipThumbs(clip)))
+  }
+  return hydrated
 }
 
 export async function appendRecording(

--- a/src/lib/storage.test.ts
+++ b/src/lib/storage.test.ts
@@ -184,6 +184,15 @@ describe('storage layer', () => {
     expect((await getSettings()).keepWatermark).toBe(false)
   })
 
+  it('serializes overlapping mark and location pref writes', async () => {
+    await markWatermarkRemoved('cs_test_pref_race')
+    await Promise.all([setKeepWatermark(true), setIncludeLocationInExports(true)])
+    expect(await getSettings()).toMatchObject({
+      keepWatermark: true,
+      includeLocationInExports: true,
+    })
+  })
+
   it('gates location capture and export preferences behind Plus', async () => {
     await expect(setLocationTaggingEnabled(true)).rejects.toBeInstanceOf(PlusRequiredError)
     await expect(setIncludeLocationInExports(true)).rejects.toBeInstanceOf(PlusRequiredError)

--- a/src/lib/storage.test.ts
+++ b/src/lib/storage.test.ts
@@ -440,6 +440,31 @@ describe('storage layer', () => {
     expect(clips.map((c) => c.id)).toEqual([c2.id, copy.id, c1.id])
   })
 
+  it('inserts a clip after a chosen neighbor instead of appending', async () => {
+    const project = await createProject('Insert after')
+    const first = await addClip({
+      projectId: project.id,
+      blob: fakeBlob('1'),
+      mimeType: 'video/webm',
+      durationMs: 1000,
+    })
+    const last = await addClip({
+      projectId: project.id,
+      blob: fakeBlob('3'),
+      mimeType: 'video/webm',
+      durationMs: 1000,
+    })
+    const middle = await addClip({
+      projectId: project.id,
+      blob: fakeBlob('2'),
+      mimeType: 'video/webm',
+      durationMs: 1000,
+      afterClipId: first.id,
+    })
+    const clips = await getClipsForProject(project.id)
+    expect(clips.map((c) => c.id)).toEqual([first.id, middle.id, last.id])
+  })
+
   it('stores photo clips and sets their duration (grow and shrink, clamped)', async () => {
     const project = await createProject('Photos')
     const photo = await addClip({

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -540,6 +540,26 @@ export interface AddClipInput {
   /** Measured whole-clip audio peak — used when importing backups so the
    * clip skips the normalization re-measure on its first load. */
   audioPeak?: number
+  /** Insert after this clip (device Add). Omit to append at the end. */
+  afterClipId?: ClipId
+}
+
+/** Place `clipId` immediately after `afterClipId`, or append when that id is missing. */
+export function insertClipIdAfter(
+  clipIds: ClipId[],
+  clipId: ClipId,
+  afterClipId?: ClipId | null,
+): ClipId[] {
+  const next = [...clipIds]
+  if (afterClipId) {
+    const index = next.indexOf(afterClipId)
+    if (index >= 0) {
+      next.splice(index + 1, 0, clipId)
+      return next
+    }
+  }
+  next.push(clipId)
+  return next
 }
 
 /**
@@ -610,7 +630,7 @@ export async function addClip(input: AddClipInput): Promise<ClipRecord> {
       tx.objectStore('clips').put(clip),
       tx.objectStore('projects').put({
         ...project,
-        clipIds: [...project.clipIds, clip.id],
+        clipIds: insertClipIdAfter(project.clipIds, clip.id, input.afterClipId),
         updatedAt: now,
       }),
     ],

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -267,21 +267,38 @@ export async function setLocationTaggingEnabled(locationTaggingEnabled: boolean)
   await db.put('meta', { ...settings, locationTaggingEnabled })
 }
 
+/** Serialize read-modify-write updates to the singleton meta record so two
+ * rapid pref toggles cannot persist an older snapshot over a newer one. */
+let metaWriteTail: Promise<void> = Promise.resolve()
+
+function enqueueMetaWrite<T>(write: () => Promise<T>): Promise<T> {
+  const run = metaWriteTail.then(write, write)
+  metaWriteTail = run.then(
+    () => undefined,
+    () => undefined,
+  )
+  return run
+}
+
 export async function setKeepWatermark(keepWatermark: boolean): Promise<void> {
-  const db = await getDb()
-  const settings = await getSettings()
-  await db.put('meta', { ...settings, keepWatermark })
+  await enqueueMetaWrite(async () => {
+    const db = await getDb()
+    const settings = await getSettings()
+    await db.put('meta', { ...settings, keepWatermark })
+  })
 }
 
 export async function setIncludeLocationInExports(
   includeLocationInExports: boolean,
 ): Promise<void> {
-  const db = await getDb()
-  const settings = await getSettings()
-  if (includeLocationInExports && settings.watermarkRemoved !== true) {
-    throw new PlusRequiredError('Location export is a Kody Video Plus perk.')
-  }
-  await db.put('meta', { ...settings, includeLocationInExports })
+  await enqueueMetaWrite(async () => {
+    const db = await getDb()
+    const settings = await getSettings()
+    if (includeLocationInExports && settings.watermarkRemoved !== true) {
+      throw new PlusRequiredError('Location export is a Kody Video Plus perk.')
+    }
+    await db.put('meta', { ...settings, includeLocationInExports })
+  })
 }
 
 export async function listProjects(): Promise<Project[]> {

--- a/src/pages/project-page.tsx
+++ b/src/pages/project-page.tsx
@@ -12,7 +12,7 @@ import { UpsellSheet } from '../components/upsell-sheet'
 import { REMOVE_WATERMARK_LINK, shouldWatermarkExports } from '../lib/entitlement'
 import { buildClipsZip } from '../lib/clips-zip'
 import { clearExportMarker, markExportStarted, reportError } from '../lib/error-reporting'
-import { exportProject, type ExportResult } from '../lib/export'
+import { exportProject, isExportCancelled, type ExportResult } from '../lib/export'
 import { exportSignature, loadMatchingExport, persistLastExport } from '../lib/export/last-export'
 import { MediaElementFailureError } from '../lib/export/media-error'
 import { unlockExportMediaPlayback, wait } from '../lib/export/shared'
@@ -25,7 +25,7 @@ import {
   shareOrDownload,
 } from '../lib/media'
 import { isCoarsePointerDevice, viewportIsLandscape } from '../lib/platform'
-import { loadProjectPage, type ProjectLoaderData } from '../lib/project-actions'
+import { hydrateProjectClips, loadProjectPage, type ProjectLoaderData } from '../lib/project-actions'
 import { projectBackupFilename, serializeProject } from '../lib/project-transfer'
 import {
   createProject,
@@ -97,6 +97,7 @@ export function ProjectPage(handle: Handle<ProjectPageProps>) {
 
   let toastTimer = 0
   let exportRun = 0
+  let exportAbort: AbortController | null = null
   let previewCanvas: HTMLCanvasElement | null = null
   const bindPreviewCanvas = (element: HTMLCanvasElement | null) => {
     previewCanvas = element
@@ -129,7 +130,7 @@ export function ProjectPage(handle: Handle<ProjectPageProps>) {
     loadedForId = projectId
     const version = ++loadVersion
     void loadProjectPage(projectId)
-      .then((loaded) => {
+      .then(async (loaded) => {
         if (handle.signal.aborted || version !== loadVersion) return
         data = loaded
         if (!onboardingInitialized) {
@@ -137,6 +138,13 @@ export function ProjectPage(handle: Handle<ProjectPageProps>) {
           onboardingOpen = !loaded.onboardingDismissed
         }
         void handle.update()
+        if (!loaded.project || loaded.error || loaded.clips.length === 0) return
+        const hydrated = await hydrateProjectClips(loaded.clips)
+        if (handle.signal.aborted || version !== loadVersion) return
+        if (data && data.project?.id === loaded.project.id) {
+          data = { ...data, clips: hydrated }
+          void handle.update()
+        }
       })
       .catch((err) => {
         if (handle.signal.aborted || version !== loadVersion) return
@@ -308,6 +316,9 @@ export function ProjectPage(handle: Handle<ProjectPageProps>) {
     const project = data.project
     const audio = data.audio
     if (clips.length === 0) return
+    exportAbort?.abort()
+    exportAbort = new AbortController()
+    const signal = exportAbort.signal
     const runId = exportRun + 1
     exportRun = runId
 
@@ -421,6 +432,7 @@ export function ProjectPage(handle: Handle<ProjectPageProps>) {
         // this marker survives the reload and reports the death at next boot.
         markExportStarted({ clips: clips.length })
         const result = await exportProject(clips, {
+          signal,
           audioContext,
           watermark: watermarked,
           includeLocation,
@@ -479,6 +491,10 @@ export function ProjectPage(handle: Handle<ProjectPageProps>) {
           usedFallback: result.engine === 'realtime' || (exportState?.usedFallback ?? false),
         })
       } catch (err) {
+        if (isExportCancelled(err) || signal.aborted) {
+          if (exportRun !== runId) return
+          return
+        }
         // Report even when the run was abandoned (closed sheet / retry) —
         // only the UI update is stale, the failure is real.
         reportError(err, 'export', {
@@ -521,8 +537,30 @@ export function ProjectPage(handle: Handle<ProjectPageProps>) {
   }
 
   const closeExport = () => {
+    exportAbort?.abort()
+    exportAbort = null
     exportRun += 1
     setExportState(null)
+  }
+
+  const persistKeepWatermark = (keep: boolean) => {
+    if (data) {
+      data = { ...data, keepWatermark: keep }
+      void handle.update()
+    }
+    void setKeepWatermark(keep).catch((err) => {
+      reportError(err, 'keep-watermark')
+    })
+  }
+
+  const persistIncludeLocation = (include: boolean) => {
+    if (data) {
+      data = { ...data, includeLocationInExports: include }
+      void handle.update()
+    }
+    void setIncludeLocationInExports(include).catch((err) => {
+      reportError(err, 'include-location')
+    })
   }
 
   const setExportNotice = (notice: string) => {
@@ -664,8 +702,28 @@ export function ProjectPage(handle: Handle<ProjectPageProps>) {
             projectName={project.name}
             progress={exportState?.progress ?? 0}
             watermarked={exportState?.watermarked === true}
+            locationIncluded={
+              data.watermarkRemoved &&
+              data.includeLocationInExports &&
+              clips.some((clip) => typeof clip.lat === 'number' && typeof clip.lng === 'number')
+            }
             usedFallback={exportState?.usedFallback === true}
+            purchased={data.watermarkRemoved}
+            keepWatermark={data.keepWatermark}
+            includeLocation={data.includeLocationInExports}
+            hasTaggedClips={clips.some(
+              (clip) => typeof clip.lat === 'number' && typeof clip.lng === 'number',
+            )}
             bindPreviewCanvas={bindPreviewCanvas}
+            onStop={closeExport}
+            onKeepWatermarkChange={(keep) => {
+              persistKeepWatermark(keep)
+              startExport({ force: true })
+            }}
+            onIncludeLocationChange={(include) => {
+              persistIncludeLocation(include)
+              startExport({ force: true })
+            }}
           />
         ) : null}
 
@@ -684,20 +742,8 @@ export function ProjectPage(handle: Handle<ProjectPageProps>) {
               (clip) => typeof clip.lat === 'number' && typeof clip.lng === 'number',
             )}
             busy={exportActionCount > 0}
-            onKeepWatermarkChange={(keep) => {
-              data = { ...data!, keepWatermark: keep }
-              void handle.update()
-              void setKeepWatermark(keep).catch((err) => {
-                reportError(err, 'keep-watermark')
-              })
-            }}
-            onIncludeLocationChange={(include) => {
-              data = { ...data!, includeLocationInExports: include }
-              void handle.update()
-              void setIncludeLocationInExports(include).catch((err) => {
-                reportError(err, 'include-location')
-              })
-            }}
+            onKeepWatermarkChange={persistKeepWatermark}
+            onIncludeLocationChange={persistIncludeLocation}
             onRemoveWatermark={() => {
               window.open(REMOVE_WATERMARK_LINK, '_blank', 'noopener')
             }}

--- a/src/pages/project-page.tsx
+++ b/src/pages/project-page.tsx
@@ -543,23 +543,25 @@ export function ProjectPage(handle: Handle<ProjectPageProps>) {
     setExportState(null)
   }
 
-  const persistKeepWatermark = (keep: boolean) => {
+  const persistKeepWatermark = (keep: boolean): Promise<void> => {
     if (data) {
       data = { ...data, keepWatermark: keep }
       void handle.update()
     }
-    void setKeepWatermark(keep).catch((err) => {
+    return setKeepWatermark(keep).catch((err) => {
       reportError(err, 'keep-watermark')
+      throw err
     })
   }
 
-  const persistIncludeLocation = (include: boolean) => {
+  const persistIncludeLocation = (include: boolean): Promise<void> => {
     if (data) {
       data = { ...data, includeLocationInExports: include }
       void handle.update()
     }
-    void setIncludeLocationInExports(include).catch((err) => {
+    return setIncludeLocationInExports(include).catch((err) => {
       reportError(err, 'include-location')
+      throw err
     })
   }
 
@@ -717,12 +719,10 @@ export function ProjectPage(handle: Handle<ProjectPageProps>) {
             bindPreviewCanvas={bindPreviewCanvas}
             onStop={closeExport}
             onKeepWatermarkChange={(keep) => {
-              persistKeepWatermark(keep)
-              startExport({ force: true })
+              void persistKeepWatermark(keep).then(() => startExport({ force: true }))
             }}
             onIncludeLocationChange={(include) => {
-              persistIncludeLocation(include)
-              startExport({ force: true })
+              void persistIncludeLocation(include).then(() => startExport({ force: true }))
             }}
           />
         ) : null}

--- a/src/pages/project-page.tsx
+++ b/src/pages/project-page.tsx
@@ -129,26 +129,38 @@ export function ProjectPage(handle: Handle<ProjectPageProps>) {
   /** Monotonic request id: an older in-flight load for the same project
    * (mount racing a post-mutation refresh) must never overwrite newer data. */
   let loadVersion = 0
+  /** Latest load's settle promise — a superseded refresh waits here so
+   * import/Go see the newer clip list instead of clearing optimistic tiles. */
+  let loadTail: Promise<void> = Promise.resolve()
   const load = (projectId: string): Promise<void> => {
     loadedForId = projectId
     const version = ++loadVersion
-    return loadProjectPage(projectId)
+    const thisLoad = loadProjectPage(projectId)
       .then(async (loaded) => {
-        if (handle.signal.aborted || version !== loadVersion) return
+        if (handle.signal.aborted) return
+        if (version !== loadVersion) {
+          await loadTail
+          return
+        }
         data = loaded
         if (!onboardingInitialized) {
           onboardingInitialized = true
           onboardingOpen = !loaded.onboardingDismissed
         }
         await handle.update()
+        if (handle.signal.aborted) return
+        if (version !== loadVersion) {
+          await loadTail
+          return
+        }
         if (!loaded.project || loaded.error || loaded.clips.length === 0) return
-        const projectId = loaded.project.id
+        const hydratedProjectId = loaded.project.id
         // Thumbs/peaks can finish after the first paint — callers of
         // refresh() only need the persisted clip list before Go/Play.
         void hydrateProjectClips(loaded.clips)
           .then((hydrated) => {
             if (handle.signal.aborted || version !== loadVersion) return
-            if (data && data.project?.id === projectId) {
+            if (data && data.project?.id === hydratedProjectId) {
               data = { ...data, clips: hydrated }
               void handle.update()
             }
@@ -159,7 +171,10 @@ export function ProjectPage(handle: Handle<ProjectPageProps>) {
           })
       })
       .catch((err) => {
-        if (handle.signal.aborted || version !== loadVersion) return
+        if (handle.signal.aborted) return
+        if (version !== loadVersion) {
+          return loadTail
+        }
         reportError(err, 'load-project')
         // Reuse the page's error rendering path (banner + back-home link).
         data = {
@@ -177,6 +192,8 @@ export function ProjectPage(handle: Handle<ProjectPageProps>) {
         }
         void handle.update()
       })
+    loadTail = thisLoad.then(() => undefined, () => undefined)
+    return thisLoad
   }
   void load(props.projectId)
 
@@ -570,6 +587,14 @@ export function ProjectPage(handle: Handle<ProjectPageProps>) {
     setExportState(null)
   }
 
+  /** Mid-export Plus toggles persist then restart. Stop, Escape, or a
+   * finished encode during that write must not launch a new forced run. */
+  const restartExportIfStillRunning = (startedAtRun: number) => {
+    if (exportRun !== startedAtRun) return
+    if (exportState?.status !== 'exporting') return
+    startExport({ force: true })
+  }
+
   const persistKeepWatermark = (keep: boolean): Promise<void> => {
     if (data) {
       data = { ...data, keepWatermark: keep }
@@ -746,10 +771,12 @@ export function ProjectPage(handle: Handle<ProjectPageProps>) {
             bindPreviewCanvas={bindPreviewCanvas}
             onStop={closeExport}
             onKeepWatermarkChange={(keep) => {
-              void persistKeepWatermark(keep).then(() => startExport({ force: true }))
+              const runId = exportRun
+              void persistKeepWatermark(keep).then(() => restartExportIfStillRunning(runId))
             }}
             onIncludeLocationChange={(include) => {
-              void persistIncludeLocation(include).then(() => startExport({ force: true }))
+              const runId = exportRun
+              void persistIncludeLocation(include).then(() => restartExportIfStillRunning(runId))
             }}
           />
         ) : null}

--- a/src/pages/project-page.tsx
+++ b/src/pages/project-page.tsx
@@ -142,12 +142,13 @@ export function ProjectPage(handle: Handle<ProjectPageProps>) {
         }
         await handle.update()
         if (!loaded.project || loaded.error || loaded.clips.length === 0) return
+        const projectId = loaded.project.id
         // Thumbs/peaks can finish after the first paint — callers of
         // refresh() only need the persisted clip list before Go/Play.
         void hydrateProjectClips(loaded.clips)
           .then((hydrated) => {
             if (handle.signal.aborted || version !== loadVersion) return
-            if (data && data.project?.id === loaded.project.id) {
+            if (data && data.project?.id === projectId) {
               data = { ...data, clips: hydrated }
               void handle.update()
             }

--- a/src/pages/project-page.tsx
+++ b/src/pages/project-page.tsx
@@ -98,6 +98,9 @@ export function ProjectPage(handle: Handle<ProjectPageProps>) {
   let toastTimer = 0
   let exportRun = 0
   let exportAbort: AbortController | null = null
+  /** Previous encode must finish (or reject) before a restarted run opens
+   * decoders — aborting the controller does not stop loadClipVideo. */
+  let exportChain: Promise<void> = Promise.resolve()
   let previewCanvas: HTMLCanvasElement | null = null
   const bindPreviewCanvas = (element: HTMLCanvasElement | null) => {
     previewCanvas = element
@@ -126,10 +129,10 @@ export function ProjectPage(handle: Handle<ProjectPageProps>) {
   /** Monotonic request id: an older in-flight load for the same project
    * (mount racing a post-mutation refresh) must never overwrite newer data. */
   let loadVersion = 0
-  const load = (projectId: string) => {
+  const load = (projectId: string): Promise<void> => {
     loadedForId = projectId
     const version = ++loadVersion
-    void loadProjectPage(projectId)
+    return loadProjectPage(projectId)
       .then(async (loaded) => {
         if (handle.signal.aborted || version !== loadVersion) return
         data = loaded
@@ -137,14 +140,22 @@ export function ProjectPage(handle: Handle<ProjectPageProps>) {
           onboardingInitialized = true
           onboardingOpen = !loaded.onboardingDismissed
         }
-        void handle.update()
+        await handle.update()
         if (!loaded.project || loaded.error || loaded.clips.length === 0) return
-        const hydrated = await hydrateProjectClips(loaded.clips)
-        if (handle.signal.aborted || version !== loadVersion) return
-        if (data && data.project?.id === loaded.project.id) {
-          data = { ...data, clips: hydrated }
-          void handle.update()
-        }
+        // Thumbs/peaks can finish after the first paint — callers of
+        // refresh() only need the persisted clip list before Go/Play.
+        void hydrateProjectClips(loaded.clips)
+          .then((hydrated) => {
+            if (handle.signal.aborted || version !== loadVersion) return
+            if (data && data.project?.id === loaded.project.id) {
+              data = { ...data, clips: hydrated }
+              void handle.update()
+            }
+          })
+          .catch((err) => {
+            if (handle.signal.aborted || version !== loadVersion) return
+            reportError(err, 'hydrate-clips')
+          })
       })
       .catch((err) => {
         if (handle.signal.aborted || version !== loadVersion) return
@@ -166,7 +177,7 @@ export function ProjectPage(handle: Handle<ProjectPageProps>) {
         void handle.update()
       })
   }
-  load(props.projectId)
+  void load(props.projectId)
 
   /** The URL is the authority on which project this page shows. Right after
    * lazy creation, `navigate(replace)` has already rewritten the path while
@@ -177,9 +188,7 @@ export function ProjectPage(handle: Handle<ProjectPageProps>) {
     return match?.[1] ?? props.projectId
   }
 
-  const refresh = () => {
-    load(currentProjectId())
-  }
+  const refresh = (): Promise<void> => load(currentProjectId())
 
   const showToast = (message: string, action?: ToastAction) => {
     window.clearTimeout(toastTimer)
@@ -386,8 +395,21 @@ export function ProjectPage(handle: Handle<ProjectPageProps>) {
       })
       .catch(() => undefined)
 
+    const previous = exportChain
+    let releaseChain = () => {}
+    exportChain = new Promise<void>((resolve) => {
+      releaseChain = resolve
+    })
+
     void (async () => {
       try {
+        await previous.catch(() => undefined)
+        if (exportRun !== runId || signal.aborted) {
+          if (exportRun === runId && exportState?.status === 'exporting') {
+            setExportState(null)
+          }
+          return
+        }
         // Flush the exporting UI so ExportOverlay's canvas is connected before
         // engines poll for it. A fire-and-forget update raced the wait on
         // slow iOS and fell back to a detached (black) canvas (KODY-VIDEO-Q).
@@ -491,8 +513,11 @@ export function ProjectPage(handle: Handle<ProjectPageProps>) {
           usedFallback: result.engine === 'realtime' || (exportState?.usedFallback ?? false),
         })
       } catch (err) {
-        if (isExportCancelled(err) || signal.aborted) {
+        if (signal.aborted || isExportCancelled(err)) {
           if (exportRun !== runId) return
+          if (exportState?.status === 'exporting') {
+            setExportState(null)
+          }
           return
         }
         // Report even when the run was abandoned (closed sheet / retry) —
@@ -532,6 +557,7 @@ export function ProjectPage(handle: Handle<ProjectPageProps>) {
         if (audioContext && audioContext.state !== 'closed') {
           void audioContext.close().catch(() => undefined)
         }
+        releaseChain()
       }
     })()
   }
@@ -575,7 +601,7 @@ export function ProjectPage(handle: Handle<ProjectPageProps>) {
   return () => {
     // The URL param changed in place (lazy create, or another project link).
     if (props.projectId !== loadedForId) {
-      load(props.projectId)
+      void load(props.projectId)
     }
     if (!data) return null
     const project = data.project

--- a/src/styles/editor.css
+++ b/src/styles/editor.css
@@ -283,6 +283,33 @@
     linear-gradient(135deg, color-mix(in srgb, var(--bg-elevated) 70%, #000), var(--bg-soft));
 }
 
+.clip-thumb.is-ghost {
+  border-style: dashed;
+  border-color: color-mix(in srgb, var(--accent) 40%, transparent);
+  pointer-events: none;
+  opacity: 0.72;
+}
+
+.clip-thumb.is-ghost .clip-filmstrip-placeholder {
+  background: linear-gradient(
+    90deg,
+    color-mix(in srgb, var(--bg-elevated) 70%, #000) 0%,
+    color-mix(in srgb, var(--accent) 18%, var(--bg-soft)) 50%,
+    color-mix(in srgb, var(--bg-elevated) 70%, #000) 100%
+  );
+  background-size: 200% 100%;
+  animation: timeline-ghost-shimmer 1.2s ease-in-out infinite;
+}
+
+@keyframes timeline-ghost-shimmer {
+  0% {
+    background-position: 100% 0;
+  }
+  100% {
+    background-position: -100% 0;
+  }
+}
+
 .clip-thumb .clip-dur {
   position: absolute;
   right: 4px;

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -781,6 +781,25 @@ a {
   margin: 0;
 }
 
+.export-overlay-prefs {
+  margin: 12px 0 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+}
+
+.export-overlay-pref-hint {
+  max-width: 22rem;
+  font-size: 0.78rem;
+  line-height: 1.4;
+}
+
+.export-overlay-stop {
+  margin-top: 14px;
+  min-width: 8rem;
+}
+
 .export-fallback-notice {
   margin: 0 0 12px;
   padding: 10px 12px;

--- a/tests/e2e/editor-playback.spec.ts
+++ b/tests/e2e/editor-playback.spec.ts
@@ -206,6 +206,55 @@ test.describe('editor', () => {
       .toBe(true)
   })
 
+  test('Add inserts the new clip after the selected one', async ({ page }) => {
+    await openEditorWithClips(page, 2)
+    const tiles = page.locator('.clip-thumb[data-clip-id]')
+    await expect(tiles).toHaveCount(2)
+    const firstId = await tiles.nth(0).getAttribute('data-clip-id')
+    const secondId = await tiles.nth(1).getAttribute('data-clip-id')
+    await tiles.first().click()
+
+    const clipPath = await page.evaluate(async () => {
+      const { makeTestClipBlob } = await import('/src/lib/testing/make-test-clip.ts')
+      const blob = await makeTestClipBlob(800)
+      const buffer = await blob.arrayBuffer()
+      return { bytes: Array.from(new Uint8Array(buffer)), type: blob.type || 'video/webm' }
+    })
+    const chooserPromise = page.waitForEvent('filechooser')
+    await page.getByRole('button', { name: 'Add clips from device' }).first().click()
+    const chooser = await chooserPromise
+    await chooser.setFiles({
+      name: 'insert-after.webm',
+      mimeType: clipPath.type,
+      buffer: Buffer.from(clipPath.bytes),
+    })
+    await expect(tiles).toHaveCount(3, { timeout: 20_000 })
+    expect(await tiles.nth(0).getAttribute('data-clip-id')).toBe(firstId)
+    expect(await tiles.nth(2).getAttribute('data-clip-id')).toBe(secondId)
+    await expect(tiles.nth(1)).toHaveClass(/selected/)
+    expect(await tiles.nth(1).getAttribute('data-clip-id')).not.toBe(firstId)
+    expect(await tiles.nth(1).getAttribute('data-clip-id')).not.toBe(secondId)
+  })
+
+  test('moving a clip with the arrow buttons keeps it in view', async ({ page }) => {
+    await openEditorWithClips(page, 8, 8000)
+    const timeline = page.getByRole('listbox', { name: 'Clip timeline' })
+    const tiles = page.locator('.clip-thumb[data-clip-id]')
+    await expect(tiles).toHaveCount(8)
+    await tiles.first().click()
+    for (let i = 0; i < 6; i += 1) {
+      await page.getByRole('button', { name: 'Move clip right' }).click()
+    }
+    const selected = tiles.nth(6)
+    await expect(selected).toHaveClass(/selected/)
+    const visible = await selected.evaluate((el, track) => {
+      const tile = el.getBoundingClientRect()
+      const strip = (track as HTMLElement).getBoundingClientRect()
+      return tile.left >= strip.left - 2 && tile.right <= strip.right + 2
+    }, await timeline.elementHandle())
+    expect(visible).toBe(true)
+  })
+
   test('empty timeline offers Add clips from your device', async ({ page }) => {
     await openSeededProject(page, { clips: 0 })
     // openSeededProject with 0 clips still creates a project; open editor.

--- a/tests/e2e/editor-playback.spec.ts
+++ b/tests/e2e/editor-playback.spec.ts
@@ -238,7 +238,6 @@ test.describe('editor', () => {
 
   test('moving a clip with the arrow buttons keeps it in view', async ({ page }) => {
     await openEditorWithClips(page, 8, 8000)
-    const timeline = page.getByRole('listbox', { name: 'Clip timeline' })
     const tiles = page.locator('.clip-thumb[data-clip-id]')
     await expect(tiles).toHaveCount(8)
     await tiles.first().click()
@@ -247,12 +246,16 @@ test.describe('editor', () => {
     }
     const selected = tiles.nth(6)
     await expect(selected).toHaveClass(/selected/)
-    const visible = await selected.evaluate((el, track) => {
-      const tile = el.getBoundingClientRect()
-      const strip = (track as HTMLElement).getBoundingClientRect()
-      return tile.left >= strip.left - 2 && tile.right <= strip.right + 2
-    }, await timeline.elementHandle())
-    expect(visible).toBe(true)
+    await expect
+      .poll(async () => {
+        return selected.evaluate((el) => {
+          const tile = el.getBoundingClientRect()
+          const strip = el.closest('.timeline')?.getBoundingClientRect()
+          if (!strip) return false
+          return tile.left >= strip.left - 4 && tile.right <= strip.right + 4
+        })
+      })
+      .toBe(true)
   })
 
   test('empty timeline offers Add clips from your device', async ({ page }) => {

--- a/tests/e2e/export.spec.ts
+++ b/tests/e2e/export.spec.ts
@@ -117,6 +117,44 @@ test.describe('Go / export', () => {
     expect(cacheEntries).toHaveLength(1)
   })
 
+  test('Stop cancels an in-flight export without waiting for the file', async ({ page }) => {
+    await openSeededProject(page, { clips: 3, clipMs: 4000 })
+    await page.locator('.go-button').click()
+    const overlay = page.getByRole('dialog', { name: 'Exporting video' })
+    await expect(overlay).toBeVisible({ timeout: 10_000 })
+    await overlay.getByRole('button', { name: 'Stop export' }).click()
+    await expect(overlay).toBeHidden()
+    await expect(page.getByText('Done! Your video is ready')).toBeHidden()
+    await expect(page.locator('.go-button')).toBeVisible()
+  })
+
+  test('Plus users can change mark and location settings during export', async ({ page }) => {
+    const projectId = await seedProject(page, {
+      clips: 3,
+      clipMs: 4000,
+      location: { lat: 40.41791, lng: -111.81496 },
+    })
+    await unlockPlus(page)
+    await page.goto(`/project/${projectId}`)
+    await waitForCameraReady(page)
+
+    await page.locator('.go-button').click()
+    const overlay = page.getByRole('dialog', { name: 'Exporting video' })
+    await expect(overlay).toBeVisible({ timeout: 10_000 })
+    const markToggle = overlay.getByRole('checkbox', { name: 'Keep the Kody mark on exports' })
+    const locationToggle = overlay.getByRole('checkbox', {
+      name: 'Include clip locations in MP4 exports',
+    })
+    await expect(markToggle).toBeVisible()
+    await expect(locationToggle).toBeVisible()
+    await expect(markToggle).not.toBeChecked()
+    await expect(locationToggle).not.toBeChecked()
+    await locationToggle.check()
+    await expect(overlay).toContainText(/includes clip locations/i)
+    await overlay.getByRole('button', { name: 'Stop export' }).click()
+    await expect(overlay).toBeHidden()
+  })
+
   test('Plus users can opt location metadata into future MP4 exports', async ({ page }) => {
     const projectId = await seedProject(page, {
       clips: 1,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Four editor/export UX fixes from the same session:

- **Stop mid-export.** The export overlay now has a Stop button (and Escape). Plus users can also flip “Keep the Kody mark” / “Include clip locations” during the encode — that cancels the current run and starts a new one with the new setting, so you do not have to wait for a full file just to turn the mark or location off.
- **Timeline follows moved clips.** Arrow-button (and Alt+arrow) reorders scroll the selected tile back into view after layout.
- **Faster, clearer device Add.** Picked files show shimmer ghost tiles immediately. Each clip is painted as soon as it is persisted (no more “Clip added” toast before the tile exists). Project load no longer blocks the first paint on thumb/audio-peak hydration.
- **Insert after the selection.** Device-imported clips land right after the currently selected clip (then after each other), not always at the end.

Review follow-up:

- Cancel during a frame callback no longer hangs or falls back to realtime; mark/location pref writes are queued and a mid-export toggle restarts only after persist succeeds.
- Device Add keeps Go/Play disabled until `refresh()` has painted the persisted clip list (optimistic tiles are editor-local).
- A restarted export waits for the aborted encode to finish before opening new decoders.
- Only an explicit `ExportCancelledError` (or an aborted signal) is treated as a user stop, so a generic `AbortError` cannot leave the overlay stuck on Exporting.
- A Plus toggle during encode does not restart after Stop/Escape or a finished sheet.
- A superseded `refresh()` waits for the newer load so import tiles and Go/Play see the latest clips.

## Test plan

- [x] `tsc -b` (lint)
- [x] Unit: storage insert-after, import-after + `onAdded`, export cancel, decoded-pump cancel policy, serialized pref writes
- [x] E2E: Stop overlay; Plus mid-export location toggle; Add inserts after selected; move-right keeps the tile in view
- [x] Re-run lint/unit/e2e after Bugbot follow-ups (343 unit, 16 e2e on `7fcb42b`)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-06cb4c3e-6fc6-4056-8b4b-707babedfbb3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-06cb4c3e-6fc6-4056-8b4b-707babedfbb3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Imported clips now appear immediately in the timeline with loading placeholders and are inserted after the selected clip.
  * Added export cancellation, including a visible stop control and Escape-key support.
  * Plus users can choose whether to include watermarks and location metadata in exports.
  * Project clips load faster while thumbnails and audio data continue processing in the background.

* **Bug Fixes**
  * Improved timeline scrolling and selection visibility during clip reordering.
  * Preserved clip order when importing multiple files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->