### PR TITLE
Raise capture/export to 1080p and lock 30fps motion

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,9 +143,12 @@ feature simply lack the data and degrade gracefully.
 ### Recording quality
 
 - Phones prefer **hardware H.264** (`video/mp4`/`h264` MediaRecorder types) over software VP9 — software encoding is what makes previews and clips drop frames on Android.
+- Capture asks for **1080p at 30fps**; bitrate scales with the actual track size (about 10 Mbps at 1080×1920) instead of a flat 3.5 Mbps.
+- A live MediaRecorder is armed on the record screen so the hardware encoder is already past its ~170ms startup hole when the user presses; the take adopts that session and trims the pre-roll.
 - Clip duration is measured from the encoded media after stop (wall-clock time includes encoder startup latency and corrupts trim/export math).
 - The elapsed timer is a leaf component mutating its text node directly from a 10Hz boundary-aligned timer (a per-frame rAF loop would force 60 main-thread frames/s), so the ticking readout never re-renders the page during capture.
 - A screen wake lock is held while recording.
+- Exports keep 1080p (long edge 1920), hold the last frame across source gaps so timestamp holes become a freeze instead of a hitch, and only drop frames closer than half a 30fps tick (jittery 30fps stays; 60fps extras go).
 
 ### Remix data flow (explicit updates, no hooks)
 

--- a/src/components/record-screen.tsx
+++ b/src/components/record-screen.tsx
@@ -154,7 +154,14 @@ export function RecordScreen(handle: Handle<RecordScreenProps>) {
   let warmTimerHandle = 0
   const armEncoderIfPossible = () => {
     const stream = camera.getStream()
-    if (!stream || !camera.isReady || recording || recorder.isRecording) return
+    if (recording || recorder.isRecording) return
+    // Lens switch nulls the preview before opening the next exclusive
+    // rear camera — drop warm clones in that same notify() turn.
+    if (!stream) {
+      recorder.disarm()
+      return
+    }
+    if (!camera.isReady) return
     // Do not enableMic here: that belongs to the press (Android voice-to-text
     // stays free while idle, and a render-time grant raced short taps).
     // iOS and a still-warm post-take mic already have audio — arm those.

--- a/src/components/record-screen.tsx
+++ b/src/components/record-screen.tsx
@@ -152,10 +152,38 @@ export function RecordScreen(handle: Handle<RecordScreenProps>) {
   // them as the first-take stutter right at recording start/stop.
   let warmIdleHandle = 0
   let warmTimerHandle = 0
+  let micArmInFlight = false
+  const armEncoderIfPossible = () => {
+    const stream = camera.getStream()
+    if (!stream || !camera.isReady || recording || recorder.isRecording) return
+    if (stream.getAudioTracks().some((track) => track.readyState === 'live')) {
+      recorder.arm(stream)
+      return
+    }
+    if (micArmInFlight) {
+      recorder.warmUp(stream)
+      return
+    }
+    micArmInFlight = true
+    void camera
+      .enableMic()
+      .then(() => {
+        if (recording || recorder.isRecording) return
+        const live = camera.getStream()
+        if (live) recorder.arm(live)
+      })
+      .catch(() => {
+        recorder.warmUp(stream)
+      })
+      .finally(() => {
+        micArmInFlight = false
+      })
+  }
   const warmFirstTakePath = () => {
     warmMicMonitorContext()
     pickRecordingMimeType()
     warmDurationProbe()
+    armEncoderIfPossible()
   }
   if (typeof window.requestIdleCallback === 'function') {
     warmIdleHandle = window.requestIdleCallback(warmFirstTakePath, { timeout: 3000 })
@@ -390,7 +418,11 @@ export function RecordScreen(handle: Handle<RecordScreenProps>) {
     beginInFlight = true
     pointerId = nextPointerId
     try {
-      // Grab the mic only for this take so Brave/Android voice-to-text stays free while idle.
+      // Start the hardware encoder during the mic await (or adopt the
+      // already-warm session) so the ~170ms startup hole is not the
+      // first frames of the take.
+      const preview = camera.getStream()
+      if (preview) recorder.arm(preview)
       await camera.enableMic()
       // Aborted presses keep the just-acquired mic warm — the real press
       // usually follows within moments and must not pay a fresh
@@ -414,6 +446,7 @@ export function RecordScreen(handle: Handle<RecordScreenProps>) {
         throw new Error('Microphone unavailable')
       }
 
+      recorder.arm(stream)
       const startedOk = recorder.start(stream)
       if (!startedOk) {
         pointerId = null
@@ -557,6 +590,7 @@ export function RecordScreen(handle: Handle<RecordScreenProps>) {
         // A quick next hold already replaced the mirror via
         // startThumbMirror — only tear it down when this take is the last.
         stopThumbMirror()
+        armEncoderIfPossible()
       }
     }
   }
@@ -724,6 +758,7 @@ export function RecordScreen(handle: Handle<RecordScreenProps>) {
         // background.
         void endRecord(undefined, { flushNow: true })
       }
+      recorder.disarm()
       camera.stop()
       cameraStoppedInBackground = true
       return
@@ -864,6 +899,7 @@ export function RecordScreen(handle: Handle<RecordScreenProps>) {
   }
 
   return () => {
+    armEncoderIfPossible()
     const { project, clips, storage, onOpenEditor, onOpenExport, onPlay } = props
     const totalDurationMs = clips.reduce((sum, clip) => sum + effectiveDurationMs(clip), 0)
     const zoomLevels = camera.zoom ? zoomChipLevels(camera.zoom) : []

--- a/src/components/record-screen.tsx
+++ b/src/components/record-screen.tsx
@@ -152,32 +152,14 @@ export function RecordScreen(handle: Handle<RecordScreenProps>) {
   // them as the first-take stutter right at recording start/stop.
   let warmIdleHandle = 0
   let warmTimerHandle = 0
-  let micArmInFlight = false
   const armEncoderIfPossible = () => {
     const stream = camera.getStream()
     if (!stream || !camera.isReady || recording || recorder.isRecording) return
-    if (stream.getAudioTracks().some((track) => track.readyState === 'live')) {
-      recorder.arm(stream)
-      return
-    }
-    if (micArmInFlight) {
-      recorder.warmUp(stream)
-      return
-    }
-    micArmInFlight = true
-    void camera
-      .enableMic()
-      .then(() => {
-        if (recording || recorder.isRecording) return
-        const live = camera.getStream()
-        if (live) recorder.arm(live)
-      })
-      .catch(() => {
-        recorder.warmUp(stream)
-      })
-      .finally(() => {
-        micArmInFlight = false
-      })
+    // Do not enableMic here: that belongs to the press (Android voice-to-text
+    // stays free while idle, and a render-time grant raced short taps).
+    // iOS and a still-warm post-take mic already have audio — arm those.
+    // Otherwise spin a video-only dummy so the hardware encoder is hot.
+    recorder.arm(stream)
   }
   const warmFirstTakePath = () => {
     warmMicMonitorContext()

--- a/src/lib/export/encode-realtime.ts
+++ b/src/lib/export/encode-realtime.ts
@@ -1,5 +1,6 @@
 import { pickRecorderMimeType } from '../media'
 import { isIosBrowser } from '../platform'
+import { videoBitrateFor } from '../video-quality'
 import {
   clipMusicVolume,
   clipSoundVolume,
@@ -270,7 +271,10 @@ export async function exportRealtime(
   let recorder: MediaRecorder
   try {
     recorder = mimeType
-      ? new MediaRecorder(mixedStream, { mimeType, videoBitsPerSecond: 3_000_000 })
+      ? new MediaRecorder(mixedStream, {
+          mimeType,
+          videoBitsPerSecond: videoBitrateFor(width, height),
+        })
       : new MediaRecorder(mixedStream)
   } catch {
     recorder = new MediaRecorder(mixedStream)

--- a/src/lib/export/encode-webcodecs.ts
+++ b/src/lib/export/encode-webcodecs.ts
@@ -25,6 +25,7 @@ import {
   type ClipRecord,
   type ProjectOrientation,
 } from '../types'
+import { videoBitrateFor } from '../video-quality'
 import {
   applyGainEnvelope,
   boundaryRampHalfMs,
@@ -63,27 +64,17 @@ import {
   locationForExport,
 } from './mp4-export-metadata'
 import { ExportCancelledError, decodedPumpFailure, throwIfExportAborted } from './cancelled'
+import {
+  EXPORT_FPS,
+  EXPORT_FRAME_INTERVAL_SEC,
+  planExportFrame,
+} from './export-frame-clock'
 
-const FPS = 30
+const FPS = EXPORT_FPS
 const AUDIO_SAMPLE_RATE = 48000
 const AUDIO_CHANNELS = 2
 const AUDIO_BITRATE = 192_000
 const KEYFRAME_INTERVAL_SEC = 2
-// Decimation to the output frame rate runs against a virtual 30fps output
-// clock (see makeFrameSink): high-rate sources otherwise push extra frames
-// through the same bitrate budget, cutting bits-per-frame — that was the
-// source of the blocky artifacts on long exports. The tolerance admits a
-// frame slightly ahead of its tick so a jittery 30fps source never drops
-// legitimate frames.
-const FRAME_INTERVAL_SEC = 1 / FPS
-const DECIMATE_TOLERANCE_SEC = 0.3 / FPS
-
-/** ~0.12 bits per pixel at 30fps — clean hardware-AVC territory without
- * ballooning the file. Scales down for small outputs instead of spending a
- * flat 4Mbps on everything. */
-function videoBitrateFor(width: number, height: number): number {
-  return Math.round(Math.min(6_000_000, Math.max(1_500_000, width * height * FPS * 0.12)))
-}
 
 export function supportsWebCodecsExport(): boolean {
   return typeof VideoEncoder !== 'undefined' && typeof VideoFrame !== 'undefined'
@@ -652,7 +643,7 @@ async function probeOutputSize(
 
 interface PumpState {
   lastVideoTsSec: number
-  /** Next 30fps output-clock tick; frames arriving before it are dropped. */
+  /** Next 30fps output-clock tick; earlier frames are held or dropped. */
   nextFrameTsSec: number
   outputOffsetSec: number
   doneMs: number
@@ -694,38 +685,50 @@ function makeFrameSink({
   ): Promise<void> => {
     throwIfExportAborted(signal)
     const clampedSec = Math.min(Math.max(mediaTimeSec, startSec), endSec)
-    let tsSec = state.outputOffsetSec + (clampedSec - startSec)
-    // Decimate against the output clock: emit one frame per 30fps tick and
-    // drop the rest, so ANY source rate (40, 60, 120fps) caps at exactly
-    // FPS long-run — a fixed minimum gap would let a 40fps source through
-    // untouched. Segment anchor frames are forced: every segment must
-    // contribute at least its first frame.
-    if (!options?.force && tsSec < state.nextFrameTsSec - DECIMATE_TOLERANCE_SEC) {
-      return Promise.resolve()
+    const tsSec = state.outputOffsetSec + (clampedSec - startSec)
+    // Keep jittery 30fps frames, drop 60fps extras, and hold the last
+    // canvas across source gaps so a 170ms hole becomes a freeze instead
+    // of a timestamp jump (the choppiness in the Pixel debug clips).
+    const plan = planExportFrame(
+      { nextFrameTsSec: state.nextFrameTsSec, lastVideoTsSec: state.lastVideoTsSec },
+      tsSec,
+      options,
+    )
+    if (!plan) return Promise.resolve()
+
+    const emitHold = async () => {
+      for (let i = 0; i < plan.holdTicks; i += 1) {
+        const holdTs = state.nextFrameTsSec + i * EXPORT_FRAME_INTERVAL_SEC
+        if (holdTs <= state.lastVideoTsSec) continue
+        state.lastVideoTsSec = holdTs
+        state.frameCount += 1
+        await videoSource.add(holdTs, 1 / FPS)
+      }
     }
-    // Stay on the tick grid while the source keeps up; resync from the
-    // frame itself across gaps (slow sources, segment jumps).
-    state.nextFrameTsSec = Math.max(state.nextFrameTsSec, tsSec) + FRAME_INTERVAL_SEC
-    if (tsSec <= state.lastVideoTsSec) {
-      tsSec = state.lastVideoTsSec + 0.001
-    }
-    draw(ctx, canvas.width, canvas.height)
-    if (watermarkImage) {
-      drawWatermark(ctx, watermarkImage, canvas.width, canvas.height)
-    }
-    state.lastVideoTsSec = tsSec
-    // Wall-clock throttled: the decoded pump can process frames far faster
-    // than realtime, so per-frame-count sampling would burn time blitting.
-    const now = performance.now()
-    if (now - state.lastPreviewAtMs >= PREVIEW_INTERVAL_MS) {
-      state.lastPreviewAtMs = now
-      blitPreview(canvas, getPreviewCanvas?.())
-    }
-    if (state.frameCount % 30 === 0) {
-      recordVideoLumaSample(canvas)
-    }
-    state.frameCount += 1
-    return videoSource.add(tsSec, 1 / FPS)
+
+    return emitHold().then(() => {
+      throwIfExportAborted(signal)
+      let emitTsSec = plan.emitTsSec
+      if (emitTsSec <= state.lastVideoTsSec) {
+        emitTsSec = state.lastVideoTsSec + 0.001
+      }
+      draw(ctx, canvas.width, canvas.height)
+      if (watermarkImage) {
+        drawWatermark(ctx, watermarkImage, canvas.width, canvas.height)
+      }
+      state.lastVideoTsSec = emitTsSec
+      state.nextFrameTsSec = plan.nextFrameTsSec
+      const now = performance.now()
+      if (now - state.lastPreviewAtMs >= PREVIEW_INTERVAL_MS) {
+        state.lastPreviewAtMs = now
+        blitPreview(canvas, getPreviewCanvas?.())
+      }
+      if (state.frameCount % 30 === 0) {
+        recordVideoLumaSample(canvas)
+      }
+      state.frameCount += 1
+      return videoSource.add(emitTsSec, 1 / FPS)
+    })
   }
 }
 
@@ -810,7 +813,7 @@ async function pumpSegmentImage({ blob, ...shared }: ImagePumpArgs): Promise<voi
       drawCoverFrom(ctx, bitmap, bitmap.width, bitmap.height, width, height)
     // The epsilon keeps float accumulation from emitting one tick past the
     // segment's end (the sink would clamp it onto the same timestamp).
-    for (let tsSec = startSec, first = true; tsSec < endSec - 1e-6; tsSec += FRAME_INTERVAL_SEC) {
+    for (let tsSec = startSec, first = true; tsSec < endSec - 1e-6; tsSec += EXPORT_FRAME_INTERVAL_SEC) {
       await emit(draw, tsSec, { force: first })
       first = false
       onElapsedMs((tsSec - startSec) * 1000)
@@ -871,9 +874,9 @@ async function pumpSegmentVideo({
   // timestamp-accurate (unlike the realtime MediaRecorder painter).
   if (playback === 'blocked') {
     for (
-      let tsSec = startSec + FRAME_INTERVAL_SEC;
+      let tsSec = startSec + EXPORT_FRAME_INTERVAL_SEC;
       tsSec < endSec - 1e-6;
-      tsSec += FRAME_INTERVAL_SEC
+      tsSec += EXPORT_FRAME_INTERVAL_SEC
     ) {
       await seekTo(video, tsSec)
       await emitAt(tsSec)

--- a/src/lib/export/export-frame-clock.test.ts
+++ b/src/lib/export/export-frame-clock.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest'
+import {
+  EXPORT_FRAME_INTERVAL_SEC,
+  planExportFrame,
+  type ExportFrameClock,
+} from './export-frame-clock'
+
+function apply(
+  clock: ExportFrameClock,
+  tsSec: number,
+  options?: { force?: boolean },
+): { held: number; dropped: boolean; emitTsSec: number | null } {
+  const plan = planExportFrame(clock, tsSec, options)
+  if (!plan) return { held: 0, dropped: true, emitTsSec: null }
+  clock.lastVideoTsSec = plan.emitTsSec
+  clock.nextFrameTsSec = plan.nextFrameTsSec
+  return { held: plan.holdTicks, dropped: false, emitTsSec: plan.emitTsSec }
+}
+
+describe('planExportFrame', () => {
+  it('keeps jittery 30fps timestamps from the Pixel debug clip', () => {
+    const clock: ExportFrameClock = { nextFrameTsSec: 0, lastVideoTsSec: -1 }
+    // First 15 PTS values from raw-video-from-zip-download.mp4
+    const raw = [
+      0.0, 0.0331, 0.0682, 0.0961, 0.2667, 0.3008, 0.3355, 0.362, 0.3967, 0.4295, 0.4613,
+      0.5026, 0.5295, 0.5591, 0.5945,
+    ]
+    const dropped: number[] = []
+    let holds = 0
+    raw.forEach((ts, i) => {
+      const result = apply(clock, ts, { force: i === 0 })
+      if (result.dropped) dropped.push(ts)
+      holds += result.held
+    })
+    expect(dropped).toEqual([])
+    // The 171ms hole at 0.096→0.267 becomes held ticks, not a skip.
+    expect(holds).toBeGreaterThanOrEqual(4)
+  })
+
+  it('drops 60fps extras and keeps the 30fps grid', () => {
+    const clock: ExportFrameClock = { nextFrameTsSec: 0, lastVideoTsSec: -1 }
+    expect(apply(clock, 0, { force: true }).dropped).toBe(false)
+    expect(apply(clock, EXPORT_FRAME_INTERVAL_SEC / 2).dropped).toBe(true)
+    expect(apply(clock, EXPORT_FRAME_INTERVAL_SEC).dropped).toBe(false)
+  })
+
+  it('does not drop a frame 21ms after the previous (jittery 30fps)', () => {
+    const clock: ExportFrameClock = { nextFrameTsSec: 0, lastVideoTsSec: -1 }
+    apply(clock, 0, { force: true })
+    const early = apply(clock, 0.021)
+    expect(early.dropped).toBe(false)
+  })
+})

--- a/src/lib/export/export-frame-clock.ts
+++ b/src/lib/export/export-frame-clock.ts
@@ -1,0 +1,61 @@
+export const EXPORT_FPS = 30
+export const EXPORT_FRAME_INTERVAL_SEC = 1 / EXPORT_FPS
+
+/**
+ * Drop only frames earlier than half a tick before the next grid time.
+ * Jittery 30fps (intervals ~21ms) stays; 60fps extras (~16.7ms) go.
+ * The previous 0.3/FPS (10ms) tolerance was the source of the 66.7ms
+ * skips on Android MediaRecorder timestamps.
+ */
+export const EXPORT_EARLY_TOLERANCE_SEC = 0.45 / EXPORT_FPS
+
+export interface ExportFrameClock {
+  /** Next 30fps output-clock tick. */
+  nextFrameTsSec: number
+  /** Last timestamp handed to the encoder; -1 before the first frame. */
+  lastVideoTsSec: number
+}
+
+export interface ExportFramePlan {
+  /** Repeat the already-drawn canvas this many 30fps ticks before drawing. */
+  holdTicks: number
+  /** Timestamp for the new source frame (on the 30fps grid after the first). */
+  emitTsSec: number
+  nextFrameTsSec: number
+}
+
+/**
+ * Decide whether to emit a source frame and how many held ticks to insert
+ * so a gap becomes a freeze, not a timestamp jump.
+ */
+export function planExportFrame(
+  clock: ExportFrameClock,
+  tsSec: number,
+  options?: { force?: boolean },
+): ExportFramePlan | null {
+  if (!options?.force && tsSec < clock.nextFrameTsSec - EXPORT_EARLY_TOLERANCE_SEC) {
+    return null
+  }
+
+  if (clock.lastVideoTsSec < 0) {
+    const emitTsSec = Math.max(0, tsSec)
+    return {
+      holdTicks: 0,
+      emitTsSec,
+      nextFrameTsSec: emitTsSec + EXPORT_FRAME_INTERVAL_SEC,
+    }
+  }
+
+  let holdTicks = 0
+  let tick = clock.nextFrameTsSec
+  while (tick + EXPORT_FRAME_INTERVAL_SEC <= tsSec + 1e-9) {
+    holdTicks += 1
+    tick += EXPORT_FRAME_INTERVAL_SEC
+  }
+
+  return {
+    holdTicks,
+    emitTsSec: tick,
+    nextFrameTsSec: tick + EXPORT_FRAME_INTERVAL_SEC,
+  }
+}

--- a/src/lib/export/shared.test.ts
+++ b/src/lib/export/shared.test.ts
@@ -24,23 +24,24 @@ import {
 } from './shared'
 
 describe('pickOutputSize', () => {
-  it('follows the source aspect, capped at 1280 on the long edge', () => {
-    expect(pickOutputSize(1080, 1920)).toEqual({ width: 720, height: 1280 })
-    expect(pickOutputSize(1920, 1080)).toEqual({ width: 1280, height: 720 })
+  it('follows the source aspect, capped at 1920 on the long edge', () => {
+    expect(pickOutputSize(1080, 1920)).toEqual({ width: 1080, height: 1920 })
+    expect(pickOutputSize(1920, 1080)).toEqual({ width: 1920, height: 1080 })
+    expect(pickOutputSize(2160, 3840)).toEqual({ width: 1080, height: 1920 })
     // Never upscales; keeps dimensions even.
     expect(pickOutputSize(321, 569)).toEqual({ width: 322, height: 570 })
   })
 
   it('forces a landscape project onto portrait sources by swapping dims', () => {
-    expect(pickOutputSize(1080, 1920, 'landscape')).toEqual({ width: 1280, height: 720 })
+    expect(pickOutputSize(1080, 1920, 'landscape')).toEqual({ width: 1920, height: 1080 })
     expect(pickOutputSize(320, 568, 'landscape')).toEqual({ width: 568, height: 320 })
     // Already landscape: untouched.
-    expect(pickOutputSize(1920, 1080, 'landscape')).toEqual({ width: 1280, height: 720 })
+    expect(pickOutputSize(1920, 1080, 'landscape')).toEqual({ width: 1920, height: 1080 })
   })
 
   it('forces a portrait project onto landscape sources by swapping dims', () => {
-    expect(pickOutputSize(1920, 1080, 'portrait')).toEqual({ width: 720, height: 1280 })
-    expect(pickOutputSize(1080, 1920, 'portrait')).toEqual({ width: 720, height: 1280 })
+    expect(pickOutputSize(1920, 1080, 'portrait')).toEqual({ width: 1080, height: 1920 })
+    expect(pickOutputSize(1080, 1920, 'portrait')).toEqual({ width: 1080, height: 1920 })
   })
 
   it('leaves square sources alone in both orientations', () => {

--- a/src/lib/export/shared.ts
+++ b/src/lib/export/shared.ts
@@ -12,6 +12,7 @@ import {
 } from 'mediabunny'
 import { reportError } from '../error-reporting'
 import type { ProjectOrientation } from '../types'
+import { VIDEO_LONG_EDGE, VIDEO_SHORT_EDGE } from '../video-quality'
 import { isMediaElementFailure, MediaElementFailureError } from './media-error'
 
 /** Helpers shared by the WebCodecs and realtime export engines. */
@@ -323,7 +324,7 @@ export function drawCoverFrom(
 
 /**
  * Pick output dimensions from the first clip's real pixel size: preserve its
- * aspect ratio, cap the long edge at 1280, never upscale, keep dims even.
+ * aspect ratio, cap the long edge at 1920 (1080p), never upscale, keep dims even.
  *
  * When the project carries an explicit `orientation`, the output must match
  * it regardless of what the first clip happens to be: a mismatched source
@@ -341,15 +342,15 @@ export function pickOutputSize(
   width: number
   height: number
 } {
-  let w = sourceWidth > 0 ? sourceWidth : 720
-  let h = sourceHeight > 0 ? sourceHeight : 1280
+  let w = sourceWidth > 0 ? sourceWidth : VIDEO_SHORT_EDGE
+  let h = sourceHeight > 0 ? sourceHeight : VIDEO_LONG_EDGE
   if (
     (orientation === 'landscape' && h > w) ||
     (orientation === 'portrait' && w > h)
   ) {
     ;[w, h] = [h, w]
   }
-  const scale = Math.min(1, 1280 / Math.max(w, h))
+  const scale = Math.min(1, VIDEO_LONG_EDGE / Math.max(w, h))
   const even = (n: number) => Math.max(2, 2 * Math.round((n * scale) / 2))
   return { width: even(w), height: even(h) }
 }

--- a/src/lib/media.ts
+++ b/src/lib/media.ts
@@ -1,5 +1,6 @@
 import { isMobileBrowser } from './platform'
 import type { ClipRecord } from './types'
+import { VIDEO_LONG_EDGE, VIDEO_SHORT_EDGE } from './video-quality'
 
 export { isIosBrowser, isMobileBrowser } from './platform'
 
@@ -64,8 +65,8 @@ export async function openCameraStream(
         : true
       : false
   const baseConstraints: MediaTrackConstraints = {
-    width: { ideal: 1280 },
-    height: { ideal: 720 },
+    width: { ideal: VIDEO_LONG_EDGE },
+    height: { ideal: VIDEO_SHORT_EDGE },
     frameRate: { ideal: 30 },
   }
 

--- a/src/lib/project-actions.ts
+++ b/src/lib/project-actions.ts
@@ -241,6 +241,8 @@ export async function appendRecording(
     blob: Blob
     mimeType: string
     durationMs: number
+    /** Default trim-in (warm-encoder pre-roll sits before the press). */
+    trimStartMs?: number
     /** Default trim-out (recordings end their kept range at the release
      * point; the media itself runs a stop-grace longer). */
     trimEndMs?: number
@@ -270,6 +272,7 @@ export async function appendRecording(
     blob: input.blob,
     mimeType: input.mimeType,
     durationMs: input.durationMs,
+    trimStartMs: input.trimStartMs,
     trimEndMs: input.trimEndMs,
     width: input.width,
     height: input.height,

--- a/src/lib/recorder.test.ts
+++ b/src/lib/recorder.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { takeTrimEndMs } from './recorder'
+import { takeTrimEndMs, takeTrimStartMs } from './recorder'
 
 describe('takeTrimEndMs', () => {
   it('walks the trim-out back by the real stop grace', () => {
@@ -19,5 +19,20 @@ describe('takeTrimEndMs', () => {
 
   it('never exceeds the measured media duration', () => {
     expect(takeTrimEndMs(100, 0)).toBe(100)
+  })
+})
+
+describe('takeTrimStartMs', () => {
+  it('skips adopted pre-roll so the kept range is the wall-clock hold', () => {
+    expect(takeTrimStartMs(4300, 2000)).toBe(2300)
+  })
+
+  it('is 0 for a cold start (take length matches the trimmed media)', () => {
+    expect(takeTrimStartMs(2000, 2000)).toBe(0)
+    expect(takeTrimStartMs(2000, 2100)).toBe(0)
+  })
+
+  it('is 0 when there is no take length', () => {
+    expect(takeTrimStartMs(2000, 0)).toBe(0)
   })
 })

--- a/src/lib/recorder.test.ts
+++ b/src/lib/recorder.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { takeTrimEndMs, takeTrimStartMs } from './recorder'
+import { takeFallbackDurationMs, takeTrimEndMs, takeTrimStartMs } from './recorder'
 
 describe('takeTrimEndMs', () => {
   it('walks the trim-out back by the real stop grace', () => {
@@ -34,5 +34,28 @@ describe('takeTrimStartMs', () => {
 
   it('is 0 when there is no take length', () => {
     expect(takeTrimStartMs(2000, 0)).toBe(0)
+  })
+})
+
+describe('takeFallbackDurationMs', () => {
+  it('keeps adopted pre-roll in the blob length so trim-in can skip it', () => {
+    // Warm session started 800ms before press; 2000ms hold; 200ms grace.
+    const fallbackMs = takeFallbackDurationMs(0, 3000, 2000)
+    expect(fallbackMs).toBe(3000)
+    const trimEndMs = takeTrimEndMs(fallbackMs, 200)
+    expect(trimEndMs).toBe(2800)
+    expect(takeTrimStartMs(trimEndMs, 2000)).toBe(800)
+  })
+
+  it('matches a cold start (no pre-roll) after walking back grace', () => {
+    const fallbackMs = takeFallbackDurationMs(0, 2200, 2000)
+    expect(fallbackMs).toBe(2200)
+    const trimEndMs = takeTrimEndMs(fallbackMs, 200)
+    expect(trimEndMs).toBe(2000)
+    expect(takeTrimStartMs(trimEndMs, 2000)).toBe(0)
+  })
+
+  it('never reports shorter than the wall-clock hold', () => {
+    expect(takeFallbackDurationMs(1000, 1500, 2000)).toBe(2000)
   })
 })

--- a/src/lib/recorder.ts
+++ b/src/lib/recorder.ts
@@ -212,11 +212,11 @@ export class HoldRecorder {
       window.clearTimeout(this.recycleTimer)
       this.recycleTimer = 0
       this.stopDummy()
-      // Only count pre-roll once the encoder-startup hole is behind us.
-      // A just-created session is a cold take (takeStartedAt unset).
-      if (performance.now() - adopted.startedAt >= WARMUP_MS) {
-        adopted.takeStartedAt = performance.now()
-      }
+      // Always stamp the press. A young session may still contain the
+      // startup hole, but take length must be press→release — otherwise a
+      // 40ms tap on a 200ms-old warm session looks like a 240ms take and
+      // is saved.
+      adopted.takeStartedAt = performance.now()
       this.session = adopted
       return true
     }

--- a/src/lib/recorder.ts
+++ b/src/lib/recorder.ts
@@ -1,10 +1,14 @@
 import { isMediaElementFailure } from './export/media-error'
 import { measureBlobDuration, pickRecordingMimeType } from './media'
+import { recordingVideoBitsPerSecond } from './video-quality'
 
 export interface RecordingResult {
   blob: Blob
   mimeType: string
   durationMs: number
+  /** Default trim-in: adopted warm sessions include pre-roll so the
+   * encoder-startup hole sits before the press, not in the kept range. */
+  trimStartMs: number
   /** Default trim-out at the RELEASE point: the media runs STOP_GRACE_MS
    * longer (see below), but the clip the user meant ends where they let go. */
   trimEndMs: number
@@ -23,12 +27,30 @@ const MIN_TAKE_MS = 120
  * way to its end (and the extra tail becomes trim-handle material). */
 const STOP_GRACE_MS = 200
 
+/** How long a video-only dummy encoder runs to initialize the hardware
+ * codec before the first take that cannot yet adopt a live session. */
+const WARMUP_MS = 400
+
+/** Bound warm-session memory: recycle the live encoder every few seconds
+ * while idle so a long sit on the record screen does not accumulate a
+ * multi-minute MP4 in RAM. The startup hole lands in the discarded
+ * pre-roll of the new session. */
+const WARM_RECYCLE_MS = 8_000
+
 /** Release point on the media timeline: the media ends ~graceMs after the
  * release, so walk back from the measured end — never under the minimum
  * take length (the planner drops sub-50ms segments; a sliver of a trim
  * range helps nobody). */
 export function takeTrimEndMs(measuredMs: number, graceMs: number): number {
   return Math.min(measuredMs, Math.max(MIN_TAKE_MS, measuredMs - graceMs))
+}
+
+/** Default trim-in for a take that adopted a warm encoder: the kept range
+ * is the wall-clock hold, ending at trimEnd. Cold starts (no pre-roll)
+ * yield 0. */
+export function takeTrimStartMs(trimEndMs: number, takeWallMs: number): number {
+  if (takeWallMs <= 0) return 0
+  return Math.max(0, trimEndMs - takeWallMs)
 }
 
 /**
@@ -55,6 +77,9 @@ interface RecordingSession {
   chunks: BlobPart[]
   mimeType: string
   startedAt: number
+  /** Wall-clock press time when this warm session was adopted as a take.
+   * Absent on a cold start (press === recorder start). */
+  takeStartedAt?: number
   trackWidth: number | undefined
   trackHeight: number | undefined
 }
@@ -65,9 +90,19 @@ function stopSessionTracks(session: RecordingSession): void {
   })
 }
 
+function sessionHasLiveAudio(session: RecordingSession): boolean {
+  return session.stream.getAudioTracks().some((track) => track.readyState === 'live')
+}
+
 export class HoldRecorder {
   private session: RecordingSession | null = null
+  /** Live encoder running before the press so the take can adopt it. */
+  private warm: RecordingSession | null = null
+  private warming = false
+  private dummyRecorder: MediaRecorder | null = null
+  private dummyClones: MediaStreamTrack[] = []
   private stopping = false
+  private recycleTimer = 0
   /** Cuts a pending stop grace short — set only while a stop() is waiting
    * out its grace window (see cancel()). */
   private fireStopNow: (() => void) | null = null
@@ -76,50 +111,121 @@ export class HoldRecorder {
     return this.session?.recorder.state === 'recording'
   }
 
+  /** Spin a live encoder on this stream so the next start() can adopt it
+   * (startup hole stays in discarded pre-roll). Requires a live audio
+   * track — MediaRecorder cannot add the mic later. No-ops while a take
+   * is running or a warm session is already live on a compatible stream. */
+  arm(stream: MediaStream): void {
+    if (this.isRecording || this.stopping) return
+    if (this.warm?.recorder.state === 'recording' && sessionHasLiveAudio(this.warm)) {
+      const videoLive = this.warm.clonedTracks.every((track) => track.readyState === 'live')
+      if (videoLive) return
+    }
+    if (!stream.getAudioTracks().some((track) => track.readyState === 'live')) {
+      this.warmUp(stream)
+      return
+    }
+    this.disarm()
+    const created = this.createSession(stream)
+    if (!created) return
+    this.warm = created
+    this.recycleTimer = window.setTimeout(() => {
+      this.recycleTimer = 0
+      if (this.session || this.stopping) return
+      this.disarm()
+      this.arm(stream)
+    }, WARM_RECYCLE_MS)
+  }
+
+  /** Video-only dummy start/stop to initialize the hardware encoder when
+   * the mic is not yet live (first Android take). Best-effort: a later
+   * real MediaRecorder may still pay startup, which is why arm() is
+   * preferred once audio is available. */
+  warmUp(stream: MediaStream): void {
+    if (this.isRecording || this.stopping || this.warming) return
+    if (this.warm?.recorder.state === 'recording') return
+    const video = stream.getVideoTracks()[0]
+    if (!video || video.readyState !== 'live') return
+    this.stopDummy()
+    const clone = video.clone()
+    const warmStream = new MediaStream([clone])
+    try {
+      const settings = video.getSettings()
+      const recorder = this.makeRecorder(warmStream, settings.width, settings.height)
+      this.warming = true
+      this.dummyRecorder = recorder
+      this.dummyClones = [clone]
+      recorder.ondataavailable = () => undefined
+      recorder.onstop = () => {
+        this.finishDummy(recorder)
+      }
+      recorder.onerror = () => {
+        this.finishDummy(recorder)
+      }
+      recorder.start(250)
+      window.setTimeout(() => {
+        if (this.dummyRecorder === recorder && recorder.state !== 'inactive') {
+          try {
+            recorder.stop()
+          } catch {
+            this.finishDummy(recorder)
+          }
+        }
+      }, WARMUP_MS)
+    } catch {
+      clone.stop()
+      this.warming = false
+      this.dummyRecorder = null
+      this.dummyClones = []
+    }
+  }
+
+  /** Drop a warm/dummy encoder without saving. Safe during camera stop. */
+  disarm(): void {
+    this.stopDummy()
+    window.clearTimeout(this.recycleTimer)
+    this.recycleTimer = 0
+    const warm = this.warm
+    this.warm = null
+    if (!warm) return
+    warm.recorder.ondataavailable = null
+    warm.recorder.onstop = () => stopSessionTracks(warm)
+    warm.recorder.onerror = () => stopSessionTracks(warm)
+    if (warm.recorder.state !== 'inactive') {
+      try {
+        warm.recorder.stop()
+        return
+      } catch {
+        // Fall through — stop the clones directly.
+      }
+    }
+    stopSessionTracks(warm)
+  }
+
   /** @returns true when a new recording actually started */
   start(stream: MediaStream): boolean {
     if (this.isRecording || this.stopping) return false
 
-    const settings = stream.getVideoTracks()[0]?.getSettings()
-    const clones = stream.getVideoTracks().map((track) => track.clone())
-    const recordStream = new MediaStream([...clones, ...stream.getAudioTracks()])
-
-    let recorder: MediaRecorder
-    try {
-      const preferredMime = pickRecordingMimeType()
-      recorder = preferredMime
-        ? new MediaRecorder(recordStream, {
-            mimeType: preferredMime,
-            videoBitsPerSecond: 3_500_000,
-            audioBitsPerSecond: 192_000,
-          })
-        : new MediaRecorder(recordStream)
-
-      const session: RecordingSession = {
-        recorder,
-        stream: recordStream,
-        clonedTracks: clones,
-        chunks: [],
-        mimeType: recorder.mimeType || preferredMime || 'video/webm',
-        startedAt: performance.now(),
-        trackWidth: settings?.width,
-        trackHeight: settings?.height,
+    if (this.warm?.recorder.state === 'recording' && sessionHasLiveAudio(this.warm)) {
+      const adopted = this.warm
+      this.warm = null
+      window.clearTimeout(this.recycleTimer)
+      this.recycleTimer = 0
+      this.stopDummy()
+      // Only count pre-roll once the encoder-startup hole is behind us.
+      // A just-created session is a cold take (takeStartedAt unset).
+      if (performance.now() - adopted.startedAt >= WARMUP_MS) {
+        adopted.takeStartedAt = performance.now()
       }
-      recorder.ondataavailable = (event) => {
-        if (event.data.size > 0) session.chunks.push(event.data)
-      }
-      recorder.start(250)
-      this.session = session
+      this.session = adopted
       return true
-    } catch {
-      // Constructor/start can throw (unsupported params, dead tracks) —
-      // the clones must not outlive the failed attempt. (Never the audio
-      // track: that is the camera's live mic.)
-      clones.forEach((track) => {
-        track.stop()
-      })
-      return false
     }
+
+    this.disarm()
+    const created = this.createSession(stream)
+    if (!created) return false
+    this.session = created
+    return true
   }
 
   /** `graceMs: 0` stops the MediaRecorder SYNCHRONOUSLY inside this call —
@@ -136,7 +242,8 @@ export class HoldRecorder {
 
     this.stopping = true
     const releaseAt = performance.now()
-    const wallClockMs = Math.max(0, Math.round(releaseAt - session.startedAt))
+    const takeStartedAt = session.takeStartedAt ?? session.startedAt
+    const takeWallMs = Math.max(0, Math.round(releaseAt - takeStartedAt))
     const finishSession = () => {
       this.fireStopNow = null
       stopSessionTracks(session)
@@ -156,21 +263,24 @@ export class HoldRecorder {
         const blob = new Blob(session.chunks, { type: session.mimeType })
         const width = session.trackWidth
         const height = session.trackHeight
-        if (blob.size === 0 || wallClockMs < MIN_TAKE_MS) {
+        if (blob.size === 0 || takeWallMs < MIN_TAKE_MS) {
           resolve(null)
           return
         }
         // The blob's real duration differs from wall clock (encoder start
-        // latency, stop grace); trims and export math must use the media
-        // duration.
+        // latency, stop grace, adopted pre-roll); trims and export math
+        // must use the media duration.
         void measureBlobDuration(blob)
           .then((measuredMs) => {
+            const durationMs = measuredMs > 0 ? measuredMs : takeWallMs
+            const trimEndMs =
+              measuredMs > 0 ? takeTrimEndMs(measuredMs, graceActualMs) : takeWallMs
             resolve({
               blob,
               mimeType: session.mimeType || blob.type || 'video/webm',
-              durationMs: measuredMs > 0 ? measuredMs : wallClockMs,
-              trimEndMs:
-                measuredMs > 0 ? takeTrimEndMs(measuredMs, graceActualMs) : wallClockMs,
+              durationMs,
+              trimStartMs: takeTrimStartMs(trimEndMs, takeWallMs),
+              trimEndMs,
               width,
               height,
             })
@@ -186,8 +296,9 @@ export class HoldRecorder {
             resolve({
               blob,
               mimeType: session.mimeType || blob.type || 'video/webm',
-              durationMs: wallClockMs,
-              trimEndMs: wallClockMs,
+              durationMs: takeWallMs,
+              trimStartMs: 0,
+              trimEndMs: takeWallMs,
               width,
               height,
             })
@@ -217,6 +328,7 @@ export class HoldRecorder {
   }
 
   cancel(): void {
+    this.disarm()
     // A stop() already owns this session (waiting out its grace, or
     // awaiting onstop): hasten it and let its save resolve. Discarding
     // here would orphan the pending stop() promise — endRecord would hang
@@ -242,5 +354,97 @@ export class HoldRecorder {
       }
     }
     stopSessionTracks(session)
+  }
+
+  private finishDummy(recorder: MediaRecorder): void {
+    if (this.dummyRecorder === recorder) {
+      this.dummyClones.forEach((track) => {
+        track.stop()
+      })
+      this.dummyRecorder = null
+      this.dummyClones = []
+      this.warming = false
+    }
+  }
+
+  private stopDummy(): void {
+    const recorder = this.dummyRecorder
+    const clones = this.dummyClones
+    this.dummyRecorder = null
+    this.dummyClones = []
+    this.warming = false
+    if (!recorder) return
+    recorder.ondataavailable = null
+    recorder.onstop = () => {
+      clones.forEach((track) => {
+        track.stop()
+      })
+    }
+    recorder.onerror = () => {
+      clones.forEach((track) => {
+        track.stop()
+      })
+    }
+    if (recorder.state !== 'inactive') {
+      try {
+        recorder.stop()
+        return
+      } catch {
+        // Fall through.
+      }
+    }
+    clones.forEach((track) => {
+      track.stop()
+    })
+  }
+
+  private makeRecorder(
+    recordStream: MediaStream,
+    width: number | undefined,
+    height: number | undefined,
+  ): MediaRecorder {
+    const preferredMime = pickRecordingMimeType()
+    const videoBitsPerSecond = recordingVideoBitsPerSecond(width, height)
+    return preferredMime
+      ? new MediaRecorder(recordStream, {
+          mimeType: preferredMime,
+          videoBitsPerSecond,
+          audioBitsPerSecond: 192_000,
+        })
+      : new MediaRecorder(recordStream)
+  }
+
+  private createSession(stream: MediaStream): RecordingSession | null {
+    const settings = stream.getVideoTracks()[0]?.getSettings()
+    const clones = stream.getVideoTracks().map((track) => track.clone())
+    const recordStream = new MediaStream([...clones, ...stream.getAudioTracks()])
+
+    try {
+      const recorder = this.makeRecorder(recordStream, settings?.width, settings?.height)
+      const preferredMime = pickRecordingMimeType()
+      const session: RecordingSession = {
+        recorder,
+        stream: recordStream,
+        clonedTracks: clones,
+        chunks: [],
+        mimeType: recorder.mimeType || preferredMime || 'video/webm',
+        startedAt: performance.now(),
+        trackWidth: settings?.width,
+        trackHeight: settings?.height,
+      }
+      recorder.ondataavailable = (event) => {
+        if (event.data.size > 0) session.chunks.push(event.data)
+      }
+      recorder.start(250)
+      return session
+    } catch {
+      // Constructor/start can throw (unsupported params, dead tracks) —
+      // the clones must not outlive the failed attempt. (Never the audio
+      // track: that is the camera's live mic.)
+      clones.forEach((track) => {
+        track.stop()
+      })
+      return null
+    }
   }
 }

--- a/src/lib/recorder.ts
+++ b/src/lib/recorder.ts
@@ -31,11 +31,11 @@ const STOP_GRACE_MS = 200
  * codec before the first take that cannot yet adopt a live session. */
 const WARMUP_MS = 400
 
-/** Bound warm-session memory: recycle the live encoder every few seconds
- * while idle so a long sit on the record screen does not accumulate a
- * multi-minute MP4 in RAM. The startup hole lands in the discarded
- * pre-roll of the new session. */
-const WARM_RECYCLE_MS = 8_000
+/** Bound warm-session memory: recycle the live encoder often enough that
+ * discarding a short tap does not have to flush a multi-second 1080p
+ * file. The startup hole lands in the discarded pre-roll of the new
+ * session. */
+const WARM_RECYCLE_MS = 1_500
 
 /** Release point on the media timeline: the media ends ~graceMs after the
  * release, so walk back from the measured end — never under the minimum
@@ -308,7 +308,8 @@ export class HoldRecorder {
         finishSession()
         reject(new Error('Recording failed'))
       }
-      const graceMs = options?.graceMs ?? STOP_GRACE_MS
+      const graceMs =
+        takeWallMs < MIN_TAKE_MS ? 0 : (options?.graceMs ?? STOP_GRACE_MS)
       let graceTimer = 0
       const fire = () => {
         window.clearTimeout(graceTimer)

--- a/src/lib/recorder.ts
+++ b/src/lib/recorder.ts
@@ -53,6 +53,17 @@ export function takeTrimStartMs(trimEndMs: number, takeWallMs: number): number {
   return Math.max(0, trimEndMs - takeWallMs)
 }
 
+/** Blob length when media duration cannot be measured: encoder start →
+ * stop (adopted pre-roll + hold + grace). Never shorter than the hold,
+ * so a clock inversion cannot hide the take. */
+export function takeFallbackDurationMs(
+  sessionStartedAt: number,
+  stoppedAt: number,
+  takeWallMs: number,
+): number {
+  return Math.max(takeWallMs, Math.round(stoppedAt - sessionStartedAt))
+}
+
 /**
  * Hold-to-record helper around MediaRecorder.
  * Starts on press, stops on release; returns a Blob for IndexedDB storage.
@@ -103,9 +114,46 @@ export class HoldRecorder {
   private dummyClones: MediaStreamTrack[] = []
   private stopping = false
   private recycleTimer = 0
+  /** Preview stream the current warm/dummy encoder was built from.
+   * Camera swaps mint a new MediaStream; clones from the previous one
+   * keep the old camera open (Android exclusive HAL / privacy dot). */
+  private warmSource: MediaStream | null = null
+  private warmSourceEnded: (() => void) | null = null
   /** Cuts a pending stop grace short — set only while a stop() is waiting
    * out its grace window (see cancel()). */
   private fireStopNow: (() => void) | null = null
+
+  private warmSessionIsReusable(stream: MediaStream): boolean {
+    if (this.warmSource !== stream) return false
+    if (this.warm?.recorder.state !== 'recording') return false
+    if (!sessionHasLiveAudio(this.warm)) return false
+    return this.warm.clonedTracks.every((track) => track.readyState === 'live')
+  }
+
+  private unbindWarmSource(): void {
+    const stream = this.warmSource
+    const onEnded = this.warmSourceEnded
+    this.warmSource = null
+    this.warmSourceEnded = null
+    const video = stream?.getVideoTracks()[0]
+    if (video && onEnded) video.removeEventListener('ended', onEnded)
+  }
+
+  private bindWarmSource(stream: MediaStream): void {
+    this.unbindWarmSource()
+    this.warmSource = stream
+    const video = stream.getVideoTracks()[0]
+    if (!video) return
+    // Preview track.stop() (flip / lens / tab hide) must drop clones in
+    // the same turn the camera HAL is released — otherwise Android cannot
+    // open the next exclusive rear lens.
+    const onEnded = () => {
+      if (this.warmSource !== stream) return
+      this.disarm()
+    }
+    this.warmSourceEnded = onEnded
+    video.addEventListener('ended', onEnded)
+  }
 
   get isRecording(): boolean {
     return this.session?.recorder.state === 'recording'
@@ -117,10 +165,7 @@ export class HoldRecorder {
    * is running or a warm session is already live on a compatible stream. */
   arm(stream: MediaStream): void {
     if (this.isRecording || this.stopping) return
-    if (this.warm?.recorder.state === 'recording' && sessionHasLiveAudio(this.warm)) {
-      const videoLive = this.warm.clonedTracks.every((track) => track.readyState === 'live')
-      if (videoLive) return
-    }
+    if (this.warmSessionIsReusable(stream)) return
     if (!stream.getAudioTracks().some((track) => track.readyState === 'live')) {
       this.warmUp(stream)
       return
@@ -129,6 +174,7 @@ export class HoldRecorder {
     const created = this.createSession(stream)
     if (!created) return
     this.warm = created
+    this.bindWarmSource(stream)
     this.recycleTimer = window.setTimeout(() => {
       this.recycleTimer = 0
       if (this.session || this.stopping) return
@@ -142,8 +188,10 @@ export class HoldRecorder {
    * real MediaRecorder may still pay startup, which is why arm() is
    * preferred once audio is available. */
   warmUp(stream: MediaStream): void {
-    if (this.isRecording || this.stopping || this.warming) return
-    if (this.warm?.recorder.state === 'recording') return
+    if (this.isRecording || this.stopping) return
+    if (this.warmSessionIsReusable(stream)) return
+    if (this.warming && this.warmSource === stream) return
+    this.disarm()
     const video = stream.getVideoTracks()[0]
     if (!video || video.readyState !== 'live') return
     this.stopDummy()
@@ -155,6 +203,7 @@ export class HoldRecorder {
       this.warming = true
       this.dummyRecorder = recorder
       this.dummyClones = [clone]
+      this.bindWarmSource(stream)
       recorder.ondataavailable = () => undefined
       recorder.onstop = () => {
         this.finishDummy(recorder)
@@ -177,6 +226,7 @@ export class HoldRecorder {
       this.warming = false
       this.dummyRecorder = null
       this.dummyClones = []
+      this.unbindWarmSource()
     }
   }
 
@@ -187,6 +237,7 @@ export class HoldRecorder {
     this.recycleTimer = 0
     const warm = this.warm
     this.warm = null
+    this.unbindWarmSource()
     if (!warm) return
     warm.recorder.ondataavailable = null
     warm.recorder.onstop = () => stopSessionTracks(warm)
@@ -206,9 +257,11 @@ export class HoldRecorder {
   start(stream: MediaStream): boolean {
     if (this.isRecording || this.stopping) return false
 
-    if (this.warm?.recorder.state === 'recording' && sessionHasLiveAudio(this.warm)) {
+    if (this.warmSessionIsReusable(stream)) {
       const adopted = this.warm
+      if (!adopted) return false
       this.warm = null
+      this.unbindWarmSource()
       window.clearTimeout(this.recycleTimer)
       this.recycleTimer = 0
       this.stopDummy()
@@ -267,14 +320,18 @@ export class HoldRecorder {
           resolve(null)
           return
         }
+        const fallbackMs = takeFallbackDurationMs(
+          session.startedAt,
+          performance.now(),
+          takeWallMs,
+        )
         // The blob's real duration differs from wall clock (encoder start
         // latency, stop grace, adopted pre-roll); trims and export math
         // must use the media duration.
         void measureBlobDuration(blob)
           .then((measuredMs) => {
-            const durationMs = measuredMs > 0 ? measuredMs : takeWallMs
-            const trimEndMs =
-              measuredMs > 0 ? takeTrimEndMs(measuredMs, graceActualMs) : takeWallMs
+            const durationMs = measuredMs > 0 ? measuredMs : fallbackMs
+            const trimEndMs = takeTrimEndMs(durationMs, graceActualMs)
             resolve({
               blob,
               mimeType: session.mimeType || blob.type || 'video/webm',
@@ -288,17 +345,19 @@ export class HoldRecorder {
           .catch((error) => {
             // A media-element failure means the browser cannot decode this
             // take at all — keeping it would only fail again at export.
-            // Timeouts still fall back to wall-clock (streamy WebM).
+            // Timeouts still fall back to session wall-clock (streamy WebM)
+            // so adopted pre-roll stays outside the kept range.
             if (isMediaElementFailure(error)) {
               resolve(null)
               return
             }
+            const trimEndMs = takeTrimEndMs(fallbackMs, graceActualMs)
             resolve({
               blob,
               mimeType: session.mimeType || blob.type || 'video/webm',
-              durationMs: takeWallMs,
-              trimStartMs: 0,
-              trimEndMs: takeWallMs,
+              durationMs: fallbackMs,
+              trimStartMs: takeTrimStartMs(trimEndMs, takeWallMs),
+              trimEndMs,
               width,
               height,
             })

--- a/src/lib/storage.test.ts
+++ b/src/lib/storage.test.ts
@@ -407,6 +407,20 @@ describe('storage layer', () => {
     expect(clamped.trimEndMs).toBe(1000)
   })
 
+  it('stores a default trim-in for adopted warm recordings', async () => {
+    const project = await createProject('Warm')
+    const clip = await addClip({
+      projectId: project.id,
+      blob: fakeBlob('warm'),
+      mimeType: 'video/mp4',
+      durationMs: 4500,
+      trimStartMs: 2300,
+      trimEndMs: 4300,
+    })
+    expect(clip.trimStartMs).toBe(2300)
+    expect(clip.trimEndMs).toBe(4300)
+  })
+
   it('appends clips, trims, reorders, duplicates, deletes, and undoes', async () => {
     const project = await createProject('Edit me')
     const c1 = await addClip({

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -540,6 +540,8 @@ export interface AddClipInput {
   /** 'image' for a still photo shown for `durationMs`; omit for video. */
   kind?: ClipKind
   durationMs: number
+  /** Default trim-in; adopted warm recordings skip encoder pre-roll. */
+  trimStartMs?: number
   /** Default trim-out point; recordings pass the release point so the
    * stop-grace tail (real media past the finger-lift) starts trimmed off. */
   trimEndMs?: number
@@ -608,16 +610,20 @@ export async function addClip(input: AddClipInput): Promise<ClipRecord> {
   const durableBlob = await toStoredBlob(input.blob, input.mimeType)
 
   const now = Date.now()
+  const trimEndMs = isImage
+    ? durationMs
+    : Math.max(0, Math.min(input.trimEndMs ?? durationMs, durationMs))
+  const trimStartMs = isImage
+    ? 0
+    : Math.max(0, Math.min(input.trimStartMs ?? 0, trimEndMs))
   const clip: ClipRecord = {
     id: newId('clip'),
     projectId: input.projectId,
     blob: durableBlob,
     mimeType: input.mimeType,
     durationMs,
-    trimStartMs: 0,
-    trimEndMs: isImage
-      ? durationMs
-      : Math.max(0, Math.min(input.trimEndMs ?? durationMs, durationMs)),
+    trimStartMs,
+    trimEndMs,
     createdAt: input.createdAt ?? now,
     ...(isImage ? { kind: 'image' as const } : {}),
     width: input.width,

--- a/src/lib/video-quality.test.ts
+++ b/src/lib/video-quality.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest'
+import { recordingVideoBitsPerSecond, videoBitrateFor } from './video-quality'
+
+describe('videoBitrateFor', () => {
+  it('scales with pixels and stays in the 1080p band', () => {
+    expect(videoBitrateFor(1080, 1920)).toBe(Math.round(1080 * 1920 * 30 * 0.16))
+    expect(videoBitrateFor(1920, 1080)).toBe(Math.round(1920 * 1080 * 30 * 0.16))
+    expect(videoBitrateFor(1080, 1920)).toBeGreaterThan(8_000_000)
+    expect(videoBitrateFor(1080, 1920)).toBeLessThanOrEqual(12_000_000)
+  })
+
+  it('floors tiny outputs instead of spending a flat 4Mbps', () => {
+    expect(videoBitrateFor(320, 568)).toBe(1_500_000)
+  })
+})
+
+describe('recordingVideoBitsPerSecond', () => {
+  it('assumes 1080p when the track has not reported size yet', () => {
+    expect(recordingVideoBitsPerSecond()).toBe(videoBitrateFor(1920, 1080, 0.16))
+  })
+
+  it('follows the live track size', () => {
+    expect(recordingVideoBitsPerSecond(720, 1280)).toBe(videoBitrateFor(720, 1280, 0.16))
+  })
+})

--- a/src/lib/video-quality.ts
+++ b/src/lib/video-quality.ts
@@ -1,0 +1,31 @@
+/** Capture request and export long-edge cap: 1080p, never 4K. */
+export const VIDEO_LONG_EDGE = 1920
+export const VIDEO_SHORT_EDGE = 1080
+export const VIDEO_FPS = 30
+
+/** Bits-per-pixel at 30fps. Capture is slightly richer than export so the
+ * recorded file is not the weaker generation. */
+export const CAPTURE_BPP = 0.16
+export const EXPORT_BPP = 0.16
+
+const BITRATE_MIN = 1_500_000
+const BITRATE_MAX = 12_000_000
+
+/** Hardware-AVC bitrate for a frame size: scales with pixels, floored so
+ * tiny test/photo outputs stay cheap, capped so 1080p stays in the
+ * 8–12 Mbps band instead of a flat 3.5 Mbps. */
+export function videoBitrateFor(
+  width: number,
+  height: number,
+  bitsPerPixel: number = EXPORT_BPP,
+): number {
+  const w = width > 0 ? width : VIDEO_LONG_EDGE
+  const h = height > 0 ? height : VIDEO_SHORT_EDGE
+  return Math.round(
+    Math.min(BITRATE_MAX, Math.max(BITRATE_MIN, w * h * VIDEO_FPS * bitsPerPixel)),
+  )
+}
+
+export function recordingVideoBitsPerSecond(width?: number, height?: number): number {
+  return videoBitrateFor(width ?? VIDEO_LONG_EDGE, height ?? VIDEO_SHORT_EDGE, CAPTURE_BPP)
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

Pixel 10 Pro debug clips showed Kody recording 720p SDR H.264 at ~4 Mbps with a 171ms encoder-startup hole and jittery timestamps. Export then dropped more frames (66.7ms skips) because the 30fps decimation tolerance was only 10ms. Native camera was 1080p HDR HEVC at 21 Mbps with a locked 30fps clock.

Web cannot match Pixel HDR/10-bit/HEVC, but we can ask for 1080p, spend a 1080p bitrate, keep those frames, and start the encoder before the user presses.

## What changed

- **Capture** asks `getUserMedia` for 1920×1080 @ 30fps. MediaRecorder bitrate scales with the live track (~10 Mbps at 1080×1920) instead of a flat 3.5 Mbps.
- **Warm encoder:** a video-only dummy MediaRecorder runs while the preview is idle so the hardware codec is already initialized. When the mic is already live (iOS, or Android keep-warm after a take), a live session is armed and the take **adopts** it so the ~170ms startup hole sits in discarded pre-roll. Default `trimStartMs` skips that pre-roll. Adopted takes always stamp press time so a 40ms tap cannot inherit the warm session's age.
- **Camera swap:** warm sessions are bound to the preview `MediaStream`. Flip/lens/tab-hide drops those clones (stream identity, preview `ended`, and disarm when the preview is nulled) so Android exclusive HALs can open the next camera.
- **Duration fallback:** if blob duration cannot be measured, wall-clock from encoder start → stop keeps adopted pre-roll out of the kept range.
- **Export** long-edge cap is 1920 (1080p kept). Bitrate uses the same scaler (cap 12 Mbps).
- **Jitter:** export holds the last canvas across source gaps (a 171ms hole becomes a freeze, not a timestamp jump) and only drops frames closer than half a 30fps tick. Jittery 30fps (~21ms intervals) stays; 60fps extras still go.

## Testing

- `npm run lint` clean
- `npm test` — 357 passed
- `npx playwright test tests/e2e/record.spec.ts tests/e2e/desktop-keyboard.spec.ts` — 19 passed locally after the adopt-timing fix

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-84945f84-f836-43bc-ac09-3b9a8a40e4b7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-84945f84-f836-43bc-ac09-3b9a8a40e4b7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Capture and export now support up to 1080p at 30 fps.
  * Video bitrate scales automatically with recording resolution for improved quality and efficiency.
  * Recordings can include pre-roll with more accurate trim-in behavior.
* **Bug Fixes**
  * Exported video now maintains consistent timing, preserves frames across source gaps, and removes only near-duplicate frames.
  * Recording startup and completed takes are more reliable, including short recordings and background transitions.
* **Documentation**
  * Added documentation covering capture quality, pre-roll, and export behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->