### PR TITLE
Add clip info sheet with permanent trim, split, and download

### DIFF
--- a/src/components/clip-info-sheet.tsx
+++ b/src/components/clip-info-sheet.tsx
@@ -1,0 +1,188 @@
+import type { Handle } from 'remix/ui'
+import { on, ref } from 'remix/ui'
+import { canSplitClip, clipHasUnusedMedia, resolveSplitMs } from '../lib/clip-edit'
+import { buildClipFacts } from '../lib/clip-facts'
+import { attachSheetModal } from '../lib/sheet-modal'
+import { effectiveDurationMs, formatDuration, isImageClip, type ClipRecord } from '../lib/types'
+import { IconDownload, IconSplit, IconTrim } from './icons'
+
+interface ClipInfoSheetProps {
+  clip: ClipRecord
+  clips: ClipRecord[]
+  index: number
+  projectName: string
+  getPlayheadMs: () => number | null
+  onPermanentlyTrim: () => Promise<void>
+  onSplit: (splitMs: number) => Promise<void>
+  onDownload: () => Promise<void>
+  onClose: () => void
+}
+
+type BusyAction = 'trim' | 'split' | 'download' | null
+
+/** Facts + destructive clip edits (permanent trim, split) and download. */
+export function ClipInfoSheet(handle: Handle<ClipInfoSheetProps>) {
+  let busy: BusyAction = null
+  let confirmingTrim = false
+  let error: string | null = null
+
+  const run = async (action: Exclude<BusyAction, null>, work: () => Promise<void>) => {
+    if (busy) return
+    busy = action
+    error = null
+    void handle.update()
+    try {
+      await work()
+      busy = null
+      void handle.update()
+    } catch (err) {
+      error = err instanceof Error ? err.message : 'Something went wrong'
+      busy = null
+      void handle.update()
+    }
+  }
+
+  return () => {
+    const { clip, clips, index, projectName, getPlayheadMs, onClose } = handle.props
+    const filmDurationMs = clips.reduce((sum, item) => sum + effectiveDurationMs(item), 0)
+    const facts = buildClipFacts(clip, {
+      index,
+      clipCount: clips.length,
+      filmDurationMs,
+    })
+    const photo = isImageClip(clip)
+    const canTrim = clipHasUnusedMedia(clip)
+    const canSplit = canSplitClip(clip)
+    const splitMs = canSplit ? resolveSplitMs(clip, getPlayheadMs()) : null
+    const working = busy !== null
+
+    return (
+      <>
+        <div
+          className="sheet-backdrop"
+          mix={on('click', () => {
+            if (!working) onClose()
+          })}
+        />
+        <div
+          className="sheet clip-info-sheet"
+          role="dialog"
+          aria-modal="true"
+          aria-label={`${photo ? 'Photo' : 'Clip'} ${index + 1} info`}
+          mix={ref((node, signal) =>
+            attachSheetModal(node as HTMLElement, signal, {
+              onDismiss: () => handle.props.onClose(),
+              busy: () => busy !== null,
+            }),
+          )}
+        >
+          <h3>{photo ? 'Photo' : 'Clip'} {index + 1}</h3>
+          <p className="sheet-lede muted">{projectName}</p>
+          <dl className="clip-info-facts">
+            {facts.map((fact) => (
+              <div key={fact.label} className="clip-info-fact">
+                <dt>{fact.label}</dt>
+                <dd>{fact.value}</dd>
+              </div>
+            ))}
+          </dl>
+
+          {error ? <p className="sheet-message is-error">{error}</p> : null}
+
+          {confirmingTrim ? (
+            <p className="sheet-message">
+              This deletes the unused start and end from the file. You cannot undo
+              it.
+            </p>
+          ) : null}
+
+          <div className="clip-info-actions">
+            {photo ? null : confirmingTrim ? (
+              <div className="sheet-actions">
+                <button
+                  type="button"
+                  className="btn btn-ghost"
+                  disabled={working}
+                  data-sheet-focus
+                  mix={on('click', () => {
+                    confirmingTrim = false
+                    void handle.update()
+                  })}
+                >
+                  Cancel
+                </button>
+                <button
+                  type="button"
+                  className="btn btn-primary confirm-sheet-danger"
+                  disabled={working}
+                  mix={on('click', () =>
+                    run('trim', () => handle.props.onPermanentlyTrim()),
+                  )}
+                >
+                  {busy === 'trim' ? 'Deleting…' : 'Delete unused parts'}
+                </button>
+              </div>
+            ) : (
+              <button
+                type="button"
+                className="btn btn-ghost clip-info-action"
+                disabled={working || !canTrim}
+                mix={on('click', () => {
+                  if (!canTrim) return
+                  confirmingTrim = true
+                  void handle.update()
+                })}
+              >
+                <IconTrim size={18} />
+                Permanently trim
+              </button>
+            )}
+            {photo ? null : (
+              <button
+                type="button"
+                className="btn btn-ghost clip-info-action"
+                disabled={working || !canSplit}
+                mix={on('click', () => {
+                  if (splitMs === null) return
+                  void run('split', () => handle.props.onSplit(splitMs))
+                })}
+              >
+                <IconSplit size={18} />
+                {busy === 'split'
+                  ? 'Splitting…'
+                  : splitMs !== null
+                    ? `Split at ${formatDuration(splitMs)}`
+                    : 'Split clip'}
+              </button>
+            )}
+            <button
+              type="button"
+              className="btn btn-ghost clip-info-action"
+              disabled={working}
+              data-sheet-focus={confirmingTrim ? undefined : true}
+              mix={on('click', () => run('download', () => handle.props.onDownload()))}
+            >
+              <IconDownload size={18} />
+              {busy === 'download' ? 'Downloading…' : 'Download'}
+            </button>
+            <button
+              type="button"
+              className="btn btn-ghost"
+              disabled={working}
+              mix={on('click', () => onClose())}
+            >
+              Close
+            </button>
+          </div>
+          {photo ? (
+            <p className="clip-info-hint muted">Photos can be downloaded; trim and split are for video clips.</p>
+          ) : !canTrim && !confirmingTrim ? (
+            <p className="clip-info-hint muted">
+              Trim the clip first, then permanently delete the unused parts.
+            </p>
+          ) : null}
+        </div>
+      </>
+    )
+  }
+}

--- a/src/components/clip-info-sheet.tsx
+++ b/src/components/clip-info-sheet.tsx
@@ -143,8 +143,9 @@ export function ClipInfoSheet(handle: Handle<ClipInfoSheetProps>) {
                 className="btn btn-ghost clip-info-action"
                 disabled={working || !canSplit}
                 mix={on('click', () => {
-                  if (splitMs === null) return
-                  void run('split', () => handle.props.onSplit(splitMs))
+                  if (!canSplit) return
+                  const liveSplitMs = resolveSplitMs(clip, handle.props.getPlayheadMs())
+                  void run('split', () => handle.props.onSplit(liveSplitMs))
                 })}
               >
                 <IconSplit size={18} />

--- a/src/components/editor-clip-preview.tsx
+++ b/src/components/editor-clip-preview.tsx
@@ -17,7 +17,7 @@ import {
 } from '../lib/preview-music-bed'
 import { BlobImage } from './blob-image'
 import { BlobVideo } from './blob-video'
-import { IconPause, IconPlay } from './icons'
+import { IconInfo, IconPause, IconPlay } from './icons'
 import {
   clipMusicVolume,
   clipSoundVolume,
@@ -33,6 +33,7 @@ const MIX_GLIDE_TAU_MS = 200
 export interface EditorClipPreviewHandle {
   seekToMs: (timeMs: number) => void
   pause: () => void
+  getCurrentTimeMs: () => number
 }
 
 interface EditorClipPreviewProps {
@@ -44,6 +45,8 @@ interface EditorClipPreviewProps {
   /** Background-music playlist (null when none / not unlocked). */
   audio: ProjectAudioRecord | null
   apiRef?: { current: EditorClipPreviewHandle | null }
+  /** Timeline view: open the clip info sheet from the preview corner. */
+  onInfoClick?: () => void
 }
 
 function nudgeFrame(video: HTMLVideoElement): void {
@@ -72,7 +75,11 @@ export function EditorClipPreview(handle: Handle<EditorClipPreviewProps>) {
     const bindImage = (_node: Element, signal: AbortSignal) => {
       const apiRef = props.apiRef
       if (!apiRef) return
-      const api = { seekToMs: () => undefined, pause: () => undefined }
+      const api = {
+        seekToMs: () => undefined,
+        pause: () => undefined,
+        getCurrentTimeMs: () => 0,
+      }
       apiRef.current = api
       signal.addEventListener('abort', () => {
         // A remount may bind the replacement before this abort runs —
@@ -88,6 +95,7 @@ export function EditorClipPreview(handle: Handle<EditorClipPreviewProps>) {
           alt="Selected photo"
           mix={ref(bindImage)}
         />
+        {props.onInfoClick ? <PreviewInfoButton onClick={props.onInfoClick} /> : null}
       </div>
     )
   }
@@ -448,6 +456,7 @@ export function EditorClipPreview(handle: Handle<EditorClipPreviewProps>) {
         el.pause()
         setPlaying(false)
       },
+      getCurrentTimeMs: () => (media?.currentTime ?? 0) * 1000,
     }
     signal.addEventListener('abort', () => {
       // A remount (remountKey change) may bind the replacement element
@@ -570,7 +579,24 @@ export function EditorClipPreview(handle: Handle<EditorClipPreviewProps>) {
         >
           {playing ? <IconPause size={18} /> : <IconPlay size={18} />}
         </button>
+        {props.onInfoClick ? <PreviewInfoButton onClick={props.onInfoClick} /> : null}
       </div>
     )
   }
+}
+
+function PreviewInfoButton(handle: Handle<{ onClick: () => void }>) {
+  return () => (
+    <button
+      type="button"
+      className="editor-preview-info"
+      aria-label="Clip info"
+      mix={on('click', (event) => {
+        event.stopPropagation()
+        handle.props.onClick()
+      })}
+    >
+      <IconInfo size={18} />
+    </button>
+  )
 }

--- a/src/components/editor-screen.tsx
+++ b/src/components/editor-screen.tsx
@@ -6,12 +6,15 @@ import {
   duplicateSelectedClip,
   importDeviceClips,
   moveSelectedClip,
+  permanentlyTrimClip,
   removeClip,
   setAudioTrackSettings,
   setClipDuration,
+  splitSelectedClip,
   trimClip,
   undoLastDelete,
 } from '../lib/project-actions'
+import { downloadClipFile } from '../lib/media'
 import {
   effectiveDurationMs,
   formatDuration,
@@ -24,6 +27,7 @@ import {
 } from '../lib/types'
 import { AudioDetailStrip } from './audio-detail-strip'
 import { AudioStrip } from './audio-strip'
+import { ClipInfoSheet } from './clip-info-sheet'
 import { EditorClipPreview, type EditorClipPreviewHandle } from './editor-clip-preview'
 import {
   IconBack,
@@ -73,6 +77,7 @@ export function EditorScreen(handle: Handle<EditorScreenProps>) {
   /** Track whose detail view (trim, level, fades) is open — the audio
    * counterpart of `trimming`. */
   let editingTrackId: string | null = null
+  let clipInfoOpen = false
   let importing = false
   /** Clips persisted but not yet in props.clips (refresh still in flight). */
   let optimisticAdds: { clip: ClipRecord; afterId: ClipId | null }[] = []
@@ -228,7 +233,10 @@ export function EditorScreen(handle: Handle<EditorScreenProps>) {
     const selected = clips.find((c) => c.id === resolvedSelectedId) ?? null
     const selectedIndex = selected ? clips.findIndex((c) => c.id === selected.id) : -1
     if (event.code === 'Escape') {
-      if (trimming) {
+      if (clipInfoOpen) {
+        clipInfoOpen = false
+        void handle.update()
+      } else if (trimming) {
         previewApi.current?.pause()
         setTrimming(false)
       } else if (editingTrackId) {
@@ -238,7 +246,7 @@ export function EditorScreen(handle: Handle<EditorScreenProps>) {
       }
       return
     }
-    if (trimming || editingTrackId) return
+    if (trimming || editingTrackId || clipInfoOpen) return
     switch (event.code) {
       case 'ArrowLeft':
       case 'ArrowRight': {
@@ -427,6 +435,15 @@ export function EditorScreen(handle: Handle<EditorScreenProps>) {
               clips={clips}
               audio={props.audio}
               apiRef={previewApi}
+              onInfoClick={
+                trimming || editingTrack
+                  ? undefined
+                  : () => {
+                      previewApi.current?.pause()
+                      clipInfoOpen = true
+                      void handle.update()
+                    }
+              }
             />
           ) : (
             <div className="editor-empty-preview">Select a clip in the timeline</div>
@@ -619,6 +636,38 @@ export function EditorScreen(handle: Handle<EditorScreenProps>) {
             <kbd>D</kbd> duplicate · <kbd>⌫</kbd> delete · <kbd>P</kbd> play · <kbd>Esc</kbd> camera
           </div>
         </div>
+
+        {clipInfoOpen && selected ? (
+          <ClipInfoSheet
+            clip={selected}
+            clips={clips}
+            index={selectedIndex}
+            projectName={project.name}
+            getPlayheadMs={() => previewApi.current?.getCurrentTimeMs() ?? null}
+            onPermanentlyTrim={async () => {
+              const updated = await permanentlyTrimClip(selected.id)
+              clipInfoOpen = false
+              selectedClipId = updated.id
+              await props.refresh()
+              props.showToast('Unused parts deleted')
+            }}
+            onSplit={async (splitMs) => {
+              const { second } = await splitSelectedClip(selected.id, splitMs)
+              clipInfoOpen = false
+              selectedClipId = second.id
+              await props.refresh()
+              props.showToast('Clip split')
+            }}
+            onDownload={async () => {
+              await downloadClipFile(selected, project.name, selectedIndex)
+              props.showToast('Clip downloaded')
+            }}
+            onClose={() => {
+              clipInfoOpen = false
+              void handle.update()
+            }}
+          />
+        ) : null}
       </div>
     )
   }

--- a/src/components/icons.tsx
+++ b/src/components/icons.tsx
@@ -153,6 +153,18 @@ export function IconTrim(handle: Handle<IconProps>) {
   )
 }
 
+/** Scissors: split one clip into two. */
+export function IconSplit(handle: Handle<IconProps>) {
+  return () => (
+    <svg {...baseProps(handle.props.size ?? 22)}>
+      <circle cx="6.5" cy="6.5" r="2.25" />
+      <circle cx="6.5" cy="17.5" r="2.25" />
+      <path d="M8.4 7.8L20 18" />
+      <path d="M8.4 16.2L20 6" />
+    </svg>
+  )
+}
+
 export function IconChevronLeft(handle: Handle<IconProps>) {
   return () => (
     <svg {...baseProps(handle.props.size ?? 22)}>

--- a/src/lib/clip-edit.test.ts
+++ b/src/lib/clip-edit.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest'
+import {
+  MIN_SLICE_MS,
+  canSplitClip,
+  clipHasUnusedMedia,
+  remapTrimToSlice,
+  resolveSplitMs,
+} from './clip-edit'
+
+const video = (trimStartMs: number, trimEndMs: number, durationMs = 2000) => ({
+  durationMs,
+  trimStartMs,
+  trimEndMs,
+})
+
+describe('clipHasUnusedMedia', () => {
+  it('is false for a fully kept video and for photos', () => {
+    expect(clipHasUnusedMedia(video(0, 2000))).toBe(false)
+    expect(clipHasUnusedMedia({ ...video(0, 3000, 3000), kind: 'image' })).toBe(false)
+  })
+
+  it('is true when a usable range is trimmed', () => {
+    expect(clipHasUnusedMedia(video(200, 1600))).toBe(true)
+    expect(clipHasUnusedMedia(video(0, 1500))).toBe(true)
+  })
+})
+
+describe('canSplitClip', () => {
+  it('requires a kept window of at least two slices', () => {
+    expect(canSplitClip(video(0, MIN_SLICE_MS * 2 - 1))).toBe(false)
+    expect(canSplitClip(video(0, MIN_SLICE_MS * 2))).toBe(true)
+    expect(canSplitClip({ ...video(0, 2000), kind: 'image' })).toBe(false)
+  })
+})
+
+describe('resolveSplitMs', () => {
+  it('uses the playhead when it sits inside the kept window', () => {
+    expect(resolveSplitMs(video(200, 1800), 900)).toBe(900)
+  })
+
+  it('falls back to the kept midpoint at the edges or when missing', () => {
+    expect(resolveSplitMs(video(200, 1800), 200)).toBe(1000)
+    expect(resolveSplitMs(video(200, 1800), null)).toBe(1000)
+  })
+})
+
+describe('remapTrimToSlice', () => {
+  it('keeps the overlapping trim on each half of a split', () => {
+    const clip = video(400, 1600, 2000)
+    expect(remapTrimToSlice(clip, 0, 1000)).toEqual({ trimStartMs: 400, trimEndMs: 1000 })
+    expect(remapTrimToSlice(clip, 1000, 1000)).toEqual({ trimStartMs: 0, trimEndMs: 600 })
+  })
+})

--- a/src/lib/clip-edit.ts
+++ b/src/lib/clip-edit.ts
@@ -1,0 +1,53 @@
+import {
+  effectiveDurationMs,
+  isImageClip,
+  type ClipMeta,
+} from './types'
+
+/** Shortest piece we will encode or keep after a permanent trim / split.
+ * Stays above the export planner's 50ms drop threshold. */
+export const MIN_SLICE_MS = 100
+
+export function clipHasUnusedMedia(
+  clip: Pick<ClipMeta, 'durationMs' | 'trimStartMs' | 'trimEndMs' | 'kind'>,
+): boolean {
+  if (isImageClip(clip)) return false
+  const kept = effectiveDurationMs(clip)
+  return kept >= MIN_SLICE_MS && kept < clip.durationMs - 1
+}
+
+export function canSplitClip(
+  clip: Pick<ClipMeta, 'durationMs' | 'trimStartMs' | 'trimEndMs' | 'kind'>,
+): boolean {
+  if (isImageClip(clip)) return false
+  return effectiveDurationMs(clip) >= MIN_SLICE_MS * 2
+}
+
+/** Absolute source time at which a split should cut. Uses the playhead when
+ * it sits far enough inside the kept window; otherwise the kept midpoint. */
+export function resolveSplitMs(
+  clip: Pick<ClipMeta, 'durationMs' | 'trimStartMs' | 'trimEndMs'>,
+  playheadMs: number | null,
+): number {
+  const end = Math.min(clip.trimEndMs, clip.durationMs)
+  const start = Math.max(0, Math.min(clip.trimStartMs, end))
+  const mid = start + (end - start) / 2
+  if (playheadMs === null || !Number.isFinite(playheadMs)) return mid
+  if (playheadMs >= start + MIN_SLICE_MS && playheadMs <= end - MIN_SLICE_MS) {
+    return playheadMs
+  }
+  return mid
+}
+
+/** Remap a source-window trim onto a sliced blob that starts at `offsetMs`. */
+export function remapTrimToSlice(
+  clip: Pick<ClipMeta, 'durationMs' | 'trimStartMs' | 'trimEndMs'>,
+  offsetMs: number,
+  sliceDurationMs: number,
+): { trimStartMs: number; trimEndMs: number } {
+  const sourceEnd = Math.min(clip.trimEndMs, clip.durationMs)
+  const sourceStart = Math.max(0, Math.min(clip.trimStartMs, sourceEnd))
+  const start = Math.max(0, Math.min(sourceStart - offsetMs, sliceDurationMs))
+  const end = Math.max(start, Math.min(sourceEnd - offsetMs, sliceDurationMs))
+  return { trimStartMs: start, trimEndMs: end }
+}

--- a/src/lib/clip-facts.test.ts
+++ b/src/lib/clip-facts.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildClipFacts,
+  clipDownloadFilename,
+  formatClipAspect,
+  formatClipBytes,
+  formatClipMime,
+  formatLatLng,
+} from './clip-facts'
+import type { ClipRecord } from './types'
+
+function clip(overrides: Partial<ClipRecord> = {}): ClipRecord {
+  return {
+    id: 'clip_1',
+    projectId: 'proj_1',
+    mimeType: 'video/webm',
+    durationMs: 2000,
+    trimStartMs: 0,
+    trimEndMs: 2000,
+    createdAt: Date.UTC(2026, 7, 15, 12, 0, 0),
+    blob: new Blob(['x'.repeat(1500)], { type: 'video/webm' }),
+    width: 320,
+    height: 568,
+    ...overrides,
+  }
+}
+
+describe('clip fact formatters', () => {
+  it('formats bytes, mime, aspect, and coordinates', () => {
+    expect(formatClipBytes(800)).toBe('800 B')
+    expect(formatClipBytes(12_500)).toBe('12 KB')
+    expect(formatClipBytes(2.4 * 1024 * 1024)).toBe('2.4 MB')
+    expect(formatClipMime('video/webm;codecs=vp8')).toBe('WebM')
+    expect(formatClipMime('image/jpeg')).toBe('JPEG')
+    expect(formatClipAspect(1080, 1920)).toBe('9:16')
+    expect(formatLatLng(40.7, -74)).toBe('40.7000° N, 74.0000° W')
+  })
+
+  it('names a downloaded clip from the project and mime', () => {
+    expect(clipDownloadFilename('Ski Trip', 0, 'video/mp4')).toBe('ski-trip-clip-01.mp4')
+    expect(clipDownloadFilename('Ski Trip', 3, 'image/png')).toBe('ski-trip-clip-04.png')
+  })
+})
+
+describe('buildClipFacts', () => {
+  it('includes place in the film, size, and unused media when trimmed', () => {
+    const facts = buildClipFacts(clip({ trimStartMs: 400, trimEndMs: 1400, lat: 10, lng: 20 }), {
+      index: 1,
+      clipCount: 4,
+      filmDurationMs: 4000,
+    })
+    const byLabel = Object.fromEntries(facts.map((fact) => [fact.label, fact.value]))
+    expect(byLabel.Clip).toBe('2 of 4')
+    expect(byLabel.Kept).toMatch(/1\.0s of 2\.0s/)
+    expect(byLabel.Unused).toMatch(/1\.0s/)
+    expect(byLabel.Size).toMatch(/320 × 568/)
+    expect(byLabel.File).toMatch(/WebM/)
+    expect(byLabel.Location).toMatch(/10\.0000° N/)
+    expect(byLabel['Of the film']).toBe('25%')
+  })
+
+  it('labels a photo and skips unused-media rows', () => {
+    const facts = buildClipFacts(clip({ kind: 'image', mimeType: 'image/jpeg' }), {
+      index: 0,
+      clipCount: 1,
+      filmDurationMs: 3000,
+    })
+    const labels = facts.map((fact) => fact.label)
+    expect(labels).toContain('Photo')
+    expect(labels).toContain('On screen')
+    expect(labels).not.toContain('Unused')
+  })
+})

--- a/src/lib/clip-facts.ts
+++ b/src/lib/clip-facts.ts
@@ -1,0 +1,169 @@
+import { formatDuration, isImageClip, type ClipRecord } from './types'
+import { clipHasUnusedMedia } from './clip-edit'
+
+export interface ClipFact {
+  label: string
+  value: string
+}
+
+export function formatClipBytes(bytes: number): string {
+  if (!Number.isFinite(bytes) || bytes <= 0) return '0 B'
+  if (bytes < 1024) return `${Math.round(bytes)} B`
+  if (bytes < 1024 * 1024) return `${Math.max(1, Math.round(bytes / 1024))} KB`
+  const mb = bytes / (1024 * 1024)
+  if (mb < 10) return `${Math.round(mb * 10) / 10} MB`
+  return `${Math.round(mb)} MB`
+}
+
+export function formatClipMime(mimeType: string): string {
+  const lower = mimeType.toLowerCase()
+  if (lower.includes('mp4') || lower.includes('quicktime')) return 'MP4'
+  if (lower.includes('webm')) return 'WebM'
+  if (lower.includes('quicktime')) return 'MOV'
+  if (lower.includes('jpeg') || lower.includes('jpg')) return 'JPEG'
+  if (lower.includes('png')) return 'PNG'
+  if (lower.includes('webp')) return 'WebP'
+  if (lower.includes('heic') || lower.includes('heif')) return 'HEIC'
+  if (lower.includes('gif')) return 'GIF'
+  const subtype = lower.split('/')[1]?.split(';')[0]
+  return subtype ? subtype.toUpperCase() : mimeType
+}
+
+export function formatClipAspect(width: number, height: number): string | null {
+  if (!(width > 0) || !(height > 0)) return null
+  const g = gcd(Math.round(width), Math.round(height))
+  const rw = Math.round(width) / g
+  const rh = Math.round(height) / g
+  if (rw <= 32 && rh <= 32) return `${rw}:${rh}`
+  return `${(width / height).toFixed(2)}:1`
+}
+
+export function formatLatLng(lat: number, lng: number): string {
+  const ns = lat >= 0 ? 'N' : 'S'
+  const ew = lng >= 0 ? 'E' : 'W'
+  return `${Math.abs(lat).toFixed(4)}° ${ns}, ${Math.abs(lng).toFixed(4)}° ${ew}`
+}
+
+export function clipDownloadExtension(mimeType: string): string {
+  const lower = mimeType.toLowerCase()
+  if (lower.includes('mp4') || lower.includes('quicktime')) return 'mp4'
+  if (lower.includes('webm')) return 'webm'
+  if (lower.includes('png')) return 'png'
+  if (lower.includes('webp')) return 'webp'
+  if (lower.includes('gif')) return 'gif'
+  if (lower.includes('heic')) return 'heic'
+  if (lower.includes('heif')) return 'heif'
+  if (lower.startsWith('image/')) return 'jpg'
+  return 'webm'
+}
+
+export function clipDownloadFilename(
+  projectName: string,
+  index: number,
+  mimeType: string,
+): string {
+  const ext = clipDownloadExtension(mimeType)
+  return `${slugify(projectName)}-clip-${String(index + 1).padStart(2, '0')}.${ext}`
+}
+
+export function buildClipFacts(
+  clip: ClipRecord,
+  options: { index: number; clipCount: number; filmDurationMs: number },
+): ClipFact[] {
+  const facts: ClipFact[] = []
+  const photo = isImageClip(clip)
+  facts.push({
+    label: photo ? 'Photo' : 'Clip',
+    value: `${options.index + 1} of ${options.clipCount}`,
+  })
+
+  const kept = Math.max(0, Math.min(clip.trimEndMs, clip.durationMs) - Math.max(0, clip.trimStartMs))
+  if (photo) {
+    facts.push({ label: 'On screen', value: formatDuration(clip.durationMs) })
+  } else if (clipHasUnusedMedia(clip)) {
+    facts.push({
+      label: 'Kept',
+      value: `${formatDuration(kept)} of ${formatDuration(clip.durationMs)}`,
+    })
+    const dropped = clip.durationMs - kept
+    facts.push({ label: 'Unused', value: `${formatDuration(dropped)} still in the file` })
+  } else {
+    facts.push({ label: 'Duration', value: formatDuration(clip.durationMs) })
+  }
+
+  if (clip.width && clip.height) {
+    const aspect = formatClipAspect(clip.width, clip.height)
+    facts.push({
+      label: 'Size',
+      value: aspect
+        ? `${clip.width} × ${clip.height} · ${aspect}`
+        : `${clip.width} × ${clip.height}`,
+    })
+  }
+
+  facts.push({ label: 'File', value: `${formatClipBytes(clip.blob.size)} · ${formatClipMime(clip.mimeType)}` })
+  facts.push({ label: 'Recorded', value: formatRecordedAt(clip.createdAt) })
+
+  if (typeof clip.lat === 'number' && typeof clip.lng === 'number') {
+    const accuracy =
+      typeof clip.locationAccuracyM === 'number' && Number.isFinite(clip.locationAccuracyM)
+        ? ` (±${Math.round(clip.locationAccuracyM)} m)`
+        : ''
+    facts.push({ label: 'Location', value: `${formatLatLng(clip.lat, clip.lng)}${accuracy}` })
+  }
+
+  if (options.filmDurationMs > 0 && options.clipCount > 0) {
+    const share = Math.round((kept / options.filmDurationMs) * 100)
+    facts.push({
+      label: 'Of the film',
+      value: `${Math.max(0, Math.min(100, share))}%`,
+    })
+  }
+
+  if (!photo && typeof clip.audioPeak === 'number' && Number.isFinite(clip.audioPeak)) {
+    facts.push({ label: 'Audio', value: describeAudioPeak(clip.audioPeak) })
+  }
+
+  return facts
+}
+
+function describeAudioPeak(peak: number): string {
+  if (peak <= 0.005) return 'Silent'
+  if (peak < 0.08) return 'Quiet'
+  if (peak < 0.35) return 'Moderate'
+  return 'Loud'
+}
+
+function formatRecordedAt(createdAt: number): string {
+  if (!Number.isFinite(createdAt) || createdAt <= 0) return 'Unknown'
+  try {
+    return new Date(createdAt).toLocaleString(undefined, {
+      dateStyle: 'medium',
+      timeStyle: 'short',
+    })
+  } catch {
+    return 'Unknown'
+  }
+}
+
+function gcd(a: number, b: number): number {
+  let x = Math.abs(a)
+  let y = Math.abs(b)
+  while (y !== 0) {
+    const next = x % y
+    x = y
+    y = next
+  }
+  return x || 1
+}
+
+function slugify(value: string): string {
+  return (
+    value
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/(^-|-$)/g, '')
+      .slice(0, 40) || 'project'
+  )
+}
+

--- a/src/lib/clip-media.test.ts
+++ b/src/lib/clip-media.test.ts
@@ -1,0 +1,70 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import { permanentlyTrimClip, splitSelectedClip } from './project-actions'
+import { __resetDbForTests, addClip, createProject, getClip, getClipsForProject, updateClipTrim } from './storage'
+import { makeTestClipBlob } from './testing/make-test-clip'
+import { sliceClipMedia } from './clip-media'
+import { measureBlobDuration } from './media'
+
+describe('sliceClipMedia', () => {
+  it('encodes a shorter file for a kept window', async () => {
+    const source = await makeTestClipBlob(1200)
+    const sliced = await sliceClipMedia(source, 200, 800)
+    expect(sliced.blob.size).toBeGreaterThan(0)
+    expect(sliced.mimeType).toMatch(/webm|mp4/)
+    expect(sliced.durationMs).toBeGreaterThanOrEqual(400)
+    expect(sliced.durationMs).toBeLessThan(1000)
+    await expect(measureBlobDuration(sliced.blob)).resolves.toBeGreaterThan(300)
+  })
+})
+
+describe('permanentlyTrimClip / splitSelectedClip', () => {
+  beforeEach(async () => {
+    await __resetDbForTests()
+  })
+
+  it('bakes the saved trim into a new blob and resets the window', async () => {
+    const project = await createProject('Cut')
+    const blob = await makeTestClipBlob(1200)
+    const clip = await addClip({
+      projectId: project.id,
+      blob,
+      mimeType: 'video/webm',
+      durationMs: 1200,
+      width: 320,
+      height: 568,
+    })
+    await updateClipTrim(clip.id, 200, 800)
+
+    const updated = await permanentlyTrimClip(clip.id)
+    expect(updated.durationMs).toBeGreaterThanOrEqual(400)
+    expect(updated.durationMs).toBeLessThan(1000)
+    expect(updated.trimStartMs).toBe(0)
+    expect(updated.trimEndMs).toBe(updated.durationMs)
+    expect(updated.blob.size).toBeGreaterThan(0)
+    expect(updated.blob.size).not.toBe(blob.size)
+  })
+
+  it('splits one clip into two adjacent pieces', async () => {
+    const project = await createProject('Split')
+    const blob = await makeTestClipBlob(1200)
+    const clip = await addClip({
+      projectId: project.id,
+      blob,
+      mimeType: 'video/webm',
+      durationMs: 1200,
+      width: 320,
+      height: 568,
+    })
+
+    const { first, second } = await splitSelectedClip(clip.id, 600)
+    expect(first.id).toBe(clip.id)
+    expect(second.id).not.toBe(clip.id)
+    expect(first.durationMs).toBeGreaterThan(200)
+    expect(second.durationMs).toBeGreaterThan(200)
+    expect(first.durationMs + second.durationMs).toBeGreaterThan(800)
+
+    const ordered = await getClipsForProject(project.id)
+    expect(ordered.map((item) => item.id)).toEqual([first.id, second.id])
+    expect(await getClip(second.id)).toBeTruthy()
+  })
+})

--- a/src/lib/clip-media.ts
+++ b/src/lib/clip-media.ts
@@ -1,0 +1,81 @@
+import { measureBlobDuration } from './media'
+import { MIN_SLICE_MS } from './clip-edit'
+
+export interface SlicedClipMedia {
+  blob: Blob
+  mimeType: string
+  durationMs: number
+  width?: number
+  height?: number
+}
+
+/**
+ * Re-mux (or transcode) a time range of a video blob into a new file.
+ * Used to permanently drop unused trim and to split a clip into two files.
+ */
+export async function sliceClipMedia(
+  blob: Blob,
+  startMs: number,
+  endMs: number,
+): Promise<SlicedClipMedia> {
+  const start = Math.max(0, startMs)
+  const end = Math.max(start + MIN_SLICE_MS, endMs)
+  if (!(end - start >= MIN_SLICE_MS)) {
+    throw new Error('That slice is too short')
+  }
+
+  const { ALL_FORMATS, BlobSource, BufferTarget, Conversion, Input, Mp4OutputFormat, Output, WebMOutputFormat } =
+    await import('mediabunny')
+
+  const input = new Input({ source: new BlobSource(blob), formats: ALL_FORMATS })
+  try {
+    const preferMp4 = (blob.type || '').toLowerCase().includes('mp4')
+    const target = new BufferTarget()
+    const mimeType = preferMp4 ? 'video/mp4' : 'video/webm'
+    const output = new Output({
+      format: preferMp4 ? new Mp4OutputFormat({ fastStart: 'in-memory' }) : new WebMOutputFormat(),
+      target,
+    })
+    const size = await probeSlicedSize(input).catch(() => ({}))
+    const conversion = await Conversion.init({
+      input,
+      output,
+      trim: { start: start / 1000, end: end / 1000 },
+      showWarnings: false,
+    })
+    if (!conversion.isValid) {
+      throw new Error('Could not cut that clip on this device')
+    }
+    await conversion.execute()
+    if (!target.buffer || target.buffer.byteLength <= 0) {
+      throw new Error('Cutting the clip produced no video')
+    }
+
+    const sliced = new Blob([target.buffer], { type: mimeType })
+    const durationMs = await measureSlicedDuration(sliced, end - start)
+    return { blob: sliced, mimeType, durationMs, ...size }
+  } finally {
+    input.dispose()
+  }
+}
+
+async function measureSlicedDuration(blob: Blob, fallbackMs: number): Promise<number> {
+  try {
+    const measured = await measureBlobDuration(blob)
+    if (Number.isFinite(measured) && measured >= MIN_SLICE_MS) return measured
+  } catch {
+    // Fall through to the requested window.
+  }
+  return Math.round(fallbackMs)
+}
+
+async function probeSlicedSize(
+  input: { getPrimaryVideoTrack: () => Promise<{ displayWidth: number; displayHeight: number; codedWidth: number; codedHeight: number } | null> },
+): Promise<{ width?: number; height?: number }> {
+  const track = await input.getPrimaryVideoTrack().catch(() => null)
+  if (!track) return {}
+  const width = track.displayWidth > 0 ? track.displayWidth : track.codedWidth
+  const height = track.displayHeight > 0 ? track.displayHeight : track.codedHeight
+  if (!(width > 0) || !(height > 0)) return {}
+  return { width, height }
+}

--- a/src/lib/media.ts
+++ b/src/lib/media.ts
@@ -1,3 +1,4 @@
+import { clipDownloadFilename } from './clip-facts'
 import { isMobileBrowser } from './platform'
 import type { ClipRecord } from './types'
 
@@ -485,9 +486,16 @@ export async function shareClipFile(
   projectName: string,
   index: number,
 ): Promise<'shared' | 'downloaded' | 'cancelled'> {
-  const ext = clip.mimeType.includes('mp4') ? 'mp4' : 'webm'
-  const filename = `${slugify(projectName)}-clip-${String(index + 1).padStart(2, '0')}.${ext}`
-  return shareOrDownload(clip.blob, filename)
+  return shareOrDownload(clip.blob, clipDownloadFilename(projectName, index, clip.mimeType))
+}
+
+/** Save a single clip to the device (no share sheet). */
+export async function downloadClipFile(
+  clip: ClipRecord,
+  projectName: string,
+  index: number,
+): Promise<void> {
+  await downloadBlob(clip.blob, clipDownloadFilename(projectName, index, clip.mimeType))
 }
 
 function slugify(value: string): string {

--- a/src/lib/project-actions.ts
+++ b/src/lib/project-actions.ts
@@ -5,6 +5,7 @@ import {
   deleteClip,
   deleteProjectIfPristine,
   duplicateClip,
+  getClip,
   getClipsForProject,
   getProject,
   getProjectAudio,
@@ -13,6 +14,7 @@ import {
   listProjects,
   moveClip,
   removeProjectAudioTrack,
+  replaceClipMedia,
   setLastOpenedProjectId,
   setProjectOrientation,
   undoDeleteLastClip,
@@ -29,9 +31,11 @@ import { probeAudioFile } from './audio-import'
 import { estimateExportCacheBytes } from './export/export-cache'
 import { estimateStorageSpace, type StorageSpace } from './storage-space'
 import type { GeneratedThumbs } from './thumbs'
+import { canSplitClip, clipHasUnusedMedia, remapTrimToSlice, resolveSplitMs } from './clip-edit'
 import {
   NEW_PROJECT_ID,
   effectiveDurationMs,
+  isImageClip,
   type ClipId,
   type ClipRecord,
   type Project,
@@ -326,6 +330,90 @@ export async function trimClip(
   trimEndMs: number,
 ): Promise<void> {
   await updateClipTrim(clipId, trimStartMs, trimEndMs)
+}
+
+/** Bake the saved trim into the file and drop the unused head/tail. */
+export async function permanentlyTrimClip(clipId: ClipId): Promise<ClipRecord> {
+  const clip = await getClip(clipId)
+  if (!clip) throw new Error('Clip not found')
+  if (isImageClip(clip)) throw new Error('Photos have no unused video to delete')
+  if (!clipHasUnusedMedia(clip)) throw new Error('This clip is already kept in full')
+
+  const startMs = Math.max(0, clip.trimStartMs)
+  const endMs = Math.min(clip.trimEndMs, clip.durationMs)
+  const { sliceClipMedia } = await import('./clip-media')
+  const sliced = await sliceClipMedia(clip.blob, startMs, endMs)
+  const updated = await replaceClipMedia(clipId, {
+    blob: sliced.blob,
+    mimeType: sliced.mimeType,
+    durationMs: sliced.durationMs,
+    width: sliced.width ?? clip.width,
+    height: sliced.height ?? clip.height,
+  })
+  await clearUndo(clip.projectId)
+  return decorateSlicedClip(updated)
+}
+
+/** Cut the clip into two timeline pieces at the playhead (or kept midpoint). */
+export async function splitSelectedClip(
+  clipId: ClipId,
+  playheadMs: number | null,
+): Promise<{ first: ClipRecord; second: ClipRecord }> {
+  const clip = await getClip(clipId)
+  if (!clip) throw new Error('Clip not found')
+  if (!canSplitClip(clip)) throw new Error('This clip is too short to split')
+
+  const splitMs = resolveSplitMs(clip, playheadMs)
+  const { sliceClipMedia } = await import('./clip-media')
+  const [left, right] = await Promise.all([
+    sliceClipMedia(clip.blob, 0, splitMs),
+    sliceClipMedia(clip.blob, splitMs, clip.durationMs),
+  ])
+
+  const firstTrim = remapTrimToSlice(clip, 0, left.durationMs)
+  const secondTrim = remapTrimToSlice(clip, splitMs, right.durationMs)
+
+  const first = await replaceClipMedia(clipId, {
+    blob: left.blob,
+    mimeType: left.mimeType,
+    durationMs: left.durationMs,
+    trimStartMs: firstTrim.trimStartMs,
+    trimEndMs: firstTrim.trimEndMs,
+    width: left.width ?? clip.width,
+    height: left.height ?? clip.height,
+  })
+  const second = await addClip({
+    projectId: clip.projectId,
+    blob: right.blob,
+    mimeType: right.mimeType,
+    durationMs: right.durationMs,
+    trimEndMs: secondTrim.trimEndMs,
+    width: right.width ?? clip.width,
+    height: right.height ?? clip.height,
+    createdAt: clip.createdAt,
+    afterClipId: clip.id,
+    clipVolume: clip.clipVolume,
+    musicVolume: clip.musicVolume,
+    lat: clip.lat,
+    lng: clip.lng,
+    locationAccuracyM: clip.locationAccuracyM,
+  })
+  if (secondTrim.trimStartMs > 0) {
+    await updateClipTrim(second.id, secondTrim.trimStartMs, secondTrim.trimEndMs)
+    second.trimStartMs = secondTrim.trimStartMs
+    second.trimEndMs = secondTrim.trimEndMs
+  }
+  await clearUndo(clip.projectId)
+  return {
+    first: await decorateSlicedClip(first),
+    second: await decorateSlicedClip(second),
+  }
+}
+
+async function decorateSlicedClip(clip: ClipRecord): Promise<ClipRecord> {
+  const { ensureClipThumbs } = await import('./thumbs')
+  const { ensureClipAudioPeak } = await import('./clip-audio-peak')
+  return ensureClipAudioPeak(await ensureClipThumbs(clip))
 }
 
 /** Set a photo clip's on-screen duration (can grow as well as shrink). */

--- a/src/lib/project-actions.ts
+++ b/src/lib/project-actions.ts
@@ -373,15 +373,9 @@ export async function splitSelectedClip(
   const firstTrim = remapTrimToSlice(clip, 0, left.durationMs)
   const secondTrim = remapTrimToSlice(clip, splitMs, right.durationMs)
 
-  const first = await replaceClipMedia(clipId, {
-    blob: left.blob,
-    mimeType: left.mimeType,
-    durationMs: left.durationMs,
-    trimStartMs: firstTrim.trimStartMs,
-    trimEndMs: firstTrim.trimEndMs,
-    width: left.width ?? clip.width,
-    height: left.height ?? clip.height,
-  })
+  // Insert the right-hand piece first so a failed replace leaves the
+  // original clip intact (the extra tail can be deleted). Replacing first
+  // would drop the second half if addClip then failed.
   const second = await addClip({
     projectId: clip.projectId,
     blob: right.blob,
@@ -398,6 +392,21 @@ export async function splitSelectedClip(
     lng: clip.lng,
     locationAccuracyM: clip.locationAccuracyM,
   })
+  let first: ClipRecord
+  try {
+    first = await replaceClipMedia(clipId, {
+      blob: left.blob,
+      mimeType: left.mimeType,
+      durationMs: left.durationMs,
+      trimStartMs: firstTrim.trimStartMs,
+      trimEndMs: firstTrim.trimEndMs,
+      width: left.width ?? clip.width,
+      height: left.height ?? clip.height,
+    })
+  } catch (error) {
+    await deleteClip(second.id).catch(() => undefined)
+    throw error
+  }
   if (secondTrim.trimStartMs > 0) {
     await updateClipTrim(second.id, secondTrim.trimStartMs, secondTrim.trimEndMs)
     second.trimStartMs = secondTrim.trimStartMs

--- a/src/lib/storage.test.ts
+++ b/src/lib/storage.test.ts
@@ -38,6 +38,7 @@ import {
   updateClipVolumes,
   updateProjectAudioTrack,
   updateClipTrim,
+  replaceClipMedia,
 } from './storage'
 import { markWatermarkRemoved } from './entitlement'
 import {
@@ -447,6 +448,43 @@ describe('storage layer', () => {
     expect(await getClip(copy.id)).toBeTruthy()
     clips = await getClipsForProject(project.id)
     expect(clips.map((c) => c.id)).toEqual([c2.id, copy.id, c1.id])
+  })
+
+  it('replaceClipMedia swaps the blob and resets thumbs and trim', async () => {
+    const project = await createProject('Bake trim')
+    const clip = await addClip({
+      projectId: project.id,
+      blob: fakeBlob('full'),
+      mimeType: 'video/webm',
+      durationMs: 2000,
+      lat: 1,
+      lng: 2,
+      clipVolume: 0.4,
+    })
+    await updateClipTrim(clip.id, 250, 1500)
+    await updateClipThumbs(clip.id, {
+      thumbs: [fakeBlob('thumb')],
+      poster: fakeBlob('poster'),
+      thumbWidth: 80,
+      thumbHeight: 140,
+    })
+
+    const replaced = await replaceClipMedia(clip.id, {
+      blob: fakeBlob('cut'),
+      mimeType: 'video/webm',
+      durationMs: 1250,
+      width: 320,
+      height: 568,
+    })
+    expect(replaced.durationMs).toBe(1250)
+    expect(replaced.trimStartMs).toBe(0)
+    expect(replaced.trimEndMs).toBe(1250)
+    expect(replaced.thumbs).toBeUndefined()
+    expect(replaced.poster).toBeUndefined()
+    expect(replaced.audioPeak).toBeUndefined()
+    expect(replaced.lat).toBe(1)
+    expect(replaced.clipVolume).toBe(0.4)
+    expect(await replaced.blob.text()).toBe('cut')
   })
 
   it('inserts a clip after a chosen neighbor instead of appending', async () => {

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -691,6 +691,75 @@ export async function updateClipThumbs(clipId: ClipId, input: ClipThumbsInput): 
   await completeTransaction([tx.store.put(updated)], tx)
 }
 
+export interface ReplaceClipMediaInput {
+  blob: Blob
+  mimeType: string
+  durationMs: number
+  trimStartMs?: number
+  trimEndMs?: number
+  width?: number
+  height?: number
+}
+
+/**
+ * Replace a clip's stored media (permanent trim / split). Thumbs, poster,
+ * and audio-peak are cleared so the next hydrate rebuilds them for the
+ * new bytes. Trim defaults to the full new duration.
+ */
+export async function replaceClipMedia(
+  clipId: ClipId,
+  input: ReplaceClipMediaInput,
+): Promise<ClipRecord> {
+  const durableBlob = await toStoredBlob(input.blob, input.mimeType)
+  const durationMs = Math.max(0, Math.round(input.durationMs))
+  const start = Math.max(0, Math.min(input.trimStartMs ?? 0, durationMs))
+  const end = Math.max(start, Math.min(input.trimEndMs ?? durationMs, durationMs))
+
+  const db = await getDb()
+  const tx = db.transaction(['clips', 'projects'], 'readwrite')
+  const clip = await tx.objectStore('clips').get(clipId)
+  if (!clip) {
+    await tx.done.catch(() => undefined)
+    throw new Error('Clip not found')
+  }
+  const project = await tx.objectStore('projects').get(clip.projectId)
+  if (!project) {
+    await tx.done.catch(() => undefined)
+    throw new Error('Project not found')
+  }
+
+  const updated: ClipRecord = {
+    id: clip.id,
+    projectId: clip.projectId,
+    mimeType: input.mimeType,
+    durationMs,
+    trimStartMs: start,
+    trimEndMs: end,
+    createdAt: clip.createdAt,
+    blob: durableBlob,
+    ...(clip.kind ? { kind: clip.kind } : {}),
+    width: input.width ?? clip.width,
+    height: input.height ?? clip.height,
+    ...(clip.lat !== undefined ? { lat: clip.lat } : {}),
+    ...(clip.lng !== undefined ? { lng: clip.lng } : {}),
+    ...(clip.locationAccuracyM !== undefined ? { locationAccuracyM: clip.locationAccuracyM } : {}),
+    ...(clip.clipVolume !== undefined ? { clipVolume: clip.clipVolume } : {}),
+    ...(clip.musicVolume !== undefined ? { musicVolume: clip.musicVolume } : {}),
+  }
+
+  await completeTransaction(
+    [
+      tx.objectStore('clips').put(updated),
+      tx.objectStore('projects').put({
+        ...project,
+        updatedAt: Date.now(),
+      }),
+    ],
+    tx,
+  )
+  return updated
+}
+
 export async function updateClipTrim(
   clipId: ClipId,
   trimStartMs: number,

--- a/src/styles/editor.css
+++ b/src/styles/editor.css
@@ -88,10 +88,10 @@
   background: #000;
 }
 
-.editor-preview-affordance {
+.editor-preview-affordance,
+.editor-preview-info {
   position: absolute;
   right: 10px;
-  bottom: 10px;
   width: 40px;
   height: 40px;
   min-height: 40px;
@@ -103,6 +103,15 @@
   border: 1px solid rgba(255, 255, 255, 0.28);
   backdrop-filter: blur(6px);
   pointer-events: auto;
+  z-index: 1;
+}
+
+.editor-preview-affordance {
+  bottom: 10px;
+}
+
+.editor-preview-info {
+  top: 10px;
 }
 
 .editor-clip-preview-image {
@@ -1002,4 +1011,49 @@
     overflow-y: auto;
     padding-right: calc(12px + env(safe-area-inset-right, 0px));
   }
+}
+
+.clip-info-facts {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin: 14px 0 0;
+}
+
+.clip-info-fact {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 16px;
+}
+
+.clip-info-fact dt {
+  color: var(--ink-muted);
+  font-size: 0.82rem;
+  font-weight: 600;
+}
+
+.clip-info-fact dd {
+  margin: 0;
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+  font-size: 0.9rem;
+}
+
+.clip-info-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-top: 16px;
+}
+
+.clip-info-action {
+  justify-content: flex-start;
+  gap: 10px;
+}
+
+.clip-info-hint {
+  margin: 10px 0 0;
+  font-size: 0.82rem;
+  line-height: 1.4;
 }

--- a/tests/e2e/clip-info.spec.ts
+++ b/tests/e2e/clip-info.spec.ts
@@ -1,0 +1,83 @@
+import { test, expect, type Page } from '@playwright/test'
+import { openSeededProject } from './helpers'
+
+async function openEditorWithClips(page: Page, clips: number, clipMs?: number): Promise<void> {
+  await openSeededProject(page, { clips, clipMs, name: 'Facts' })
+  await page.getByRole('button', { name: 'Open editor' }).click()
+  await expect(page.locator('.editor-screen')).toBeVisible()
+}
+
+async function openClipInfo(page: Page): Promise<void> {
+  await page.getByRole('button', { name: 'Clip info' }).click()
+  await expect(page.getByRole('dialog', { name: /clip 1 info/i })).toBeVisible()
+}
+
+test.describe('clip info sheet', () => {
+  test('info button opens facts about the selected clip', async ({ page }) => {
+    await openEditorWithClips(page, 2, 1500)
+    await openClipInfo(page)
+    const sheet = page.locator('.clip-info-sheet')
+    await expect(sheet.getByText('1 of 2')).toBeVisible()
+    await expect(sheet.getByText(/1\.5s/)).toBeVisible()
+    await expect(sheet.getByText(/WebM/)).toBeVisible()
+    await expect(sheet.getByRole('button', { name: 'Download' })).toBeVisible()
+    await expect(sheet.getByRole('button', { name: /split at/i })).toBeVisible()
+    await expect(sheet.getByRole('button', { name: 'Permanently trim' })).toBeDisabled()
+  })
+
+  test('download saves the selected clip', async ({ page }) => {
+    await openEditorWithClips(page, 1)
+    await openClipInfo(page)
+    const [download] = await Promise.all([
+      page.waitForEvent('download'),
+      page.getByRole('button', { name: 'Download' }).click(),
+    ])
+    expect(download.suggestedFilename()).toMatch(/facts-clip-01\.webm/)
+  })
+
+  test('split turns one clip into two timeline tiles', async ({ page }) => {
+    await openEditorWithClips(page, 1, 1600)
+    const tiles = page.locator('.clip-thumb[data-clip-id]')
+    await expect(tiles).toHaveCount(1)
+    await openClipInfo(page)
+    await page.getByRole('button', { name: /split at/i }).click()
+    await expect(page.locator('.toast')).toContainText('Clip split', { timeout: 20_000 })
+    await expect(tiles).toHaveCount(2, { timeout: 20_000 })
+  })
+
+  test('permanently trim deletes unused media from the file', async ({ page }) => {
+    await openEditorWithClips(page, 1, 2000)
+    await page.evaluate(async () => {
+      const storage = await import('/src/lib/storage.ts')
+      const projects = await storage.listProjects()
+      const clips = await storage.getClipMetasForProject(projects[0]!.id)
+      await storage.updateClipTrim(clips[0]!.id, 400, 1400)
+    })
+    await page.reload()
+    await page.getByRole('button', { name: 'Open editor' }).click()
+    await expect(page.locator('.editor-screen')).toBeVisible()
+
+    await openClipInfo(page)
+    const sheet = page.locator('.clip-info-sheet')
+    await expect(sheet.getByRole('button', { name: 'Permanently trim' })).toBeEnabled()
+    await sheet.getByRole('button', { name: 'Permanently trim' }).click()
+    await sheet.getByRole('button', { name: 'Delete unused parts' }).click()
+    await expect(page.locator('.toast')).toContainText('Unused parts deleted', { timeout: 20_000 })
+
+    const after = await page.evaluate(async () => {
+      const storage = await import('/src/lib/storage.ts')
+      const projects = await storage.listProjects()
+      const clips = await storage.getClipMetasForProject(projects[0]!.id)
+      const clip = clips[0]!
+      return {
+        durationMs: clip.durationMs,
+        trimStartMs: clip.trimStartMs,
+        trimEndMs: clip.trimEndMs,
+      }
+    })
+    expect(after.durationMs).toBeGreaterThanOrEqual(700)
+    expect(after.durationMs).toBeLessThan(1800)
+    expect(after.trimStartMs).toBe(0)
+    expect(after.trimEndMs).toBe(after.durationMs)
+  })
+})

--- a/tests/e2e/clip-info.spec.ts
+++ b/tests/e2e/clip-info.spec.ts
@@ -9,12 +9,13 @@ async function openEditorWithClips(page: Page, clips: number, clipMs?: number): 
 
 async function openClipInfo(page: Page): Promise<void> {
   await page.getByRole('button', { name: 'Clip info' }).click()
-  await expect(page.getByRole('dialog', { name: /clip 1 info/i })).toBeVisible()
+  await expect(page.getByRole('dialog', { name: /clip \d+ info/i })).toBeVisible()
 }
 
 test.describe('clip info sheet', () => {
   test('info button opens facts about the selected clip', async ({ page }) => {
     await openEditorWithClips(page, 2, 1500)
+    await page.locator('.clip-thumb').first().click()
     await openClipInfo(page)
     const sheet = page.locator('.clip-info-sheet')
     await expect(sheet.getByText('1 of 2')).toBeVisible()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The timeline clip preview now has an info button in the top-right corner. Tapping it opens a sheet with facts about the selected clip (place in the film, kept vs full duration, resolution, file size/format, recorded time, location when tagged) plus three actions:

- **Permanently trim** — bakes the saved in/out points into a new file and deletes the unused head/tail. Confirmation required; not undoable.
- **Split** — cuts the clip into two timeline pieces at the playhead (or the kept midpoint if the playhead is at an end). Existing trims remap onto each half.
- **Download** — saves the stored clip file to the device.

Photos get facts and download only (no unused video to cut).

### Testing
- Unit: clip fact formatters, split/trim helpers, `replaceClipMedia`, mediabunny slice + permanent trim/split against fixture WebM.
- E2E: open facts, download filename, split tile count, permanent trim duration.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7c9b3b80-f921-4265-a575-81a72ae8995d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7c9b3b80-f921-4265-a575-81a72ae8995d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

