### PR TITLE
Fix QuickTime clip slicing and split rollback undo

### DIFF
--- a/src/lib/clip-facts.test.ts
+++ b/src/lib/clip-facts.test.ts
@@ -38,6 +38,7 @@ describe('clip fact formatters', () => {
 
   it('names a downloaded clip from the project and mime', () => {
     expect(clipDownloadFilename('Ski Trip', 0, 'video/mp4')).toBe('ski-trip-clip-01.mp4')
+    expect(clipDownloadFilename('Ski Trip', 1, 'video/quicktime')).toBe('ski-trip-clip-02.mp4')
     expect(clipDownloadFilename('Ski Trip', 3, 'image/png')).toBe('ski-trip-clip-04.png')
   })
 })

--- a/src/lib/clip-media.test.ts
+++ b/src/lib/clip-media.test.ts
@@ -2,8 +2,18 @@ import { beforeEach, describe, expect, it } from 'vitest'
 import { permanentlyTrimClip, splitSelectedClip } from './project-actions'
 import { __resetDbForTests, addClip, createProject, getClip, getClipsForProject, updateClipTrim } from './storage'
 import { makeTestClipBlob } from './testing/make-test-clip'
-import { sliceClipMedia } from './clip-media'
+import { outputMimeForClipMedia, sliceClipMedia } from './clip-media'
 import { measureBlobDuration } from './media'
+
+describe('outputMimeForClipMedia', () => {
+  it('keeps MP4-family camera-roll types on MP4', () => {
+    expect(outputMimeForClipMedia('video/mp4')).toBe('video/mp4')
+    expect(outputMimeForClipMedia('video/quicktime')).toBe('video/mp4')
+    expect(outputMimeForClipMedia('video/x-m4v')).toBe('video/mp4')
+    expect(outputMimeForClipMedia('video/webm')).toBe('video/webm')
+    expect(outputMimeForClipMedia('')).toBe('video/webm')
+  })
+})
 
 describe('sliceClipMedia', () => {
   it('encodes a shorter file for a kept window', async () => {

--- a/src/lib/clip-media.ts
+++ b/src/lib/clip-media.ts
@@ -9,6 +9,21 @@ export interface SlicedClipMedia {
   height?: number
 }
 
+/** MP4-family sources (phone camera-roll .mov / .m4v included) must stay
+ * MP4 — Safari often cannot encode those bitstreams into WebM. */
+export function outputMimeForClipMedia(mimeType: string): 'video/mp4' | 'video/webm' {
+  const lower = mimeType.toLowerCase()
+  if (
+    lower.includes('mp4') ||
+    lower.includes('quicktime') ||
+    lower.includes('m4v') ||
+    lower.includes('x-m4v')
+  ) {
+    return 'video/mp4'
+  }
+  return 'video/webm'
+}
+
 /**
  * Re-mux (or transcode) a time range of a video blob into a new file.
  * Used to permanently drop unused trim and to split a clip into two files.
@@ -17,6 +32,7 @@ export async function sliceClipMedia(
   blob: Blob,
   startMs: number,
   endMs: number,
+  mimeHint?: string,
 ): Promise<SlicedClipMedia> {
   const start = Math.max(0, startMs)
   const end = Math.max(start + MIN_SLICE_MS, endMs)
@@ -29,9 +45,9 @@ export async function sliceClipMedia(
 
   const input = new Input({ source: new BlobSource(blob), formats: ALL_FORMATS })
   try {
-    const preferMp4 = (blob.type || '').toLowerCase().includes('mp4')
+    const mimeType = outputMimeForClipMedia(blob.type || mimeHint || '')
+    const preferMp4 = mimeType === 'video/mp4'
     const target = new BufferTarget()
-    const mimeType = preferMp4 ? 'video/mp4' : 'video/webm'
     const output = new Output({
       format: preferMp4 ? new Mp4OutputFormat({ fastStart: 'in-memory' }) : new WebMOutputFormat(),
       target,

--- a/src/lib/project-actions.ts
+++ b/src/lib/project-actions.ts
@@ -3,6 +3,7 @@ import {
   addProjectAudioTrack,
   clearUndo,
   deleteClip,
+  discardClip,
   deleteProjectIfPristine,
   duplicateClip,
   getClip,
@@ -345,7 +346,7 @@ export async function permanentlyTrimClip(clipId: ClipId): Promise<ClipRecord> {
   const startMs = Math.max(0, clip.trimStartMs)
   const endMs = Math.min(clip.trimEndMs, clip.durationMs)
   const { sliceClipMedia } = await import('./clip-media')
-  const sliced = await sliceClipMedia(clip.blob, startMs, endMs)
+  const sliced = await sliceClipMedia(clip.blob, startMs, endMs, clip.mimeType)
   const updated = await replaceClipMedia(clipId, {
     blob: sliced.blob,
     mimeType: sliced.mimeType,
@@ -369,8 +370,8 @@ export async function splitSelectedClip(
   const splitMs = resolveSplitMs(clip, playheadMs)
   const { sliceClipMedia } = await import('./clip-media')
   const [left, right] = await Promise.all([
-    sliceClipMedia(clip.blob, 0, splitMs),
-    sliceClipMedia(clip.blob, splitMs, clip.durationMs),
+    sliceClipMedia(clip.blob, 0, splitMs, clip.mimeType),
+    sliceClipMedia(clip.blob, splitMs, clip.durationMs, clip.mimeType),
   ])
 
   const firstTrim = remapTrimToSlice(clip, 0, left.durationMs)
@@ -407,7 +408,9 @@ export async function splitSelectedClip(
       height: left.height ?? clip.height,
     })
   } catch (error) {
-    await deleteClip(second.id).catch(() => undefined)
+    // discardClip (not deleteClip) so a failed split cannot overwrite a
+    // real undo snapshot with the orphaned right-hand half.
+    await discardClip(second.id).catch(() => undefined)
     throw error
   }
   if (secondTrim.trimStartMs > 0) {

--- a/src/lib/storage.test.ts
+++ b/src/lib/storage.test.ts
@@ -8,6 +8,7 @@ import {
   createProject,
   ProjectLimitError,
   deleteClip,
+  discardClip,
   deleteProject,
   deleteProjectIfPristine,
   duplicateClip,
@@ -499,6 +500,28 @@ describe('storage layer', () => {
     expect(replaced.lat).toBe(1)
     expect(replaced.clipVolume).toBe(0.4)
     expect(await replaced.blob.text()).toBe('cut')
+  })
+
+  it('discardClip removes a clip without writing undo', async () => {
+    const project = await createProject('Rollback')
+    const keep = await addClip({
+      projectId: project.id,
+      blob: fakeBlob('keep'),
+      mimeType: 'video/webm',
+      durationMs: 800,
+    })
+    const extra = await addClip({
+      projectId: project.id,
+      blob: fakeBlob('extra'),
+      mimeType: 'video/webm',
+      durationMs: 800,
+    })
+    await deleteClip(keep.id)
+    expect((await getUndoSnapshot(project.id))?.clip.id).toBe(keep.id)
+
+    expect(await discardClip(extra.id)).toBe(true)
+    expect(await getClip(extra.id)).toBeUndefined()
+    expect((await getUndoSnapshot(project.id))?.clip.id).toBe(keep.id)
   })
 
   it('inserts a clip after a chosen neighbor instead of appending', async () => {

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -1230,6 +1230,34 @@ export async function deleteClip(clipId: ClipId): Promise<DeletedClipSnapshot | 
   return snapshot
 }
 
+/** Remove a clip without writing an undo snapshot — for rolling back a
+ * failed split so a real prior undo is not overwritten. */
+export async function discardClip(clipId: ClipId): Promise<boolean> {
+  const db = await getDb()
+  const clip = await db.get('clips', clipId)
+  if (!clip) return false
+  const project = await db.get('projects', clip.projectId)
+  if (!project) return false
+
+  const index = project.clipIds.indexOf(clipId)
+  if (index < 0) return false
+
+  const clipIds = project.clipIds.filter((id) => id !== clipId)
+  const tx = db.transaction(['clips', 'projects'], 'readwrite')
+  await completeTransaction(
+    [
+      tx.objectStore('clips').delete(clipId),
+      tx.objectStore('projects').put({
+        ...project,
+        clipIds,
+        updatedAt: Date.now(),
+      }),
+    ],
+    tx,
+  )
+  return true
+}
+
 export async function getUndoSnapshot(projectId: ProjectId): Promise<DeletedClipSnapshot | undefined> {
   const db = await getDb()
   return db.get('undo', projectId)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Follow-up to #160 for the Bugbot findings that landed after merge:

- **QuickTime / .mov slices** now remux to MP4 (Safari often cannot encode those sources into WebM).
- **Failed-split rollback** uses `discardClip` so it does not write an undo snapshot. That keeps a real prior undo intact and prevents Undo delete from restoring an orphaned right-hand half.

The earlier “replace before add” data-loss path was already fixed in #160 (`addClip` first, then `replaceClipMedia`).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7c9b3b80-f921-4265-a575-81a72ae8995d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7c9b3b80-f921-4265-a575-81a72ae8995d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

