### PR TITLE
Add a filmstrip handle for choosing the split point

### DIFF
--- a/src/components/clip-info-sheet.tsx
+++ b/src/components/clip-info-sheet.tsx
@@ -1,9 +1,9 @@
 import type { Handle } from 'remix/ui'
 import { on, ref } from 'remix/ui'
-import { canSplitClip, clipHasUnusedMedia, resolveSplitMs } from '../lib/clip-edit'
+import { canSplitClip, clipHasUnusedMedia } from '../lib/clip-edit'
 import { buildClipFacts } from '../lib/clip-facts'
 import { attachSheetModal } from '../lib/sheet-modal'
-import { effectiveDurationMs, formatDuration, isImageClip, type ClipRecord } from '../lib/types'
+import { effectiveDurationMs, isImageClip, type ClipRecord } from '../lib/types'
 import { IconDownload, IconSplit, IconTrim } from './icons'
 
 interface ClipInfoSheetProps {
@@ -11,14 +11,13 @@ interface ClipInfoSheetProps {
   clips: ClipRecord[]
   index: number
   projectName: string
-  getPlayheadMs: () => number | null
   onPermanentlyTrim: () => Promise<void>
-  onSplit: (splitMs: number) => Promise<void>
+  onStartSplit: () => void
   onDownload: () => Promise<void>
   onClose: () => void
 }
 
-type BusyAction = 'trim' | 'split' | 'download' | null
+type BusyAction = 'trim' | 'download' | null
 
 /** Facts + destructive clip edits (permanent trim, split) and download. */
 export function ClipInfoSheet(handle: Handle<ClipInfoSheetProps>) {
@@ -43,7 +42,7 @@ export function ClipInfoSheet(handle: Handle<ClipInfoSheetProps>) {
   }
 
   return () => {
-    const { clip, clips, index, projectName, getPlayheadMs, onClose } = handle.props
+    const { clip, clips, index, projectName, onClose } = handle.props
     const filmDurationMs = clips.reduce((sum, item) => sum + effectiveDurationMs(item), 0)
     const facts = buildClipFacts(clip, {
       index,
@@ -53,7 +52,6 @@ export function ClipInfoSheet(handle: Handle<ClipInfoSheetProps>) {
     const photo = isImageClip(clip)
     const canTrim = clipHasUnusedMedia(clip)
     const canSplit = canSplitClip(clip)
-    const splitMs = canSplit ? resolveSplitMs(clip, getPlayheadMs()) : null
     const working = busy !== null
 
     return (
@@ -143,17 +141,12 @@ export function ClipInfoSheet(handle: Handle<ClipInfoSheetProps>) {
                 className="btn btn-ghost clip-info-action"
                 disabled={working || !canSplit}
                 mix={on('click', () => {
-                  if (!canSplit) return
-                  const liveSplitMs = resolveSplitMs(clip, handle.props.getPlayheadMs())
-                  void run('split', () => handle.props.onSplit(liveSplitMs))
+                  if (!canSplit || working) return
+                  handle.props.onStartSplit()
                 })}
               >
                 <IconSplit size={18} />
-                {busy === 'split'
-                  ? 'Splitting…'
-                  : splitMs !== null
-                    ? `Split at ${formatDuration(splitMs)}`
-                    : 'Split clip'}
+                Split clip
               </button>
             )}
             <button
@@ -177,11 +170,20 @@ export function ClipInfoSheet(handle: Handle<ClipInfoSheetProps>) {
           </div>
           {photo ? (
             <p className="clip-info-hint muted">Photos can be downloaded; trim and split are for video clips.</p>
-          ) : !canTrim && !confirmingTrim ? (
-            <p className="clip-info-hint muted">
-              Trim the clip first, then permanently delete the unused parts.
-            </p>
-          ) : null}
+          ) : confirmingTrim ? null : (
+            <>
+              {!canTrim ? (
+                <p className="clip-info-hint muted">
+                  Trim the clip first, then permanently delete the unused parts.
+                </p>
+              ) : null}
+              {canSplit ? (
+                <p className="clip-info-hint muted">
+                  Split opens a handle on the filmstrip so you can choose the cut.
+                </p>
+              ) : null}
+            </>
+          )}
         </div>
       </>
     )

--- a/src/components/editor-screen.tsx
+++ b/src/components/editor-screen.tsx
@@ -524,7 +524,6 @@ export function EditorScreen(handle: Handle<EditorScreenProps>) {
               }}
               onDone={async (splitMs) => {
                 const { second } = await splitSelectedClip(selected.id, splitMs)
-                selectedClipId = second.id
                 previewApi.current?.pause()
                 try {
                   await props.refresh()
@@ -533,9 +532,10 @@ export function EditorScreen(handle: Handle<EditorScreenProps>) {
                   reportError(err, 'refresh-after-split')
                   props.showToast('Clip split, but the timeline could not refresh')
                 } finally {
-                  // Stay on the strip until refresh settles so the timeline
-                  // never flashes the pre-split list. Do not throw after a
-                  // successful cut — that would re-enable Split on the leftover.
+                  // Keep selection on the source clip (same id as the left
+                  // half) until we leave the strip, so SplitStrip does not
+                  // remount onto the new right half with saving reset.
+                  selectedClipId = second.id
                   setSplitting(false)
                 }
               }}

--- a/src/components/editor-screen.tsx
+++ b/src/components/editor-screen.tsx
@@ -15,6 +15,7 @@ import {
   undoLastDelete,
 } from '../lib/project-actions'
 import { downloadClipFile } from '../lib/media'
+import { resolveSplitMs } from '../lib/clip-edit'
 import {
   effectiveDurationMs,
   formatDuration,
@@ -41,6 +42,7 @@ import {
   IconUndo,
 } from './icons'
 import { ImageDurationStrip } from './image-duration-strip'
+import { SplitStrip } from './split-strip'
 import { Timeline } from './timeline'
 import { TrimStrip } from './trim-strip'
 import type { ToastAction } from './record-screen'
@@ -74,6 +76,9 @@ export function EditorScreen(handle: Handle<EditorScreenProps>) {
   const { props } = handle
   let selectedClipId: ClipId | null = props.clips.at(-1)?.id ?? null
   let trimming = false
+  /** Filmstrip split-point picker (peer of `trimming`). */
+  let splitting = false
+  let splitInitialMs = 0
   /** Track whose detail view (trim, level, fades) is open — the audio
    * counterpart of `trimming`. */
   let editingTrackId: string | null = null
@@ -125,6 +130,7 @@ export function EditorScreen(handle: Handle<EditorScreenProps>) {
             pendingGhostCount = Math.max(0, pendingGhostCount - 1)
             selectedClipId = clip.id
             trimming = false
+            splitting = false
             void handle.update()
           },
           onProgress: (done, total) => {
@@ -136,6 +142,7 @@ export function EditorScreen(handle: Handle<EditorScreenProps>) {
         const last = result.added.at(-1)
         if (last) selectedClipId = last.id
         trimming = false
+        splitting = false
         if (result.added.length > 0) {
           await props.refresh()
           optimisticAdds = optimisticAdds.filter(
@@ -178,6 +185,13 @@ export function EditorScreen(handle: Handle<EditorScreenProps>) {
   }
   const setTrimming = (next: boolean) => {
     trimming = next
+    if (next) splitting = false
+    void handle.update()
+  }
+
+  const setSplitting = (next: boolean) => {
+    splitting = next
+    if (next) trimming = false
     void handle.update()
   }
 
@@ -189,6 +203,7 @@ export function EditorScreen(handle: Handle<EditorScreenProps>) {
   const openTrim = (clip: ClipRecord) => {
     previewApi.current?.pause()
     trimming = true
+    splitting = false
     editingTrackId = null
     // Seek after the commit: entering trim can remount the preview (the trim
     // override changes its remount key), and the seek must land on the new
@@ -200,6 +215,20 @@ export function EditorScreen(handle: Handle<EditorScreenProps>) {
     void handle.update()
   }
 
+  const openSplit = (clip: ClipRecord) => {
+    previewApi.current?.pause()
+    const playheadMs = previewApi.current?.getCurrentTimeMs() ?? null
+    splitInitialMs = resolveSplitMs(clip, playheadMs)
+    clipInfoOpen = false
+    trimming = false
+    splitting = true
+    editingTrackId = null
+    // Same remount-then-seek as trim: the preview shows the full source
+    // while the handle is dragged, so the cut frame is visible.
+    handle.queueTask(() => previewApi.current?.seekToMs(splitInitialMs))
+    void handle.update()
+  }
+
   const handleDelete = () => {
     const id = resolveSelectedId()
     if (!id) return
@@ -207,6 +236,7 @@ export function EditorScreen(handle: Handle<EditorScreenProps>) {
       await removeClip(id)
       selectedClipId = null
       trimming = false
+      splitting = false
       void handle.update()
       props.refresh()
       props.showToast('Clip deleted', {
@@ -239,6 +269,9 @@ export function EditorScreen(handle: Handle<EditorScreenProps>) {
       } else if (trimming) {
         previewApi.current?.pause()
         setTrimming(false)
+      } else if (splitting) {
+        previewApi.current?.pause()
+        setSplitting(false)
       } else if (editingTrackId) {
         setEditingTrackId(null)
       } else {
@@ -246,7 +279,7 @@ export function EditorScreen(handle: Handle<EditorScreenProps>) {
       }
       return
     }
-    if (trimming || editingTrackId || clipInfoOpen) return
+    if (trimming || splitting || editingTrackId || clipInfoOpen) return
     switch (event.code) {
       case 'ArrowLeft':
       case 'ArrowRight': {
@@ -357,7 +390,7 @@ export function EditorScreen(handle: Handle<EditorScreenProps>) {
 
     return (
       <div
-        className={`editor-screen${trimming ? ' is-trimming' : ''}${editingTrack ? ' is-audio-editing' : ''}${importing ? ' is-importing' : ''}`}
+        className={`editor-screen${trimming ? ' is-trimming' : ''}${splitting ? ' is-splitting' : ''}${editingTrack ? ' is-audio-editing' : ''}${importing ? ' is-importing' : ''}`}
         mix={ref((_node, signal) => {
           window.addEventListener('keydown', onWindowKeyDown)
           signal.addEventListener('abort', () => {
@@ -423,10 +456,11 @@ export function EditorScreen(handle: Handle<EditorScreenProps>) {
             <EditorClipPreview
               key={selected.id}
               clip={
-                trimming
+                trimming || splitting
                   ? {
                       ...selected,
-                      // While trimming, show full clip so handle seeks are visible.
+                      // While trimming or splitting, show full clip so handle
+                      // seeks are visible (including into unused regions).
                       trimStartMs: 0,
                       trimEndMs: selected.durationMs,
                     }
@@ -436,7 +470,7 @@ export function EditorScreen(handle: Handle<EditorScreenProps>) {
               audio={props.audio}
               apiRef={previewApi}
               onInfoClick={
-                trimming || editingTrack
+                trimming || splitting || editingTrack
                   ? undefined
                   : () => {
                       previewApi.current?.pause()
@@ -478,6 +512,25 @@ export function EditorScreen(handle: Handle<EditorScreenProps>) {
                 setTrimming(false)
               }}
             />
+          ) : splitting && selected ? (
+            <SplitStrip
+              key={selected.id}
+              clip={selected}
+              initialSplitMs={splitInitialMs}
+              onSeek={(timeMs) => previewApi.current?.seekToMs(timeMs)}
+              onCancel={() => {
+                previewApi.current?.pause()
+                setSplitting(false)
+              }}
+              onDone={async (splitMs) => {
+                const { second } = await splitSelectedClip(selected.id, splitMs)
+                selectedClipId = second.id
+                await props.refresh()
+                previewApi.current?.pause()
+                setSplitting(false)
+                props.showToast('Clip split')
+              }}
+            />
           ) : editingTrack && props.audio ? (
             <AudioDetailStrip
               key={editingTrack.id}
@@ -499,6 +552,7 @@ export function EditorScreen(handle: Handle<EditorScreenProps>) {
               onSelect={(id) => {
                 selectedClipId = id
                 trimming = false
+                splitting = false
                 void handle.update()
               }}
               onAddFromDevice={openDevicePicker}
@@ -510,7 +564,7 @@ export function EditorScreen(handle: Handle<EditorScreenProps>) {
             />
           )}
 
-          {!trimming && !editingTrack ? (
+          {!trimming && !splitting && !editingTrack ? (
             <AudioStrip
               ensureProjectId={props.ensureProjectId}
               audio={props.audio}
@@ -523,6 +577,7 @@ export function EditorScreen(handle: Handle<EditorScreenProps>) {
               onEditTrack={(trackId) => {
                 previewApi.current?.pause()
                 trimming = false
+                splitting = false
                 setEditingTrackId(trackId)
               }}
               showToast={props.showToast}
@@ -530,7 +585,7 @@ export function EditorScreen(handle: Handle<EditorScreenProps>) {
             />
           ) : null}
 
-          {!trimming && !editingTrack ? (
+          {!trimming && !splitting && !editingTrack ? (
             <div className="editor-actions" role="toolbar" aria-label="Clip actions">
               <ActionButton
                 label="Delete"
@@ -643,7 +698,6 @@ export function EditorScreen(handle: Handle<EditorScreenProps>) {
             clips={clips}
             index={selectedIndex}
             projectName={project.name}
-            getPlayheadMs={() => previewApi.current?.getCurrentTimeMs() ?? null}
             onPermanentlyTrim={async () => {
               const updated = await permanentlyTrimClip(selected.id)
               clipInfoOpen = false
@@ -651,12 +705,8 @@ export function EditorScreen(handle: Handle<EditorScreenProps>) {
               await props.refresh()
               props.showToast('Unused parts deleted')
             }}
-            onSplit={async (splitMs) => {
-              const { second } = await splitSelectedClip(selected.id, splitMs)
-              clipInfoOpen = false
-              selectedClipId = second.id
-              await props.refresh()
-              props.showToast('Clip split')
+            onStartSplit={() => {
+              if (selected) openSplit(selected)
             }}
             onDownload={async () => {
               await downloadClipFile(selected, project.name, selectedIndex)

--- a/src/components/editor-screen.tsx
+++ b/src/components/editor-screen.tsx
@@ -526,13 +526,17 @@ export function EditorScreen(handle: Handle<EditorScreenProps>) {
                 const { second } = await splitSelectedClip(selected.id, splitMs)
                 selectedClipId = second.id
                 previewApi.current?.pause()
-                setSplitting(false)
                 try {
                   await props.refresh()
                   props.showToast('Clip split')
                 } catch (err) {
                   reportError(err, 'refresh-after-split')
                   props.showToast('Clip split, but the timeline could not refresh')
+                } finally {
+                  // Stay on the strip until refresh settles so the timeline
+                  // never flashes the pre-split list. Do not throw after a
+                  // successful cut — that would re-enable Split on the leftover.
+                  setSplitting(false)
                 }
               }}
             />

--- a/src/components/editor-screen.tsx
+++ b/src/components/editor-screen.tsx
@@ -525,10 +525,15 @@ export function EditorScreen(handle: Handle<EditorScreenProps>) {
               onDone={async (splitMs) => {
                 const { second } = await splitSelectedClip(selected.id, splitMs)
                 selectedClipId = second.id
-                await props.refresh()
                 previewApi.current?.pause()
                 setSplitting(false)
-                props.showToast('Clip split')
+                try {
+                  await props.refresh()
+                  props.showToast('Clip split')
+                } catch (err) {
+                  reportError(err, 'refresh-after-split')
+                  props.showToast('Clip split, but the timeline could not refresh')
+                }
               }}
             />
           ) : editingTrack && props.audio ? (

--- a/src/components/split-strip.tsx
+++ b/src/components/split-strip.tsx
@@ -31,13 +31,14 @@ export function SplitStrip(handle: Handle<SplitStripProps>) {
   }
 
   const applySplitMs = (next: number) => {
+    if (saving) return
     splitMs = clampSplitMs(props.clip, next)
     props.onSeek(splitMs)
     void handle.update()
   }
 
   const startHandleDrag = (event: PointerEvent) => {
-    if (event.button !== 0) return
+    if (event.button !== 0 || saving) return
     event.preventDefault()
     event.stopPropagation()
     const dragHandle = event.currentTarget as HTMLElement
@@ -73,7 +74,7 @@ export function SplitStrip(handle: Handle<SplitStripProps>) {
   }
 
   const startTrackScrub = (event: PointerEvent) => {
-    if (event.button !== 0) return
+    if (event.button !== 0 || saving) return
     if ((event.target as HTMLElement | null)?.closest('.split-handle')) return
     event.preventDefault()
     const strip = event.currentTarget as HTMLElement
@@ -177,6 +178,7 @@ export function SplitStrip(handle: Handle<SplitStripProps>) {
             type="button"
             className={`split-handle${dragging ? ' active' : ''}`}
             style={{ left: `${splitPct}%` }}
+            disabled={saving}
             role="slider"
             aria-label="Split point"
             aria-valuemin={bounds.min}
@@ -186,12 +188,19 @@ export function SplitStrip(handle: Handle<SplitStripProps>) {
             mix={[
               on('pointerdown', (event) => startHandleDrag(event)),
               on('keydown', (event) => {
+                if (saving) return
                 if (event.key === 'ArrowLeft') {
                   event.preventDefault()
                   applySplitMs(splitMs - NUDGE_MS)
                 } else if (event.key === 'ArrowRight') {
                   event.preventDefault()
                   applySplitMs(splitMs + NUDGE_MS)
+                } else if (event.key === 'Home') {
+                  event.preventDefault()
+                  applySplitMs(bounds.min)
+                } else if (event.key === 'End') {
+                  event.preventDefault()
+                  applySplitMs(bounds.max)
                 }
               }),
             ]}

--- a/src/components/split-strip.tsx
+++ b/src/components/split-strip.tsx
@@ -45,12 +45,18 @@ export function SplitStrip(handle: Handle<SplitStripProps>) {
     const strip = dragHandle.closest('.trim-strip-track') as HTMLElement | null
     if (!strip) return
 
+    const originMs = splitMs
+    const originX = event.clientX
     dragHandle.setPointerCapture(event.pointerId)
     dragging = true
     void handle.update()
+    props.onSeek(splitMs)
 
     const onMove = (ev: PointerEvent) => {
-      applySplitMs(msFromClientX(ev.clientX, strip))
+      const width = strip.getBoundingClientRect().width
+      if (width <= 0) return
+      const deltaMs = Math.round(((ev.clientX - originX) / width) * duration())
+      applySplitMs(originMs + deltaMs)
     }
 
     const onUp = (ev: PointerEvent) => {
@@ -69,8 +75,6 @@ export function SplitStrip(handle: Handle<SplitStripProps>) {
     dragHandle.addEventListener('pointermove', onMove)
     dragHandle.addEventListener('pointerup', onUp)
     dragHandle.addEventListener('pointercancel', onUp)
-
-    applySplitMs(msFromClientX(event.clientX, strip))
   }
 
   const startTrackScrub = (event: PointerEvent) => {

--- a/src/components/split-strip.tsx
+++ b/src/components/split-strip.tsx
@@ -1,0 +1,222 @@
+import type { Handle } from 'remix/ui'
+import { on } from 'remix/ui'
+import { clampSplitMs, splitBounds } from '../lib/clip-edit'
+import { formatDuration, type ClipRecord } from '../lib/types'
+import { TimelineThumbImage } from './timeline-thumb-image'
+
+const NUDGE_MS = 50
+
+interface SplitStripProps {
+  clip: ClipRecord
+  initialSplitMs: number
+  onSeek: (timeMs: number) => void
+  onDone: (splitMs: number) => Promise<void>
+  onCancel: () => void
+}
+
+export function SplitStrip(handle: Handle<SplitStripProps>) {
+  const { props } = handle
+  let splitMs = clampSplitMs(props.clip, props.initialSplitMs)
+  let saving = false
+  let error: string | null = null
+  let dragging = false
+
+  const duration = () => Math.max(1, props.clip.durationMs)
+
+  const msFromClientX = (clientX: number, strip: HTMLElement) => {
+    const rect = strip.getBoundingClientRect()
+    if (rect.width <= 0) return 0
+    const ratio = Math.min(1, Math.max(0, (clientX - rect.left) / rect.width))
+    return Math.round(ratio * duration())
+  }
+
+  const applySplitMs = (next: number) => {
+    splitMs = clampSplitMs(props.clip, next)
+    props.onSeek(splitMs)
+    void handle.update()
+  }
+
+  const startHandleDrag = (event: PointerEvent) => {
+    if (event.button !== 0) return
+    event.preventDefault()
+    event.stopPropagation()
+    const dragHandle = event.currentTarget as HTMLElement
+    const strip = dragHandle.closest('.trim-strip-track') as HTMLElement | null
+    if (!strip) return
+
+    dragHandle.setPointerCapture(event.pointerId)
+    dragging = true
+    void handle.update()
+
+    const onMove = (ev: PointerEvent) => {
+      applySplitMs(msFromClientX(ev.clientX, strip))
+    }
+
+    const onUp = (ev: PointerEvent) => {
+      try {
+        dragHandle.releasePointerCapture(ev.pointerId)
+      } catch {
+        /* already released */
+      }
+      dragHandle.removeEventListener('pointermove', onMove)
+      dragHandle.removeEventListener('pointerup', onUp)
+      dragHandle.removeEventListener('pointercancel', onUp)
+      dragging = false
+      void handle.update()
+    }
+
+    dragHandle.addEventListener('pointermove', onMove)
+    dragHandle.addEventListener('pointerup', onUp)
+    dragHandle.addEventListener('pointercancel', onUp)
+
+    applySplitMs(msFromClientX(event.clientX, strip))
+  }
+
+  const startTrackScrub = (event: PointerEvent) => {
+    if (event.button !== 0) return
+    if ((event.target as HTMLElement | null)?.closest('.split-handle')) return
+    event.preventDefault()
+    const strip = event.currentTarget as HTMLElement
+    strip.setPointerCapture(event.pointerId)
+    dragging = true
+    applySplitMs(msFromClientX(event.clientX, strip))
+
+    const onMove = (ev: PointerEvent) => {
+      applySplitMs(msFromClientX(ev.clientX, strip))
+    }
+
+    const onUp = (ev: PointerEvent) => {
+      try {
+        strip.releasePointerCapture(ev.pointerId)
+      } catch {
+        /* already released */
+      }
+      strip.removeEventListener('pointermove', onMove)
+      strip.removeEventListener('pointerup', onUp)
+      strip.removeEventListener('pointercancel', onUp)
+      dragging = false
+      void handle.update()
+    }
+
+    strip.addEventListener('pointermove', onMove)
+    strip.addEventListener('pointerup', onUp)
+    strip.addEventListener('pointercancel', onUp)
+  }
+
+  const onDoneClick = () => {
+    void (async () => {
+      saving = true
+      error = null
+      void handle.update()
+      try {
+        await props.onDone(Math.round(splitMs))
+      } catch (err) {
+        error = err instanceof Error ? err.message : 'Could not split clip'
+        saving = false
+        void handle.update()
+      }
+    })()
+  }
+
+  return () => {
+    const clip = props.clip
+    const bounds = splitBounds(clip)
+    const thumbs = clip.thumbs?.filter(Boolean) ?? []
+    const startPct = (bounds.start / duration()) * 100
+    const endPct = (bounds.end / duration()) * 100
+    const splitPct = (splitMs / duration()) * 100
+    const leftMs = Math.max(0, splitMs - bounds.start)
+    const rightMs = Math.max(0, bounds.end - splitMs)
+
+    return (
+      <div className="trim-strip split-strip" role="group" aria-label="Split clip">
+        <div className="trim-strip-meta">
+          <span className="trim-kept-label">
+            Split at {formatDuration(splitMs)}
+            <span className="split-halves-label">
+              {' '}
+              · {formatDuration(leftMs)} + {formatDuration(rightMs)}
+            </span>
+          </span>
+          {error ? <span className="trim-error">{error}</span> : null}
+        </div>
+
+        <p className="split-strip-hint muted">
+          Drag the line — or tap the filmstrip — to choose the cut.
+        </p>
+
+        <div
+          className="trim-strip-track"
+          mix={on('pointerdown', (event) => startTrackScrub(event))}
+        >
+          <div className="trim-strip-filmstrip" aria-hidden>
+            {thumbs.length > 0 ? (
+              thumbs.map((thumb, index) => (
+                <TimelineThumbImage
+                  key={`${clip.id}-split-thumb-${index}`}
+                  blob={thumb}
+                  className="trim-strip-frame"
+                  alt=""
+                />
+              ))
+            ) : (
+              <div className="clip-filmstrip-placeholder" />
+            )}
+          </div>
+
+          <div className="trim-dim trim-dim-left" style={{ width: `${startPct}%` }} aria-hidden />
+          <div
+            className="trim-dim trim-dim-right"
+            style={{ width: `${100 - endPct}%` }}
+            aria-hidden
+          />
+
+          <div className="split-cut" style={{ left: `${splitPct}%` }} aria-hidden />
+
+          <button
+            type="button"
+            className={`split-handle${dragging ? ' active' : ''}`}
+            style={{ left: `${splitPct}%` }}
+            role="slider"
+            aria-label="Split point"
+            aria-valuemin={bounds.min}
+            aria-valuemax={bounds.max}
+            aria-valuenow={Math.round(splitMs)}
+            aria-valuetext={formatDuration(splitMs)}
+            mix={[
+              on('pointerdown', (event) => startHandleDrag(event)),
+              on('keydown', (event) => {
+                if (event.key === 'ArrowLeft') {
+                  event.preventDefault()
+                  applySplitMs(splitMs - NUDGE_MS)
+                } else if (event.key === 'ArrowRight') {
+                  event.preventDefault()
+                  applySplitMs(splitMs + NUDGE_MS)
+                }
+              }),
+            ]}
+          />
+        </div>
+
+        <div className="trim-strip-actions">
+          <button
+            type="button"
+            className="btn btn-ghost"
+            disabled={saving}
+            mix={on('click', () => props.onCancel())}
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            className="btn btn-primary"
+            disabled={saving}
+            mix={on('click', onDoneClick)}
+          >
+            {saving ? 'Splitting…' : 'Split'}
+          </button>
+        </div>
+      </div>
+    )
+  }
+}

--- a/src/lib/clip-edit.test.ts
+++ b/src/lib/clip-edit.test.ts
@@ -2,9 +2,11 @@ import { describe, expect, it } from 'vitest'
 import {
   MIN_SLICE_MS,
   canSplitClip,
+  clampSplitMs,
   clipHasUnusedMedia,
   remapTrimToSlice,
   resolveSplitMs,
+  splitBounds,
 } from './clip-edit'
 
 const video = (trimStartMs: number, trimEndMs: number, durationMs = 2000) => ({
@@ -30,6 +32,29 @@ describe('canSplitClip', () => {
     expect(canSplitClip(video(0, MIN_SLICE_MS * 2 - 1))).toBe(false)
     expect(canSplitClip(video(0, MIN_SLICE_MS * 2))).toBe(true)
     expect(canSplitClip({ ...video(0, 2000), kind: 'image' })).toBe(false)
+  })
+})
+
+describe('splitBounds', () => {
+  it('keeps a MIN_SLICE_MS margin inside the kept window', () => {
+    expect(splitBounds(video(200, 1800))).toEqual({
+      start: 200,
+      end: 1800,
+      min: 300,
+      max: 1700,
+    })
+  })
+})
+
+describe('clampSplitMs', () => {
+  it('clamps into the legal cut range', () => {
+    expect(clampSplitMs(video(200, 1800), 900)).toBe(900)
+    expect(clampSplitMs(video(200, 1800), 200)).toBe(300)
+    expect(clampSplitMs(video(200, 1800), 1800)).toBe(1700)
+  })
+
+  it('falls back to the midpoint when the value is not finite', () => {
+    expect(clampSplitMs(video(200, 1800), Number.NaN)).toBe(1000)
   })
 })
 

--- a/src/lib/clip-edit.test.ts
+++ b/src/lib/clip-edit.test.ts
@@ -56,6 +56,10 @@ describe('clampSplitMs', () => {
   it('falls back to the midpoint when the value is not finite', () => {
     expect(clampSplitMs(video(200, 1800), Number.NaN)).toBe(1000)
   })
+
+  it('falls back to the midpoint when no legal cut range exists', () => {
+    expect(clampSplitMs(video(0, MIN_SLICE_MS * 2 - 1), 50)).toBe((MIN_SLICE_MS * 2 - 1) / 2)
+  })
 })
 
 describe('resolveSplitMs', () => {

--- a/src/lib/clip-edit.ts
+++ b/src/lib/clip-edit.ts
@@ -23,19 +23,41 @@ export function canSplitClip(
   return effectiveDurationMs(clip) >= MIN_SLICE_MS * 2
 }
 
+/** Kept window and the legal cut range (each half at least `MIN_SLICE_MS`). */
+export function splitBounds(
+  clip: Pick<ClipMeta, 'durationMs' | 'trimStartMs' | 'trimEndMs'>,
+): { start: number; end: number; min: number; max: number } {
+  const end = Math.min(clip.trimEndMs, clip.durationMs)
+  const start = Math.max(0, Math.min(clip.trimStartMs, end))
+  return {
+    start,
+    end,
+    min: start + MIN_SLICE_MS,
+    max: end - MIN_SLICE_MS,
+  }
+}
+
+/** Clamp a proposed cut into the legal split range (or the midpoint if none). */
+export function clampSplitMs(
+  clip: Pick<ClipMeta, 'durationMs' | 'trimStartMs' | 'trimEndMs'>,
+  splitMs: number,
+): number {
+  const { start, end, min, max } = splitBounds(clip)
+  const mid = start + (end - start) / 2
+  if (max < min || !Number.isFinite(splitMs)) return mid
+  return Math.max(min, Math.min(splitMs, max))
+}
+
 /** Absolute source time at which a split should cut. Uses the playhead when
  * it sits far enough inside the kept window; otherwise the kept midpoint. */
 export function resolveSplitMs(
   clip: Pick<ClipMeta, 'durationMs' | 'trimStartMs' | 'trimEndMs'>,
   playheadMs: number | null,
 ): number {
-  const end = Math.min(clip.trimEndMs, clip.durationMs)
-  const start = Math.max(0, Math.min(clip.trimStartMs, end))
+  const { start, end, min, max } = splitBounds(clip)
   const mid = start + (end - start) / 2
   if (playheadMs === null || !Number.isFinite(playheadMs)) return mid
-  if (playheadMs >= start + MIN_SLICE_MS && playheadMs <= end - MIN_SLICE_MS) {
-    return playheadMs
-  }
+  if (playheadMs >= min && playheadMs <= max) return playheadMs
   return mid
 }
 

--- a/src/lib/project-actions.ts
+++ b/src/lib/project-actions.ts
@@ -358,7 +358,7 @@ export async function permanentlyTrimClip(clipId: ClipId): Promise<ClipRecord> {
   return decorateSlicedClip(updated)
 }
 
-/** Cut the clip into two timeline pieces at the playhead (or kept midpoint). */
+/** Cut the clip into two timeline pieces at `playheadMs` (or the kept midpoint). */
 export async function splitSelectedClip(
   clipId: ClipId,
   playheadMs: number | null,

--- a/src/styles/editor.css
+++ b/src/styles/editor.css
@@ -58,6 +58,7 @@
 }
 
 .editor-screen.is-trimming .editor-stage,
+.editor-screen.is-splitting .editor-stage,
 .editor-screen.is-audio-editing .editor-stage {
   flex: 0.9 1 auto;
 }
@@ -532,6 +533,70 @@
   background: var(--accent);
 }
 
+.split-strip-hint {
+  margin: 0;
+  font-size: 0.78rem;
+}
+
+.split-halves-label {
+  font-weight: 500;
+  color: var(--ink-muted);
+}
+
+.split-cut {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: 2px;
+  transform: translateX(-50%);
+  background: var(--accent);
+  box-shadow: 0 0 0 1px color-mix(in srgb, var(--bg-elevated) 55%, transparent);
+  pointer-events: none;
+  z-index: 2;
+}
+
+.split-handle {
+  position: absolute;
+  top: -4px;
+  bottom: -4px;
+  width: 22px;
+  min-height: var(--tap);
+  margin: 0;
+  padding: 0;
+  transform: translateX(-50%);
+  border-radius: 8px;
+  background: var(--accent);
+  border: 2px solid color-mix(in srgb, var(--bg-elevated) 70%, #fff);
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.35);
+  z-index: 3;
+  cursor: ew-resize;
+  touch-action: none;
+}
+
+.split-handle::before,
+.split-handle::after {
+  content: '';
+  position: absolute;
+  left: 50%;
+  width: 3px;
+  height: 10px;
+  transform: translateX(-50%);
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--ink-strong) 70%, transparent);
+}
+
+.split-handle::before {
+  top: 8px;
+}
+
+.split-handle::after {
+  bottom: 8px;
+}
+
+.split-handle.active {
+  transform: translateX(-50%) scale(1.06);
+}
+
 .trim-strip-actions {
   display: flex;
   gap: 8px;
@@ -1000,6 +1065,7 @@
   }
 
   .orientation-landscape .editor-screen.is-trimming .editor-stage,
+  .orientation-landscape .editor-screen.is-splitting .editor-stage,
   .orientation-landscape .editor-screen.is-audio-editing .editor-stage {
     flex: none;
   }

--- a/src/styles/editor.css
+++ b/src/styles/editor.css
@@ -443,7 +443,8 @@
   z-index: 2;
 }
 
-.trim-handle {
+.trim-handle,
+.split-handle {
   position: absolute;
   top: -4px;
   bottom: -4px;
@@ -473,7 +474,8 @@
   background: color-mix(in srgb, var(--ink-strong) 70%, transparent);
 }
 
-.trim-handle.active {
+.trim-handle.active,
+.split-handle.active {
   transform: translateX(-50%) scale(1.06);
 }
 
@@ -555,24 +557,6 @@
   z-index: 2;
 }
 
-.split-handle {
-  position: absolute;
-  top: -4px;
-  bottom: -4px;
-  width: 22px;
-  min-height: var(--tap);
-  margin: 0;
-  padding: 0;
-  transform: translateX(-50%);
-  border-radius: 8px;
-  background: var(--accent);
-  border: 2px solid color-mix(in srgb, var(--bg-elevated) 70%, #fff);
-  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.35);
-  z-index: 3;
-  cursor: ew-resize;
-  touch-action: none;
-}
-
 .split-handle::before,
 .split-handle::after {
   content: '';
@@ -591,10 +575,6 @@
 
 .split-handle::after {
   bottom: 8px;
-}
-
-.split-handle.active {
-  transform: translateX(-50%) scale(1.06);
 }
 
 .trim-strip-actions {

--- a/tests/e2e/clip-info.spec.ts
+++ b/tests/e2e/clip-info.spec.ts
@@ -82,6 +82,13 @@ test.describe('clip info sheet', () => {
     await strip.getByRole('button', { name: 'Cancel' }).click()
     await expect(strip).toBeHidden()
     await expect(tiles).toHaveCount(1)
+
+    await openClipInfo(page)
+    await page.getByRole('button', { name: 'Split clip' }).click()
+    await expect(strip).toBeVisible()
+    await page.keyboard.press('Escape')
+    await expect(strip).toBeHidden()
+    await expect(tiles).toHaveCount(1)
   })
 
   test('permanently trim deletes unused media from the file', async ({ page }) => {

--- a/tests/e2e/clip-info.spec.ts
+++ b/tests/e2e/clip-info.spec.ts
@@ -22,7 +22,8 @@ test.describe('clip info sheet', () => {
     await expect(sheet.getByText(/1\.5s/)).toBeVisible()
     await expect(sheet.getByText(/WebM/)).toBeVisible()
     await expect(sheet.getByRole('button', { name: 'Download' })).toBeVisible()
-    await expect(sheet.getByRole('button', { name: /split at/i })).toBeVisible()
+    await expect(sheet.getByRole('button', { name: 'Split clip' })).toBeVisible()
+    await expect(sheet.getByText(/handle on the filmstrip/i)).toBeVisible()
     await expect(sheet.getByRole('button', { name: 'Permanently trim' })).toBeDisabled()
   })
 
@@ -36,14 +37,51 @@ test.describe('clip info sheet', () => {
     expect(download.suggestedFilename()).toMatch(/facts-clip-01\.webm/)
   })
 
-  test('split turns one clip into two timeline tiles', async ({ page }) => {
+  test('split opens a filmstrip handle, then cuts at the chosen point', async ({ page }) => {
+    const clipMs = 4000
+    await openEditorWithClips(page, 1, clipMs)
+    const tiles = page.locator('.clip-thumb[data-clip-id]')
+    await expect(tiles).toHaveCount(1)
+    await openClipInfo(page)
+    await page.getByRole('button', { name: 'Split clip' }).click()
+    await expect(page.getByRole('dialog', { name: /clip \d+ info/i })).toBeHidden()
+
+    const strip = page.locator('.split-strip')
+    await expect(strip).toBeVisible()
+    await expect(strip.getByText(/drag the line/i)).toBeVisible()
+    const handle = strip.getByRole('slider', { name: 'Split point' })
+    await expect(handle).toBeVisible()
+
+    const preview = page.locator('.editor-clip-preview')
+    const previewTime = () => preview.evaluate((el) => (el as HTMLVideoElement).currentTime)
+    const track = await strip.locator('.trim-strip-track').boundingBox()
+    const handleBox = await handle.boundingBox()
+    if (!track || !handleBox) throw new Error('split geometry unavailable')
+    const y = handleBox.y + handleBox.height / 2
+    const xAt = (fraction: number) => track.x + track.width * fraction
+    await page.mouse.move(handleBox.x + handleBox.width / 2, y)
+    await page.mouse.down()
+    await page.mouse.move(xAt(0.25), y, { steps: 8 })
+    await expect.poll(previewTime).toBeGreaterThan(0.25 * (clipMs / 1000) - 0.25)
+    expect(await previewTime()).toBeLessThan(0.25 * (clipMs / 1000) + 0.25)
+    await page.mouse.up()
+
+    await strip.getByRole('button', { name: 'Split' }).click()
+    await expect(page.locator('.toast')).toContainText('Clip split', { timeout: 20_000 })
+    await expect(tiles).toHaveCount(2, { timeout: 20_000 })
+  })
+
+  test('canceling split leaves the timeline unchanged', async ({ page }) => {
     await openEditorWithClips(page, 1, 1600)
     const tiles = page.locator('.clip-thumb[data-clip-id]')
     await expect(tiles).toHaveCount(1)
     await openClipInfo(page)
-    await page.getByRole('button', { name: /split at/i }).click()
-    await expect(page.locator('.toast')).toContainText('Clip split', { timeout: 20_000 })
-    await expect(tiles).toHaveCount(2, { timeout: 20_000 })
+    await page.getByRole('button', { name: 'Split clip' }).click()
+    const strip = page.locator('.split-strip')
+    await expect(strip).toBeVisible()
+    await strip.getByRole('button', { name: 'Cancel' }).click()
+    await expect(strip).toBeHidden()
+    await expect(tiles).toHaveCount(1)
   })
 
   test('permanently trim deletes unused media from the file', async ({ page }) => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Tapping **Split** in the clip info sheet cut immediately — at the playhead if it happened to sit inside the kept window, otherwise the midpoint. The sheet covers the preview, so there was no way to scrub and pick the cut. That felt like the app chose for you.

## Change

**Split clip** now closes the sheet and opens a trim-style filmstrip:

- One draggable handle (tap the strip or drag the line)
- Preview scrubs to the cut frame as you move it
- Label shows `Split at X.Xs · left + right`
- **Cancel** / Escape leaves the timeline alone; **Split** encodes the two halves
- Handle stays inside the kept window (`MIN_SLICE_MS` on each side)
- After the cut lands, the picker closes even if refresh fails, so Split cannot run twice on the leftover half

The encode/rollback path is unchanged — this is only the picker.

![Clip info sheet with Split clip](https://cursor.com/artifacts/c/art-63820dda-1eda-4131-9b8c-757f0e50294a)
![Split point picker on the filmstrip](https://cursor.com/artifacts/c/art-14d28b8d-e6bd-4739-a063-1508088d9927)

## Test plan

- [x] `npm run lint` (`tsc -b`)
- [x] Unit: `splitBounds` / `clampSplitMs` / `resolveSplitMs`
- [x] E2E `tests/e2e/clip-info.spec.ts`
  - Info sheet lists facts and **Split clip**
  - Split clip opens the strip; drag scrubs the preview; confirm yields two tiles
  - Cancel and Escape leave one tile
  - Permanent trim still works

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7c9b3b80-f921-4265-a575-81a72ae8995d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7c9b3b80-f921-4265-a575-81a72ae8995d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an interactive split mode for clips with a draggable cut handle, timeline seeking, keyboard controls, preview, and cancel support.
  - Added visual split guidance, labels, and filmstrip-based editing controls.
  - Split actions now launch the dedicated split workflow from the clip information panel.

- **Bug Fixes**
  - Split points are constrained to valid clip boundaries, with safe midpoint fallback when needed.

- **Tests**
  - Added coverage for split positioning, dragging, successful splitting, and cancellation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->