### PR TITLE
Add kody.video credit and clip-count tags to MP4 exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,18 +118,23 @@ src/
   router.tsx                Tiny client router (route-pattern matching + history)
 ```
 
-### Chapters & optional location
+### Chapters & file metadata
 
 MP4 exports carry **chapter markers** at every clip boundary (Nero `chpl`,
 injected post-mux by `lib/export/mp4-metadata.ts`), titled with each clip's
-recording time. Kody Video Plus users can opt into **location tagging** on the
-record screen; clips then store device coordinates in IndexedDB alongside the
-clip, never inside the MediaRecorder blob. Exports omit those coordinates by
-default. A separate Plus-only export toggle adds them to chapter titles and a
+recording time, plus QuickTime text tags: the project title (`©nam`), a short
+composition note (`©cmt` / `©des` — clip and photo counts, duration, music),
+and an encoder credit (`©too`) pointing at [kody.video](https://kody.video).
+Kody Video Plus users can opt into **location tagging** on the record screen;
+clips then store device coordinates in IndexedDB alongside the clip, never
+inside the MediaRecorder blob. Exports omit those coordinates — and filming
+dates — by default, so a public share does not disclose where or when it was
+made. A separate Plus-only export toggle adds coordinates to chapter titles, a
 `©xyz` geotag derived by averaging the majority cluster of clip locations
-(within 5 km), falling back to the first located clip. WebM exports skip both
-(the WebM subset of Matroska excludes chapters). Clips recorded before this
-feature simply lack the data and degrade gracefully.
+(within 5 km), falling back to the first located clip, and a `©day` filming
+date. WebM exports skip this injection (the WebM subset of Matroska excludes
+chapters). Clips recorded before this feature simply lack the data and degrade
+gracefully.
 
 ### Export pipeline
 

--- a/manual-test-checklist.md
+++ b/manual-test-checklist.md
@@ -141,9 +141,11 @@ see the README) — plain `http://<lan-ip>` fails in most browsers.
   clips with no clicks at joints, smooth frame rate
 - [ ] Watermark (before purchase): small Kody mark + domain bottom-right at
   50% opacity; gone after purchase
-- [ ] MP4 chapters at clip boundaries in VLC/mpv; tagged clips export as
-  chapters only by default, while enabling export location adds coordinates
-  to chapter titles and a ©xyz geotag
+- [ ] MP4 chapters at clip boundaries in VLC/mpv; file info shows the project
+  title, a clip-count comment, and a Kody Video / kody.video encoder credit.
+  Tagged clips export as chapters only by default (no coordinates or filming
+  date), while enabling export location adds coordinates to chapter titles, a
+  ©xyz geotag, and a ©day date
 - [ ] Share opens the system share sheet (fresh tap, no silent failure)
 - [ ] Export failure path offers "Save clips instead"
 

--- a/src/components/export-sheet.tsx
+++ b/src/components/export-sheet.tsx
@@ -247,7 +247,9 @@ export function ExportSheet(handle: Handle<ExportSheetProps>) {
                     </p>
                   ) : null}
                   <p className="export-location-note">
-                    Location is off by default. Chapter markers stay in the video either way.
+                    Location is off by default. Exports still credit kody.video and note the clip
+                    count — never where or when you filmed, unless you turn this on. Chapter
+                    markers stay in the video either way.
                   </p>
                 </div>
               ) : null}

--- a/src/lib/export/encode-webcodecs.ts
+++ b/src/lib/export/encode-webcodecs.ts
@@ -59,6 +59,7 @@ import {
   type ExportResult,
 } from './shared'
 import {
+  buildExportDescriptiveMetadata,
   clipsSpanMultipleDays,
   formatChapterTitle,
   locationForExport,
@@ -135,6 +136,7 @@ export async function exportWithWebCodecs(
   orientation?: ProjectOrientation,
   includeLocation = false,
   signal?: AbortSignal,
+  projectName = '',
 ): Promise<ExportResult> {
   if (!supportsWebCodecsExport()) {
     throw new Error('WebCodecs is not available')
@@ -539,6 +541,11 @@ export async function exportWithWebCodecs(
       chapters,
       clipsInPlan,
       includeLocation,
+      {
+        projectName,
+        filmDurationMs: plan.totalMs,
+        hasMusic: Boolean(background && background.tracks.length > 0),
+      },
     )
     blob = metadata.blob
     locationIncluded = metadata.locationIncluded
@@ -560,9 +567,9 @@ export async function exportWithWebCodecs(
 }
 
 /** Metadata injection needs the whole file in memory (once) — worth it for
- * chapters/geotags on normal exports, but never worth risking a very long
- * export over: oversized files skip it, and any failure returns the
- * perfectly playable un-injected file. */
+ * chapters, descriptive tags, and geotags on normal exports, but never
+ * worth risking a very long export over: oversized files skip it, and any
+ * failure returns the perfectly playable un-injected file. */
 const METADATA_INJECT_LIMIT_BYTES = 256 * 1024 * 1024
 
 async function injectMetadataBestEffort(
@@ -571,16 +578,25 @@ async function injectMetadataBestEffort(
   chapters: Mp4Chapter[],
   clipsInPlan: ClipRecord[],
   includeLocation: boolean,
+  descriptive: { projectName: string; filmDurationMs: number; hasMusic: boolean },
 ): Promise<{ blob: Blob; locationIncluded: boolean }> {
   if (blob.size > METADATA_INJECT_LIMIT_BYTES) {
     return { blob, locationIncluded: false }
   }
   try {
     const location = locationForExport(clipsInPlan, includeLocation)
+    const tags = buildExportDescriptiveMetadata({
+      projectName: descriptive.projectName,
+      clips: clipsInPlan,
+      filmDurationMs: descriptive.filmDurationMs,
+      hasMusic: descriptive.hasMusic,
+      includeLocation,
+    })
     const source = await blob.arrayBuffer()
     const injected = injectMp4Metadata(source, {
       chapters,
       location,
+      ...tags,
     })
     return {
       blob: new Blob([injected], { type: mimeType }),

--- a/src/lib/export/index.ts
+++ b/src/lib/export/index.ts
@@ -41,9 +41,11 @@ export interface ExportOptions {
   /**
    * Include captured coordinates in MP4 metadata and chapter titles.
    * Default false so exports do not disclose location without an explicit
-   * Plus-user opt-in.
+   * Plus-user opt-in. When off, descriptive tags also omit filming dates.
    */
   includeLocation?: boolean
+  /** Project title written into MP4 `©nam` (and the export cache key). */
+  projectName?: string
   /** Background-music playlist mixed under the clips at their per-clip
    * volumes; tracks play one after the other until the film ends. */
   background?: BackgroundAudio | null
@@ -107,6 +109,7 @@ async function runExport(
         options.orientation,
         options.includeLocation === true,
         options.signal,
+        options.projectName ?? '',
       )
       reportSilentExportAudio({ engine: 'webcodecs', outputMime: result.mimeType })
       reportBlackExportVideo({ engine: 'webcodecs', outputMime: result.mimeType })

--- a/src/lib/export/last-export.test.ts
+++ b/src/lib/export/last-export.test.ts
@@ -39,4 +39,11 @@ describe('exportSignature', () => {
       exportSignature(clips, false, null, 'portrait', false),
     )
   })
+
+  it('signs the project title so a rename cannot reuse the old file metadata', () => {
+    const clips = [fakeClip('clip_a')]
+    expect(exportSignature(clips, false, null, 'portrait', false, 'Beach day')).not.toBe(
+      exportSignature(clips, false, null, 'portrait', false, 'Road trip'),
+    )
+  })
 })

--- a/src/lib/export/last-export.ts
+++ b/src/lib/export/last-export.ts
@@ -29,12 +29,15 @@ export function exportSignature(
   audio?: Pick<ProjectAudioRecord, 'tracks' | 'fadeIn' | 'fadeOut'> | null,
   orientation?: ProjectOrientation,
   includeLocation = false,
+  projectName = '',
 ): string {
   return JSON.stringify({
     watermarked,
     // Sign explicitly, including false, to invalidate legacy cached exports
     // that may contain location metadata before this privacy control existed.
     includeLocation,
+    // Title is written into the file; a rename must not reuse the old MP4.
+    projectName,
     // Only landscape signs (JSON drops undefined).
     orientation: orientation === 'landscape' ? 'landscape' : undefined,
     clips: clips.map((clip) => [

--- a/src/lib/export/mp4-export-metadata.test.ts
+++ b/src/lib/export/mp4-export-metadata.test.ts
@@ -1,6 +1,14 @@
 import { describe, expect, it } from 'vitest'
 import type { ClipRecord } from '../types'
-import { formatChapterTitle, locationForExport } from './mp4-export-metadata'
+import {
+  KODY_VIDEO_ENCODER,
+  KODY_VIDEO_SITE,
+  buildExportDescriptiveMetadata,
+  formatChapterTitle,
+  formatClipMix,
+  formatMetadataDuration,
+  locationForExport,
+} from './mp4-export-metadata'
 
 function locatedClip(): Pick<ClipRecord, 'createdAt' | 'durationMs' | 'lat' | 'lng'> {
   return {
@@ -33,6 +41,17 @@ describe('MP4 export location metadata', () => {
     })
   })
 
+  it('omits the calendar date from chapter titles when location is off', () => {
+    const clip = locatedClip()
+    const publicTitle = formatChapterTitle(clip, true, false)
+    const privateTitle = formatChapterTitle(clip, true, true)
+
+    expect(publicTitle).toMatch(/\d/)
+    expect(publicTitle).not.toContain(clip.lat!.toFixed(4))
+    expect(privateTitle.length).toBeGreaterThan(publicTitle.length)
+    expect(privateTitle).toContain(clip.lat!.toFixed(4))
+  })
+
   it('omits malformed non-finite coordinates from opted-in chapter titles', () => {
     const clip = locatedClip()
 
@@ -40,5 +59,85 @@ describe('MP4 export location metadata', () => {
     expect(
       formatChapterTitle({ ...clip, lng: Number.POSITIVE_INFINITY }, false, true),
     ).not.toContain('Infinity')
+  })
+})
+
+describe('MP4 export descriptive metadata', () => {
+  const video = {
+    createdAt: new Date(2026, 7, 8, 14, 30).getTime() + 4_000,
+    durationMs: 4_000,
+    kind: 'video' as const,
+  }
+  const photo = {
+    createdAt: new Date(2026, 7, 8, 15, 0).getTime() + 3_000,
+    durationMs: 3_000,
+    kind: 'image' as const,
+  }
+
+  it('credits kody.video and summarizes clips without capture-context by default', () => {
+    const tags = buildExportDescriptiveMetadata({
+      projectName: 'Beach day',
+      clips: [video, video, photo],
+      filmDurationMs: 24_400,
+      hasMusic: true,
+      includeLocation: false,
+    })
+
+    expect(tags.title).toBe('Beach day')
+    expect(tags.encoder).toBe(KODY_VIDEO_ENCODER)
+    expect(tags.encoder).toContain(KODY_VIDEO_SITE)
+    expect(tags.comment).toBe('3 clips (2 videos, 1 photo) · 24s · with music · kody.video')
+    expect(tags.description).toBe(
+      ['3 clips (2 videos, 1 photo) · 24s · with music', `Made with Kody Video — ${KODY_VIDEO_SITE}`].join(
+        '\n',
+      ),
+    )
+    expect(tags.date).toBeUndefined()
+    expect(tags.comment).not.toMatch(/20\d\d/)
+    expect(tags.description).not.toMatch(/Filmed/)
+    expect(`${tags.title}\n${tags.comment}\n${tags.description}`).not.toContain('40.4179')
+  })
+
+  it('adds a filming date only when location metadata is opted in', () => {
+    const laterDay = {
+      ...video,
+      createdAt: new Date(2026, 7, 9, 9, 0).getTime() + 2_000,
+      durationMs: 2_000,
+    }
+    const tags = buildExportDescriptiveMetadata({
+      projectName: 'Road trip',
+      clips: [video, laterDay],
+      filmDurationMs: 6_000,
+      hasMusic: false,
+      includeLocation: true,
+    })
+
+    expect(tags.date).toBe('2026-08-08')
+    expect(tags.description).toContain('Filmed 2026-08-08 – 2026-08-09')
+    expect(tags.comment).toBe('2 clips · 6s · kody.video')
+    expect(tags.comment).not.toContain('2026-08-08')
+  })
+
+  it('falls back to a generic title and never treats empty names as identifying', () => {
+    const tags = buildExportDescriptiveMetadata({
+      projectName: '   ',
+      clips: [photo],
+      filmDurationMs: 3_000,
+      hasMusic: false,
+      includeLocation: false,
+    })
+    expect(tags.title).toBe('Kody Video')
+    expect(tags.comment).toBe('1 photo · 3s · kody.video')
+  })
+
+  it('formats clip mixes and compact durations', () => {
+    expect(formatClipMix([{ kind: 'video' }])).toBe('1 clip')
+    expect(formatClipMix([{ kind: 'image' }, { kind: 'image' }])).toBe('2 photos')
+    expect(formatClipMix([{ kind: 'video' }, { kind: 'image' }])).toBe(
+      '2 clips (1 video, 1 photo)',
+    )
+    expect(formatMetadataDuration(500)).toBe('1s')
+    expect(formatMetadataDuration(65_000)).toBe('1:05')
+    expect(formatMetadataDuration(3_661_000)).toBe('1:01:01')
   })
 })

--- a/src/lib/export/mp4-export-metadata.ts
+++ b/src/lib/export/mp4-export-metadata.ts
@@ -1,8 +1,30 @@
 import { deriveProjectLocation } from '../geo'
-import type { ClipRecord } from '../types'
+import { isImageClip, type ClipRecord } from '../types'
 
 type ChapterClip = Pick<ClipRecord, 'createdAt' | 'durationMs' | 'lat' | 'lng'>
 type LocatedClip = Pick<ClipRecord, 'lat' | 'lng'>
+type CompositionClip = Pick<ClipRecord, 'kind' | 'createdAt' | 'durationMs'>
+
+export const KODY_VIDEO_SITE = 'https://kody.video'
+export const KODY_VIDEO_ENCODER = 'Kody Video (https://kody.video)'
+export const KODY_VIDEO_TITLE_FALLBACK = 'Kody Video'
+
+export interface ExportDescriptiveMetadataInput {
+  projectName?: string
+  clips: CompositionClip[]
+  filmDurationMs: number
+  hasMusic: boolean
+  includeLocation: boolean
+}
+
+export interface ExportDescriptiveMetadata {
+  title: string
+  encoder: string
+  description: string
+  comment: string
+  /** Earliest clip day (`YYYY-MM-DD`) — only when location is opted in. */
+  date?: string
+}
 
 /** Recording start ≈ createdAt − durationMs (wall-clock capture window). */
 function clipRecordingStartMs(clip: Pick<ClipRecord, 'createdAt' | 'durationMs'>): number {
@@ -29,9 +51,10 @@ export function formatChapterTitle(
 ): string {
   const start = new Date(clipRecordingStartMs(clip))
   const time = start.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' })
-  const datePrefix = includeDate
-    ? `${start.toLocaleDateString([], { month: 'short', day: 'numeric' })} `
-    : ''
+  const datePrefix =
+    includeDate && includeLocation
+      ? `${start.toLocaleDateString([], { month: 'short', day: 'numeric' })} `
+      : ''
   let title = `${datePrefix}${time}`
   if (
     includeLocation &&
@@ -50,4 +73,96 @@ export function locationForExport(
   includeLocation: boolean,
 ): { lat: number; lng: number } | null {
   return includeLocation ? deriveProjectLocation(clips) : null
+}
+
+/**
+ * Title, encoder, comment, and description for an MP4 share. Location-off
+ * is treated as a public share: no filming dates, coordinates, or other
+ * capture-context that could identify the person who made the film.
+ */
+export function buildExportDescriptiveMetadata(
+  input: ExportDescriptiveMetadataInput,
+): ExportDescriptiveMetadata {
+  const title = sanitizeMetadataText(input.projectName) || KODY_VIDEO_TITLE_FALLBACK
+  const mix = formatClipMix(input.clips)
+  const duration = formatMetadataDuration(input.filmDurationMs)
+  const parts = [mix, duration]
+  if (input.hasMusic) parts.push('with music')
+
+  const commentParts = [...parts, 'kody.video']
+  const descriptionLines = [`${parts.join(' · ')}`]
+
+  let date: string | undefined
+  if (input.includeLocation) {
+    const range = filmedLocalDateRange(input.clips)
+    if (range) {
+      date = range.start
+      descriptionLines.push(
+        range.start === range.end
+          ? `Filmed ${range.start}`
+          : `Filmed ${range.start} – ${range.end}`,
+      )
+    }
+  }
+
+  descriptionLines.push(`Made with Kody Video — ${KODY_VIDEO_SITE}`)
+
+  return {
+    title,
+    encoder: KODY_VIDEO_ENCODER,
+    comment: commentParts.join(' · '),
+    description: descriptionLines.join('\n'),
+    date,
+  }
+}
+
+export function formatClipMix(clips: Pick<ClipRecord, 'kind'>[]): string {
+  const photos = clips.filter((clip) => isImageClip(clip)).length
+  const videos = clips.length - photos
+  if (photos === 0) return clips.length === 1 ? '1 clip' : `${clips.length} clips`
+  if (videos === 0) return photos === 1 ? '1 photo' : `${photos} photos`
+  return `${clips.length} clips (${plural(videos, 'video')}, ${plural(photos, 'photo')})`
+}
+
+export function formatMetadataDuration(ms: number): string {
+  const totalSeconds = Math.max(0, Math.round(ms / 1000))
+  const hours = Math.floor(totalSeconds / 3600)
+  const minutes = Math.floor((totalSeconds % 3600) / 60)
+  const seconds = totalSeconds % 60
+  if (hours > 0) {
+    return `${hours}:${pad2(minutes)}:${pad2(seconds)}`
+  }
+  if (minutes > 0) return `${minutes}:${pad2(seconds)}`
+  return `${totalSeconds}s`
+}
+
+function filmedLocalDateRange(
+  clips: Pick<ClipRecord, 'createdAt' | 'durationMs'>[],
+): { start: string; end: string } | null {
+  if (clips.length === 0) return null
+  let start = ''
+  let end = ''
+  for (const clip of clips) {
+    const day = localIsoDate(clipRecordingStartMs(clip))
+    if (!start || day < start) start = day
+    if (!end || day > end) end = day
+  }
+  return start && end ? { start, end } : null
+}
+
+function localIsoDate(ms: number): string {
+  const date = new Date(ms)
+  return `${date.getFullYear()}-${pad2(date.getMonth() + 1)}-${pad2(date.getDate())}`
+}
+
+function sanitizeMetadataText(value: string | undefined): string {
+  return value?.replace(/[\u0000-\u0008\u000b\u000c\u000e-\u001f]/g, '').trim() ?? ''
+}
+
+function plural(count: number, noun: string): string {
+  return `${count} ${noun}${count === 1 ? '' : 's'}`
+}
+
+function pad2(value: number): string {
+  return String(value).padStart(2, '0')
 }

--- a/src/lib/export/mp4-metadata.test.ts
+++ b/src/lib/export/mp4-metadata.test.ts
@@ -8,6 +8,7 @@ import {
 import { describe, expect, it } from 'vitest'
 import { commands } from 'vitest/browser'
 import { formatIso6709, injectMp4Metadata, type Mp4Chapter } from './mp4-metadata'
+import { KODY_VIDEO_ENCODER, KODY_VIDEO_SITE } from './mp4-export-metadata'
 
 const AVC_DESC = new Uint8Array([
   0x01, 0x42, 0x00, 0x1e, 0xff, 0xe1, 0x00, 0x08, 0x67, 0x42, 0x00, 0x1e, 0xda, 0x02, 0xd0,
@@ -99,6 +100,13 @@ function findBox(bytes: Uint8Array, type: number, start = 0, end = bytes.byteLen
   return listBoxes(bytes, start, end).find((b) => b.type === type) ?? null
 }
 
+function readUdtaString(bytes: Uint8Array, box: Box): string {
+  const payload = bytes.subarray(box.offset + box.headerSize, box.offset + box.size)
+  const textLen = readU16(payload, 0)
+  expect(readU16(payload, 2)).toBe(0x15c7)
+  return new TextDecoder().decode(payload.subarray(4, 4 + textLen))
+}
+
 function toBase64(buffer: ArrayBuffer): string {
   const bytes = new Uint8Array(buffer)
   let binary = ''
@@ -169,12 +177,35 @@ describe('injectMp4Metadata', () => {
 
     const xyz = findBox(out, fourCC('\xa9xyz'), udta!.offset + udta!.headerSize, udta!.offset + udta!.size)
     expect(xyz).not.toBeNull()
-    const xyzPayload = out.subarray(xyz!.offset + xyz!.headerSize, xyz!.offset + xyz!.size)
-    const textLen = readU16(xyzPayload, 0)
-    expect(readU16(xyzPayload, 2)).toBe(0x15c7)
-    const iso = new TextDecoder().decode(xyzPayload.subarray(4, 4 + textLen))
-    expect(iso).toBe(formatIso6709(37.7749, -122.4194))
-    expect(iso).toBe('+37.7749-122.4194/')
+    expect(readUdtaString(out, xyz!)).toBe(formatIso6709(37.7749, -122.4194))
+    expect(readUdtaString(out, xyz!)).toBe('+37.7749-122.4194/')
+  })
+
+  it('appends title, description, comment, encoder, and date without requiring chapters', async () => {
+    const out = new Uint8Array(
+      injectMp4Metadata(await buildTinyMp4(), {
+        chapters: [],
+        title: 'Beach day',
+        description: `3 clips · 24s\nMade with Kody Video — ${KODY_VIDEO_SITE}`,
+        comment: '3 clips · 24s · kody.video',
+        encoder: KODY_VIDEO_ENCODER,
+        date: '2026-08-08',
+      }),
+    )
+    const moov = findBox(out, fourCC('moov'))
+    const udta = findBox(out, fourCC('udta'), moov!.offset + moov!.headerSize, moov!.offset + moov!.size)
+    expect(udta).not.toBeNull()
+    const start = udta!.offset + udta!.headerSize
+    const end = udta!.offset + udta!.size
+    expect(readUdtaString(out, findBox(out, fourCC('\xa9nam'), start, end)!)).toBe('Beach day')
+    expect(readUdtaString(out, findBox(out, fourCC('\xa9cmt'), start, end)!)).toBe(
+      '3 clips · 24s · kody.video',
+    )
+    expect(readUdtaString(out, findBox(out, fourCC('\xa9too'), start, end)!)).toBe(KODY_VIDEO_ENCODER)
+    expect(readUdtaString(out, findBox(out, fourCC('\xa9day'), start, end)!)).toBe('2026-08-08')
+    expect(readUdtaString(out, findBox(out, fourCC('\xa9des'), start, end)!)).toContain(KODY_VIDEO_SITE)
+    expect(findBox(out, fourCC('\xa9xyz'), start, end)).toBeNull()
+    expect(findBox(out, fourCC('chpl'), start, end)).toBeNull()
   })
 
   it('is validated by ffmpeg when an MP4-capable binary is available', async () => {
@@ -186,6 +217,9 @@ describe('injectMp4Metadata', () => {
         { startMs: 2000, title: 'Later' },
       ],
       location,
+      title: 'Beach day',
+      comment: '2 clips · 4s · kody.video',
+      encoder: KODY_VIDEO_ENCODER,
     })
 
     // ffmpeg runs on the Vitest server (Node), not in the browser — see
@@ -198,6 +232,8 @@ describe('injectMp4Metadata', () => {
     expect(stderr).toMatch(/Chapters/i)
     expect(stderr).toContain(title)
     expect(stderr).toMatch(/\+37\.7749-122\.4194\//)
+    expect(stderr).toContain('kody.video')
+    expect(stderr).toContain('Beach day')
   })
 })
 

--- a/src/lib/export/mp4-metadata.ts
+++ b/src/lib/export/mp4-metadata.ts
@@ -6,17 +6,29 @@ export interface Mp4Chapter {
 export interface Mp4MetadataInput {
   chapters: Mp4Chapter[]
   location?: { lat: number; lng: number } | null
+  title?: string
+  description?: string
+  comment?: string
+  encoder?: string
+  /** `YYYY-MM-DD` filming/creation date (omit for public shares). */
+  date?: string
 }
 
 const TYPE_MOOV = fourCC('moov')
 const TYPE_UDTA = fourCC('udta')
 const TYPE_CHPL = fourCC('chpl')
 const TYPE_XYZ = fourCC('\xa9xyz')
+const TYPE_NAM = fourCC('\xa9nam')
+const TYPE_DES = fourCC('\xa9des')
+const TYPE_CMT = fourCC('\xa9cmt')
+const TYPE_TOO = fourCC('\xa9too')
+const TYPE_DAY = fourCC('\xa9day')
 
 /**
- * Append Nero chapters (`chpl`) and/or a QuickTime `©xyz` geotag under
- * `moov/udta`. Only safe when `moov` is the last top-level box (trailing moov
- * / no faststart) — otherwise returns the input unchanged.
+ * Append Nero chapters (`chpl`), QuickTime text tags (`©nam` / `©des` /
+ * `©cmt` / `©too` / `©day`), and/or a `©xyz` geotag under `moov/udta`.
+ * Only safe when `moov` is the last top-level box (trailing moov / no
+ * faststart) — otherwise returns the input unchanged.
  */
 export function injectMp4Metadata(buffer: ArrayBuffer, input: Mp4MetadataInput): ArrayBuffer {
   try {
@@ -29,7 +41,14 @@ export function injectMp4Metadata(buffer: ArrayBuffer, input: Mp4MetadataInput):
 function injectMp4MetadataInner(buffer: ArrayBuffer, input: Mp4MetadataInput): ArrayBuffer {
   const hasChapters = input.chapters.length > 0
   const location = input.location ?? null
-  if (!hasChapters && !location) return buffer
+  const title = optionalText(input.title)
+  const description = optionalText(input.description)
+  const comment = optionalText(input.comment)
+  const encoder = optionalText(input.encoder)
+  const date = optionalText(input.date)
+  if (!hasChapters && !location && !title && !description && !comment && !encoder && !date) {
+    return buffer
+  }
 
   const bytes = new Uint8Array(buffer)
   const top = listTopLevelBoxes(bytes)
@@ -47,6 +66,11 @@ function injectMp4MetadataInner(buffer: ArrayBuffer, input: Mp4MetadataInput): A
 
   const children: Uint8Array[] = []
   if (hasChapters) children.push(buildChplBox(input.chapters))
+  if (title) children.push(buildUdtaStringBox(TYPE_NAM, title))
+  if (description) children.push(buildUdtaStringBox(TYPE_DES, description))
+  if (comment) children.push(buildUdtaStringBox(TYPE_CMT, comment))
+  if (encoder) children.push(buildUdtaStringBox(TYPE_TOO, encoder))
+  if (date) children.push(buildUdtaStringBox(TYPE_DAY, date))
   if (location) children.push(buildXyzBox(location.lat, location.lng))
   if (children.length === 0) return buffer
 
@@ -95,14 +119,23 @@ function buildChplBox(chapters: Mp4Chapter[]): Uint8Array {
 
 /** QuickTime `©xyz`: u16 length, u16 language 0x15c7 (eng), ISO 6709 string. */
 function buildXyzBox(lat: number, lng: number): Uint8Array {
-  const text = formatIso6709(lat, lng)
-  const textBytes = new TextEncoder().encode(text)
+  return buildUdtaStringBox(TYPE_XYZ, formatIso6709(lat, lng))
+}
+
+/** QuickTime user-data text: u16 length, u16 language 0x15c7 (eng), UTF-8. */
+function buildUdtaStringBox(type: number, text: string): Uint8Array {
+  const textBytes = truncateUtf8(text, 0xffff)
   const payload = new Uint8Array(4 + textBytes.byteLength)
   const view = new DataView(payload.buffer)
   view.setUint16(0, textBytes.byteLength)
   view.setUint16(2, 0x15c7)
   payload.set(textBytes, 4)
-  return wrapBox(TYPE_XYZ, payload)
+  return wrapBox(type, payload)
+}
+
+function optionalText(value: string | undefined): string | null {
+  const trimmed = value?.trim() ?? ''
+  return trimmed ? trimmed : null
 }
 
 /** `+DD.DDDD+DDD.DDDD/` (signs always present, 4 decimal places). */

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -217,8 +217,8 @@ export interface AppMeta {
   keepWatermark?: boolean
   /**
    * Plus opt-in: include captured clip coordinates in MP4 metadata and
-   * chapter titles. Default off so a share cannot disclose location unless
-   * the user explicitly enables it.
+   * chapter titles, and filming dates in the file description. Default off
+   * so a public share cannot disclose location or when it was filmed.
    */
   includeLocationInExports?: boolean
   /** Opt-in: tag new clips with device location. */

--- a/src/pages/privacy-page.tsx
+++ b/src/pages/privacy-page.tsx
@@ -14,7 +14,7 @@ export function PrivacyPage() {
 
       <div className="about-body">
         <h1>Privacy</h1>
-        <p className="legal-updated">Last updated: July 2026</p>
+        <p className="legal-updated">Last updated: August 2026</p>
 
         <section className="about-section">
           <h2>Everything stays on your device</h2>
@@ -66,8 +66,10 @@ export function PrivacyPage() {
             opt in with a button, which asks the browser for permission. When it&rsquo;s on, each
             new clip stores device coordinates locally. Exported videos omit location by default;
             Plus users can explicitly include it in MP4 metadata and chapter titles from the export
-            sheet. You can turn location tagging off anytime; existing clips keep whatever they
-            already captured, and deleting a clip deletes its location data with it.
+            sheet. Leaving that export option off is treated as a public share: the file will not
+            include coordinates, filming dates, or other capture-context that could identify you.
+            You can turn location tagging off anytime; existing clips keep whatever they already
+            captured, and deleting a clip deletes its location data with it.
           </p>
         </section>
 
@@ -84,6 +86,10 @@ export function PrivacyPage() {
           <h2>Exports &amp; sharing</h2>
           <p>
             Exported or shared files leave the device only when you share or save them yourself.
+            MP4 exports always credit Kody Video (<a href="https://kody.video">kody.video</a>) and
+            note how many clips (and photos, and whether there is music) made the film. That
+            credit is not personal information. Location, filming dates, and chapter coordinates
+            stay out of the file unless you turn on the Plus option to include clip locations.
           </p>
         </section>
 

--- a/src/pages/project-page.tsx
+++ b/src/pages/project-page.tsx
@@ -379,7 +379,14 @@ export function ProjectPage(handle: Handle<ProjectPageProps>) {
     // recordings are landscape media in "portrait" projects — cropping
     // those would be a regression, not a feature).
     const orientation = effectiveOrientation() === 'landscape' ? 'landscape' : undefined
-    const signature = exportSignature(clips, watermarked, audio, orientation, includeLocation)
+    const signature = exportSignature(
+      clips,
+      watermarked,
+      audio,
+      orientation,
+      includeLocation,
+      project?.name ?? '',
+    )
     // Stop camera/mic immediately rather than waiting on record-screen
     // unmount. On iOS the combined mic+camera session can hold decoder
     // slots past the first paints, and WebKit reports that race as
@@ -476,6 +483,7 @@ export function ProjectPage(handle: Handle<ProjectPageProps>) {
           audioContext,
           watermark: watermarked,
           includeLocation,
+          projectName: project?.name ?? '',
           orientation,
           background:
             audio && audio.tracks.length > 0


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
MP4 exports now carry useful, share-friendly file metadata — and stay private when location is off.

## What lands in the file

Every MP4 export gets QuickTime user-data tags (same `moov/udta` injection as chapters):

- **Title** (`©nam`) — the project name
- **Encoder** (`©too`) — `Kody Video (https://kody.video)`
- **Comment** (`©cmt`) — clip/photo count, duration, optional “with music”, and `kody.video`
- **Description** (`©des`) — the same composition note plus a “Made with Kody Video” line

`ffprobe` on a public-share file shows:

```
title           : Beach day
comment         : 3 clips (2 videos, 1 photo) · 24s · with music · kody.video
encoder         : Kody Video (https://kody.video)
```

## Privacy (location toggle off = public share)

If **Include clip locations** is unchecked, the file does **not** get:

- GPS (`©xyz`) or coordinates in chapter titles (already the case)
- Filming dates (`©day`, “Filmed …” in the description)
- Calendar dates on multi-day chapter titles

No device IDs, user-agent, or other personal identifiers are written either way.

When a Plus user opts location **in**, we also write the geotag, chapter coordinates, and a `©day` / “Filmed YYYY-MM-DD” range. `ffprobe` then also shows `date` and `location`.

Renaming a project invalidates the last-export cache so the title in the file stays truthful.

## Tests

- `npm run lint` — pass
- `npm test` — 39 files, 384 tests passed (including new public-vs-opted-in tag tests, atom-byte tests, and ffmpeg probe for `kody.video` + title)
- Playwright `export.spec` + privacy page — 4 passed

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9c131e63-b7fc-4a99-b06a-4636e4fce737?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9c131e63-b7fc-4a99-b06a-4636e4fce737&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * MP4 exports now include project title, clip count, duration, music details, and Kody Video attribution.
  * Optional location-enabled exports include coordinates, geotags, and filming dates; these remain excluded by default.
  * Renaming a project now creates a distinct export rather than reusing a previous file.
  * WebM exports continue without embedded metadata.

* **Documentation**
  * Updated export, privacy, and metadata documentation to clarify included information and privacy defaults.

* **Tests**
  * Expanded coverage for metadata, location settings, project titles, dates, and export reuse.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->