### PR TITLE
Clarify MP4 metadata privacy copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,18 +122,19 @@ src/
 
 MP4 exports carry **chapter markers** at every clip boundary (Nero `chpl`,
 injected post-mux by `lib/export/mp4-metadata.ts`), titled with each clip's
-recording time, plus QuickTime text tags: the project title (`©nam`), a short
-composition note (`©cmt` / `©des` — clip and photo counts, duration, music),
-and an encoder credit (`©too`) pointing at [kody.video](https://kody.video).
-Kody Video Plus users can opt into **location tagging** on the record screen;
-clips then store device coordinates in IndexedDB alongside the clip, never
-inside the MediaRecorder blob. Exports omit those coordinates — and filming
-dates — by default, so a public share does not disclose where or when it was
-made. A separate Plus-only export toggle adds coordinates to chapter titles, a
-`©xyz` geotag derived by averaging the majority cluster of clip locations
-(within 5 km), falling back to the first located clip, and a `©day` filming
-date. WebM exports skip this injection (the WebM subset of Matroska excludes
-chapters). Clips recorded before this feature simply lack the data and degrade
+time of day (no calendar date), plus QuickTime text tags: the project title
+(`©nam`), a short composition note (`©cmt` / `©des` — clip and photo counts,
+duration, music), and an encoder credit (`©too`) pointing at
+[kody.video](https://kody.video). Kody Video Plus users can opt into
+**location tagging** on the record screen; clips then store device coordinates
+in IndexedDB alongside the clip, never inside the MediaRecorder blob. Exports
+omit those coordinates — and filming dates — by default, so a public share
+does not disclose where or when it was made. A separate Plus-only export
+toggle adds calendar dates and coordinates to chapter titles, a `©xyz` geotag
+derived by averaging the majority cluster of clip locations (within 5 km),
+falling back to the first located clip, and a `©day` filming date. WebM
+exports skip this injection (the WebM subset of Matroska excludes chapters).
+Clips recorded before this feature simply lack the data and degrade
 gracefully.
 
 ### Export pipeline

--- a/src/components/export-sheet.tsx
+++ b/src/components/export-sheet.tsx
@@ -247,7 +247,7 @@ export function ExportSheet(handle: Handle<ExportSheetProps>) {
                     </p>
                   ) : null}
                   <p className="export-location-note">
-                    Location is off by default. Exports still credit kody.video and note the clip
+                    Location is off by default. MP4 exports credit kody.video and note the clip
                     count — never where or when you filmed, unless you turn this on. Chapter
                     markers stay in the video either way.
                   </p>

--- a/src/pages/privacy-page.tsx
+++ b/src/pages/privacy-page.tsx
@@ -67,9 +67,9 @@ export function PrivacyPage() {
             new clip stores device coordinates locally. Exported videos omit location by default;
             Plus users can explicitly include it in MP4 metadata and chapter titles from the export
             sheet. Leaving that export option off is treated as a public share: the file will not
-            include coordinates, filming dates, or other capture-context that could identify you.
-            You can turn location tagging off anytime; existing clips keep whatever they already
-            captured, and deleting a clip deletes its location data with it.
+            include automatically captured coordinates, filming dates, or chapter-coordinate
+            metadata. You can turn location tagging off anytime; existing clips keep whatever they
+            already captured, and deleting a clip deletes its location data with it.
           </p>
         </section>
 
@@ -86,10 +86,12 @@ export function PrivacyPage() {
           <h2>Exports &amp; sharing</h2>
           <p>
             Exported or shared files leave the device only when you share or save them yourself.
-            MP4 exports always credit Kody Video (<a href="https://kody.video">kody.video</a>) and
-            note how many clips (and photos, and whether there is music) made the film. That
-            credit is not personal information. Location, filming dates, and chapter coordinates
-            stay out of the file unless you turn on the Plus option to include clip locations.
+            MP4 exports always include the project title you chose, credit Kody Video (
+            <a href="https://kody.video">kody.video</a>), and note how many clips (and photos, and
+            whether there is music) made the film. The title is whatever you named the project — it
+            can identify a person, place, or event if you put that in the name. Automatically
+            captured coordinates, filming dates, and chapter coordinates stay out of the file
+            unless you turn on the Plus option to include clip locations.
           </p>
         </section>
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Follow-up to #163 after CodeRabbit’s review landed on the already-merged PR.

Three copy fixes, rebased onto main after #165/#166/#167:

1. **Privacy page** — disclose that MP4s include the user-chosen project title (which can identify a person, place, or event). Automatically captured coordinates and filming dates inside the MP4 stay off unless location export is on. Share/Save still stamp the file date from the last clip.
2. **Export sheet** — say “MP4 exports credit kody.video…” so WebM results are not promised tags they do not get. File-date stamp stays in the note.
3. **README** — chapter titles default to time of day (no calendar date); dates and coordinates only when location export is on. Keeps the later median geotag, last-clip capture time, and Synology file-date facts.

No behavior change.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9c131e63-b7fc-4a99-b06a-4636e4fce737?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9c131e63-b7fc-4a99-b06a-4636e4fce737&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated MP4 metadata documentation to cover clip and photo counts, project titles, and capture time-of-day details.
  * Clarified privacy behavior for public-share exports, including location and filming metadata.
  * Documented export credits, project-title handling, included film details, and timestamp preservation.

* **User Experience**
  * Updated the location disclaimer to identify the credit shown on MP4 exports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->