### PR TITLE
Use last-clip capture time and median geotag in MP4 exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,9 +130,11 @@ clips then store device coordinates in IndexedDB alongside the clip, never
 inside the MediaRecorder blob. Exports omit those coordinates — and filming
 dates — by default, so a public share does not disclose where or when it was
 made. A separate Plus-only export toggle adds coordinates to chapter titles, a
-`©xyz` geotag derived by averaging the majority cluster of clip locations
-(within 5 km), falling back to the first located clip, and a `©day` filming
-date. WebM exports skip this injection (the WebM subset of Matroska excludes
+`©xyz` geotag at the median of the majority cluster of clip locations
+(within 5 km), falling back to the last located clip, and a capture timestamp
+(`©day` plus `mvhd`/`tkhd` creation_time) from the last timeline video that
+has one — so a Photos library can place the film on the right day and map pin.
+WebM exports skip this injection (the WebM subset of Matroska excludes
 chapters). Clips recorded before this feature simply lack the data and degrade
 gracefully.
 

--- a/manual-test-checklist.md
+++ b/manual-test-checklist.md
@@ -145,7 +145,8 @@ see the README) — plain `http://<lan-ip>` fails in most browsers.
   title, a clip-count comment, and a Kody Video / kody.video encoder credit.
   Tagged clips export as chapters only by default (no coordinates or filming
   date), while enabling export location adds coordinates to chapter titles, a
-  ©xyz geotag, and a ©day date
+  median ©xyz geotag, and a capture timestamp (©day + file creation_time) from
+  the last timeline video
 - [ ] Share opens the system share sheet (fresh tap, no silent failure)
 - [ ] Export failure path offers "Save clips instead"
 

--- a/src/lib/export/mp4-export-metadata.test.ts
+++ b/src/lib/export/mp4-export-metadata.test.ts
@@ -7,6 +7,8 @@ import {
   formatChapterTitle,
   formatClipMix,
   formatMetadataDuration,
+  formatQuickTimeDay,
+  lastCaptureTimeMs,
   locationForExport,
 } from './mp4-export-metadata'
 
@@ -112,10 +114,24 @@ describe('MP4 export descriptive metadata', () => {
       includeLocation: true,
     })
 
-    expect(tags.date).toBe('2026-08-08')
+    expect(tags.creationTimeMs).toBe(laterDay.createdAt)
+    expect(tags.date).toBe(formatQuickTimeDay(laterDay.createdAt))
     expect(tags.description).toContain('Filmed 2026-08-08 – 2026-08-09')
     expect(tags.comment).toBe('2 clips · 6s · kody.video')
     expect(tags.comment).not.toContain('2026-08-08')
+  })
+
+  it('uses the last timeline video for created-at, skipping a trailing photo', () => {
+    const lastVideo = {
+      ...video,
+      createdAt: new Date(2026, 7, 8, 16, 0).getTime(),
+    }
+    const trailingPhoto = {
+      ...photo,
+      createdAt: new Date(2026, 7, 10, 12, 0).getTime(),
+    }
+    expect(lastCaptureTimeMs([video, lastVideo, trailingPhoto])).toBe(lastVideo.createdAt)
+    expect(lastCaptureTimeMs([photo, trailingPhoto])).toBe(trailingPhoto.createdAt)
   })
 
   it('falls back to a generic title and never treats empty names as identifying', () => {

--- a/src/lib/export/mp4-export-metadata.ts
+++ b/src/lib/export/mp4-export-metadata.ts
@@ -22,8 +22,13 @@ export interface ExportDescriptiveMetadata {
   encoder: string
   description: string
   comment: string
-  /** Earliest clip day (`YYYY-MM-DD`) — only when location is opted in. */
+  /**
+   * QuickTime `©day` for the last timeline video that has a capture time —
+   * only when location is opted in.
+   */
   date?: string
+  /** Same instant as `date`, for patching `mvhd`/`tkhd`/`mdhd` creation_time. */
+  creationTimeMs?: number
 }
 
 /** Recording start ≈ createdAt − durationMs (wall-clock capture window). */
@@ -93,10 +98,15 @@ export function buildExportDescriptiveMetadata(
   const descriptionLines = [`${parts.join(' · ')}`]
 
   let date: string | undefined
+  let creationTimeMs: number | undefined
   if (input.includeLocation) {
+    const captureMs = lastCaptureTimeMs(input.clips)
     const range = filmedLocalDateRange(input.clips)
+    if (captureMs !== null) {
+      creationTimeMs = captureMs
+      date = formatQuickTimeDay(captureMs)
+    }
     if (range) {
-      date = range.start
       descriptionLines.push(
         range.start === range.end
           ? `Filmed ${range.start}`
@@ -113,7 +123,35 @@ export function buildExportDescriptiveMetadata(
     comment: commentParts.join(' · '),
     description: descriptionLines.join('\n'),
     date,
+    creationTimeMs,
   }
+}
+
+/**
+ * Capture time of the last timeline video that has `createdAt`. Photos and
+ * imported stills are skipped so a trailing photo does not move the film;
+ * if the film is photos-only, the last photo's time is used.
+ */
+export function lastCaptureTimeMs(
+  clips: Pick<ClipRecord, 'kind' | 'createdAt'>[],
+): number | null {
+  for (let i = clips.length - 1; i >= 0; i -= 1) {
+    if (isImageClip(clips[i])) continue
+    if (Number.isFinite(clips[i].createdAt)) return clips[i].createdAt
+  }
+  for (let i = clips.length - 1; i >= 0; i -= 1) {
+    if (Number.isFinite(clips[i].createdAt)) return clips[i].createdAt
+  }
+  return null
+}
+
+/** Local ISO-8601 with offset — what Photos reads from QuickTime `©day`. */
+export function formatQuickTimeDay(ms: number): string {
+  const date = new Date(ms)
+  const offsetMin = -date.getTimezoneOffset()
+  const sign = offsetMin >= 0 ? '+' : '-'
+  const abs = Math.abs(offsetMin)
+  return `${date.getFullYear()}-${pad2(date.getMonth() + 1)}-${pad2(date.getDate())}T${pad2(date.getHours())}:${pad2(date.getMinutes())}:${pad2(date.getSeconds())}${sign}${pad2(Math.floor(abs / 60))}${pad2(abs % 60)}`
 }
 
 export function formatClipMix(clips: Pick<ClipRecord, 'kind'>[]): string {

--- a/src/lib/export/mp4-metadata.test.ts
+++ b/src/lib/export/mp4-metadata.test.ts
@@ -7,7 +7,12 @@ import {
 } from 'mediabunny'
 import { describe, expect, it } from 'vitest'
 import { commands } from 'vitest/browser'
-import { formatIso6709, injectMp4Metadata, type Mp4Chapter } from './mp4-metadata'
+import {
+  MP4_MAC_EPOCH_OFFSET,
+  formatIso6709,
+  injectMp4Metadata,
+  type Mp4Chapter,
+} from './mp4-metadata'
 import { KODY_VIDEO_ENCODER, KODY_VIDEO_SITE } from './mp4-export-metadata'
 
 const AVC_DESC = new Uint8Array([
@@ -206,6 +211,40 @@ describe('injectMp4Metadata', () => {
     expect(readUdtaString(out, findBox(out, fourCC('\xa9des'), start, end)!)).toContain(KODY_VIDEO_SITE)
     expect(findBox(out, fourCC('\xa9xyz'), start, end)).toBeNull()
     expect(findBox(out, fourCC('chpl'), start, end)).toBeNull()
+  })
+
+  it('patches mvhd creation_time to the capture instant', async () => {
+    const captureMs = Date.UTC(2026, 7, 8, 20, 30, 0)
+    const src = new Uint8Array(await buildTinyMp4())
+    const srcMoov = findBox(src, fourCC('moov'))
+    const before = findBox(
+      src,
+      fourCC('mvhd'),
+      srcMoov!.offset + srcMoov!.headerSize,
+      srcMoov!.offset + srcMoov!.size,
+    )
+    expect(before).not.toBeNull()
+    const beforeTime = readU32(src, before!.offset + before!.headerSize + 4)
+
+    const out = new Uint8Array(
+      injectMp4Metadata(src.buffer, {
+        chapters: [],
+        creationTimeMs: captureMs,
+      }),
+    )
+    const moov = findBox(out, fourCC('moov'))
+    const mvhd = findBox(
+      out,
+      fourCC('mvhd'),
+      moov!.offset + moov!.headerSize,
+      moov!.offset + moov!.size,
+    )
+    expect(mvhd).not.toBeNull()
+    const version = out[mvhd!.offset + mvhd!.headerSize]
+    expect(version).toBe(0)
+    const written = readU32(out, mvhd!.offset + mvhd!.headerSize + 4)
+    expect(written).toBe(Math.floor(captureMs / 1000) + MP4_MAC_EPOCH_OFFSET)
+    expect(written).not.toBe(beforeTime)
   })
 
   it('is validated by ffmpeg when an MP4-capable binary is available', async () => {

--- a/src/lib/export/mp4-metadata.ts
+++ b/src/lib/export/mp4-metadata.ts
@@ -10,19 +10,29 @@ export interface Mp4MetadataInput {
   description?: string
   comment?: string
   encoder?: string
-  /** `YYYY-MM-DD` filming/creation date (omit for public shares). */
+  /** QuickTime `©day` (ISO-8601). Omit for public shares. */
   date?: string
+  /** Unix ms written into `mvhd`/`tkhd`/`mdhd` creation_time (Photos sort). */
+  creationTimeMs?: number
 }
 
 const TYPE_MOOV = fourCC('moov')
 const TYPE_UDTA = fourCC('udta')
 const TYPE_CHPL = fourCC('chpl')
+const TYPE_TRAK = fourCC('trak')
+const TYPE_MDIA = fourCC('mdia')
+const TYPE_MVHD = fourCC('mvhd')
+const TYPE_TKHD = fourCC('tkhd')
+const TYPE_MDHD = fourCC('mdhd')
 const TYPE_XYZ = fourCC('\xa9xyz')
 const TYPE_NAM = fourCC('\xa9nam')
 const TYPE_DES = fourCC('\xa9des')
 const TYPE_CMT = fourCC('\xa9cmt')
 const TYPE_TOO = fourCC('\xa9too')
 const TYPE_DAY = fourCC('\xa9day')
+
+/** Seconds from 1904-01-01 to 1970-01-01 (QuickTime / MP4 epoch). */
+export const MP4_MAC_EPOCH_OFFSET = 2_082_844_800
 
 /**
  * Append Nero chapters (`chpl`), QuickTime text tags (`©nam` / `©des` /
@@ -46,7 +56,20 @@ function injectMp4MetadataInner(buffer: ArrayBuffer, input: Mp4MetadataInput): A
   const comment = optionalText(input.comment)
   const encoder = optionalText(input.encoder)
   const date = optionalText(input.date)
-  if (!hasChapters && !location && !title && !description && !comment && !encoder && !date) {
+  const creationTimeMs =
+    typeof input.creationTimeMs === 'number' && Number.isFinite(input.creationTimeMs)
+      ? input.creationTimeMs
+      : null
+  if (
+    !hasChapters &&
+    !location &&
+    !title &&
+    !description &&
+    !comment &&
+    !encoder &&
+    !date &&
+    creationTimeMs === null
+  ) {
     return buffer
   }
 
@@ -72,17 +95,70 @@ function injectMp4MetadataInner(buffer: ArrayBuffer, input: Mp4MetadataInput): A
   if (encoder) children.push(buildUdtaStringBox(TYPE_TOO, encoder))
   if (date) children.push(buildUdtaStringBox(TYPE_DAY, date))
   if (location) children.push(buildXyzBox(location.lat, location.lng))
-  if (children.length === 0) return buffer
 
-  const udta = wrapBox(TYPE_UDTA, concat(children))
-  const newMoovSize = moov.size + udta.byteLength
-  if (newMoovSize > 0xffff_ffff) return buffer
-
-  const out = new Uint8Array(bytes.byteLength + udta.byteLength)
-  out.set(bytes, 0)
-  writeU32(out, moov.offset, newMoovSize)
-  out.set(udta, bytes.byteLength)
+  let out: Uint8Array
+  if (children.length > 0) {
+    const udta = wrapBox(TYPE_UDTA, concat(children))
+    const newMoovSize = moov.size + udta.byteLength
+    if (newMoovSize > 0xffff_ffff) return buffer
+    out = new Uint8Array(bytes.byteLength + udta.byteLength)
+    out.set(bytes, 0)
+    writeU32(out, moov.offset, newMoovSize)
+    out.set(udta, bytes.byteLength)
+  } else {
+    out = new Uint8Array(bytes)
+  }
+  if (creationTimeMs !== null) patchCreationTimes(out, moov, creationTimeMs)
   return out.buffer
+}
+
+/**
+ * Rewrite movie/track/media creation + modification times so Photos libraries
+ * sort the file by capture time instead of export time.
+ */
+function patchCreationTimes(bytes: Uint8Array, moov: BoxInfo, unixMs: number): void {
+  const macTime = Math.floor(unixMs / 1000) + MP4_MAC_EPOCH_OFFSET
+  if (macTime < 0 || macTime > 0xffff_ffff) return
+  const kids = listBoxes(bytes, moov.offset + moov.headerSize, moov.offset + moov.size)
+  for (const box of kids) {
+    if (box.type === TYPE_MVHD) {
+      patchHeaderTimestamps(bytes, box, macTime)
+      continue
+    }
+    if (box.type !== TYPE_TRAK) continue
+    const trakKids = listBoxes(bytes, box.offset + box.headerSize, box.offset + box.size)
+    for (const trakKid of trakKids) {
+      if (trakKid.type === TYPE_TKHD) patchHeaderTimestamps(bytes, trakKid, macTime)
+      if (trakKid.type !== TYPE_MDIA) continue
+      const mdiaKids = listBoxes(
+        bytes,
+        trakKid.offset + trakKid.headerSize,
+        trakKid.offset + trakKid.size,
+      )
+      for (const mdiaKid of mdiaKids) {
+        if (mdiaKid.type === TYPE_MDHD) patchHeaderTimestamps(bytes, mdiaKid, macTime)
+      }
+    }
+  }
+}
+
+function patchHeaderTimestamps(bytes: Uint8Array, box: BoxInfo, macTime: number): void {
+  const payload = box.offset + box.headerSize
+  if (payload + 5 > bytes.byteLength) return
+  const version = bytes[payload]
+  if (version === 0) {
+    if (payload + 12 > bytes.byteLength) return
+    writeU32(bytes, payload + 4, macTime)
+    writeU32(bytes, payload + 8, macTime)
+    return
+  }
+  if (version === 1) {
+    if (payload + 20 > bytes.byteLength) return
+    writeU32(bytes, payload + 4, 0)
+    writeU32(bytes, payload + 8, macTime)
+    writeU32(bytes, payload + 12, 0)
+    writeU32(bytes, payload + 16, macTime)
+  }
 }
 
 /**
@@ -157,24 +233,28 @@ interface BoxInfo {
 }
 
 function listTopLevelBoxes(bytes: Uint8Array): BoxInfo[] {
+  return listBoxes(bytes, 0, bytes.byteLength)
+}
+
+function listBoxes(bytes: Uint8Array, start: number, end: number): BoxInfo[] {
   const boxes: BoxInfo[] = []
-  let offset = 0
-  while (offset + 8 <= bytes.byteLength) {
-    const view = new DataView(bytes.buffer, bytes.byteOffset + offset, bytes.byteLength - offset)
+  let offset = start
+  while (offset + 8 <= end) {
+    const view = new DataView(bytes.buffer, bytes.byteOffset + offset, end - offset)
     let size = view.getUint32(0)
     const type = view.getUint32(4)
     let headerSize = 8
     if (size === 1) {
-      if (offset + 16 > bytes.byteLength) break
+      if (offset + 16 > end) break
       // Large-size boxes are unused by our muxer; treat as unreadable.
       const large = Number(view.getBigUint64(8))
       if (!Number.isSafeInteger(large) || large < 16) break
       size = large
       headerSize = 16
     } else if (size === 0) {
-      size = bytes.byteLength - offset
+      size = end - offset
     }
-    if (size < headerSize || offset + size > bytes.byteLength) break
+    if (size < headerSize || offset + size > end) break
     boxes.push({ offset, size, type, headerSize })
     offset += size
   }

--- a/src/lib/geo.test.ts
+++ b/src/lib/geo.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { deriveProjectLocation, haversineMeters } from './geo'
+import { deriveProjectLocation, haversineMeters, medianPoint } from './geo'
 
 describe('haversineMeters', () => {
   it('returns ~0 for identical points', () => {
@@ -32,7 +32,7 @@ describe('deriveProjectLocation', () => {
     })
   })
 
-  it('averages a tight city cluster', () => {
+  it('uses the median of a tight city cluster', () => {
     const points = [
       { lat: 37.7749, lng: -122.4194 },
       { lat: 37.7751, lng: -122.4192 },
@@ -40,33 +40,24 @@ describe('deriveProjectLocation', () => {
       { lat: 37.7750, lng: -122.4190 },
     ]
     const loc = deriveProjectLocation(points)
-    expect(loc).not.toBeNull()
-    const avgLat = points.reduce((s, p) => s + p.lat, 0) / points.length
-    const avgLng = points.reduce((s, p) => s + p.lng, 0) / points.length
-    expect(loc!.lat).toBeCloseTo(avgLat, 10)
-    expect(loc!.lng).toBeCloseTo(avgLng, 10)
+    expect(loc).toEqual(medianPoint(points))
   })
 
-  it('averages the majority cluster and excludes a far outlier', () => {
-    // Asymmetric so the result cannot accidentally equal the first clip alone.
+  it('uses the median of the majority cluster and excludes a far outlier', () => {
     const cluster = [
       { lat: 48.8566, lng: 2.3522 },
-      { lat: 48.8600, lng: 2.3600 },
-      { lat: 48.8500, lng: 2.3400 },
+      { lat: 48.86, lng: 2.36 },
+      { lat: 48.85, lng: 2.34 },
     ]
     const outlier = { lat: -33.8688, lng: 151.2093 } // Sydney
     const loc = deriveProjectLocation([...cluster, outlier])
-    expect(loc).not.toBeNull()
-    const avgLat = cluster.reduce((s, p) => s + p.lat, 0) / cluster.length
-    const avgLng = cluster.reduce((s, p) => s + p.lng, 0) / cluster.length
-    expect(loc!.lat).toBeCloseTo(avgLat, 10)
-    expect(loc!.lng).toBeCloseTo(avgLng, 10)
-    expect(loc).not.toEqual(cluster[0])
+    expect(loc).toEqual(medianPoint(cluster))
   })
 
-  it('falls back to the first geo clip when there is no majority cluster', () => {
+  it('falls back to the last geo clip when there is no majority cluster', () => {
     const first = { lat: 40.7128, lng: -74.006 } // NYC
     const second = { lat: 35.6762, lng: 139.6503 } // Tokyo
-    expect(deriveProjectLocation([first, second])).toEqual(first)
+    const third = { lat: -33.8688, lng: 151.2093 } // Sydney
+    expect(deriveProjectLocation([first, second, third])).toEqual(third)
   })
 })

--- a/src/lib/geo.test.ts
+++ b/src/lib/geo.test.ts
@@ -16,6 +16,12 @@ describe('haversineMeters', () => {
   })
 })
 
+describe('medianPoint', () => {
+  it('rejects an empty list', () => {
+    expect(() => medianPoint([])).toThrow(RangeError)
+  })
+})
+
 describe('deriveProjectLocation', () => {
   it('returns null when there are no clips', () => {
     expect(deriveProjectLocation([])).toBeNull()

--- a/src/lib/geo.ts
+++ b/src/lib/geo.ts
@@ -68,6 +68,9 @@ export function deriveProjectLocation(
 export function medianPoint(
   points: { lat: number; lng: number }[],
 ): { lat: number; lng: number } {
+  if (points.length === 0) {
+    throw new RangeError('Expected at least one point')
+  }
   return {
     lat: medianNumber(points.map((p) => p.lat)),
     lng: medianNumber(points.map((p) => p.lng)),

--- a/src/lib/geo.ts
+++ b/src/lib/geo.ts
@@ -19,13 +19,14 @@ export function haversineMeters(
 }
 
 /**
- * Pick a single project geotag from clip coordinates.
+ * Pick a single project geotag from clip coordinates (timeline order).
  *
  * 1. Collect points with both lat and lng.
  * 2. For each point as a seed, form the subset within 5 km (haversine).
  * 3. Keep the largest such subset (stable on ties: first seed wins).
- * 4. If that subset is a majority (≥ 50%) of geo points, return its average;
- *    otherwise return the first geo clip's coordinates.
+ * 4. If that subset is a majority (≥ 50%) of geo points, return its
+ *    component-wise median (Photos-friendly pin, outlier-resistant);
+ *    otherwise return the last geo clip's coordinates.
  *
  * Seeding (vs a single global centroid) is required so a far outlier cannot
  * yank the centroid outside the dense cluster and erase the majority.
@@ -58,11 +59,23 @@ export function deriveProjectLocation(
   const aroundCentroid = points.filter((p) => haversineMeters(p, centroid) <= CLUSTER_RADIUS_M)
   if (aroundCentroid.length > best.length) best = aroundCentroid
 
-  if (best.length * 2 >= points.length) {
-    return {
-      lat: best.reduce((sum, p) => sum + p.lat, 0) / best.length,
-      lng: best.reduce((sum, p) => sum + p.lng, 0) / best.length,
-    }
+  if (best.length * 2 >= points.length) return medianPoint(best)
+  const last = points[points.length - 1]
+  return { lat: last.lat, lng: last.lng }
+}
+
+/** Independent median of lat and lng — the typical pin for a tight cluster. */
+export function medianPoint(
+  points: { lat: number; lng: number }[],
+): { lat: number; lng: number } {
+  return {
+    lat: medianNumber(points.map((p) => p.lat)),
+    lng: medianNumber(points.map((p) => p.lng)),
   }
-  return { lat: points[0].lat, lng: points[0].lng }
+}
+
+function medianNumber(values: number[]): number {
+  const sorted = [...values].sort((a, b) => a - b)
+  const mid = Math.floor(sorted.length / 2)
+  return sorted.length % 2 === 0 ? (sorted[mid - 1] + sorted[mid]) / 2 : sorted[mid]
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
You were close. Two things were off for a personal Photos library:

1. **Date** — we wrote `©day` as the *earliest* calendar day, and the file’s real `creation_time` (what Photos sorts on) was still “when you exported.” It now uses the **last timeline video** that has a capture time: QuickTime `©day` (full local timestamp) plus `mvhd`/`tkhd`/`mdhd` `creation_time`.
2. **Location** — the `©xyz` geotag was the *mean* of the majority 5 km cluster (or the first clip). It is now the **median** of that cluster, or the last located clip if there is no majority. That is the pin Photos/Google Photos/Lightroom read.

Still gated on the Plus “include clip locations” toggle. Public shares get no capture time and no geotag.

A trailing photo does not move the film’s created-at; a photos-only project uses the last photo.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9c131e63-b7fc-4a99-b06a-4636e4fce737?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9c131e63-b7fc-4a99-b06a-4636e4fce737&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * MP4 exports now include the final timeline video’s capture timestamp in video metadata and file creation time.
  * Location metadata uses the median position of the majority location cluster, with a fallback to the last located clip.
* **Bug Fixes**
  * Trailing photos no longer override the final video’s timestamp.
  * Photo-only timelines continue to use the final photo timestamp.
* **Documentation**
  * Updated export verification guidance for timestamp metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->