### PR TITLE
Stamp export file dates from the last clip for Synology Photos

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,9 +134,11 @@ made. A separate Plus-only export toggle adds coordinates to chapter titles, a
 (within 5 km), falling back to the last located clip, and a capture timestamp
 (`©day` plus `mvhd`/`tkhd` creation_time) from the last timeline video that
 has one — so a Photos library can place the film on the right day and map pin.
-WebM exports skip this injection (the WebM subset of Matroska excludes
-chapters). Clips recorded before this feature simply lack the data and degrade
-gracefully.
+Share and Save also stamp `File.lastModified` from that same last-clip time
+(Web Share copies it onto the filesystem created/modified dates). Synology
+Photos sorts by those file dates rather than the MP4 atoms. WebM exports skip
+this injection (the WebM subset of Matroska excludes chapters). Clips recorded
+before this feature simply lack the data and degrade gracefully.
 
 ### Export pipeline
 

--- a/manual-test-checklist.md
+++ b/manual-test-checklist.md
@@ -147,7 +147,9 @@ see the README) — plain `http://<lan-ip>` fails in most browsers.
   date), while enabling export location adds coordinates to chapter titles, a
   median ©xyz geotag, and a capture timestamp (©day + file creation_time) from
   the last timeline video
-- [ ] Share opens the system share sheet (fresh tap, no silent failure)
+- [ ] Share opens the system share sheet (fresh tap, no silent failure). The
+  shared/saved File's lastModified is the last timeline video's capture time
+  (Synology Photos sorts by that filesystem date)
 - [ ] Export failure path offers "Save clips instead"
 
 ### Purchases (Stripe, production)

--- a/src/components/export-sheet.tsx
+++ b/src/components/export-sheet.tsx
@@ -248,8 +248,9 @@ export function ExportSheet(handle: Handle<ExportSheetProps>) {
                   ) : null}
                   <p className="export-location-note">
                     Location is off by default. Exports still credit kody.video and note the clip
-                    count — never where or when you filmed, unless you turn this on. Chapter
-                    markers stay in the video either way.
+                    count — never where you filmed, unless you turn this on. Share and Save stamp
+                    the file date from the last clip so Photos apps can sort. Chapter markers stay
+                    in the video either way.
                   </p>
                 </div>
               ) : null}

--- a/src/lib/media.test.ts
+++ b/src/lib/media.test.ts
@@ -1,5 +1,10 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { pickRecordingMimeType, resetRecordingMimeTypeForTests } from './media'
+import {
+  fileFromBlob,
+  pickRecordingMimeType,
+  resetRecordingMimeTypeForTests,
+  shareFile,
+} from './media'
 
 // The recording mime preference is cached at module scope (it runs inside
 // the pointerdown that starts every take); resetRecordingMimeTypeForTests
@@ -46,5 +51,45 @@ describe('pickRecordingMimeType', () => {
     const probesAfterFirst = FakeMediaRecorder.probes.length
     expect(pickRecordingMimeType()).toBe('')
     expect(FakeMediaRecorder.probes.length).toBe(probesAfterFirst)
+  })
+})
+
+describe('fileFromBlob', () => {
+  it('stamps lastModified so share targets keep the capture time', () => {
+    const file = fileFromBlob(new Blob(['mp4'], { type: 'video/mp4' }), 'beach.mp4', 1_700_000_000_000)
+    expect(file).toBeInstanceOf(File)
+    expect(file.name).toBe('beach.mp4')
+    expect(file.type).toBe('video/mp4')
+    expect(file.lastModified).toBe(1_700_000_000_000)
+  })
+
+  it('omits invalid stamps so the browser defaults to now', () => {
+    const before = Date.now()
+    expect(fileFromBlob(new Blob(['x'], { type: 'video/mp4' }), 'x.mp4').lastModified).toBeGreaterThanOrEqual(
+      before,
+    )
+    expect(
+      fileFromBlob(new Blob(['x'], { type: 'video/mp4' }), 'x.mp4', Number.NaN).lastModified,
+    ).toBeGreaterThanOrEqual(before)
+    expect(fileFromBlob(new Blob(['x'], { type: 'video/mp4' }), 'x.mp4', 0).lastModified).toBeGreaterThanOrEqual(
+      before,
+    )
+  })
+})
+
+describe('shareFile', () => {
+  it('hands Web Share a File stamped with the capture time', async () => {
+    const share = vi.fn().mockResolvedValue(undefined)
+    vi.stubGlobal('navigator', { ...navigator, share })
+
+    await expect(
+      shareFile(new Blob(['x'], { type: 'video/mp4' }), 'film.mp4', 1_234_000),
+    ).resolves.toBe('shared')
+
+    expect(share).toHaveBeenCalledOnce()
+    const file = share.mock.calls[0]?.[0]?.files?.[0] as File
+    expect(file).toBeInstanceOf(File)
+    expect(file.name).toBe('film.mp4')
+    expect(file.lastModified).toBe(1_234_000)
   })
 })

--- a/src/lib/media.ts
+++ b/src/lib/media.ts
@@ -430,8 +430,27 @@ export async function canFlipCamera(): Promise<boolean> {
   }
 }
 
-export async function downloadBlob(blob: Blob, filename: string): Promise<void> {
-  const url = URL.createObjectURL(blob)
+/**
+ * Wrap bytes as a named File. `lastModified` is the only timestamp the File
+ * API exposes — Synology Photos (and many NAS/photo libraries) sort by the
+ * filesystem created/modified times, which Web Share copies from this field.
+ * Created and updated become the same instant when the OS first writes the
+ * file. Invalid stamps are omitted so the browser defaults to now.
+ */
+export function fileFromBlob(blob: Blob, filename: string, lastModified?: number): File {
+  const options: FilePropertyBag = { type: blob.type || 'video/webm' }
+  if (typeof lastModified === 'number' && Number.isFinite(lastModified) && lastModified > 0) {
+    options.lastModified = lastModified
+  }
+  return new File([blob], filename, options)
+}
+
+export async function downloadBlob(
+  blob: Blob,
+  filename: string,
+  lastModified?: number,
+): Promise<void> {
+  const url = URL.createObjectURL(fileFromBlob(blob, filename, lastModified))
   const anchor = document.createElement('a')
   anchor.href = url
   anchor.download = filename
@@ -443,8 +462,8 @@ export async function downloadBlob(blob: Blob, filename: string): Promise<void> 
   setTimeout(() => URL.revokeObjectURL(url), 60_000)
 }
 
-export function canShareFile(blob: Blob, filename: string): boolean {
-  const file = new File([blob], filename, { type: blob.type || 'video/webm' })
+export function canShareFile(blob: Blob, filename: string, lastModified?: number): boolean {
+  const file = fileFromBlob(blob, filename, lastModified)
   return navigator.canShare?.({ files: [file] }) === true
 }
 
@@ -453,8 +472,12 @@ export function canShareFile(blob: Blob, filename: string): boolean {
  * (Web Share requires transient activation) — never from the tail of an
  * async flow.
  */
-export async function shareFile(blob: Blob, filename: string): Promise<'shared' | 'cancelled'> {
-  const file = new File([blob], filename, { type: blob.type || 'video/webm' })
+export async function shareFile(
+  blob: Blob,
+  filename: string,
+  lastModified?: number,
+): Promise<'shared' | 'cancelled'> {
+  const file = fileFromBlob(blob, filename, lastModified)
   try {
     await navigator.share({ files: [file], title: filename })
     return 'shared'
@@ -469,15 +492,16 @@ export async function shareFile(blob: Blob, filename: string): Promise<'shared' 
 export async function shareOrDownload(
   blob: Blob,
   filename: string,
+  lastModified?: number,
 ): Promise<'shared' | 'downloaded' | 'cancelled'> {
-  if (canShareFile(blob, filename)) {
+  if (canShareFile(blob, filename, lastModified)) {
     try {
-      return await shareFile(blob, filename)
+      return await shareFile(blob, filename, lastModified)
     } catch {
       // Fall through to download attempt.
     }
   }
-  await downloadBlob(blob, filename)
+  await downloadBlob(blob, filename, lastModified)
   return 'downloaded'
 }
 
@@ -487,7 +511,11 @@ export async function shareClipFile(
   projectName: string,
   index: number,
 ): Promise<'shared' | 'downloaded' | 'cancelled'> {
-  return shareOrDownload(clip.blob, clipDownloadFilename(projectName, index, clip.mimeType))
+  return shareOrDownload(
+    clip.blob,
+    clipDownloadFilename(projectName, index, clip.mimeType),
+    clip.createdAt,
+  )
 }
 
 /** Save a single clip to the device (no share sheet). */
@@ -496,7 +524,11 @@ export async function downloadClipFile(
   projectName: string,
   index: number,
 ): Promise<void> {
-  await downloadBlob(clip.blob, clipDownloadFilename(projectName, index, clip.mimeType))
+  await downloadBlob(
+    clip.blob,
+    clipDownloadFilename(projectName, index, clip.mimeType),
+    clip.createdAt,
+  )
 }
 
 function slugify(value: string): string {

--- a/src/pages/privacy-page.tsx
+++ b/src/pages/privacy-page.tsx
@@ -88,8 +88,11 @@ export function PrivacyPage() {
             Exported or shared files leave the device only when you share or save them yourself.
             MP4 exports always credit Kody Video (<a href="https://kody.video">kody.video</a>) and
             note how many clips (and photos, and whether there is music) made the film. That
-            credit is not personal information. Location, filming dates, and chapter coordinates
-            stay out of the file unless you turn on the Plus option to include clip locations.
+            credit is not personal information. Location, filming dates inside the MP4, and
+            chapter coordinates stay out of the file unless you turn on the Plus option to
+            include clip locations. Share and Save still stamp the file&rsquo;s last-modified
+            time from the last clip so photo libraries (including Synology Photos) can sort by
+            when you filmed.
           </p>
         </section>
 

--- a/src/pages/project-page.tsx
+++ b/src/pages/project-page.tsx
@@ -14,6 +14,7 @@ import { buildClipsZip } from '../lib/clips-zip'
 import { clearExportMarker, markExportStarted, reportError } from '../lib/error-reporting'
 import { exportProject, isExportCancelled, type ExportResult } from '../lib/export'
 import { exportSignature, loadMatchingExport, persistLastExport } from '../lib/export/last-export'
+import { lastCaptureTimeMs } from '../lib/export/mp4-export-metadata'
 import { MediaElementFailureError } from '../lib/export/media-error'
 import { unlockExportMediaPlayback, wait } from '../lib/export/shared'
 import {
@@ -682,6 +683,9 @@ export function ProjectPage(handle: Handle<ProjectPageProps>) {
     const exportFilename = exportState?.result
       ? projectFilename(project.name, exportState.result.fileExtension)
       : null
+    // Synology Photos sorts by filesystem created/modified, which Web Share
+    // copies from File.lastModified — stamp the last timeline video's time.
+    const captureTimeMs = lastCaptureTimeMs(clips) ?? undefined
     const orientation = effectiveOrientation()
     const unlocked = orientationUnlocked()
     syncShellOrientation(orientation, unlocked)
@@ -816,7 +820,7 @@ export function ProjectPage(handle: Handle<ProjectPageProps>) {
             canShare={
               !!exportState.result &&
               !!exportFilename &&
-              canShareFile(exportState.result.blob, exportFilename)
+              canShareFile(exportState.result.blob, exportFilename, captureTimeMs)
             }
             fileExtension={exportState.result?.fileExtension ?? null}
             fileSizeBytes={exportState.result?.blob.size ?? null}
@@ -824,7 +828,7 @@ export function ProjectPage(handle: Handle<ProjectPageProps>) {
               const result = exportState?.result
               if (!result || !exportFilename) return
               beginExportAction()
-              void shareFile(result.blob, exportFilename)
+              void shareFile(result.blob, exportFilename, captureTimeMs)
                 .then((outcome) => {
                   // A cancel (AbortError → 'cancelled') is a routine user action,
                   // not something worth announcing — only confirm real shares.
@@ -839,7 +843,7 @@ export function ProjectPage(handle: Handle<ProjectPageProps>) {
               const result = exportState?.result
               if (!result || !exportFilename) return
               beginExportAction()
-              void downloadBlob(result.blob, exportFilename)
+              void downloadBlob(result.blob, exportFilename, captureTimeMs)
                 .then(() => {
                   setExportNotice('Saved — check your downloads.')
                 })


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

Synology Photos sorts videos by the **filesystem** created/modified times, not the QuickTime/`mvhd` dates we already write when location is on. Browser Share/Save was wrapping the export as a `File` without `lastModified`, so the NAS treated every film as “today.”

The File API only exposes `lastModified`. When the OS first writes a shared file, created and updated become that same instant — which is what Synology reads.

## What changed

- `fileFromBlob` stamps `lastModified` from the last timeline video (`lastCaptureTimeMs` — same rule as MP4 capture time: skip trailing photos).
- Share, Save, and single-clip download pass that stamp through. Web Share copies it onto the filesystem dates.
- Privacy / export-sheet / README note that this file date is always stamped (MP4 filming dates and GPS stay behind the Plus location toggle).

`<a download>` on some browsers still rewrites mtime to “now.” Share to DS File / Synology Drive is the path that keeps the date.

## Testing

- `npm run lint` — clean
- `npm test` — 39 files, 390 tests passed
- New coverage: `fileFromBlob` stamps / ignores invalid times; `shareFile` hands Web Share a File with that `lastModified`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9c131e63-b7fc-4a99-b06a-4636e4fce737?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9c131e63-b7fc-4a99-b06a-4636e4fce737&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

