### PR TITLE
Document that kody-video ships ready PRs by default

### DIFF
--- a/.cursor/skills/ship-pr/SKILL.md
+++ b/.cursor/skills/ship-pr/SKILL.md
@@ -13,6 +13,10 @@ description: >
 
 Self-assess; user policy overrides.
 
+**Kody Video default:** ship when ready. Do not wait for a separate "Go"
+once CI is green and Bugbot is clear (valid feedback addressed). CodeRabbit
+rate-limits do not block. High-risk work, or an explicit pause, still waits.
+
 - **Low** — green CI; nits ignorable; squash-merge when policy allows.
 - **Medium** — wait for AI reviewer(s); address **valid** feedback (ignore
   insignificant nits / already-fixed / wrong); then merge when policy allows.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,13 @@
 
 Kody Video is a mobile-first, on-device PWA "clips camera": hold to record clips, arrange/trim them on a filmstrip timeline, then export/share one video file (see `README.md` for architecture).
 
+## Shipping
+
+Ship ready PRs by default: once CI is green and Bugbot is clear (valid
+feedback addressed), squash-merge and watch the deploy. Do not wait for a
+separate "Go" unless the change is high-risk or the user pauses. CodeRabbit
+rate-limits do not block. Follow `.cursor/skills/ship-pr/SKILL.md`.
+
 ## Cursor Cloud specific instructions
 
 Contributor and cloud-agent docs live in `docs/contribute/`:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

Kent said **ship by default**. Ready kody-video PRs should squash-merge once CI is green and Bugbot is clear, without waiting for a separate “Go.”

## What changed

- `AGENTS.md` — shipping default for cloud agents
- `.cursor/skills/ship-pr/SKILL.md` — same rule on the ship skill (high-risk or an explicit pause still waits; CodeRabbit rate-limits do not block)

No product code.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9c131e63-b7fc-4a99-b06a-4636e4fce737?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9c131e63-b7fc-4a99-b06a-4636e4fce737&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated shipping guidance to allow standard releases once automated checks pass.
  * Rate limits no longer block eligible releases.
  * High-risk changes or explicitly paused releases continue to require additional review.
  * Added guidance to squash-merge approved changes and monitor deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->