### PR TITLE
Require an inbound CLA for external contributions

### DIFF
--- a/.github/cla-signers.json
+++ b/.github/cla-signers.json
@@ -1,0 +1,9 @@
+{
+	"version": 1,
+	"document": "docs/legal/individual-cla.md",
+	"allowlist": {
+		"github": ["kentcdodds", "kody-bot"],
+		"email": ["me@kentcdodds.com", "me+github@kentcdodds.com"]
+	},
+	"signers": []
+}

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Checkout base
         uses: actions/checkout@v6.0.2
         with:
-          ref: ${{ github.event.pull_request.base.sha }}
+          ref: ${{ github.event.pull_request.base.ref }}
           persist-credentials: false
 
       - name: Setup Node

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,0 +1,127 @@
+name: CLA
+
+on:
+  pull_request:
+    branches:
+      - main
+    types:
+      - opened
+      - reopened
+      - synchronize
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  cla:
+    runs-on: ubuntu-latest
+    name: CLA
+    timeout-minutes: 5
+    steps:
+      - name: Checkout base
+        uses: actions/checkout@v6.0.2
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          persist-credentials: false
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
+      - name: Collect identities
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        with:
+          script: |
+            const identities = [
+              {
+                githubLogin: context.payload.pull_request.user.login,
+                name: context.payload.pull_request.user.login,
+                email: null,
+              },
+            ]
+            const commits = await github.paginate(
+              github.rest.pulls.listCommits,
+              {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: context.payload.pull_request.number,
+                per_page: 100,
+              },
+            )
+            for (const commit of commits) {
+              identities.push({
+                githubLogin: commit.author?.login ?? null,
+                name: commit.commit.author?.name ?? null,
+                email: commit.commit.author?.email ?? null,
+              })
+            }
+            const fs = await import('node:fs/promises')
+            await fs.writeFile(
+              'cla-identities.json',
+              `${JSON.stringify(identities, null, '\t')}\n`,
+            )
+
+      - name: Check CLA
+        id: check
+        run: |
+          if [ ! -f tools/ci/check-cla.mjs ] || [ ! -f .github/cla-signers.json ]; then
+            echo "CLA checker is not on the base branch yet."
+            exit 0
+          fi
+          set +e
+          node tools/ci/check-cla.mjs \
+            --signers .github/cla-signers.json \
+            --identities-json cla-identities.json
+          code=$?
+          echo "exit_code=$code" >> "$GITHUB_OUTPUT"
+          if [ "$code" -ne 0 ] && [ "$code" -ne 1 ]; then
+            exit "$code"
+          fi
+
+      - name: Comment when unsigned
+        if: steps.check.outputs.exit_code == '1'
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        with:
+          script: |
+            const marker = '<!-- kody-cla-check -->'
+            const body = `${marker}
+            Unsigned contributions cannot merge.
+
+            1. Read the [Individual CLA](https://github.com/${{ github.repository }}/blob/main/docs/legal/individual-cla.md) (or the [Entity CLA](https://github.com/${{ github.repository }}/blob/main/docs/legal/entity-cla.md) if an organization owns the work).
+            2. Comment exactly: \`I have read the CLA and I hereby sign the CLA\`
+            3. A maintainer records your GitHub username on \`main\`. See [Inbound contributions](https://github.com/${{ github.repository }}/blob/main/docs/contribute/inbound-contributions.md).
+
+            Adding your own username on this branch does not pass the check.`
+            const comments = await github.paginate(
+              github.rest.issues.listComments,
+              {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.pull_request.number,
+                per_page: 100,
+              },
+            )
+            const existing = comments.find((comment) =>
+              comment.body?.includes(marker),
+            )
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              })
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.pull_request.number,
+                body,
+              })
+            }
+
+      - name: Fail when unsigned
+        if: steps.check.outputs.exit_code == '1'
+        run: exit 1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,3 +16,4 @@ Contributor and cloud-agent docs live in `docs/contribute/`:
 - [`environment.md`](docs/contribute/environment.md) — required Node version (`>=24.3.0`) and dependency/install caveats.
 - [`running-and-testing.md`](docs/contribute/running-and-testing.md) — dev server, lint, unit, and e2e/smoke test commands.
 - [`manual-camera-testing.md`](docs/contribute/manual-camera-testing.md) — driving the camera/record/export flow in a headless VM.
+- [`inbound-contributions.md`](docs/contribute/inbound-contributions.md) — inbound CLA for outside pull requests.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,15 @@
+# Contributing
+
+This repository is Fair Source ([FSL-1.1-ALv2](./LICENSE)). Outside pull
+requests need a signed inbound Contributor License Agreement. You keep
+copyright; the CLA is the license grant that keeps Kody Video a
+single-licensor tree.
+
+- [Inbound contributions](./docs/contribute/inbound-contributions.md) —
+  who signs, how to sign, and maintainer steps
+- [Individual CLA](./docs/legal/individual-cla.md)
+- [Entity CLA](./docs/legal/entity-cla.md)
+- [Inbound CLA decision](./docs/contribute/inbound-cla.md)
+
+- [Running and testing](./docs/contribute/running-and-testing.md)
+- [Environment](./docs/contribute/environment.md)

--- a/README.md
+++ b/README.md
@@ -335,6 +335,12 @@ under `/api/` so no service worker or cached shell can interfere:
 | `node scripts/probe-touch-timeline.mjs` | Touch timeline gestures (scroll, long-press lift) |
 | `node scripts/probe-webkit.mjs`      | WebKit engine sanity + feature matrix (iOS proxy, not a substitute for a real device) |
 
+## Contributing
+
+Outside pull requests to this repository need a signed inbound
+[Contributor License Agreement](./docs/contribute/inbound-contributions.md).
+See [`CONTRIBUTING.md`](./CONTRIBUTING.md).
+
 ## License
 
 Kody Video is licensed under the

--- a/docs/contribute/inbound-cla.md
+++ b/docs/contribute/inbound-cla.md
@@ -1,0 +1,58 @@
+# Inbound CLA for external contributions
+
+- **Status:** accepted
+- **Date:** 2026-08-16
+
+## Context
+
+This repository is Fair Source under [FSL-1.1-ALv2](../../LICENSE). Copyright
+is held by Kent C. Dodds as the sole Licensor. FSL's competing-use
+restriction, two-year Apache 2.0 conversion, and any later relicensing or
+commercial license only work cleanly when one party can speak as "We" for the
+whole tree.
+
+GitHub's inbound-same-license rule is not enough here. It licenses a patch
+under FSL, but it does not grant relicensing rights, a contributor patent
+license, or a warranty that the contributor (or their employer) actually owns
+the patch. A Developer Certificate of Origin records provenance only.
+
+The repo is public. History is almost entirely Kent C. Dodds and allowlisted automation, with at least one outside human commit.
+
+This matches the inbound CLA process on
+[kody](https://github.com/kentcdodds/kody).
+
+## Decision
+
+Require a signed **inbound Contributor License Agreement** (not assignment)
+before merging a pull request that includes commits from anyone other than
+the Licensor or an allowlisted bot.
+
+The contributor keeps copyright. They grant Kent C. Dodds a perpetual,
+worldwide, irrevocable, sublicensable copyright and patent license, including
+the right to relicense the contribution under FSL-1.1-ALv2, Apache 2.0, and
+any commercial or other terms the Licensor offers.
+
+How it works:
+
+- **Scope.** This git repository only.
+- **Who signs.** Every GitHub identity that authors a commit on the pull
+  request, unless that identity is `kentcdodds`, `kody-bot`, a `*[bot]`
+  or `app/*` account, or an email listed as Licensor-owned in
+  [`.github/cla-signers.json`](../../.github/cla-signers.json).
+- **Which form.** [Individual CLA](../legal/individual-cla.md) by default.
+  [Entity CLA](../legal/entity-cla.md) when an organization owns the work.
+- **How they sign.** Read the CLA, then comment:
+  `I have read the CLA and I hereby sign the CLA`. A maintainer records the
+  GitHub username in `.github/cla-signers.json` on `main`.
+- **Enforcement.** The `CLA` workflow reads signers from `main` (never
+  from the pull request head) and fails closed. No trivial-contribution
+  exception.
+
+## Consequences
+
+- The Licensor stays one party for FSL, the Apache conversion, relicensing,
+  and enforcement.
+- Outside pull requests take one extra maintainer step (record the signer on
+  `main`).
+- Revisit if the Licensor becomes a company, if counsel revises the CLA
+  text, or if contribution volume justifies hosted click-to-sign.

--- a/docs/contribute/inbound-contributions.md
+++ b/docs/contribute/inbound-contributions.md
@@ -1,0 +1,83 @@
+# Inbound contributions
+
+How outside patches enter [Kody Video](https://github.com/kentcdodds/kody-video).
+The decision and the why live in [Inbound CLA](./inbound-cla.md).
+
+## What needs a CLA
+
+A pull request needs a signed Contributor License Agreement when any commit
+on it is authored by someone other than Kent C. Dodds or an allowlisted bot.
+
+The contributor keeps copyright. The CLA is an inbound license so the
+repository can stay a single-licensor Fair Source tree under
+[FSL-1.1-ALv2](../../LICENSE).
+
+Sign the [Individual CLA](../legal/individual-cla.md) unless an employer owns
+the work. If an organization owns the work, an authorized representative
+completes the [Entity CLA](../legal/entity-cla.md) instead.
+
+There is no exception for docs-only or one-line patches.
+
+## How to sign (individual)
+
+1. Open the pull request.
+2. Read the [Individual CLA](../legal/individual-cla.md).
+3. Comment exactly:
+
+   ```
+   I have read the CLA and I hereby sign the CLA
+   ```
+
+4. Wait for a maintainer to record your GitHub username in
+   [`.github/cla-signers.json`](../../.github/cla-signers.json) on `main`.
+5. Re-run the `CLA` check, or push another commit.
+
+Signing once covers past, present, and future contributions from that GitHub
+identity. People who contributed before this process sign the same way before
+their next merge. The `CLA` workflow reads signers from `main`, not from
+the pull request branch, so adding your own username on the branch does not
+pass the check.
+
+## How to sign (entity)
+
+An authorized representative emails
+[me@kentcdodds.com](mailto:me@kentcdodds.com) with:
+
+- subject `Kody Entity CLA`
+- legal name and address of the organization
+- representative name and title
+- GitHub usernames authorized to submit on the organization's behalf
+- a statement that the organization accepts the
+  [Entity CLA](../legal/entity-cla.md)
+
+Licensor records those usernames after accepting the agreement.
+
+## Who does not sign
+
+These identities are allowlisted in `.github/cla-signers.json` and do not
+sign:
+
+- `kentcdodds` (Licensor)
+- `kody-bot` and other logins listed in that file
+- Licensor-owned commit emails listed in that file
+- GitHub accounts whose login ends in `[bot]` or starts with `app/`
+
+Cursor Cloud Agent pull requests that GitHub authors as `kentcdodds` follow
+the Licensor path.
+
+## Maintainer steps
+
+Do not merge a pull request while the `CLA` check is red.
+
+After a valid individual signing comment, add a `signers` entry on `main`
+(GitHub login, `signedAt` as an ISO date, `cla` of `individual`) and
+re-run the check. After an accepted Entity CLA, add each authorized username
+with `cla` of `entity`.
+
+Make the `CLA` check required for `main` in GitHub branch protection so a
+green review cannot skip it.
+
+## Out of scope
+
+- Issues and discussions that do not include a patch
+- Unsubmitted forks

--- a/docs/contribute/running-and-testing.md
+++ b/docs/contribute/running-and-testing.md
@@ -40,3 +40,7 @@ npx playwright install chromium
 The e2e suite runs with a fake camera/mic, so it does not need real hardware.
 See [manual-camera-testing.md](./manual-camera-testing.md) for driving the
 camera/record/export flow manually in a headless environment.
+
+## CLA checker
+
+`node tools/ci/check-cla.mjs --self-test` verifies the inbound CLA allowlist and signer rules.

--- a/docs/legal/entity-cla.md
+++ b/docs/legal/entity-cla.md
@@ -1,0 +1,95 @@
+# Kody Video Entity Contributor License Agreement
+
+Thank you for your interest in Kody Video ("the Project"), a project of
+Kent C. Dodds ("Licensor").
+
+This Entity Contributor License Agreement ("Agreement") is for an
+organization that owns work being submitted to the Project. Individuals who
+own their own work should sign the [Individual CLA](./individual-cla.md)
+instead.
+
+The organization keeps copyright in its contributions. This Agreement is a
+license grant, not an assignment of copyright.
+
+To accept this Agreement, an authorized representative emails
+[me@kentcdodds.com](mailto:me@kentcdodds.com) with the subject
+`Kody Entity CLA`, the legal name and address of the organization, the
+representative's name and title, and the GitHub usernames authorized to
+Submit on the organization's behalf. Licensor records those usernames after
+accepting the Agreement.
+
+## 1. Definitions
+
+**"You"** means the organization identified in the acceptance email.
+
+**"Contribution"** means any original work of authorship, including any
+modifications or additions to an existing work, that a person acting on Your
+behalf Submits to the Project in any form (including pull requests, patches,
+issues that include code or documentation, and git commits).
+
+**"Submit"** means any form of electronic, verbal, or written communication
+sent to the Project or Licensor, excluding communication conspicuously marked
+as "Not a Contribution."
+
+## 2. Copyright license
+
+You grant Licensor a perpetual, worldwide, non-exclusive, no-charge,
+royalty-free, irrevocable, sublicensable copyright license to reproduce,
+prepare derivative works of, publicly display, publicly perform, sublicense,
+and distribute Your Contributions and such derivative works.
+
+You also grant Licensor the right to relicense Your Contributions under any
+license terms, including the Functional Source License, Version 1.1, ALv2
+Future License (FSL-1.1-ALv2), the Apache License 2.0, and any commercial or
+other license terms Licensor offers.
+
+## 3. Patent license
+
+You grant Licensor a perpetual, worldwide, non-exclusive, no-charge,
+royalty-free, irrevocable (except as stated in this section) patent license
+to make, have made, use, offer to sell, sell, import, and otherwise transfer
+the Project, where such license applies only to those patent claims
+licensable by You that are necessarily infringed by Your Contribution(s)
+alone or by combination of Your Contribution(s) with the Project to which
+such Contribution(s) were submitted.
+
+If You institute patent litigation against any entity (including a
+cross-claim or counterclaim in a lawsuit) alleging that the Project or a
+Contribution incorporated within the Project constitutes direct or
+contributory patent infringement, then any patent licenses granted to You
+under this Agreement for that Project terminate as of the date such
+litigation is filed.
+
+## 4. Representations
+
+You represent that:
+
+1. You are legally entitled to grant the above licenses.
+2. Each Contribution is Your original creation, or You have sufficient rights
+   to grant the licenses in this Agreement for material You Submit that You
+   did not create.
+3. Each person who Submits a Contribution on Your behalf is authorized to do
+   so, and You will keep Licensor's recorded GitHub username list current.
+
+## 5. Disclaimer
+
+Unless required by applicable law or agreed to in writing, You provide Your
+Contributions on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied, including, without limitation, any
+warranties or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or
+FITNESS FOR A PARTICULAR PURPOSE.
+
+## 6. Notice of inaccuracy
+
+You agree to notify Licensor of any facts or circumstances of which You
+become aware that would make Your representations in this Agreement
+inaccurate in any respect.
+
+## 7. Successor
+
+Licensor may assign this Agreement to a successor that continues the Project.
+This Agreement does not grant You any trademark rights.
+
+## How to sign
+
+See [Inbound contributions](../contribute/inbound-contributions.md).

--- a/docs/legal/individual-cla.md
+++ b/docs/legal/individual-cla.md
@@ -1,0 +1,95 @@
+# Kody Video Individual Contributor License Agreement
+
+Thank you for your interest in Kody Video ("the Project"), a project of
+Kent C. Dodds ("Licensor").
+
+This Contributor License Agreement ("Agreement") records the rights you grant
+so the Project can remain a single-licensor Fair Source work. You keep
+copyright in your contributions. You are not assigning copyright to Licensor.
+
+You accept this Agreement for your past, present, and future Contributions by
+commenting `I have read the CLA and I hereby sign the CLA` on a Project pull
+request, or by otherwise accepting these terms in a form Licensor records.
+
+## 1. Definitions
+
+**"You"** means the individual who accepts this Agreement.
+
+**"Contribution"** means any original work of authorship, including any
+modifications or additions to an existing work, that You submit to the
+Project in any form (including pull requests, patches, issues that include
+code or documentation, and git commits).
+
+**"Submit"** means any form of electronic, verbal, or written communication
+sent to the Project or Licensor, excluding communication conspicuously marked
+by You as "Not a Contribution."
+
+## 2. Copyright license
+
+You grant Licensor a perpetual, worldwide, non-exclusive, no-charge,
+royalty-free, irrevocable, sublicensable copyright license to reproduce,
+prepare derivative works of, publicly display, publicly perform, sublicense,
+and distribute Your Contributions and such derivative works.
+
+You also grant Licensor the right to relicense Your Contributions under any
+license terms, including the Functional Source License, Version 1.1, ALv2
+Future License (FSL-1.1-ALv2), the Apache License 2.0, and any commercial or
+other license terms Licensor offers.
+
+## 3. Patent license
+
+You grant Licensor a perpetual, worldwide, non-exclusive, no-charge,
+royalty-free, irrevocable (except as stated in this section) patent license
+to make, have made, use, offer to sell, sell, import, and otherwise transfer
+the Project, where such license applies only to those patent claims
+licensable by You that are necessarily infringed by Your Contribution(s)
+alone or by combination of Your Contribution(s) with the Project to which
+such Contribution(s) were submitted.
+
+If You institute patent litigation against any entity (including a
+cross-claim or counterclaim in a lawsuit) alleging that the Project or a
+Contribution incorporated within the Project constitutes direct or
+contributory patent infringement, then any patent licenses granted to You
+under this Agreement for that Project terminate as of the date such
+litigation is filed.
+
+## 4. Representations
+
+You represent that:
+
+1. You are legally entitled to grant the above licenses.
+2. If your employer has rights to intellectual property that You create, You
+   have received permission to make Contributions on behalf of that employer,
+   that your employer has waived such rights for Your Contributions to the
+   Project, or that You will not Submit that work until an
+   [Entity CLA](./entity-cla.md) is on file.
+3. Each of Your Contributions is Your original creation, or You have
+   sufficient rights to grant the licenses in this Agreement for material You
+   Submit that You did not create.
+4. You will complete an Entity CLA instead of this Agreement when You are
+   signing for an organization rather than as an individual.
+
+## 5. Disclaimer
+
+You are not expected to provide support for Your Contributions, except to the
+extent You want to provide support. You may provide support for free, for a
+fee, or not at all. Unless required by applicable law or agreed to in
+writing, You provide Your Contributions on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied, including,
+without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT,
+MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE.
+
+## 6. Notice of inaccuracy
+
+You agree to notify Licensor of any facts or circumstances of which You
+become aware that would make Your representations in this Agreement
+inaccurate in any respect.
+
+## 7. Successor
+
+Licensor may assign this Agreement to a successor that continues the Project.
+This Agreement does not grant You any trademark rights.
+
+## How to sign
+
+See [Inbound contributions](../contribute/inbound-contributions.md).

--- a/tools/ci/check-cla.mjs
+++ b/tools/ci/check-cla.mjs
@@ -1,0 +1,211 @@
+import { readFile } from 'node:fs/promises'
+import { pathToFileURL } from 'node:url'
+import path from 'node:path'
+
+const githubBotLoginPattern = /\[bot\]$/i
+
+function normalize(value) {
+	return value.trim().toLowerCase()
+}
+
+function identityLabel(identity) {
+	if (identity.githubLogin) {
+		return `@${identity.githubLogin}`
+	}
+	if (identity.email) {
+		return identity.email
+	}
+	if (identity.name) {
+		return identity.name
+	}
+	return 'unknown identity'
+}
+
+export function parseClaSignersFile(raw) {
+	const parsed = JSON.parse(raw)
+	if (
+		typeof parsed !== 'object' ||
+		parsed === null ||
+		parsed.version !== 1
+	) {
+		throw new Error('CLA signers file must be version 1 JSON')
+	}
+	if (
+		typeof parsed.document !== 'string' ||
+		typeof parsed.allowlist !== 'object' ||
+		parsed.allowlist === null ||
+		!Array.isArray(parsed.allowlist.github) ||
+		!Array.isArray(parsed.allowlist.email) ||
+		!Array.isArray(parsed.signers)
+	) {
+		throw new Error('CLA signers file is missing allowlist or signers')
+	}
+	return parsed
+}
+
+export function isAllowlistedIdentity(identity, signersFile) {
+	const login = identity.githubLogin ? normalize(identity.githubLogin) : null
+	if (
+		login &&
+		(githubBotLoginPattern.test(login) || login.startsWith('app/'))
+	) {
+		return true
+	}
+	if (
+		login &&
+		signersFile.allowlist.github.some((entry) => normalize(entry) === login)
+	) {
+		return true
+	}
+	const email = identity.email ? normalize(identity.email) : null
+	return Boolean(
+		email &&
+			signersFile.allowlist.email.some((entry) => normalize(entry) === email),
+	)
+}
+
+export function hasSignedCla(identity, signersFile) {
+	const login = identity.githubLogin ? normalize(identity.githubLogin) : null
+	if (!login) {
+		return false
+	}
+	return signersFile.signers.some(
+		(signer) => normalize(signer.github) === login,
+	)
+}
+
+export function checkClaIdentities(identities, signersFile) {
+	const missing = []
+	const seen = new Set()
+	for (const identity of identities) {
+		const key = [identity.githubLogin, identity.email, identity.name]
+			.map((part) => (part ? normalize(part) : ''))
+			.join('|')
+		if (seen.has(key)) {
+			continue
+		}
+		seen.add(key)
+		if (isAllowlistedIdentity(identity, signersFile)) {
+			continue
+		}
+		if (hasSignedCla(identity, signersFile)) {
+			continue
+		}
+		const reason = identity.githubLogin
+			? `${identityLabel(identity)} has not signed the CLA`
+			: `${identityLabel(identity)} has no GitHub login and is not a Licensor email`
+		missing.push({ identity, reason })
+	}
+	return missing.length === 0 ? { ok: true } : { ok: false, missing }
+}
+
+export function formatClaFailure(result) {
+	return [
+		'Unsigned contributions cannot merge.',
+		'Read docs/legal/individual-cla.md (or the Entity CLA if an organization owns the work).',
+		'Comment on the pull request: I have read the CLA and I hereby sign the CLA',
+		'A maintainer then records your GitHub username on main. See the inbound contributions doc.',
+		'',
+		'Missing signatures:',
+		...result.missing.map((entry) => `- ${entry.reason}`),
+	].join('\n')
+}
+
+function runSelfTest() {
+	const file = {
+		version: 1,
+		document: 'docs/legal/individual-cla.md',
+		allowlist: {
+			github: ['kentcdodds', 'kody-bot'],
+			email: ['me@kentcdodds.com', 'me+github@kentcdodds.com'],
+		},
+		signers: [
+			{ github: 'VojtaHolik', signedAt: '2026-08-16', cla: 'individual' },
+		],
+	}
+	const passing = checkClaIdentities(
+		[
+			{ githubLogin: 'kentcdodds', name: 'Kent', email: null },
+			{ githubLogin: 'kody-bot', name: 'Kody', email: null },
+			{ githubLogin: 'cursor[bot]', name: 'cursor[bot]', email: null },
+			{ githubLogin: 'app/imgbot', name: 'ImgBot', email: null },
+			{
+				githubLogin: null,
+				name: 'Kent C. Dodds',
+				email: 'me+github@kentcdodds.com',
+			},
+			{
+				githubLogin: 'vojtaholik',
+				name: 'Vojta Holik',
+				email: 'vojta@egghead.io',
+			},
+		],
+		file,
+	)
+	if (!passing.ok) {
+		throw new Error('expected allowlisted and signed identities to pass')
+	}
+	const failing = checkClaIdentities(
+		[
+			{ githubLogin: 'kentcdodds', name: 'Kent', email: null },
+			{
+				githubLogin: 'someone-else',
+				name: 'Someone',
+				email: 'someone@example.com',
+			},
+			{
+				githubLogin: null,
+				name: 'Someone',
+				email: 'someone@example.com',
+			},
+		],
+		file,
+	)
+	if (failing.ok) {
+		throw new Error('expected unsigned identities to fail')
+	}
+	const reasons = failing.missing.map((entry) => entry.reason)
+	if (
+		reasons[0] !== '@someone-else has not signed the CLA' ||
+		reasons[1] !==
+			'someone@example.com has no GitHub login and is not a Licensor email'
+	) {
+		throw new Error(`unexpected failure reasons: ${reasons.join('; ')}`)
+	}
+	console.log('CLA self-test passed')
+}
+
+async function runCli(args) {
+	if (args.includes('--self-test')) {
+		runSelfTest()
+		return
+	}
+	const signersFlag = args.indexOf('--signers')
+	const identitiesFlag = args.indexOf('--identities-json')
+	const signersPath = signersFlag === -1 ? null : args[signersFlag + 1]
+	const identitiesPath =
+		identitiesFlag === -1 ? null : args[identitiesFlag + 1]
+	if (!signersPath || !identitiesPath) {
+		throw new Error(
+			'Usage: node tools/ci/check-cla.mjs --signers <file> --identities-json <file>',
+		)
+	}
+	const signersFile = parseClaSignersFile(await readFile(signersPath, 'utf8'))
+	const identitiesRaw = JSON.parse(await readFile(identitiesPath, 'utf8'))
+	if (!Array.isArray(identitiesRaw)) {
+		throw new Error('Identities JSON must be an array')
+	}
+	const result = checkClaIdentities(identitiesRaw, signersFile)
+	if (!result.ok) {
+		console.error(formatClaFailure(result))
+		process.exitCode = 1
+	}
+}
+
+const entryPoint = process.argv[1]
+if (
+	entryPoint &&
+	pathToFileURL(path.resolve(entryPoint)).href === import.meta.url
+) {
+	await runCli(process.argv.slice(2))
+}


### PR DESCRIPTION
Same inbound CLA process as [kody#1460](https://github.com/kentcdodds/kody/pull/1460).

## Why

Kody Video is Fair Source (`FSL-1.1-ALv2`) with Kent C. Dodds as sole Licensor. GitHub TOS and a DCO do not grant relicensing rights, a contributor patent grant, or an employer-IP warranty. An inbound CLA is required before outside PRs merge.

## What this adds

- Individual and Entity CLA text under `docs/legal/`
- Contributor and agent docs
- `.github/cla-signers.json` (empty until someone signs)
- `CLA` workflow that reads signers from the **base** branch only
- Portable checker at `tools/ci/check-cla.mjs`

## After merge

Make the `CLA` check required for `main` in branch protection.

Prior outside contributor: `iambharathpadhu` (Barath Kumar). Ask them to sign before their next merge.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are documentation, CI workflow, and a standalone CLA checker with no impact on runtime app behavior or production data paths.
> 
> **Overview**
> Adds an **inbound Contributor License Agreement** gate for outside pull requests so the Fair Source tree stays single-licensor, mirroring the process on the main `kody` repo.
> 
> **Legal & docs:** New Individual and Entity CLA under `docs/legal/`, decision record and contributor how-to (`inbound-cla.md`, `inbound-contributions.md`), plus `CONTRIBUTING.md` and README/AGENTS pointers.
> 
> **Enforcement:** `.github/cla-signers.json` holds Licensor allowlists and recorded signers (empty `signers` until maintainers add people on `main`). `tools/ci/check-cla.mjs` validates PR author/commit identities against that file (bots, `app/*`, allowlisted emails exempt). The **`CLA` GitHub Action** checks out the **base** branch only (so PR branches cannot self-approve), posts or updates an unsigned PR comment, and fails the job when signatures are missing; it no-ops if the checker is not on base yet. `running-and-testing.md` documents `node tools/ci/check-cla.mjs --self-test`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce485dd52bade9d9901d3535a2676658ca5105e5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated CLA checks for pull requests, including unsigned-contribution notifications.
  * Added individual and entity contributor license agreements.
  * Added configuration for approved signers and identity validation.

* **Documentation**
  * Added contributor guidance covering CLA requirements, signing procedures, licensing, and testing.
  * Updated repository documentation with contribution and legal information.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->