### PR TITLE
Add Plus send-to-device over WebRTC (STUN, no cloud copies)

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,10 @@ For a phone on the same network, use your machine’s LAN URL over HTTPS, or tun
   move a project between devices or browser origins (storage is per-origin);
   ⋯ → Save backup on a slot, import from the About page or by dropping a
   `.kodyvideo` file anywhere in the app
+- **Send to another device** (Plus): a pairing code + QR introduces two
+  browsers; the `.kodyvideo` travels over a WebRTC DataChannel (STUN only —
+  same Wi‑Fi usually). Clips never land on our servers. Receiving is free
+  at `/receive`. If the devices cannot connect, Save backup still works
 - Installable PWA (manifest + Workbox service worker for the app shell)
 - **No accounts, no uploads, no analytics**
 
@@ -110,6 +114,7 @@ src/
   lib/recorder.ts           Hold-to-record MediaRecorder wrapper (hardware-codec aware)
   lib/media.ts              getUserMedia/permissions/share/download helpers
   lib/thumbs.ts             Filmstrip thumbnail generation (stored per clip)
+  lib/sync-*.ts             Plus send-to-device (WebRTC + /api/sync matchmaker)
   lib/sheet-modal.ts        Bottom-sheet modality (focus trap, Esc, sheet stack)
   lib/export/               Export engines (see below)
   components/record-screen  Camera surface (capture, zoom, timer, dock)
@@ -241,15 +246,16 @@ API is missing.
 
 The free plan includes one project, and exports carry a small Kody Video mark
 in the corner. Kody Video Plus — a one-time $0.99 Stripe Payment Link —
-removes the watermark, unlocks six project slots, background music, and
-landscape projects: the export sheet (or a locked home slot, the locked "Add
-music" button in the editor, or rotating an empty project sideways on the
-free plan) links to checkout, Stripe redirects back to
-`/unlocked?session_id=…`, and a single Cloudflare Pages Function
-(`functions/api/verify-purchase.ts`) verifies the session server-side before
-the entitlement is stored in IndexedDB. 100%-off promotion codes (friends /
-the developer) flow through the exact same verification. Restore on another
-device: "Already paid?" on the export sheet or a locked slot's upsell.
+removes the watermark, unlocks six project slots, background music,
+landscape projects, and sending a project to another device: the export
+sheet (or a locked home slot, the locked "Add music" button in the editor,
+or rotating an empty project sideways on the free plan) links to checkout,
+Stripe redirects back to `/unlocked?session_id=…`, and a single Cloudflare
+Pages Function (`functions/api/verify-purchase.ts`) verifies the session
+server-side before the entitlement is stored in IndexedDB. 100%-off
+promotion codes (friends / the developer) flow through the exact same
+verification. Restore on another device: "Already paid?" on the export
+sheet or a locked slot's upsell.
 
 Projects are also created lazily — "New project" opens the camera at
 `/project/new` and nothing is persisted until the first clip is recorded, so
@@ -258,8 +264,13 @@ holds after creation: a project exited while still in its default state (no
 clips, default name, no music) is silently deleted when the home screen
 loads, since keeping it would change nothing the user can see.
 
-Deployment requirement: set `STRIPE_SECRET_KEY` (a restricted key with
-Checkout Sessions read access is enough) on the Cloudflare Pages project.
+Deployment requirements on the Cloudflare Pages project:
+
+- `STRIPE_SECRET_KEY` (a restricted key with Checkout Sessions read access
+  is enough)
+- KV namespace binding `SYNC_ROOMS` for Plus send-to-device matchmaking
+  (room codes + WebRTC descriptions only; never media). Without it, Send
+  shows a configuration error and Save backup still works.
 
 ## Rewrite showcases
 
@@ -304,12 +315,14 @@ under `/api/` so no service worker or cached shell can interfere:
 - No clip upload endpoints exist in this app.
 - Share/export uses user-gesture download or the Web Share API only.
 - Network calls besides Stripe checkout (opened in the browser): the
-  purchase-verification function above (never sees media), and anonymous
+  purchase-verification function above (never sees media); anonymous
   Sentry crash reports (error + stack trace only — breadcrumbs and request
   metadata are stripped in the SDK config; no PII, no media; only from
-  production hostnames — dev and tests never report). Export and import
-  failures the UI surfaces as friendly messages are also captured, tagged
-  with the failing step, so real-device bugs surface.
+  production hostnames — dev and tests never report); and, only when you
+  tap Send to device, a short-lived `/api/sync` matchmaking room (code +
+  WebRTC descriptions, never clips). Export and import failures the UI
+  surfaces as friendly messages are also captured, tagged with the failing
+  step, so real-device bugs surface.
 - The home-screen tour video (shown to first-time users) streams from
   `media.kody.video` (an R2 bucket behind the app's own zone — no third-party
   player, no tracking) and only when the user taps play on it.

--- a/functions/api/sync/[[path]].ts
+++ b/functions/api/sync/[[path]].ts
@@ -1,0 +1,15 @@
+import { handleSyncRequest, type SyncKv } from '../../../src/lib/sync-rooms'
+
+interface Env {
+  SYNC_ROOMS?: SyncKv
+}
+
+interface PagesContext {
+  request: Request
+  env: Env
+}
+
+/** Matchmaker only — room codes and WebRTC descriptions, never media. */
+export async function onRequest(context: PagesContext): Promise<Response> {
+  return handleSyncRequest(context.request, context.env)
+}

--- a/manual-test-checklist.md
+++ b/manual-test-checklist.md
@@ -58,7 +58,9 @@ npm test           # unit tests
   uses the styled confirm (no browser dialog) and frees stored clips; backup
   downloads a `.kodyvideo` file and import (About → Import a backup, or drop
   the file anywhere in the app) restores it; import at the plan limit is
-  refused with a clear message; slot order is stable
+  refused with a clear message; slot order is stable; Plus Send to device
+  copies a project to another browser over WebRTC; free Send opens the
+  upsell; `/receive` renders
 - **Storage**: the footer storage gauge opens a "X of Y used" popover on
   tap; ≥80% shows the amber banner, ≥92%
   turns critical; the banner offers one-tap "Clear cached exports"; the boot
@@ -75,7 +77,7 @@ npm test           # unit tests
   permanently, hidden in standalone and non-iOS browsers
 - **Meta**: `viewport-fit=cover`, `apple-mobile-web-app-status-bar-style`
   black-translucent, theme colors, og/twitter card tags; onboarding shows
-  once and dismisses for good; /about, /privacy, /terms render
+  once and dismisses for good; /about, /privacy, /terms, /receive render
 
 Specialized probes (run each individually, e.g.
 `node scripts/probe-fast-export.mjs`) additionally cover: the fast

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,8 @@
         "client-zip": "^2.5.0",
         "idb": "^8.0.3",
         "mediabunny": "^1.52.1",
-        "remix": "3.0.0-beta.5"
+        "remix": "3.0.0-beta.5",
+        "uqr": "^0.1.3"
       },
       "devDependencies": {
         "@playwright/test": "^1.62.0",
@@ -9448,6 +9449,12 @@
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
       }
+    },
+    "node_modules/uqr": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/uqr/-/uqr-0.1.3.tgz",
+      "integrity": "sha512-0rjE8iEJe4YmT9TOhwsZtqCMRLc5DXZUI2UEYUUg63ikBkqqE5EYWaI0etFe/5KUcmcYwLih2RND1kq+hrUJXA==",
+      "license": "MIT"
     },
     "node_modules/v8-to-istanbul": {
       "version": "9.3.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "client-zip": "^2.5.0",
     "idb": "^8.0.3",
     "mediabunny": "^1.52.1",
-    "remix": "3.0.0-beta.5"
+    "remix": "3.0.0-beta.5",
+    "uqr": "^0.1.3"
   },
   "devDependencies": {
     "@playwright/test": "^1.62.0",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -29,6 +29,9 @@ export default defineConfig({
         '--use-fake-ui-for-media-stream',
         '--use-fake-device-for-media-stream',
         '--autoplay-policy=no-user-gesture-required',
+        // Headless CI has no mDNS: without this, WebRTC host candidates are
+        // *.local names the other context cannot resolve (send-to-device).
+        '--disable-features=WebRtcHideLocalIpsWithMdns',
       ],
     },
   },

--- a/public/_redirects
+++ b/public/_redirects
@@ -17,3 +17,5 @@
 /about        /app    200
 /privacy      /app    200
 /terms        /app    200
+/receive      /app    200
+/receive/*    /app    200

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -10,6 +10,7 @@ Kody Video is a free and open source progressive web app. Projects stay private 
 - [About](https://kody.video/about): Product overview and credits
 - [Privacy](https://kody.video/privacy): Privacy policy
 - [Terms](https://kody.video/terms): Terms of use
+- [Receive](https://kody.video/receive): Accept a project sent from another device
 
 ## For agents
 

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -12,4 +12,7 @@
   <url>
     <loc>https://kody.video/terms</loc>
   </url>
+  <url>
+    <loc>https://kody.video/receive</loc>
+  </url>
 </urlset>

--- a/scripts/vite-sync-api-plugin.ts
+++ b/scripts/vite-sync-api-plugin.ts
@@ -1,0 +1,58 @@
+import type { IncomingMessage, ServerResponse } from 'node:http'
+import type { Plugin } from 'vite'
+import { handleSyncRequest, memorySyncKv } from '../src/lib/sync-rooms'
+
+const kv = memorySyncKv()
+
+async function nodeToRequest(req: IncomingMessage): Promise<Request> {
+  const host = req.headers.host ?? '127.0.0.1'
+  const url = `http://${host}${req.url ?? '/'}`
+  const chunks: Buffer[] = []
+  for await (const chunk of req) {
+    chunks.push(typeof chunk === 'string' ? Buffer.from(chunk) : chunk)
+  }
+  const body = Buffer.concat(chunks)
+  const headers = new Headers()
+  for (const [name, value] of Object.entries(req.headers)) {
+    if (typeof value === 'string') headers.set(name, value)
+    else if (Array.isArray(value)) headers.set(name, value.join(', '))
+  }
+  const method = req.method ?? 'GET'
+  return new Request(url, {
+    method,
+    headers,
+    body: method === 'GET' || method === 'HEAD' ? undefined : body,
+  })
+}
+
+async function writeResponse(res: ServerResponse, response: Response): Promise<void> {
+  res.statusCode = response.status
+  response.headers.forEach((value, name) => {
+    res.setHeader(name, value)
+  })
+  const bytes = Buffer.from(await response.arrayBuffer())
+  res.end(bytes)
+}
+
+/** In-memory /api/sync/* so Vite and Playwright can exercise send-to-device. */
+export function syncApiPlugin(): Plugin {
+  return {
+    name: 'kody-sync-api',
+    configureServer(server) {
+      server.middlewares.use((req, res, next) => {
+        if (!req.url?.startsWith('/api/sync/')) {
+          next()
+          return
+        }
+        void nodeToRequest(req)
+          .then((request) => handleSyncRequest(request, { SYNC_ROOMS: kv }))
+          .then((response) => writeResponse(res, response))
+          .catch((error: unknown) => {
+            res.statusCode = 500
+            res.setHeader('content-type', 'application/json')
+            res.end(JSON.stringify({ error: error instanceof Error ? error.message : 'sync api' }))
+          })
+      })
+    },
+  }
+}

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -12,6 +12,7 @@ const UnlockedPage = lazyPage(() => import('./pages/unlocked-page'), 'UnlockedPa
 const AboutPage = lazyPage(() => import('./pages/about-page'), 'AboutPage')
 const PrivacyPage = lazyPage(() => import('./pages/privacy-page'), 'PrivacyPage')
 const TermsPage = lazyPage(() => import('./pages/terms-page'), 'TermsPage')
+const ReceivePage = lazyPage(() => import('./pages/receive-page'), 'ReceivePage')
 
 export function App(handle: Handle) {
   let needRefresh = false
@@ -52,6 +53,8 @@ export function App(handle: Handle) {
           '/about': () => <AboutPage />,
           '/privacy': () => <PrivacyPage />,
           '/terms': () => <TermsPage />,
+          '/receive': () => <ReceivePage />,
+          '/receive/:code': (params) => <ReceivePage code={params.code ?? ''} />,
         }}
       />
       <BackupDropOverlay />

--- a/src/components/home-options-sheet.tsx
+++ b/src/components/home-options-sheet.tsx
@@ -7,6 +7,7 @@ interface HomeOptionsSheetProps {
   onOpen: () => void
   onRename: () => void
   onBackup: () => void
+  onSend: () => void
   onDelete: () => void
   onClose: () => void
 }
@@ -14,7 +15,7 @@ interface HomeOptionsSheetProps {
 /** Bottom sheet with Open / Rename / Backup / Delete for a filled project slot. */
 export function HomeOptionsSheet(handle: Handle<HomeOptionsSheetProps>) {
   return () => {
-    const { projectName, onOpen, onRename, onBackup, onDelete, onClose } = handle.props
+    const { projectName, onOpen, onRename, onBackup, onSend, onDelete, onClose } = handle.props
     return (
       <>
         <div className="sheet-backdrop" mix={on('click', () => onClose())} />
@@ -37,6 +38,9 @@ export function HomeOptionsSheet(handle: Handle<HomeOptionsSheetProps>) {
             </button>
             <button type="button" className="home-option-btn" mix={on('click', () => onRename())}>
               Rename
+            </button>
+            <button type="button" className="home-option-btn" mix={on('click', () => onSend())}>
+              Send to device
             </button>
             <button type="button" className="home-option-btn" mix={on('click', () => onBackup())}>
               Save backup

--- a/src/components/send-sheet.tsx
+++ b/src/components/send-sheet.tsx
@@ -112,13 +112,14 @@ export function SendSheet(handle: Handle<SendSheetProps>) {
 
   return () => {
     const { projectName, onClose, onBackupInstead } = handle.props
-    const busy = phase !== 'done' && phase !== 'failed'
+    const inFlight = () => phase !== 'done' && phase !== 'failed'
     return (
       <>
         <div
           className="sheet-backdrop"
           mix={on('click', () => {
-            if (!busy) onClose()
+            if (inFlight()) return
+            onClose()
           })}
         />
         <div
@@ -129,7 +130,7 @@ export function SendSheet(handle: Handle<SendSheetProps>) {
           mix={ref((node, signal) =>
             attachSheetModal(node as HTMLElement, signal, {
               onDismiss: () => handle.props.onClose(),
-              busy: () => busy,
+              busy: inFlight,
             }),
           )}
         >

--- a/src/components/send-sheet.tsx
+++ b/src/components/send-sheet.tsx
@@ -1,0 +1,193 @@
+import type { Handle } from 'remix/ui'
+import { on, ref } from 'remix/ui'
+import { attachSheetModal } from '../lib/sheet-modal'
+import { reportError } from '../lib/error-reporting'
+import { formatRoomCode, type SyncPhase } from '../lib/sync-protocol'
+import { createSyncRoom, httpSyncSignaling, SyncSignalError } from '../lib/sync-signaling'
+import { sendBackupToPeer, SyncTransferError } from '../lib/sync-peer'
+import { getClipsForProject, getProject, getProjectAudio } from '../lib/storage'
+import { projectBackupFilename, serializeProject } from '../lib/project-transfer'
+import { formatBytes } from '../lib/storage-space'
+import { SyncQr } from './sync-qr'
+
+interface SendSheetProps {
+  projectId: string
+  projectName: string
+  onClose: () => void
+  onBackupInstead: () => void
+}
+
+function phaseCopy(phase: SyncPhase, error: string | null): string {
+  switch (phase) {
+    case 'creating':
+      return 'Starting a send room…'
+    case 'waiting':
+      return 'Open kody.video/receive on the other device and scan or type this code. Keep both screens open.'
+    case 'connecting':
+      return 'Connecting to the other device…'
+    case 'transferring':
+      return 'Sending the project. Keep both screens open.'
+    case 'importing':
+      return 'Sending the project. Keep both screens open.'
+    case 'done':
+      return 'Sent. The other device is importing it as a new project.'
+    case 'failed':
+      return error ?? 'Could not send this project.'
+    default: {
+      const _exhaustive: never = phase
+      return _exhaustive
+    }
+  }
+}
+
+/** Plus: push this project to another device over WebRTC (STUN, no cloud copy). */
+export function SendSheet(handle: Handle<SendSheetProps>) {
+  let phase: SyncPhase = 'creating'
+  let code: string | null = null
+  let error: string | null = null
+  let progress = ''
+  let copied = false
+  const abort = new AbortController()
+
+  handle.signal.addEventListener('abort', () => abort.abort(), { once: true })
+
+  const fail = (err: unknown) => {
+    if (abort.signal.aborted) return
+    if (err instanceof DOMException && err.name === 'AbortError') return
+    if (!(err instanceof SyncSignalError) && !(err instanceof SyncTransferError)) {
+      reportError(err, 'sync-send')
+    }
+    error = err instanceof Error ? err.message : 'Could not send this project.'
+    phase = 'failed'
+    void handle.update()
+  }
+
+  void (async () => {
+    try {
+      const room = await createSyncRoom()
+      if (abort.signal.aborted) return
+      code = room.code
+      phase = 'waiting'
+      void handle.update()
+
+      const [clips, audio, project] = await Promise.all([
+        getClipsForProject(handle.props.projectId),
+        getProjectAudio(handle.props.projectId),
+        getProject(handle.props.projectId),
+      ])
+      if (abort.signal.aborted) return
+      if (clips.length === 0) throw new Error('Nothing to send — this project has no clips.')
+      if (!project) throw new Error('That project is gone.')
+      const backup = serializeProject(project, clips, audio)
+      const filename = projectBackupFilename(project.name)
+
+      await sendBackupToPeer(
+        httpSyncSignaling(room.code),
+        backup,
+        filename,
+        abort.signal,
+        (sent, total) => {
+          if (abort.signal.aborted) return
+          progress = `${formatBytes(sent)} of ${formatBytes(total)}`
+          void handle.update()
+        },
+        () => {
+          if (abort.signal.aborted) return
+          phase = 'transferring'
+          void handle.update()
+        },
+      )
+      if (abort.signal.aborted) return
+      phase = 'done'
+      void handle.update()
+    } catch (err) {
+      fail(err)
+    }
+  })()
+
+  const receiveHref = () => {
+    const origin = window.location.origin
+    return code ? `${origin}/receive/${code}` : `${origin}/receive`
+  }
+
+  return () => {
+    const { projectName, onClose, onBackupInstead } = handle.props
+    const busy = phase !== 'done' && phase !== 'failed'
+    return (
+      <>
+        <div
+          className="sheet-backdrop"
+          mix={on('click', () => {
+            if (!busy) onClose()
+          })}
+        />
+        <div
+          className="sheet send-sheet"
+          role="dialog"
+          aria-modal="true"
+          aria-label={`Send ${projectName}`}
+          mix={ref((node, signal) =>
+            attachSheetModal(node as HTMLElement, signal, {
+              onDismiss: () => handle.props.onClose(),
+              busy: () => busy,
+            }),
+          )}
+        >
+          <h3>Send to another device</h3>
+          <p className={phase === 'failed' ? 'sheet-lede is-error' : 'sheet-lede muted'}>
+            {phaseCopy(phase, error)}
+          </p>
+          {code && phase !== 'failed' ? (
+            <div className="sync-code-block">
+              <p className="sync-code" aria-label={`Send code ${formatRoomCode(code)}`}>
+                {formatRoomCode(code)}
+              </p>
+              <SyncQr href={receiveHref()} />
+              <button
+                type="button"
+                className="link-button"
+                mix={on('click', () => {
+                  void navigator.clipboard?.writeText(receiveHref()).then(
+                    () => {
+                      copied = true
+                      void handle.update()
+                    },
+                    () => undefined,
+                  )
+                })}
+              >
+                {copied ? 'Link copied' : 'Copy receive link'}
+              </button>
+            </div>
+          ) : null}
+          {progress && (phase === 'transferring' || phase === 'connecting') ? (
+            <p className="export-percent" role="status">
+              {progress}
+            </p>
+          ) : null}
+          <div className="sheet-actions">
+            {phase === 'failed' ? (
+              <button
+                type="button"
+                className="btn btn-primary"
+                mix={on('click', () => onBackupInstead())}
+              >
+                Save backup instead
+              </button>
+            ) : null}
+            <button
+              type="button"
+              className="btn btn-ghost"
+              mix={on('click', () => {
+                abort.abort()
+                onClose()
+              })}
+            >
+              {phase === 'done' ? 'Done' : 'Cancel'}
+            </button>
+          </div>
+        </div>
+      </>
+    )
+  }
+}

--- a/src/components/sync-qr.tsx
+++ b/src/components/sync-qr.tsx
@@ -1,0 +1,29 @@
+import type { Handle } from 'remix/ui'
+import { ref } from 'remix/ui'
+import { renderSVG } from 'uqr'
+
+interface SyncQrProps {
+  href: string
+}
+
+/** QR for the receive URL — scanned on the other device. */
+export function SyncQr(handle: Handle<SyncQrProps>) {
+  return () => {
+    const svg = renderSVG(handle.props.href, {
+      ecc: 'M',
+      pixelSize: 8,
+      whiteColor: '#f3f5f4',
+      blackColor: '#1a2824',
+    })
+    return (
+      <div
+        className="sync-qr"
+        role="img"
+        aria-label="QR code to receive this project"
+        mix={ref((node) => {
+          ;(node as HTMLElement).innerHTML = svg
+        })}
+      />
+    )
+  }
+}

--- a/src/components/upsell-sheet.tsx
+++ b/src/components/upsell-sheet.tsx
@@ -32,8 +32,8 @@ export function UpsellSheet(handle: Handle<UpsellSheetProps>) {
           <p className="sheet-copy">
             The free plan includes 1 project. Plus is a one-time $0.99 purchase that unlocks{' '}
             {MAX_PROJECTS} project slots, background music, landscape projects, optional location
-            tagging, and removes the watermark from exports — forever, on this device and any
-            device you restore it on.
+            tagging, sending a project to another device, and removes the watermark from exports —
+            forever, on this device and any device you restore it on.
           </p>
           <div className="sheet-actions">
             <button type="button" className="btn btn-ghost" mix={on('click', () => onClose())}>

--- a/src/lib/sync-peer.test.ts
+++ b/src/lib/sync-peer.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'vitest'
+import { receiveBackupOnChannel, sendBackupOnChannel } from './sync-peer'
+import { STUN_ICE_SERVERS } from './sync-protocol'
+
+async function waitForIce(pc: RTCPeerConnection): Promise<void> {
+  if (pc.iceGatheringState === 'complete') return
+  await new Promise<void>((resolve) => {
+    const done = () => {
+      if (pc.iceGatheringState === 'complete') {
+        pc.removeEventListener('icegatheringstatechange', done)
+        resolve()
+      }
+    }
+    pc.addEventListener('icegatheringstatechange', done)
+    window.setTimeout(resolve, 4000)
+  })
+}
+
+async function connectedPair(): Promise<{
+  sender: RTCDataChannel
+  receiver: RTCDataChannel
+  close: () => void
+}> {
+  const left = new RTCPeerConnection({ iceServers: STUN_ICE_SERVERS })
+  const right = new RTCPeerConnection({ iceServers: STUN_ICE_SERVERS })
+  const incoming = new Promise<RTCDataChannel>((resolve) => {
+    right.addEventListener('datachannel', (event) => {
+      event.channel.binaryType = 'arraybuffer'
+      resolve(event.channel)
+    })
+  })
+  const sender = left.createDataChannel('kody-video', { ordered: true })
+  sender.binaryType = 'arraybuffer'
+  const offer = await left.createOffer()
+  await left.setLocalDescription(offer)
+  await waitForIce(left)
+  await right.setRemoteDescription(left.localDescription!)
+  const answer = await right.createAnswer()
+  await right.setLocalDescription(answer)
+  await waitForIce(right)
+  await left.setRemoteDescription(right.localDescription!)
+  const receiver = await incoming
+  await new Promise<void>((resolve, reject) => {
+    const timer = window.setTimeout(() => reject(new Error('channel did not open')), 8000)
+    if (sender.readyState === 'open' && receiver.readyState === 'open') {
+      window.clearTimeout(timer)
+      resolve()
+      return
+    }
+    sender.onopen = () => {
+      if (receiver.readyState === 'open') {
+        window.clearTimeout(timer)
+        resolve()
+      }
+    }
+    receiver.onopen = () => {
+      if (sender.readyState === 'open') {
+        window.clearTimeout(timer)
+        resolve()
+      }
+    }
+  })
+  return {
+    sender,
+    receiver,
+    close: () => {
+      sender.close()
+      receiver.close()
+      left.close()
+      right.close()
+    },
+  }
+}
+
+describe('sync DataChannel transfer', () => {
+  it('moves backup bytes peer-to-peer', async () => {
+    const pair = await connectedPair()
+    const payload = new Uint8Array(80_000)
+    for (let i = 0; i < payload.length; i += 1) payload[i] = i % 251
+    const backup = new Blob([payload], { type: 'application/octet-stream' })
+    const signal = new AbortController().signal
+    const received = receiveBackupOnChannel(pair.receiver, signal)
+    await sendBackupOnChannel(pair.sender, backup, 'trip.kodyvideo', signal)
+    const result = await received
+    expect(result.filename).toBe('trip.kodyvideo')
+    expect(result.blob.size).toBe(backup.size)
+    const bytes = new Uint8Array(await result.blob.arrayBuffer())
+    expect(bytes).toEqual(payload)
+    pair.close()
+  })
+})

--- a/src/lib/sync-peer.test.ts
+++ b/src/lib/sync-peer.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { receiveBackupOnChannel, sendBackupOnChannel } from './sync-peer'
+import { normalizeSdp, receiveBackupOnChannel, sendBackupOnChannel } from './sync-peer'
 import { STUN_ICE_SERVERS } from './sync-protocol'
 
 async function waitForIce(pc: RTCPeerConnection): Promise<void> {
@@ -71,6 +71,13 @@ async function connectedPair(): Promise<{
     },
   }
 }
+
+describe('SDP line endings', () => {
+  it('rewrites LF-only SDP so Chrome will parse data-channel lines', () => {
+    const sdp = 'v=0\na=max-message-size:262144\n'
+    expect(normalizeSdp(sdp)).toBe('v=0\r\na=max-message-size:262144\r\n')
+  })
+})
 
 describe('sync DataChannel transfer', () => {
   it('moves backup bytes peer-to-peer', async () => {

--- a/src/lib/sync-peer.test.ts
+++ b/src/lib/sync-peer.test.ts
@@ -124,6 +124,23 @@ describe('sync DataChannel transfer', () => {
     pair.close()
   })
 
+  it('treats a receiver hang-up after EOF as a successful send', async () => {
+    const pair = await connectedPair()
+    const payload = new Uint8Array(40_000)
+    for (let i = 0; i < payload.length; i += 1) payload[i] = i % 251
+    const backup = new Blob([payload], { type: 'application/octet-stream' })
+    const signal = new AbortController().signal
+    const received = receiveBackupOnChannel(pair.receiver, signal).then((result) => {
+      pair.receiver.close()
+      return result
+    })
+    await sendBackupOnChannel(pair.sender, backup, 'hangup.kodyvideo', signal)
+    const result = await received
+    expect(result.filename).toBe('hangup.kodyvideo')
+    expect(result.blob.size).toBe(backup.size)
+    pair.close()
+  })
+
   it('rejects send when the channel closes mid-transfer', async () => {
     const pair = await connectedPair()
     const backup = new Blob([new Uint8Array(80_000)], { type: 'application/octet-stream' })

--- a/src/lib/sync-peer.test.ts
+++ b/src/lib/sync-peer.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import { normalizeSdp, receiveBackupOnChannel, sendBackupOnChannel } from './sync-peer'
-import { STUN_ICE_SERVERS } from './sync-protocol'
+import { encodeSyncHeader, STUN_ICE_SERVERS } from './sync-protocol'
 
 async function waitForIce(pc: RTCPeerConnection): Promise<void> {
   if (pc.iceGatheringState === 'complete') return
@@ -93,6 +93,45 @@ describe('sync DataChannel transfer', () => {
     expect(result.blob.size).toBe(backup.size)
     const bytes = new Uint8Array(await result.blob.arrayBuffer())
     expect(bytes).toEqual(payload)
+    pair.close()
+  })
+
+  it('completes receive when the peer closes after all bytes without EOF', async () => {
+    const pair = await connectedPair()
+    const payload = new Uint8Array(1200)
+    for (let i = 0; i < payload.length; i += 1) payload[i] = i % 199
+    const signal = new AbortController().signal
+    const received = receiveBackupOnChannel(pair.receiver, signal)
+    pair.sender.send(
+      encodeSyncHeader({ v: 1, byteLength: payload.byteLength, filename: 'no-eof.kodyvideo' }),
+    )
+    pair.sender.send(payload.buffer)
+    pair.sender.close()
+    const result = await received
+    expect(result.filename).toBe('no-eof.kodyvideo')
+    expect(new Uint8Array(await result.blob.arrayBuffer())).toEqual(payload)
+    pair.close()
+  })
+
+  it('rejects receive when the peer closes before all bytes arrive', async () => {
+    const pair = await connectedPair()
+    const signal = new AbortController().signal
+    const received = receiveBackupOnChannel(pair.receiver, signal)
+    pair.sender.send(encodeSyncHeader({ v: 1, byteLength: 10_000, filename: 'cut.kodyvideo' }))
+    pair.sender.send(new Uint8Array(200).buffer)
+    pair.sender.close()
+    await expect(received).rejects.toThrow(/closed before the project finished/)
+    pair.close()
+  })
+
+  it('rejects send when the channel closes mid-transfer', async () => {
+    const pair = await connectedPair()
+    const backup = new Blob([new Uint8Array(80_000)], { type: 'application/octet-stream' })
+    const signal = new AbortController().signal
+    const sending = sendBackupOnChannel(pair.sender, backup, 'cut.kodyvideo', signal, (sent) => {
+      if (sent > 0) pair.sender.close()
+    })
+    await expect(sending).rejects.toThrow(/dropped mid-send/)
     pair.close()
   })
 })

--- a/src/lib/sync-peer.ts
+++ b/src/lib/sync-peer.ts
@@ -222,23 +222,60 @@ export async function openReceiverChannel(
 }
 
 async function waitForBufferedAmountLow(channel: RTCDataChannel, signal: AbortSignal): Promise<void> {
-  if (channel.bufferedAmount <= BUFFER_LOW) return
+  if (channel.readyState !== 'open') {
+    throw new SyncTransferError('The connection dropped mid-send. Try again with both screens open.')
+  }
+  if (channel.bufferedAmount <= channel.bufferedAmountLowThreshold) return
   await new Promise<void>((resolve, reject) => {
     const finish = () => {
       channel.removeEventListener('bufferedamountlow', onLow)
+      channel.removeEventListener('close', onDead)
+      channel.removeEventListener('error', onDead)
       signal.removeEventListener('abort', onAbort)
     }
     const onLow = () => {
       finish()
       resolve()
     }
+    const onDead = () => {
+      finish()
+      reject(
+        new SyncTransferError('The connection dropped mid-send. Try again with both screens open.'),
+      )
+    }
     const onAbort = () => {
       finish()
       reject(abortError())
     }
     channel.addEventListener('bufferedamountlow', onLow)
+    channel.addEventListener('close', onDead)
+    channel.addEventListener('error', onDead)
     signal.addEventListener('abort', onAbort, { once: true })
+    if (channel.readyState !== 'open') {
+      onDead()
+      return
+    }
+    if (channel.bufferedAmount <= channel.bufferedAmountLowThreshold) onLow()
   })
+}
+
+function sendOnChannel(channel: RTCDataChannel, data: string | ArrayBuffer): void {
+  if (channel.readyState !== 'open') {
+    throw new SyncTransferError('The connection dropped mid-send. Try again with both screens open.')
+  }
+  try {
+    channel.send(data)
+  } catch {
+    throw new SyncTransferError('The connection dropped mid-send. Try again with both screens open.')
+  }
+}
+
+async function waitForChannelDrain(channel: RTCDataChannel, signal: AbortSignal): Promise<void> {
+  channel.bufferedAmountLowThreshold = 0
+  while (channel.bufferedAmount > 0) {
+    throwIfAborted(signal)
+    await waitForBufferedAmountLow(channel, signal)
+  }
 }
 
 export async function sendBackupOnChannel(
@@ -250,21 +287,19 @@ export async function sendBackupOnChannel(
 ): Promise<void> {
   throwIfAborted(signal)
   const header: SyncBackupHeader = { v: 1, byteLength: backup.size, filename }
-  channel.send(encodeSyncHeader(header))
+  sendOnChannel(channel, encodeSyncHeader(header))
   let offset = 0
   while (offset < backup.size) {
     throwIfAborted(signal)
-    if (channel.readyState !== 'open') {
-      throw new SyncTransferError('The connection dropped mid-send. Try again with both screens open.')
-    }
     await waitForBufferedAmountLow(channel, signal)
     const end = Math.min(offset + SYNC_CHUNK_BYTES, backup.size)
     const chunk = await backup.slice(offset, end).arrayBuffer()
-    channel.send(chunk)
+    sendOnChannel(channel, chunk)
     offset = end
     onProgress?.(offset, backup.size)
   }
-  channel.send(SYNC_EOF)
+  sendOnChannel(channel, SYNC_EOF)
+  await waitForChannelDrain(channel, signal)
 }
 
 export async function receiveBackupOnChannel(
@@ -291,10 +326,19 @@ export async function receiveBackupOnChannel(
       reject(error)
     }
     const onAbort = () => fail(abortError())
+    const succeed = () => {
+      finish()
+      resolve({
+        blob: new Blob(parts, { type: 'application/octet-stream' }),
+        filename,
+      })
+    }
     const onClose = () => {
-      if (!sawHeader || received < expected) {
-        fail(new SyncTransferError('The connection closed before the project finished arriving.'))
+      if (sawHeader && received === expected) {
+        succeed()
+        return
       }
+      fail(new SyncTransferError('The connection closed before the project finished arriving.'))
     }
     const onError = () => fail(new SyncTransferError('The connection failed while receiving.'))
     const onMessage = (event: MessageEvent) => {
@@ -305,11 +349,7 @@ export async function receiveBackupOnChannel(
             if (!sawHeader || received !== expected) {
               throw new SyncTransferError('The project arrived incomplete.')
             }
-            finish()
-            resolve({
-              blob: new Blob(parts, { type: 'application/octet-stream' }),
-              filename,
-            })
+            succeed()
             return
           }
           if (sawHeader) throw new SyncTransferError('Unexpected text on the project channel.')

--- a/src/lib/sync-peer.ts
+++ b/src/lib/sync-peer.ts
@@ -264,7 +264,8 @@ function sendOnChannel(channel: RTCDataChannel, data: string | ArrayBuffer): voi
     throw new SyncTransferError('The connection dropped mid-send. Try again with both screens open.')
   }
   try {
-    channel.send(data)
+    if (typeof data === 'string') channel.send(data)
+    else channel.send(data)
   } catch {
     throw new SyncTransferError('The connection dropped mid-send. Try again with both screens open.')
   }

--- a/src/lib/sync-peer.ts
+++ b/src/lib/sync-peer.ts
@@ -1,0 +1,371 @@
+import {
+  decodeSyncHeader,
+  encodeSyncHeader,
+  STUN_ICE_SERVERS,
+  SYNC_CHUNK_BYTES,
+  SYNC_EOF,
+  type SyncBackupHeader,
+} from './sync-protocol'
+import type { SyncSignaling } from './sync-signaling'
+
+const ICE_GATHER_MS = 8_000
+const OPEN_MS = 20_000
+const BUFFER_LOW = 64 * 1024
+
+export class SyncTransferError extends Error {
+  override readonly name = 'SyncTransferError'
+}
+
+export function holdWakeLock(signal: AbortSignal): void {
+  const nav = navigator as Navigator & {
+    wakeLock?: { request: (type: 'screen') => Promise<WakeLockSentinel> }
+  }
+  if (!nav.wakeLock) return
+  let sentinel: WakeLockSentinel | null = null
+  void nav.wakeLock
+    .request('screen')
+    .then((lock) => {
+      if (signal.aborted) {
+        void lock.release().catch(() => undefined)
+        return
+      }
+      sentinel = lock
+    })
+    .catch(() => undefined)
+  signal.addEventListener(
+    'abort',
+    () => {
+      void sentinel?.release().catch(() => undefined)
+    },
+    { once: true },
+  )
+}
+
+function abortError(): DOMException {
+  return new DOMException('Send cancelled.', 'AbortError')
+}
+
+function throwIfAborted(signal: AbortSignal): void {
+  if (signal.aborted) throw abortError()
+}
+
+function wait(ms: number, signal: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (signal.aborted) {
+      reject(abortError())
+      return
+    }
+    const timer = window.setTimeout(resolve, ms)
+    signal.addEventListener(
+      'abort',
+      () => {
+        window.clearTimeout(timer)
+        reject(abortError())
+      },
+      { once: true },
+    )
+  })
+}
+
+async function waitForIceGathering(pc: RTCPeerConnection, signal: AbortSignal): Promise<void> {
+  if (pc.iceGatheringState === 'complete') return
+  await new Promise<void>((resolve, reject) => {
+    const finish = () => {
+      pc.removeEventListener('icegatheringstatechange', onChange)
+      signal.removeEventListener('abort', onAbort)
+      window.clearTimeout(timer)
+    }
+    const onChange = () => {
+      if (pc.iceGatheringState === 'complete') {
+        finish()
+        resolve()
+      }
+    }
+    const onAbort = () => {
+      finish()
+      reject(abortError())
+    }
+    const timer = window.setTimeout(() => {
+      finish()
+      resolve()
+    }, ICE_GATHER_MS)
+    pc.addEventListener('icegatheringstatechange', onChange)
+    signal.addEventListener('abort', onAbort, { once: true })
+  })
+}
+
+function attachFailureWatch(pc: RTCPeerConnection, signal: AbortSignal): void {
+  const onState = () => {
+    if (pc.connectionState === 'failed' || pc.iceConnectionState === 'failed') {
+      pc.removeEventListener('connectionstatechange', onState)
+      pc.removeEventListener('iceconnectionstatechange', onState)
+    }
+  }
+  pc.addEventListener('connectionstatechange', onState)
+  pc.addEventListener('iceconnectionstatechange', onState)
+  signal.addEventListener(
+    'abort',
+    () => {
+      pc.removeEventListener('connectionstatechange', onState)
+      pc.removeEventListener('iceconnectionstatechange', onState)
+      pc.close()
+    },
+    { once: true },
+  )
+}
+
+function connectionFailed(pc: RTCPeerConnection): boolean {
+  return pc.connectionState === 'failed' || pc.iceConnectionState === 'failed'
+}
+
+async function waitForOpen(channel: RTCDataChannel, pc: RTCPeerConnection, signal: AbortSignal): Promise<void> {
+  const deadline = Date.now() + OPEN_MS
+  while (Date.now() < deadline) {
+    throwIfAborted(signal)
+    const state = channel.readyState
+    if (state === 'open') return
+    if (state === 'closed' || connectionFailed(pc)) {
+      throw new SyncTransferError(
+        'Could not connect to the other device. Stay on the same Wi‑Fi, or Save backup and import it there.',
+      )
+    }
+    await wait(100, signal)
+  }
+  throw new SyncTransferError(
+    'The other device never connected. Keep both screens open, or Save backup and import it there.',
+  )
+}
+
+async function waitForDataChannel(
+  pc: RTCPeerConnection,
+  signal: AbortSignal,
+): Promise<RTCDataChannel> {
+  return new Promise((resolve, reject) => {
+    const finish = () => {
+      pc.removeEventListener('datachannel', onChannel)
+      signal.removeEventListener('abort', onAbort)
+      window.clearTimeout(timer)
+    }
+    const onChannel = (event: RTCDataChannelEvent) => {
+      event.channel.binaryType = 'arraybuffer'
+      finish()
+      resolve(event.channel)
+    }
+    const onAbort = () => {
+      finish()
+      reject(abortError())
+    }
+    const timer = window.setTimeout(() => {
+      finish()
+      reject(
+        new SyncTransferError(
+          'The other device never opened a channel. Keep both screens open, or Save backup and import it there.',
+        ),
+      )
+    }, OPEN_MS)
+    pc.addEventListener('datachannel', onChannel)
+    signal.addEventListener('abort', onAbort, { once: true })
+  })
+}
+
+function newPeer(signal: AbortSignal): RTCPeerConnection {
+  const pc = new RTCPeerConnection({ iceServers: STUN_ICE_SERVERS })
+  attachFailureWatch(pc, signal)
+  return pc
+}
+
+export async function openSenderChannel(
+  signaling: SyncSignaling,
+  signal: AbortSignal,
+): Promise<{ pc: RTCPeerConnection; channel: RTCDataChannel }> {
+  throwIfAborted(signal)
+  const pc = newPeer(signal)
+  const channel = pc.createDataChannel('kody-video', { ordered: true })
+  channel.binaryType = 'arraybuffer'
+  channel.bufferedAmountLowThreshold = BUFFER_LOW
+  const offer = await pc.createOffer()
+  await pc.setLocalDescription(offer)
+  await waitForIceGathering(pc, signal)
+  const local = pc.localDescription?.sdp
+  if (!local) throw new SyncTransferError('Could not build a connection offer.')
+  await signaling.publishOffer(local)
+  const answer = await signaling.waitForAnswer(signal)
+  await pc.setRemoteDescription({ type: 'answer', sdp: answer })
+  await waitForOpen(channel, pc, signal)
+  return { pc, channel }
+}
+
+export async function openReceiverChannel(
+  signaling: SyncSignaling,
+  signal: AbortSignal,
+): Promise<{ pc: RTCPeerConnection; channel: RTCDataChannel }> {
+  throwIfAborted(signal)
+  const pc = newPeer(signal)
+  const incoming = waitForDataChannel(pc, signal)
+  const offer = await signaling.waitForOffer(signal)
+  await pc.setRemoteDescription({ type: 'offer', sdp: offer })
+  const answer = await pc.createAnswer()
+  await pc.setLocalDescription(answer)
+  await waitForIceGathering(pc, signal)
+  const local = pc.localDescription?.sdp
+  if (!local) throw new SyncTransferError('Could not build a connection answer.')
+  await signaling.publishAnswer(local)
+  const channel = await incoming
+  channel.binaryType = 'arraybuffer'
+  await waitForOpen(channel, pc, signal)
+  return { pc, channel }
+}
+
+async function waitForBufferedAmountLow(channel: RTCDataChannel, signal: AbortSignal): Promise<void> {
+  if (channel.bufferedAmount <= BUFFER_LOW) return
+  await new Promise<void>((resolve, reject) => {
+    const finish = () => {
+      channel.removeEventListener('bufferedamountlow', onLow)
+      signal.removeEventListener('abort', onAbort)
+    }
+    const onLow = () => {
+      finish()
+      resolve()
+    }
+    const onAbort = () => {
+      finish()
+      reject(abortError())
+    }
+    channel.addEventListener('bufferedamountlow', onLow)
+    signal.addEventListener('abort', onAbort, { once: true })
+  })
+}
+
+export async function sendBackupOnChannel(
+  channel: RTCDataChannel,
+  backup: Blob,
+  filename: string,
+  signal: AbortSignal,
+  onProgress?: (sentBytes: number, totalBytes: number) => void,
+): Promise<void> {
+  throwIfAborted(signal)
+  const header: SyncBackupHeader = { v: 1, byteLength: backup.size, filename }
+  channel.send(encodeSyncHeader(header))
+  let offset = 0
+  while (offset < backup.size) {
+    throwIfAborted(signal)
+    if (channel.readyState !== 'open') {
+      throw new SyncTransferError('The connection dropped mid-send. Try again with both screens open.')
+    }
+    await waitForBufferedAmountLow(channel, signal)
+    const end = Math.min(offset + SYNC_CHUNK_BYTES, backup.size)
+    const chunk = await backup.slice(offset, end).arrayBuffer()
+    channel.send(chunk)
+    offset = end
+    onProgress?.(offset, backup.size)
+  }
+  channel.send(SYNC_EOF)
+}
+
+export async function receiveBackupOnChannel(
+  channel: RTCDataChannel,
+  signal: AbortSignal,
+  onProgress?: (receivedBytes: number, totalBytes: number) => void,
+): Promise<{ blob: Blob; filename: string }> {
+  throwIfAborted(signal)
+  const parts: ArrayBuffer[] = []
+  let expected = 0
+  let received = 0
+  let filename = 'project.kodyvideo'
+  let sawHeader = false
+
+  return new Promise((resolve, reject) => {
+    const finish = () => {
+      channel.removeEventListener('message', onMessage)
+      channel.removeEventListener('close', onClose)
+      channel.removeEventListener('error', onError)
+      signal.removeEventListener('abort', onAbort)
+    }
+    const fail = (error: Error) => {
+      finish()
+      reject(error)
+    }
+    const onAbort = () => fail(abortError())
+    const onClose = () => {
+      if (!sawHeader || received < expected) {
+        fail(new SyncTransferError('The connection closed before the project finished arriving.'))
+      }
+    }
+    const onError = () => fail(new SyncTransferError('The connection failed while receiving.'))
+    const onMessage = (event: MessageEvent) => {
+      try {
+        throwIfAborted(signal)
+        if (typeof event.data === 'string') {
+          if (event.data === SYNC_EOF) {
+            if (!sawHeader || received !== expected) {
+              throw new SyncTransferError('The project arrived incomplete.')
+            }
+            finish()
+            resolve({
+              blob: new Blob(parts, { type: 'application/octet-stream' }),
+              filename,
+            })
+            return
+          }
+          if (sawHeader) throw new SyncTransferError('Unexpected text on the project channel.')
+          const header = decodeSyncHeader(event.data)
+          expected = header.byteLength
+          filename = header.filename
+          sawHeader = true
+          onProgress?.(0, expected)
+          return
+        }
+        if (!sawHeader) throw new SyncTransferError('Project bytes arrived before the header.')
+        if (!(event.data instanceof ArrayBuffer)) {
+          throw new SyncTransferError('Unexpected payload on the project channel.')
+        }
+        parts.push(event.data)
+        received += event.data.byteLength
+        if (received > expected) throw new SyncTransferError('The project was larger than announced.')
+        onProgress?.(received, expected)
+      } catch (error) {
+        fail(error instanceof Error ? error : new SyncTransferError('Could not receive the project.'))
+      }
+    }
+    channel.addEventListener('message', onMessage)
+    channel.addEventListener('close', onClose)
+    channel.addEventListener('error', onError)
+    signal.addEventListener('abort', onAbort, { once: true })
+  })
+}
+
+export async function sendBackupToPeer(
+  signaling: SyncSignaling,
+  backup: Blob,
+  filename: string,
+  signal: AbortSignal,
+  onProgress?: (sentBytes: number, totalBytes: number) => void,
+  onConnected?: () => void,
+): Promise<void> {
+  holdWakeLock(signal)
+  const { pc, channel } = await openSenderChannel(signaling, signal)
+  try {
+    onConnected?.()
+    await sendBackupOnChannel(channel, backup, filename, signal, onProgress)
+  } finally {
+    channel.close()
+    pc.close()
+  }
+}
+
+export async function receiveBackupFromPeer(
+  signaling: SyncSignaling,
+  signal: AbortSignal,
+  onProgress?: (receivedBytes: number, totalBytes: number) => void,
+  onConnected?: () => void,
+): Promise<{ blob: Blob; filename: string }> {
+  holdWakeLock(signal)
+  const { pc, channel } = await openReceiverChannel(signaling, signal)
+  try {
+    onConnected?.()
+    return await receiveBackupOnChannel(channel, signal, onProgress)
+  } finally {
+    channel.close()
+    pc.close()
+  }
+}

--- a/src/lib/sync-peer.ts
+++ b/src/lib/sync-peer.ts
@@ -174,6 +174,11 @@ function newPeer(signal: AbortSignal): RTCPeerConnection {
   return pc
 }
 
+/** Chrome rejects `a=max-message-size` (and similar) unless lines are CRLF. */
+export function normalizeSdp(sdp: string): string {
+  return `${sdp.replace(/\r\n/g, '\n').replace(/\n/g, '\r\n').trim()}\r\n`
+}
+
 export async function openSenderChannel(
   signaling: SyncSignaling,
   signal: AbortSignal,
@@ -188,9 +193,9 @@ export async function openSenderChannel(
   await waitForIceGathering(pc, signal)
   const local = pc.localDescription?.sdp
   if (!local) throw new SyncTransferError('Could not build a connection offer.')
-  await signaling.publishOffer(local)
+  await signaling.publishOffer(normalizeSdp(local))
   const answer = await signaling.waitForAnswer(signal)
-  await pc.setRemoteDescription({ type: 'answer', sdp: answer })
+  await pc.setRemoteDescription({ type: 'answer', sdp: normalizeSdp(answer) })
   await waitForOpen(channel, pc, signal)
   return { pc, channel }
 }
@@ -203,13 +208,13 @@ export async function openReceiverChannel(
   const pc = newPeer(signal)
   const incoming = waitForDataChannel(pc, signal)
   const offer = await signaling.waitForOffer(signal)
-  await pc.setRemoteDescription({ type: 'offer', sdp: offer })
+  await pc.setRemoteDescription({ type: 'offer', sdp: normalizeSdp(offer) })
   const answer = await pc.createAnswer()
   await pc.setLocalDescription(answer)
   await waitForIceGathering(pc, signal)
   const local = pc.localDescription?.sdp
   if (!local) throw new SyncTransferError('Could not build a connection answer.')
-  await signaling.publishAnswer(local)
+  await signaling.publishAnswer(normalizeSdp(local))
   const channel = await incoming
   channel.binaryType = 'arraybuffer'
   await waitForOpen(channel, pc, signal)

--- a/src/lib/sync-peer.ts
+++ b/src/lib/sync-peer.ts
@@ -273,9 +273,15 @@ function sendOnChannel(channel: RTCDataChannel, data: string | ArrayBuffer): voi
 
 async function waitForChannelDrain(channel: RTCDataChannel, signal: AbortSignal): Promise<void> {
   channel.bufferedAmountLowThreshold = 0
-  while (channel.bufferedAmount > 0) {
+  while (channel.bufferedAmount > 0 && channel.readyState === 'open') {
     throwIfAborted(signal)
-    await waitForBufferedAmountLow(channel, signal)
+    try {
+      await waitForBufferedAmountLow(channel, signal)
+    } catch (error) {
+      if (error instanceof DOMException && error.name === 'AbortError') throw error
+      // Receiver closes as soon as EOF lands. That is success, not a drop.
+      return
+    }
   }
 }
 

--- a/src/lib/sync-protocol.test.ts
+++ b/src/lib/sync-protocol.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest'
+import {
+  decodeSyncHeader,
+  encodeSyncHeader,
+  formatRoomCode,
+  normalizeRoomCode,
+  randomRoomCode,
+  ROOM_CODE_LENGTH,
+  ROOM_CODE_PATTERN,
+} from './sync-protocol'
+
+describe('sync protocol', () => {
+  it('mints unambiguous room codes', () => {
+    const codes = new Set<string>()
+    for (let i = 0; i < 40; i += 1) {
+      const code = randomRoomCode()
+      expect(code).toHaveLength(ROOM_CODE_LENGTH)
+      expect(code).toMatch(ROOM_CODE_PATTERN)
+      expect(code).not.toMatch(/[01IO]/)
+      codes.add(code)
+    }
+    expect(codes.size).toBe(40)
+  })
+
+  it('normalizes typed codes and rejects lookalikes', () => {
+    expect(normalizeRoomCode('ab3-k9q')).toBe('AB3K9Q')
+    const minted = randomRoomCode()
+    expect(normalizeRoomCode(` ${minted.slice(0, 3)}-${minted.slice(3)} `)).toBe(minted)
+    expect(normalizeRoomCode('SHORT')).toBeNull()
+    expect(normalizeRoomCode('IIIIII')).toBeNull()
+  })
+
+  it('formats a code for reading off a phone', () => {
+    expect(formatRoomCode('AB3K9Q')).toBe('AB3-K9Q')
+  })
+
+  it('round-trips the DataChannel header', () => {
+    const encoded = encodeSyncHeader({
+      v: 1,
+      byteLength: 1234,
+      filename: 'trip.kodyvideo',
+    })
+    expect(decodeSyncHeader(encoded)).toEqual({
+      v: 1,
+      byteLength: 1234,
+      filename: 'trip.kodyvideo',
+    })
+    expect(() => decodeSyncHeader('nope')).toThrow(/not a Kody Video project/)
+  })
+})

--- a/src/lib/sync-protocol.ts
+++ b/src/lib/sync-protocol.ts
@@ -1,0 +1,96 @@
+/** Shared wire types for Plus “Send to device” (signaling + DataChannel). */
+
+export const ROOM_CODE_LENGTH = 6
+/** Crockford-ish: no 0/O/1/I so a code read off a phone is unambiguous. */
+export const ROOM_CODE_ALPHABET = 'ABCDEFGHJKLMNPQRSTUVWXYZ23456789'
+export const ROOM_CODE_PATTERN = /^[ABCDEFGHJKLMNPQRSTUVWXYZ23456789]{6}$/
+export const ROOM_TTL_MS = 10 * 60 * 1000
+export const SYNC_CHUNK_BYTES = 16 * 1024
+export const SYNC_HEADER_PREFIX = 'KODY1'
+export const SYNC_EOF = 'KODY1EOF'
+
+export const STUN_ICE_SERVERS: RTCIceServer[] = [{ urls: 'stun:stun.cloudflare.com:3478' }]
+
+export type SyncRoomStatus = 'waiting' | 'offered' | 'answered'
+
+export interface SyncRoomView {
+  code: string
+  status: SyncRoomStatus
+  offer: string | null
+  answer: string | null
+  createdAt: number
+}
+
+export interface SyncRoomRecord extends SyncRoomView {
+  expiresAt: number
+}
+
+export interface SyncBackupHeader {
+  v: 1
+  byteLength: number
+  filename: string
+}
+
+export type SyncPhase =
+  | 'creating'
+  | 'waiting'
+  | 'connecting'
+  | 'transferring'
+  | 'importing'
+  | 'done'
+  | 'failed'
+
+export function randomRoomCode(): string {
+  const bytes = new Uint8Array(ROOM_CODE_LENGTH)
+  crypto.getRandomValues(bytes)
+  let code = ''
+  for (const byte of bytes) {
+    code += ROOM_CODE_ALPHABET[byte % ROOM_CODE_ALPHABET.length]
+  }
+  return code
+}
+
+/** Strip spaces/hyphens and uppercase; null when it is not a valid code. */
+export function normalizeRoomCode(input: string): string | null {
+  const compact = input.toUpperCase().replace(/[^A-Z0-9]/g, '')
+  return ROOM_CODE_PATTERN.test(compact) ? compact : null
+}
+
+export function formatRoomCode(code: string): string {
+  const normalized = normalizeRoomCode(code) ?? code.toUpperCase()
+  if (normalized.length !== ROOM_CODE_LENGTH) return normalized
+  return `${normalized.slice(0, 3)}-${normalized.slice(3)}`
+}
+
+export function isSyncBackupHeader(value: unknown): value is SyncBackupHeader {
+  if (value === null || typeof value !== 'object') return false
+  const header = value as Partial<SyncBackupHeader>
+  return (
+    header.v === 1 &&
+    typeof header.byteLength === 'number' &&
+    Number.isFinite(header.byteLength) &&
+    header.byteLength > 0 &&
+    typeof header.filename === 'string' &&
+    header.filename.length > 0
+  )
+}
+
+export function encodeSyncHeader(header: SyncBackupHeader): string {
+  return `${SYNC_HEADER_PREFIX}${JSON.stringify(header)}`
+}
+
+export function decodeSyncHeader(message: string): SyncBackupHeader {
+  if (!message.startsWith(SYNC_HEADER_PREFIX)) {
+    throw new Error('This device sent something that is not a Kody Video project.')
+  }
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(message.slice(SYNC_HEADER_PREFIX.length))
+  } catch {
+    throw new Error('This device sent a damaged project header.')
+  }
+  if (!isSyncBackupHeader(parsed)) {
+    throw new Error('This device sent a damaged project header.')
+  }
+  return parsed
+}

--- a/src/lib/sync-rooms.test.ts
+++ b/src/lib/sync-rooms.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from 'vitest'
+import { handleSyncRequest, memorySyncKv } from './sync-rooms'
+
+function env() {
+  return { SYNC_ROOMS: memorySyncKv() }
+}
+
+async function body(response: Response) {
+  return (await response.json()) as {
+    code?: string
+    status?: string
+    offer?: string | null
+    answer?: string | null
+    error?: string
+  }
+}
+
+describe('sync room HTTP', () => {
+  it('returns 503 when the KV binding is missing', async () => {
+    const response = await handleSyncRequest(
+      new Request('https://kody.video/api/sync/rooms', { method: 'POST' }),
+      {},
+    )
+    expect(response.status).toBe(503)
+    expect((await body(response)).error).toMatch(/SYNC_ROOMS/)
+  })
+
+  it('creates a room and exchanges offer then answer', async () => {
+    const rooms = env()
+    const created = await handleSyncRequest(
+      new Request('https://kody.video/api/sync/rooms', { method: 'POST' }),
+      rooms,
+    )
+    expect(created.status).toBe(201)
+    const room = await body(created)
+    expect(room.code).toMatch(/^[A-Z2-9]{6}$/)
+    expect(room.status).toBe('waiting')
+
+    const offered = await handleSyncRequest(
+      new Request(`https://kody.video/api/sync/rooms/${room.code}`, {
+        method: 'PUT',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ offer: 'v=0 offer' }),
+      }),
+      rooms,
+    )
+    expect(offered.status).toBe(200)
+    expect((await body(offered)).status).toBe('offered')
+
+    const answered = await handleSyncRequest(
+      new Request(`https://kody.video/api/sync/rooms/${room.code}`, {
+        method: 'PUT',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ answer: 'v=0 answer' }),
+      }),
+      rooms,
+    )
+    expect((await body(answered)).status).toBe('answered')
+
+    const got = await handleSyncRequest(
+      new Request(`https://kody.video/api/sync/rooms/${room.code}`),
+      rooms,
+    )
+    const view = await body(got)
+    expect(view.offer).toBe('v=0 offer')
+    expect(view.answer).toBe('v=0 answer')
+  })
+
+  it('rejects a second sender and an answer before an offer', async () => {
+    const rooms = env()
+    const created = await body(
+      await handleSyncRequest(
+        new Request('https://kody.video/api/sync/rooms', { method: 'POST' }),
+        rooms,
+      ),
+    )
+    const earlyAnswer = await handleSyncRequest(
+      new Request(`https://kody.video/api/sync/rooms/${created.code}`, {
+        method: 'PUT',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ answer: 'too-soon' }),
+      }),
+      rooms,
+    )
+    expect(earlyAnswer.status).toBe(409)
+
+    await handleSyncRequest(
+      new Request(`https://kody.video/api/sync/rooms/${created.code}`, {
+        method: 'PUT',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ offer: 'first' }),
+      }),
+      rooms,
+    )
+    const second = await handleSyncRequest(
+      new Request(`https://kody.video/api/sync/rooms/${created.code}`, {
+        method: 'PUT',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ offer: 'second' }),
+      }),
+      rooms,
+    )
+    expect(second.status).toBe(409)
+  })
+
+  it('404s unknown or malformed codes', async () => {
+    const rooms = env()
+    const missing = await handleSyncRequest(
+      new Request('https://kody.video/api/sync/rooms/ABCDEF'),
+      rooms,
+    )
+    expect(missing.status).toBe(404)
+    const bad = await handleSyncRequest(new Request('https://kody.video/api/sync/rooms/IIIIII'), rooms)
+    expect(bad.status).toBe(400)
+  })
+})

--- a/src/lib/sync-rooms.ts
+++ b/src/lib/sync-rooms.ts
@@ -1,0 +1,248 @@
+import {
+  normalizeRoomCode,
+  randomRoomCode,
+  ROOM_TTL_MS,
+  type SyncRoomRecord,
+  type SyncRoomStatus,
+  type SyncRoomView,
+} from './sync-protocol'
+
+export interface SyncKv {
+  get(key: string, type: 'text'): Promise<string | null>
+  put(key: string, value: string, options?: { expirationTtl?: number }): Promise<void>
+  delete(key: string): Promise<void>
+}
+
+export interface SyncRoomsEnv {
+  SYNC_ROOMS?: SyncKv
+}
+
+const ROOM_KEY_PREFIX = 'room:'
+const RATE_KEY_PREFIX = 'rate:'
+const CREATE_RATE_LIMIT = 30
+const RATE_WINDOW_SEC = 10 * 60
+
+export class SyncRoomError extends Error {
+  override readonly name = 'SyncRoomError'
+  readonly status: number
+  constructor(message: string, status: number) {
+    super(message)
+    this.status = status
+  }
+}
+
+export function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      'content-type': 'application/json',
+      'cache-control': 'no-store',
+    },
+  })
+}
+
+export function memorySyncKv(): SyncKv {
+  const values = new Map<string, { value: string; expiresAt: number }>()
+  const now = () => Date.now()
+  const read = (key: string): string | null => {
+    const entry = values.get(key)
+    if (!entry) return null
+    if (entry.expiresAt <= now()) {
+      values.delete(key)
+      return null
+    }
+    return entry.value
+  }
+  return {
+    async get(key) {
+      return read(key)
+    },
+    async put(key, value, options) {
+      const ttlMs = (options?.expirationTtl ?? 600) * 1000
+      values.set(key, { value, expiresAt: now() + ttlMs })
+    },
+    async delete(key) {
+      values.delete(key)
+    },
+  }
+}
+
+function roomKey(code: string): string {
+  return `${ROOM_KEY_PREFIX}${code}`
+}
+
+function viewOf(record: SyncRoomRecord): SyncRoomView {
+  return {
+    code: record.code,
+    status: record.status,
+    offer: record.offer,
+    answer: record.answer,
+    createdAt: record.createdAt,
+  }
+}
+
+function statusOf(record: Pick<SyncRoomRecord, 'offer' | 'answer'>): SyncRoomStatus {
+  if (record.answer) return 'answered'
+  if (record.offer) return 'offered'
+  return 'waiting'
+}
+
+async function readRoom(kv: SyncKv, code: string): Promise<SyncRoomRecord | null> {
+  const raw = await kv.get(roomKey(code), 'text')
+  if (!raw) return null
+  try {
+    const parsed = JSON.parse(raw) as SyncRoomRecord
+    if (parsed.expiresAt <= Date.now()) {
+      await kv.delete(roomKey(code))
+      return null
+    }
+    return parsed
+  } catch {
+    await kv.delete(roomKey(code))
+    return null
+  }
+}
+
+async function writeRoom(kv: SyncKv, record: SyncRoomRecord): Promise<void> {
+  const ttlSec = Math.max(30, Math.ceil((record.expiresAt - Date.now()) / 1000))
+  await kv.put(roomKey(record.code), JSON.stringify(record), { expirationTtl: ttlSec })
+}
+
+async function enforceCreateRateLimit(kv: SyncKv, ip: string): Promise<void> {
+  const key = `${RATE_KEY_PREFIX}${ip}`
+  const raw = await kv.get(key, 'text')
+  let count = 0
+  if (raw) {
+    const parsed = Number(raw)
+    if (Number.isFinite(parsed)) count = parsed
+  }
+  if (count >= CREATE_RATE_LIMIT) {
+    throw new SyncRoomError('Too many send rooms from this network. Try again in a few minutes.', 429)
+  }
+  await kv.put(key, String(count + 1), { expirationTtl: RATE_WINDOW_SEC })
+}
+
+export async function createSyncRoom(kv: SyncKv, ip: string): Promise<SyncRoomView> {
+  await enforceCreateRateLimit(kv, ip)
+  const createdAt = Date.now()
+  const expiresAt = createdAt + ROOM_TTL_MS
+  for (let attempt = 0; attempt < 8; attempt += 1) {
+    const code = randomRoomCode()
+    if (await readRoom(kv, code)) continue
+    const record: SyncRoomRecord = {
+      code,
+      status: 'waiting',
+      offer: null,
+      answer: null,
+      createdAt,
+      expiresAt,
+    }
+    await writeRoom(kv, record)
+    return viewOf(record)
+  }
+  throw new SyncRoomError('Could not allocate a send code. Try again.', 503)
+}
+
+export async function getSyncRoom(kv: SyncKv, code: string): Promise<SyncRoomView> {
+  const normalized = normalizeRoomCode(code)
+  if (!normalized) throw new SyncRoomError('That is not a valid send code.', 400)
+  const record = await readRoom(kv, normalized)
+  if (!record) throw new SyncRoomError('No send waiting with that code — it may have expired.', 404)
+  return viewOf(record)
+}
+
+export async function updateSyncRoom(
+  kv: SyncKv,
+  code: string,
+  patch: { offer?: string; answer?: string },
+): Promise<SyncRoomView> {
+  const normalized = normalizeRoomCode(code)
+  if (!normalized) throw new SyncRoomError('That is not a valid send code.', 400)
+  const record = await readRoom(kv, normalized)
+  if (!record) throw new SyncRoomError('No send waiting with that code — it may have expired.', 404)
+
+  const offer = typeof patch.offer === 'string' ? patch.offer.trim() : ''
+  const answer = typeof patch.answer === 'string' ? patch.answer.trim() : ''
+  if (offer && answer) {
+    throw new SyncRoomError('Send one description at a time.', 400)
+  }
+  if (!offer && !answer) {
+    throw new SyncRoomError('Missing connection description.', 400)
+  }
+  if (offer.length > 20_000 || answer.length > 20_000) {
+    throw new SyncRoomError('Connection description is too large.', 413)
+  }
+
+  if (offer) {
+    if (record.offer) throw new SyncRoomError('This send already has a sender.', 409)
+    record.offer = offer
+  } else {
+    if (!record.offer) throw new SyncRoomError('The sender has not published a connection yet.', 409)
+    if (record.answer) throw new SyncRoomError('This send already has a receiver.', 409)
+    record.answer = answer
+  }
+  record.status = statusOf(record)
+  await writeRoom(kv, record)
+  return viewOf(record)
+}
+
+function clientIp(request: Request): string {
+  return request.headers.get('CF-Connecting-IP') ?? request.headers.get('x-forwarded-for') ?? 'local'
+}
+
+function requireKv(env: SyncRoomsEnv): SyncKv {
+  if (!env.SYNC_ROOMS) {
+    throw new SyncRoomError(
+      'Send-to-device is not configured on this deployment (missing SYNC_ROOMS).',
+      503,
+    )
+  }
+  return env.SYNC_ROOMS
+}
+
+/**
+ * HTTP surface used by the Pages Function and the Vite dev middleware:
+ * POST /api/sync/rooms
+ * GET  /api/sync/rooms/:code
+ * PUT  /api/sync/rooms/:code  { offer? | answer? }
+ */
+export async function handleSyncRequest(request: Request, env: SyncRoomsEnv): Promise<Response> {
+  try {
+    const url = new URL(request.url)
+    const parts = url.pathname.split('/').filter(Boolean)
+    if (parts[0] !== 'api' || parts[1] !== 'sync' || parts[2] !== 'rooms') {
+      return jsonResponse({ error: 'Not found.' }, 404)
+    }
+    const code = parts[3]
+    if (parts.length > 4) return jsonResponse({ error: 'Not found.' }, 404)
+
+    if (!code) {
+      if (request.method !== 'POST') return jsonResponse({ error: 'Method not allowed.' }, 405)
+      const room = await createSyncRoom(requireKv(env), clientIp(request))
+      return jsonResponse(room, 201)
+    }
+
+    switch (request.method) {
+      case 'GET':
+        return jsonResponse(await getSyncRoom(requireKv(env), code))
+      case 'PUT': {
+        const body = (await request.json().catch(() => null)) as {
+          offer?: unknown
+          answer?: unknown
+        } | null
+        const room = await updateSyncRoom(requireKv(env), code, {
+          offer: typeof body?.offer === 'string' ? body.offer : undefined,
+          answer: typeof body?.answer === 'string' ? body.answer : undefined,
+        })
+        return jsonResponse(room)
+      }
+      default:
+        return jsonResponse({ error: 'Method not allowed.' }, 405)
+    }
+  } catch (error) {
+    if (error instanceof SyncRoomError) {
+      return jsonResponse({ error: error.message }, error.status)
+    }
+    return jsonResponse({ error: 'Could not update the send room.' }, 500)
+  }
+}

--- a/src/lib/sync-signaling.ts
+++ b/src/lib/sync-signaling.ts
@@ -1,0 +1,128 @@
+import { normalizeRoomCode, type SyncRoomView } from './sync-protocol'
+
+export class SyncSignalError extends Error {
+  override readonly name = 'SyncSignalError'
+  readonly status?: number
+  constructor(message: string, status?: number) {
+    super(message)
+    this.status = status
+  }
+}
+
+async function readRoomResponse(response: Response): Promise<SyncRoomView> {
+  const body = (await response.json().catch(() => null)) as
+    | (Partial<SyncRoomView> & { error?: string })
+    | null
+  if (!response.ok) {
+    throw new SyncSignalError(body?.error ?? 'Could not reach the send room.', response.status)
+  }
+  if (!body || typeof body.code !== 'string') {
+    throw new SyncSignalError('The send room returned a damaged response.')
+  }
+  return {
+    code: body.code,
+    status: body.status === 'answered' || body.status === 'offered' ? body.status : 'waiting',
+    offer: typeof body.offer === 'string' ? body.offer : null,
+    answer: typeof body.answer === 'string' ? body.answer : null,
+    createdAt: typeof body.createdAt === 'number' ? body.createdAt : Date.now(),
+  }
+}
+
+export async function createSyncRoom(): Promise<SyncRoomView> {
+  const response = await fetch('/api/sync/rooms', {
+    method: 'POST',
+    headers: { accept: 'application/json' },
+  })
+  return readRoomResponse(response)
+}
+
+export async function fetchSyncRoom(code: string): Promise<SyncRoomView> {
+  const normalized = normalizeRoomCode(code)
+  if (!normalized) throw new SyncSignalError('That is not a valid send code.')
+  const response = await fetch(`/api/sync/rooms/${encodeURIComponent(normalized)}`, {
+    headers: { accept: 'application/json' },
+  })
+  return readRoomResponse(response)
+}
+
+export async function publishSyncOffer(code: string, offer: string): Promise<SyncRoomView> {
+  const normalized = normalizeRoomCode(code)
+  if (!normalized) throw new SyncSignalError('That is not a valid send code.')
+  const response = await fetch(`/api/sync/rooms/${encodeURIComponent(normalized)}`, {
+    method: 'PUT',
+    headers: { accept: 'application/json', 'content-type': 'application/json' },
+    body: JSON.stringify({ offer }),
+  })
+  return readRoomResponse(response)
+}
+
+export async function publishSyncAnswer(code: string, answer: string): Promise<SyncRoomView> {
+  const normalized = normalizeRoomCode(code)
+  if (!normalized) throw new SyncSignalError('That is not a valid send code.')
+  const response = await fetch(`/api/sync/rooms/${encodeURIComponent(normalized)}`, {
+    method: 'PUT',
+    headers: { accept: 'application/json', 'content-type': 'application/json' },
+    body: JSON.stringify({ answer }),
+  })
+  return readRoomResponse(response)
+}
+
+export async function waitForSyncRoom(
+  code: string,
+  ready: (room: SyncRoomView) => boolean,
+  signal: AbortSignal,
+  intervalMs = 700,
+): Promise<SyncRoomView> {
+  while (!signal.aborted) {
+    const room = await fetchSyncRoom(code)
+    if (ready(room)) return room
+    await sleep(intervalMs, signal)
+  }
+  throw new DOMException('Send cancelled.', 'AbortError')
+}
+
+function sleep(ms: number, signal: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (signal.aborted) {
+      reject(new DOMException('Send cancelled.', 'AbortError'))
+      return
+    }
+    const timer = window.setTimeout(resolve, ms)
+    signal.addEventListener(
+      'abort',
+      () => {
+        window.clearTimeout(timer)
+        reject(new DOMException('Send cancelled.', 'AbortError'))
+      },
+      { once: true },
+    )
+  })
+}
+
+export interface SyncSignaling {
+  publishOffer(sdp: string): Promise<void>
+  publishAnswer(sdp: string): Promise<void>
+  waitForOffer(signal: AbortSignal): Promise<string>
+  waitForAnswer(signal: AbortSignal): Promise<string>
+}
+
+export function httpSyncSignaling(code: string): SyncSignaling {
+  return {
+    async publishOffer(sdp) {
+      await publishSyncOffer(code, sdp)
+    },
+    async publishAnswer(sdp) {
+      await publishSyncAnswer(code, sdp)
+    },
+    async waitForOffer(signal) {
+      const room = await waitForSyncRoom(code, (current) => Boolean(current.offer), signal)
+      if (!room.offer) throw new SyncSignalError('The sender never published a connection.')
+      return room.offer
+    },
+    async waitForAnswer(signal) {
+      const room = await waitForSyncRoom(code, (current) => Boolean(current.answer), signal)
+      if (!room.answer) throw new SyncSignalError('The receiver never published a connection.')
+      return room.answer
+    },
+  }
+}

--- a/src/pages/about-page.tsx
+++ b/src/pages/about-page.tsx
@@ -289,8 +289,10 @@ export function AboutPage(handle: Handle) {
               storage until you export and share them yourself. The app&rsquo;s only own network
               traffic: Stripe checkout and its purchase verification if you buy the watermark
               removal, anonymous crash reports (error and stack trace only — never your media) when
-              something breaks, cookieless page-view counts via Fathom Analytics, and the tour
-              video streaming from this app&rsquo;s own domain if you tap play on it.
+              something breaks, cookieless page-view counts via Fathom Analytics, the tour video
+              streaming from this app&rsquo;s own domain if you tap play on it, and — only if you
+              tap Send to device — a short-lived matchmaking room so two browsers can find each
+              other. Clips still never upload.
             </p>
           </section>
 
@@ -346,7 +348,10 @@ export function AboutPage(handle: Handle) {
             <p>
               Every project can be saved as a single <code>.kodyvideo</code> file (⋯ →{' '}
               <strong>Save backup</strong> on the home screen) — a safety net, and the way to move
-              a project between devices. Restore one here, or drop the file anywhere in the app:
+              a project between devices. Plus can also <strong>Send to device</strong> over the
+              local network (the other device opens{' '}
+              <a href="/receive">kody.video/receive</a>). Restore a backup here, or drop the file
+              anywhere in the app:
             </p>
             <label className={`btn btn-ghost about-import${importing ? ' is-disabled' : ''}`}>
               Import a backup

--- a/src/pages/home-page.tsx
+++ b/src/pages/home-page.tsx
@@ -5,6 +5,7 @@ import { BlobImage } from '../components/blob-image'
 import { BrandMark } from '../components/brand-mark'
 import { ConfirmSheet } from '../components/confirm-sheet'
 import { HomeOptionsSheet } from '../components/home-options-sheet'
+import { SendSheet } from '../components/send-sheet'
 import {
   IconClose,
   IconDownload,
@@ -75,6 +76,7 @@ export function HomePage(handle: Handle) {
   let showInstallHint = shouldShowIosInstallHint()
   let upselling = false
   let restoring = false
+  let sending: ProjectSummary | null = null
   let installPopoverOpen = false
   const showcase = showcaseForHostname(location.hostname)
   let showShowcaseBanner = showcase !== null && !isShowcaseBannerDismissed()
@@ -510,7 +512,10 @@ export function HomePage(handle: Handle) {
           </section>
 
           <p className="home-privacy">
-            <span>Clips stay on this phone until you share.</span>
+            <span>
+              Clips stay on this phone until you share.{' '}
+              <a href="/receive">Receive a project</a>
+            </span>
             {storage ? <StorageMeter storage={storage} /> : null}
           </p>
         </div>
@@ -538,6 +543,16 @@ export function HomePage(handle: Handle) {
               menuProject = null
               void handle.update()
               backupProject(project)
+            }}
+            onSend={() => {
+              const project = menuProject!
+              menuProject = null
+              if (!plus) {
+                upselling = true
+              } else {
+                sending = project
+              }
+              void handle.update()
             }}
             onDelete={() => {
               deleting = menuProject
@@ -574,6 +589,24 @@ export function HomePage(handle: Handle) {
             onConfirm={async () => {
               await deleteProject(deleting!.id)
               refresh()
+            }}
+          />
+        ) : null}
+
+        {sending ? (
+          <SendSheet
+            key={sending.id}
+            projectId={sending.id}
+            projectName={sending.name}
+            onClose={() => {
+              sending = null
+              void handle.update()
+            }}
+            onBackupInstead={() => {
+              const project = sending!
+              sending = null
+              void handle.update()
+              backupProject(project)
             }}
           />
         ) : null}

--- a/src/pages/privacy-page.tsx
+++ b/src/pages/privacy-page.tsx
@@ -44,8 +44,22 @@ export function PrivacyPage() {
             When the app itself breaks, an error report (the error message, a stack trace, browser
             and OS names, and which step failed — e.g. &ldquo;export&rdquo;) is sent to Sentry so
             bugs get found and fixed. Crash reports never contain your clips, audio, location, or
-            any account identifier, and no IP-based user profile is kept. Page-view counts and
-            crash reports are the only data the app sends anywhere on its own.
+            any account identifier, and no IP-based user profile is kept. Page-view counts, crash
+            reports, and (only if you tap Send to device) a short-lived matchmaking room are the
+            only data the app sends anywhere on its own.
+          </p>
+        </section>
+
+        <section className="about-section">
+          <h2>Send to another device</h2>
+          <p>
+            Kody Video Plus can send a project to another phone or computer that has the app open.
+            A Cloudflare matchmaker introduces the two browsers (a short code plus the WebRTC
+            connection description, which includes network addresses). Your clips never go to our
+            servers — they travel device-to-device, encrypted. Rooms expire in minutes and are not
+            stored as a library. If the devices cannot connect (different networks, strict Wi‑Fi),
+            use Save backup and import instead. Receiving a project is free and is the same as
+            importing a backup.
           </p>
         </section>
 

--- a/src/pages/receive-page.tsx
+++ b/src/pages/receive-page.tsx
@@ -1,0 +1,187 @@
+import type { Handle } from 'remix/ui'
+import { on } from 'remix/ui'
+import { IconBack } from '../components/icons'
+import { BrandMark } from '../components/brand-mark'
+import { reportError } from '../lib/error-reporting'
+import { BackupFormatError, importKodyVideoBackupFile } from '../lib/project-transfer'
+import { ProjectLimitError } from '../lib/storage'
+import { formatBytes } from '../lib/storage-space'
+import { formatRoomCode, normalizeRoomCode, type SyncPhase } from '../lib/sync-protocol'
+import { httpSyncSignaling, SyncSignalError } from '../lib/sync-signaling'
+import { receiveBackupFromPeer, SyncTransferError } from '../lib/sync-peer'
+import { navigate } from '../router'
+
+interface ReceivePageProps {
+  code?: string
+}
+
+function phaseCopy(phase: SyncPhase, error: string | null, hasCode: boolean): string {
+  switch (phase) {
+    case 'creating':
+      return hasCode
+        ? 'Waiting for the sender. Keep this screen open.'
+        : 'Type the code from the other device, or open the link / QR it showed.'
+    case 'waiting':
+      return 'Waiting for the sender. Keep this screen open.'
+    case 'connecting':
+      return 'Connecting…'
+    case 'transferring':
+      return 'Receiving the project. Keep this screen open.'
+    case 'importing':
+      return 'Saving the project on this device…'
+    case 'done':
+      return 'Project received.'
+    case 'failed':
+      return error ?? 'Could not receive a project.'
+    default: {
+      const _exhaustive: never = phase
+      return _exhaustive
+    }
+  }
+}
+
+/** Free: accept a Plus send and import it as a new project. */
+export function ReceivePage(handle: Handle<ReceivePageProps>) {
+  let typed = handle.props.code ?? ''
+  let phase: SyncPhase = handle.props.code ? 'waiting' : 'creating'
+  let error: string | null = null
+  let progress = ''
+  const abort = new AbortController()
+
+  handle.signal.addEventListener('abort', () => abort.abort(), { once: true })
+
+  const fail = (err: unknown) => {
+    if (abort.signal.aborted) return
+    if (err instanceof DOMException && err.name === 'AbortError') return
+    if (
+      !(err instanceof SyncSignalError) &&
+      !(err instanceof SyncTransferError) &&
+      !(err instanceof BackupFormatError) &&
+      !(err instanceof ProjectLimitError)
+    ) {
+      reportError(err, 'sync-receive')
+    }
+    error = err instanceof Error ? err.message : 'Could not receive a project.'
+    phase = 'failed'
+    void handle.update()
+  }
+
+  const receive = (rawCode: string) => {
+    const code = normalizeRoomCode(rawCode)
+    if (!code) {
+      error = 'That is not a valid send code.'
+      phase = 'failed'
+      void handle.update()
+      return
+    }
+    phase = 'waiting'
+    error = null
+    progress = ''
+    void handle.update()
+    void (async () => {
+      try {
+        const received = await receiveBackupFromPeer(
+          httpSyncSignaling(code),
+          abort.signal,
+          (receivedBytes, totalBytes) => {
+            if (abort.signal.aborted) return
+            progress = `${formatBytes(receivedBytes)} of ${formatBytes(totalBytes)}`
+            void handle.update()
+          },
+          () => {
+            if (abort.signal.aborted) return
+            phase = 'transferring'
+            void handle.update()
+          },
+        )
+        if (abort.signal.aborted) return
+        phase = 'importing'
+        void handle.update()
+        const file = new File([received.blob], received.filename, {
+          type: 'application/octet-stream',
+        })
+        const project = await importKodyVideoBackupFile(file)
+        if (abort.signal.aborted) return
+        phase = 'done'
+        void handle.update()
+        navigate(`/project/${project.id}`)
+      } catch (err) {
+        fail(err)
+      }
+    })()
+  }
+
+  if (handle.props.code) receive(handle.props.code)
+
+  return () => (
+    <div className="screen about-screen receive-screen">
+      <div className="about-top">
+        <a href="/" className="btn-icon" aria-label="Back to projects">
+          <IconBack />
+        </a>
+        <strong>Receive</strong>
+        <span className="about-top-spacer" aria-hidden="true" />
+      </div>
+      <div className="about-body">
+        <div className="about-hero" aria-hidden="true">
+          <BrandMark size={96} className="brand-hero-art" variant="share" />
+        </div>
+        <h1>Receive a project</h1>
+        <p className="muted">{phaseCopy(phase, error, Boolean(handle.props.code))}</p>
+        {handle.props.code && phase !== 'failed' && phase !== 'creating' ? (
+          <p className="sync-code receive-code">{formatRoomCode(handle.props.code)}</p>
+        ) : null}
+        {!handle.props.code && phase === 'creating' ? (
+          <form
+            className="receive-form"
+            mix={on('submit', (event) => {
+              event.preventDefault()
+              receive(typed)
+            })}
+          >
+            <div className="field">
+              <label htmlFor="receive-code">Send code</label>
+              <input
+                id="receive-code"
+                type="text"
+                inputMode="text"
+                autoCapitalize="characters"
+                autoCorrect="off"
+                spellCheck={false}
+                autoComplete="off"
+                placeholder="AB3-K9Q"
+                value={typed}
+                mix={on('input', (event) => {
+                  typed = (event.currentTarget as HTMLInputElement).value
+                  void handle.update()
+                })}
+              />
+            </div>
+            <button
+              type="submit"
+              className="btn btn-primary"
+              disabled={!normalizeRoomCode(typed)}
+            >
+              Receive
+            </button>
+          </form>
+        ) : null}
+        {progress && (phase === 'transferring' || phase === 'importing') ? (
+          <p className="export-percent" role="status">
+            {progress}
+          </p>
+        ) : null}
+        {phase === 'failed' ? (
+          <div className="sheet-actions receive-actions">
+            <a className="btn btn-ghost" href="/receive">
+              Try another code
+            </a>
+            <a className="btn btn-primary" href="/about">
+              Import a backup
+            </a>
+          </div>
+        ) : null}
+      </div>
+    </div>
+  )
+}

--- a/src/pages/terms-page.tsx
+++ b/src/pages/terms-page.tsx
@@ -36,8 +36,9 @@ export function TermsPage() {
           <h2>Kody Video Plus</h2>
           <p>
             Kody Video Plus is a one-time $0.99 purchase that unlocks watermark-free exports,
-            optional location tagging, and up to six project slots (the free plan includes one
-            project) for the browser profile where it&rsquo;s verified. You can restore the
+            optional location tagging, sending a project to another device, and up to six project
+            slots (the free plan includes one project) for the browser profile where it&rsquo;s
+            verified. You can restore the
             purchase on another device via the Stripe receipt link. Payments are handled by Stripe.
             For refunds or purchase trouble, email{' '}
             <a href="mailto:team@kody.video">team@kody.video</a>.

--- a/src/pages/unlocked-page.tsx
+++ b/src/pages/unlocked-page.tsx
@@ -39,9 +39,9 @@ export function UnlockedPage(handle: Handle) {
             <h1>Kody Video Plus unlocked! 🎉</h1>
             <p className="muted">
               Thank you for supporting Kody Video. Every export from this device is now
-              watermark-free, all six project slots are open, and optional location tagging is
-              available. Keep your Stripe receipt email — its link restores the purchase on another
-              device.
+              watermark-free, all six project slots are open, optional location tagging is
+              available, and you can send a project to another device. Keep your Stripe receipt
+              email — its link restores the purchase on another device.
             </p>
           </>
         ) : (

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -402,6 +402,10 @@ a {
   line-height: 1.45;
 }
 
+.sheet-lede.is-error {
+  color: var(--danger-ink);
+}
+
 .sheet-message {
   margin: 12px 0 0;
   line-height: 1.4;
@@ -562,6 +566,58 @@ a {
   color: var(--ink);
   padding: 0 12px;
   outline: none;
+}
+
+.sync-code-block {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+  margin-top: 16px;
+}
+
+.sync-code,
+.receive-code {
+  margin: 0;
+  font-family: var(--font-display);
+  font-size: 2rem;
+  letter-spacing: 0.12em;
+  font-variant-numeric: tabular-nums;
+}
+
+.sync-qr {
+  width: min(220px, 70vw);
+  aspect-ratio: 1;
+  padding: 10px;
+  border-radius: 16px;
+  background: #f3f5f4;
+}
+
+.sync-qr svg {
+  display: block;
+  width: 100%;
+  height: 100%;
+}
+
+.receive-form {
+  width: min(320px, 100%);
+  margin: 12px auto 0;
+}
+
+.receive-form .btn {
+  width: 100%;
+  margin-top: 14px;
+}
+
+.receive-actions {
+  justify-content: center;
+}
+
+.receive-screen h1 {
+  font-family: var(--font-display);
+  font-size: 1.8rem;
+  letter-spacing: -0.03em;
+  margin: 0 0 8px;
 }
 
 .field input:focus {

--- a/tests/e2e/home.spec.ts
+++ b/tests/e2e/home.spec.ts
@@ -286,6 +286,8 @@ test.describe('home & app shell', () => {
     await expect(page.getByRole('heading', { name: 'Privacy', exact: true })).toBeVisible()
     await page.goto('/terms')
     await expect(page.getByRole('heading', { name: 'Terms', exact: true })).toBeVisible()
+    await page.goto('/receive')
+    await expect(page.getByRole('heading', { name: 'Receive a project' })).toBeVisible()
   })
 })
 

--- a/tests/e2e/sync.spec.ts
+++ b/tests/e2e/sync.spec.ts
@@ -1,0 +1,48 @@
+import { test, expect } from '@playwright/test'
+import { seedProject, unlockPlus } from './helpers'
+
+test.describe('send to device', () => {
+  test('free plan opens Plus upsell from Send to device', async ({ page }) => {
+    await seedProject(page, { clips: 1, name: 'Family' })
+    await page.goto('/')
+    await page.locator('.slot-options').click()
+    await page.getByRole('button', { name: 'Send to device' }).click()
+    const upsell = page.getByRole('dialog', { name: 'Kody Video Plus' })
+    await expect(upsell).toBeVisible()
+    await expect(upsell).toContainText(/sending a project to another device/i)
+  })
+
+  test('Plus send copies a project to another browser over WebRTC', async ({ browser }) => {
+    const senderContext = await browser.newContext()
+    const receiverContext = await browser.newContext()
+    const sender = await senderContext.newPage()
+    const receiver = await receiverContext.newPage()
+    try {
+      await seedProject(sender, { clips: 1, name: 'Lan trip' })
+      await unlockPlus(sender)
+      await sender.goto('/')
+      await expect(sender.locator('.project-slot.filled')).toContainText('Lan trip')
+      await sender.locator('.slot-options').click()
+      await sender.getByRole('button', { name: 'Send to device' }).click()
+      const sheet = sender.getByRole('dialog', { name: /Send Lan trip/ })
+      await expect(sheet).toBeVisible()
+      const code = await sheet.locator('.sync-code').innerText()
+      expect(code.replace(/[^A-Z0-9]/g, '')).toHaveLength(6)
+
+      await receiver.goto(`/receive/${code.replace(/[^A-Z0-9]/g, '')}`)
+      await receiver.waitForURL(/\/project\//, { timeout: 45_000 })
+      const received = await receiver.evaluate(async () => {
+        const storage = await import('/src/lib/storage.ts')
+        const projects = await storage.listProjects()
+        if (projects.length !== 1) return null
+        const clips = await storage.getClipMetasForProject(projects[0]!.id)
+        return { name: projects[0]!.name, clips: clips.length }
+      })
+      expect(received).toEqual({ name: 'Lan trip', clips: 1 })
+      await expect(sheet).toContainText(/Sent/)
+    } finally {
+      await senderContext.close()
+      await receiverContext.close()
+    }
+  })
+})

--- a/tests/e2e/sync.spec.ts
+++ b/tests/e2e/sync.spec.ts
@@ -12,24 +12,27 @@ test.describe('send to device', () => {
     await expect(upsell).toContainText(/sending a project to another device/i)
   })
 
-  test('Plus send copies a project to another browser over WebRTC', async ({ browser }) => {
-    const senderContext = await browser.newContext()
-    const receiverContext = await browser.newContext()
-    const sender = await senderContext.newPage()
+  test('Plus send copies a project to another browser over WebRTC', async ({
+    page,
+    browser,
+    baseURL,
+  }) => {
+    const receiverContext = await browser.newContext({ baseURL })
     const receiver = await receiverContext.newPage()
     try {
-      await seedProject(sender, { clips: 1, name: 'Lan trip' })
-      await unlockPlus(sender)
-      await sender.goto('/')
-      await expect(sender.locator('.project-slot.filled')).toContainText('Lan trip')
-      await sender.locator('.slot-options').click()
-      await sender.getByRole('button', { name: 'Send to device' }).click()
-      const sheet = sender.getByRole('dialog', { name: /Send Lan trip/ })
+      await seedProject(page, { clips: 1, name: 'Lan trip' })
+      await unlockPlus(page)
+      await page.goto('/')
+      await expect(page.locator('.project-slot.filled')).toContainText('Lan trip')
+      await page.locator('.slot-options').click()
+      await page.getByRole('button', { name: 'Send to device' }).click()
+      const sheet = page.getByRole('dialog', { name: /Send Lan trip/ })
       await expect(sheet).toBeVisible()
-      const code = await sheet.locator('.sync-code').innerText()
-      expect(code.replace(/[^A-Z0-9]/g, '')).toHaveLength(6)
+      const code = (await sheet.locator('.sync-code').innerText()).replace(/[^A-Z0-9]/g, '')
+      expect(code).toHaveLength(6)
 
-      await receiver.goto(`/receive/${code.replace(/[^A-Z0-9]/g, '')}`)
+      await receiver.goto(`/receive/${code}`)
+      await expect(receiver.getByRole('heading', { name: 'Receive a project' })).toBeVisible()
       await receiver.waitForURL(/\/project\//, { timeout: 45_000 })
       const received = await receiver.evaluate(async () => {
         const storage = await import('/src/lib/storage.ts')
@@ -41,7 +44,6 @@ test.describe('send to device', () => {
       expect(received).toEqual({ name: 'Lan trip', clips: 1 })
       await expect(sheet).toContainText(/Sent/)
     } finally {
-      await senderContext.close()
       await receiverContext.close()
     }
   })

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.node.tsbuildinfo",
     "target": "ES2023",
-    "lib": ["ES2023"],
+    "lib": ["ES2023", "DOM"],
     "module": "ESNext",
     "skipLibCheck": true,
     "moduleResolution": "bundler",
@@ -18,5 +18,5 @@
     "noUncheckedSideEffectImports": true,
     "types": ["node"]
   },
-  "include": ["vite.config.ts", "vitest.config.ts"]
+  "include": ["vite.config.ts", "vitest.config.ts", "scripts/vite-sync-api-plugin.ts"]
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,6 +2,7 @@ import { copyFile } from 'node:fs/promises'
 import { defineConfig } from 'vite'
 import { VitePWA } from 'vite-plugin-pwa'
 import { sentryVitePlugin } from '@sentry/vite-plugin'
+import { syncApiPlugin } from './scripts/vite-sync-api-plugin'
 
 // Cloudflare Pages exposes the commit; local builds tag as 'dev'.
 const commitSha = process.env.CF_PAGES_COMMIT_SHA ?? 'dev'
@@ -25,6 +26,7 @@ export default defineConfig({
     jsxImportSource: 'remix/ui',
   },
   plugins: [
+    syncApiPlugin(),
     ...(sentryUpload
       ? [
           sentryVitePlugin({


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Plus can send a project to another open Kody Video without uploading clips.

## Why

Jakub asked for sync across devices, ideally over LAN so nothing lives on our servers. Continuous cloud sync would need accounts and stored media. This ships the useful version of that idea: **push this project to the device that is open right now**.

## What lands

- Home ⋯ → **Send to device** (Plus). Free taps open the Plus upsell.
- A 6-character code + QR (`/receive/AB3K9Q`). Receiving is free and uses the existing backup import path.
- WebRTC DataChannel carries the `.kodyvideo`. STUN (`stun.cloudflare.com`) only — same Wi‑Fi usually connects directly. No TURN in this PR.
- `/api/sync` is a matchmaker only: room code + offer/answer in a KV namespace (`SYNC_ROOMS`). Rooms expire in 10 minutes. **Media never hits the server.**
- If peers cannot connect, the sheet offers **Save backup instead**.

## Deploy note

Bind a KV namespace named `SYNC_ROOMS` on the Cloudflare Pages project. Without it, Send returns a configuration error and backup/import still work. Vite/Playwright use an in-memory stand-in, so local tests do not need KV.

## Tests

- Unit: room HTTP, codes/headers, Chromium DataChannel round-trip, close-without-EOF, mid-send drop, and receiver hang-up after EOF
- E2E: free Send opens upsell; Plus send copies a seeded project into a second browser (CRLF SDP + host ICE candidates)

Risk: **medium** (new backend surface + WebRTC). Ship after CI + Bugbot.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-04283985-9019-4c2b-bbfb-f5e85da7eb55?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-04283985-9019-4c2b-bbfb-f5e85da7eb55&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

