### PR TITLE
Fix PWA updates that reload but keep the old shell

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -1,0 +1,16 @@
+# Service worker + version must revalidate. A cached sw.js is how a phone
+# can sit on a retired shell while About says it is already up to date.
+/sw.js
+  Cache-Control: public, max-age=0, must-revalidate
+
+/workbox-*.js
+  Cache-Control: public, max-age=0, must-revalidate
+
+/version.json
+  Cache-Control: no-store
+
+/index.html
+  Cache-Control: public, max-age=0, must-revalidate
+
+/app.html
+  Cache-Control: public, max-age=0, must-revalidate

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -3,7 +3,7 @@ import { on } from 'remix/ui'
 import { registerSW } from 'virtual:pwa-register'
 import { BackupDropOverlay } from './components/backup-drop-overlay'
 import { lazyPage } from './components/lazy-page'
-import { registerUpdateHandles } from './lib/app-update'
+import { applyWaitingUpdate, registerUpdateHandles } from './lib/app-update'
 import { Router } from './router'
 import { HomePage } from './pages/home-page'
 
@@ -23,22 +23,33 @@ export function App(handle: Handle) {
       needRefresh = true
       void handle.update()
     },
+    // vite-plugin-pwa reloads on `controlling` unless we take this hook.
+    // A blind location.reload() there (and the old 1.5s fallback) is what
+    // left installed PWAs on the previous shell after tapping Update.
+    onNeedReload() {
+      // Reload is owned by applyWaitingUpdate.
+    },
     onRegisteredSW(_url, registration) {
-      registerUpdateHandles(registration, (reload) => updateServiceWorker(reload))
+      registerUpdateHandles(
+        registration,
+        (reload) => updateServiceWorker(reload),
+        () => {
+          needRefresh = true
+          void handle.update()
+        },
+      )
     },
   })
 
   const applyUpdate = () => {
     needRefresh = false
     void handle.update()
-    void updateServiceWorker(true).catch(() => undefined)
-    // clientsClaim + controllerchange normally reload the page. Workers
-    // deployed before clientsClaim never fire controllerchange, so tapping
-    // Update "did nothing" — the forced reload is what rescues those
-    // sessions (the new worker IS active by then; a reload runs under it).
-    window.setTimeout(() => {
-      window.location.reload()
-    }, 1500)
+    void applyWaitingUpdate().then((result) => {
+      if (result === 'unavailable') {
+        needRefresh = true
+        void handle.update()
+      }
+    })
   }
 
   return () => (

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -44,12 +44,16 @@ export function App(handle: Handle) {
   const applyUpdate = () => {
     needRefresh = false
     void handle.update()
-    void applyWaitingUpdate().then((result) => {
-      if (result === 'unavailable') {
+    void applyWaitingUpdate()
+      .then((result) => {
+        if (result !== 'unavailable') return
         needRefresh = true
         void handle.update()
-      }
-    })
+      })
+      .catch(() => {
+        needRefresh = true
+        void handle.update()
+      })
   }
 
   return () => (

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -46,7 +46,7 @@ export function App(handle: Handle) {
     void handle.update()
     void applyWaitingUpdate()
       .then((result) => {
-        if (result !== 'unavailable') return
+        if (result === 'updated') return
         needRefresh = true
         void handle.update()
       })

--- a/src/lib/app-update.test.ts
+++ b/src/lib/app-update.test.ts
@@ -288,6 +288,27 @@ describe('applyWaitingUpdate', () => {
     ])
   })
 
+  it('does not purge while a worker is still installing', async () => {
+    const installing = mockWaitingWorker()
+    const navigate = vi.fn()
+    const purge = vi.fn()
+    resetAppUpdateForTests({
+      fetchDeployed: async () => null,
+      navigate,
+      purge,
+      claimTimeoutMs: 20,
+    })
+    registerUpdateHandles(mockRegistration({ installing }), vi.fn())
+    await expect(applyWaitingUpdate()).resolves.toBe('downloading')
+    expect(installing.postMessage).not.toHaveBeenCalled()
+    expect(purge).not.toHaveBeenCalled()
+    expect(navigate).not.toHaveBeenCalled()
+    expect(getUpdateDiagnostics().events.map((event) => event.phase)).toEqual([
+      'apply-start',
+      'installing',
+    ])
+  })
+
   it('does not purge when the toast is tapped and no worker is waiting', async () => {
     const navigate = vi.fn()
     const purge = vi.fn()

--- a/src/lib/app-update.test.ts
+++ b/src/lib/app-update.test.ts
@@ -288,6 +288,40 @@ describe('applyWaitingUpdate', () => {
     ])
   })
 
+  it('does not purge when the toast is tapped and no worker is waiting', async () => {
+    const navigate = vi.fn()
+    const purge = vi.fn()
+    resetAppUpdateForTests({
+      fetchDeployed: async () => ({ commit: 'same-sha' }),
+      runningSha: 'same-sha',
+      navigate,
+      purge,
+    })
+    registerUpdateHandles(mockRegistration(), vi.fn())
+    await expect(applyWaitingUpdate()).resolves.toBe('unavailable')
+    expect(purge).not.toHaveBeenCalled()
+    expect(navigate).not.toHaveBeenCalled()
+    expect(getUpdateDiagnostics().events.map((event) => event.phase)).toEqual([
+      'apply-start',
+      'no-worker',
+    ])
+  })
+
+  it('purges a stale shell even when no worker is waiting', async () => {
+    const navigate = vi.fn()
+    const purge = vi.fn().mockResolvedValue(undefined)
+    resetAppUpdateForTests({
+      fetchDeployed: async () => ({ commit: 'deployed-sha' }),
+      runningSha: 'running-sha',
+      navigate,
+      purge,
+    })
+    registerUpdateHandles(mockRegistration(), vi.fn())
+    await expect(applyWaitingUpdate()).resolves.toBe('updated')
+    expect(purge).toHaveBeenCalledTimes(1)
+    expect(navigate).toHaveBeenCalledTimes(1)
+  })
+
   it('purges caches when the waiting worker never claims', async () => {
     const waiting = mockWaitingWorker()
     const navigate = vi.fn()

--- a/src/lib/app-update.test.ts
+++ b/src/lib/app-update.test.ts
@@ -5,6 +5,7 @@ import {
   getUpdateDiagnostics,
   isRunningStale,
   probeForUpdates,
+  reconcileUpdateCheckResult,
   registerUpdateHandles,
   resetAppUpdateForTests,
   stripUpdateNavigationMark,
@@ -254,6 +255,73 @@ describe('checkForUpdates (manual)', () => {
     await expect(checkForUpdates()).resolves.toBe('updated')
     expect(purge).toHaveBeenCalledTimes(1)
     expect(navigate).toHaveBeenCalledTimes(1)
+  })
+
+  it('purges a stale shell when registration.update() throws and no worker is waiting', async () => {
+    const navigate = vi.fn()
+    const purge = vi.fn().mockResolvedValue(undefined)
+    resetAppUpdateForTests({
+      fetchDeployed: async () => ({ commit: 'deployed-sha' }),
+      runningSha: 'running-sha',
+      navigate,
+      purge,
+    })
+    registerUpdateHandles(
+      mockRegistration({ update: vi.fn().mockRejectedValue(new Error('offline')) }),
+      vi.fn(),
+    )
+    await expect(checkForUpdates()).resolves.toBe('updated')
+    expect(purge).toHaveBeenCalledTimes(1)
+    expect(navigate).toHaveBeenCalledTimes(1)
+  })
+
+  it('returns unavailable when update() throws, no worker is present, and version.json is unknown', async () => {
+    const purge = vi.fn()
+    resetAppUpdateForTests({
+      fetchDeployed: async () => null,
+      navigate: vi.fn(),
+      purge,
+    })
+    registerUpdateHandles(
+      mockRegistration({ update: vi.fn().mockRejectedValue(new Error('offline')) }),
+      vi.fn(),
+    )
+    await expect(checkForUpdates()).resolves.toBe('unavailable')
+    expect(purge).not.toHaveBeenCalled()
+  })
+
+  it('returns downloading when update() throws and a worker is still installing', async () => {
+    const purge = vi.fn()
+    resetAppUpdateForTests({
+      fetchDeployed: async () => null,
+      navigate: vi.fn(),
+      purge,
+    })
+    const installing = mockWaitingWorker()
+    registerUpdateHandles(
+      mockRegistration({
+        installing,
+        update: vi.fn().mockRejectedValue(new Error('offline')),
+      }),
+      vi.fn(),
+    )
+    await expect(checkForUpdates()).resolves.toBe('downloading')
+    expect(purge).not.toHaveBeenCalled()
+  })
+})
+
+describe('reconcileUpdateCheckResult', () => {
+  afterEach(() => {
+    resetAppUpdateForTests()
+  })
+
+  it('does not let a current result override a known-stale deployed SHA', () => {
+    resetAppUpdateForTests({ runningSha: 'running-sha' })
+    expect(reconcileUpdateCheckResult('current', { commit: 'deployed-sha' })).toBe(
+      'unavailable',
+    )
+    expect(reconcileUpdateCheckResult('current', { commit: 'running-sha' })).toBe('current')
+    expect(reconcileUpdateCheckResult('updated', { commit: 'deployed-sha' })).toBe('updated')
   })
 })
 

--- a/src/lib/app-update.test.ts
+++ b/src/lib/app-update.test.ts
@@ -1,9 +1,14 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
+  applyWaitingUpdate,
   checkForUpdates,
+  getUpdateDiagnostics,
+  isRunningStale,
   probeForUpdates,
   registerUpdateHandles,
   resetAppUpdateForTests,
+  stripUpdateNavigationMark,
+  UPDATE_NAV_PARAM,
 } from './app-update'
 
 function mockRegistration(
@@ -18,6 +23,45 @@ function mockRegistration(
     removeEventListener: vi.fn(),
     ...overrides,
   } as unknown as ServiceWorkerRegistration
+}
+
+function mockWaitingWorker(): ServiceWorker {
+  return {
+    scriptURL: `${location.origin}/sw.js`,
+    state: 'installed',
+    postMessage: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+  } as unknown as ServiceWorker
+}
+
+function captureControllerChange() {
+  const listeners = new Set<EventListener>()
+  const add = navigator.serviceWorker.addEventListener.bind(navigator.serviceWorker)
+  const remove = navigator.serviceWorker.removeEventListener.bind(navigator.serviceWorker)
+  vi.spyOn(navigator.serviceWorker, 'addEventListener').mockImplementation(
+    (type, listener, options) => {
+      if (type === 'controllerchange') {
+        listeners.add(listener as EventListener)
+        return
+      }
+      add(type, listener as EventListener, options)
+    },
+  )
+  vi.spyOn(navigator.serviceWorker, 'removeEventListener').mockImplementation(
+    (type, listener, options) => {
+      if (type === 'controllerchange') {
+        listeners.delete(listener as EventListener)
+        return
+      }
+      remove(type, listener as EventListener, options)
+    },
+  )
+  return {
+    fire() {
+      for (const listener of listeners) listener(new Event('controllerchange'))
+    },
+  }
 }
 
 // Browser mode: app-update listens on the real document/window, so tests
@@ -46,7 +90,7 @@ function restoreVisibilityState() {
 
 describe('app-update resume checks', () => {
   beforeEach(() => {
-    resetAppUpdateForTests({ minIntervalMs: 1_000 })
+    resetAppUpdateForTests({ minIntervalMs: 1_000, fetchDeployed: async () => null })
   })
 
   afterEach(() => {
@@ -123,11 +167,22 @@ describe('app-update resume checks', () => {
     expect(update).toHaveBeenCalledTimes(1)
     expect(apply).not.toHaveBeenCalled()
   })
+
+  it('raises the toast when version.json does not match the running bundle', async () => {
+    const notify = vi.fn()
+    resetAppUpdateForTests({
+      fetchDeployed: async () => ({ commit: 'deployed-sha' }),
+      runningSha: 'running-sha',
+    })
+    registerUpdateHandles(mockRegistration(), vi.fn(), notify)
+    probeForUpdates()
+    await vi.waitFor(() => expect(notify).toHaveBeenCalledTimes(1))
+  })
 })
 
 describe('checkForUpdates (manual)', () => {
   beforeEach(() => {
-    resetAppUpdateForTests()
+    resetAppUpdateForTests({ fetchDeployed: async () => null })
   })
 
   afterEach(() => {
@@ -149,5 +204,129 @@ describe('checkForUpdates (manual)', () => {
     await vi.advanceTimersByTimeAsync(1_500)
     await expect(resultPromise).resolves.toBe('current')
     vi.useRealTimers()
+  })
+
+  it('applies a waiting worker instead of reporting current', async () => {
+    const waiting = mockWaitingWorker()
+    const navigate = vi.fn()
+    const purge = vi.fn()
+    resetAppUpdateForTests({
+      fetchDeployed: async () => null,
+      navigate,
+      purge,
+      claimTimeoutMs: 5_000,
+    })
+    const controller = captureControllerChange()
+    registerUpdateHandles(mockRegistration({ waiting }), vi.fn())
+
+    const resultPromise = checkForUpdates()
+    await vi.waitFor(() => expect(waiting.postMessage).toHaveBeenCalled())
+    controller.fire()
+    await expect(resultPromise).resolves.toBe('updated')
+    expect(waiting.postMessage).toHaveBeenCalledWith({ type: 'SKIP_WAITING' })
+    expect(navigate).toHaveBeenCalledTimes(1)
+    expect(String(navigate.mock.calls[0]?.[0])).toContain(`${UPDATE_NAV_PARAM}=`)
+    expect(purge).not.toHaveBeenCalled()
+  })
+
+  it('purges and reloads when the running SHA does not match version.json', async () => {
+    const navigate = vi.fn()
+    const purge = vi.fn().mockResolvedValue(undefined)
+    resetAppUpdateForTests({
+      fetchDeployed: async () => ({ commit: 'deployed-sha' }),
+      runningSha: 'running-sha',
+      navigate,
+      purge,
+    })
+    registerUpdateHandles(mockRegistration(), vi.fn())
+    await expect(checkForUpdates()).resolves.toBe('updated')
+    expect(purge).toHaveBeenCalledTimes(1)
+    expect(navigate).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('applyWaitingUpdate', () => {
+  afterEach(() => {
+    resetAppUpdateForTests()
+    vi.restoreAllMocks()
+  })
+
+  it('navigates after the waiting worker claims the page', async () => {
+    const waiting = mockWaitingWorker()
+    const navigate = vi.fn()
+    const purge = vi.fn()
+    resetAppUpdateForTests({
+      fetchDeployed: async () => null,
+      navigate,
+      purge,
+      claimTimeoutMs: 5_000,
+    })
+    const controller = captureControllerChange()
+    registerUpdateHandles(mockRegistration({ waiting }), vi.fn())
+
+    const resultPromise = applyWaitingUpdate()
+    await vi.waitFor(() => expect(waiting.postMessage).toHaveBeenCalled())
+    controller.fire()
+    await expect(resultPromise).resolves.toBe('updated')
+    expect(purge).not.toHaveBeenCalled()
+    expect(navigate).toHaveBeenCalledTimes(1)
+    expect(getUpdateDiagnostics().events.map((event) => event.phase)).toEqual([
+      'apply-start',
+      'claim',
+    ])
+  })
+
+  it('purges caches when the waiting worker never claims', async () => {
+    const waiting = mockWaitingWorker()
+    const navigate = vi.fn()
+    const purge = vi.fn().mockResolvedValue(undefined)
+    resetAppUpdateForTests({
+      fetchDeployed: async () => null,
+      navigate,
+      purge,
+      claimTimeoutMs: 20,
+    })
+    captureControllerChange()
+    registerUpdateHandles(mockRegistration({ waiting }), vi.fn())
+
+    await expect(applyWaitingUpdate()).resolves.toBe('updated')
+    expect(waiting.postMessage).toHaveBeenCalledWith({ type: 'SKIP_WAITING' })
+    expect(purge).toHaveBeenCalledTimes(1)
+    expect(navigate).toHaveBeenCalledTimes(1)
+    expect(getUpdateDiagnostics().events.map((event) => event.phase)).toEqual([
+      'apply-start',
+      'claim',
+      'purged-reload',
+    ])
+  })
+})
+
+describe('isRunningStale / stripUpdateNavigationMark', () => {
+  afterEach(() => {
+    resetAppUpdateForTests()
+    const url = new URL(location.href)
+    url.searchParams.delete(UPDATE_NAV_PARAM)
+    history.replaceState(null, '', `${url.pathname}${url.search}${url.hash}`)
+  })
+
+  it('never treats a local dev bundle as stale', () => {
+    resetAppUpdateForTests({ runningSha: 'dev' })
+    expect(isRunningStale({ commit: 'anything' })).toBe(false)
+    expect(isRunningStale(null)).toBe(false)
+  })
+
+  it('detects a retired production shell', () => {
+    resetAppUpdateForTests({ runningSha: 'old-sha' })
+    expect(isRunningStale({ commit: 'new-sha' })).toBe(true)
+    expect(isRunningStale({ commit: 'old-sha' })).toBe(false)
+  })
+
+  it('strips the one-shot update navigation mark', () => {
+    const url = new URL(location.href)
+    url.searchParams.set(UPDATE_NAV_PARAM, '1')
+    history.replaceState(null, '', `${url.pathname}${url.search}${url.hash}`)
+    expect(new URL(location.href).searchParams.has(UPDATE_NAV_PARAM)).toBe(true)
+    stripUpdateNavigationMark()
+    expect(new URL(location.href).searchParams.has(UPDATE_NAV_PARAM)).toBe(false)
   })
 })

--- a/src/lib/app-update.test.ts
+++ b/src/lib/app-update.test.ts
@@ -308,6 +308,28 @@ describe('checkForUpdates (manual)', () => {
     await expect(checkForUpdates()).resolves.toBe('downloading')
     expect(purge).not.toHaveBeenCalled()
   })
+
+  it('does not purge a stale shell while a worker is still installing after update() throws', async () => {
+    const navigate = vi.fn()
+    const purge = vi.fn()
+    resetAppUpdateForTests({
+      fetchDeployed: async () => ({ commit: 'deployed-sha' }),
+      runningSha: 'running-sha',
+      navigate,
+      purge,
+    })
+    const installing = mockWaitingWorker()
+    registerUpdateHandles(
+      mockRegistration({
+        installing,
+        update: vi.fn().mockRejectedValue(new Error('offline')),
+      }),
+      vi.fn(),
+    )
+    await expect(checkForUpdates()).resolves.toBe('downloading')
+    expect(purge).not.toHaveBeenCalled()
+    expect(navigate).not.toHaveBeenCalled()
+  })
 })
 
 describe('reconcileUpdateCheckResult', () => {

--- a/src/lib/app-update.test.ts
+++ b/src/lib/app-update.test.ts
@@ -168,6 +168,16 @@ describe('app-update resume checks', () => {
     expect(apply).not.toHaveBeenCalled()
   })
 
+  it('raises the toast on register when this tab is already a retired shell', async () => {
+    const notify = vi.fn()
+    resetAppUpdateForTests({
+      fetchDeployed: async () => ({ commit: 'deployed-sha' }),
+      runningSha: 'running-sha',
+    })
+    registerUpdateHandles(mockRegistration(), vi.fn(), notify)
+    await vi.waitFor(() => expect(notify).toHaveBeenCalledTimes(1))
+  })
+
   it('raises the toast when version.json does not match the running bundle', async () => {
     const notify = vi.fn()
     resetAppUpdateForTests({
@@ -175,6 +185,8 @@ describe('app-update resume checks', () => {
       runningSha: 'running-sha',
     })
     registerUpdateHandles(mockRegistration(), vi.fn(), notify)
+    await vi.waitFor(() => expect(notify).toHaveBeenCalledTimes(1))
+    notify.mockClear()
     probeForUpdates()
     await vi.waitFor(() => expect(notify).toHaveBeenCalledTimes(1))
   })

--- a/src/lib/app-update.ts
+++ b/src/lib/app-update.ts
@@ -1,26 +1,71 @@
 /**
- * Service-worker update helpers. Registration + apply come from
- * `registerSW` in app.tsx; this module holds them so any screen can
- * trigger a check, and so the app can re-check when the user returns.
+ * Service-worker update helpers. Registration comes from `registerSW` in
+ * app.tsx; this module owns apply + resume probes so any screen can trigger
+ * a check, and so the app can re-check when the user returns.
+ *
+ * Applying an update is not "skipWaiting + location.reload()". A reload
+ * that races the new worker (or that iOS standalone recycles in-place)
+ * keeps serving the old precache — the toast comes back, About still shows
+ * the old SHA, and only killing the PWA actually boots the new build.
+ * Apply waits for `controllerchange`, then force-navigates; if the new
+ * worker never claims, it drops the worker + Cache Storage (never
+ * IndexedDB) and reloads from the network, same idea as /api/recover.
  */
+
+import { COMMIT_SHA } from './build-info'
 
 let registration: ServiceWorkerRegistration | null = null
 let applyUpdate: ((reloadPage?: boolean) => Promise<void>) | null = null
+let notifyNeedRefresh: (() => void) | null = null
 
 /** Minimum gap between quiet resume probes (visibility/focus/pageshow burst). */
 const DEFAULT_RESUME_MIN_INTERVAL_MS = 30_000
+const DEFAULT_CLAIM_TIMEOUT_MS = 2_500
+const DEPLOYED_CACHE_MS = 10_000
+const DIAG_KEY = 'kody:update-diag'
+const DIAG_MAX_EVENTS = 12
+/** Query mark so iOS standalone cannot recycle the in-memory document. */
+export const UPDATE_NAV_PARAM = '_sw'
 
 let resumeChecksAttached = false
 let lastQuietProbeAt = 0
 let quietProbeInFlight = false
 let resumeMinIntervalMs = DEFAULT_RESUME_MIN_INTERVAL_MS
+let claimTimeoutMs = DEFAULT_CLAIM_TIMEOUT_MS
+let deployedInFlight: Promise<DeployedVersion | null> | null = null
+let deployedCache: { at: number; value: DeployedVersion | null } | null = null
+
+type UpdateTestHooks = {
+  navigate?: (url: string) => void
+  fetchDeployed?: () => Promise<DeployedVersion | null>
+  purge?: () => Promise<void>
+  runningSha?: string
+}
+
+let testHooks: UpdateTestHooks = {}
+
+export type DeployedVersion = { commit: string }
+
+export type UpdateDiagEvent = {
+  at: number
+  phase: string
+  reason?: string
+  claimed?: boolean
+  running?: string
+  deployed?: string | null
+  waiting?: boolean
+  installing?: boolean
+  hasController?: boolean
+}
 
 export function registerUpdateHandles(
   reg: ServiceWorkerRegistration | null | undefined,
   apply: (reloadPage?: boolean) => Promise<void>,
+  notifyRefresh?: () => void,
 ): void {
   registration = reg ?? null
   applyUpdate = apply
+  notifyNeedRefresh = notifyRefresh ?? null
   // The initial registerSW({ immediate: true }) already probed once —
   // don't fire again from the first focus/pageshow burst after load.
   lastQuietProbeAt = Date.now()
@@ -31,19 +76,24 @@ export type UpdateCheckResult = 'updated' | 'current' | 'downloading' | 'unavail
 
 /**
  * Ask the service worker for a new version right now. When one is found it
- * is applied immediately (the page reloads into the new version) — the user
+ * is applied immediately (the page navigates into the new version) — the user
  * explicitly asked, so no extra confirmation step. A slow install that
  * outlives the wait reports 'downloading'; the standard update toast offers
  * it when it finishes.
+ *
+ * If the worker reports "already current" but this JS bundle's commit does
+ * not match /version.json, the shell is stale and we force a clean reload.
  */
 export async function checkForUpdates(): Promise<UpdateCheckResult> {
   const reg = registration
-  const apply = applyUpdate
-  if (!reg || !apply) return 'unavailable'
+  if (!reg) return 'unavailable'
+  const deployedPromise = fetchDeployedVersion()
   try {
     await reg.update()
   } catch {
-    // Offline or the update request failed — report the truth: no update.
+    if (reg.waiting || reg.installing) {
+      return activateWaitingWorker({ reason: 'manual-offline-waiting' })
+    }
     return 'unavailable'
   }
   // update() can resolve before a found worker shows up on `installing` —
@@ -65,22 +115,25 @@ export async function checkForUpdates(): Promise<UpdateCheckResult> {
       }
       reg.addEventListener('updatefound', onFound)
     }))
-  if (!workerAppeared) return 'current'
-
-  // Follow the install through to `waiting`, then apply.
-  const deadline = Date.now() + 8000
-  while (Date.now() < deadline) {
-    if (reg.waiting) return applyAndReload(apply)
-    if (!reg.installing) {
-      // A worker appeared but is neither installing nor waiting anymore:
-      // the install failed (worker went redundant). Don't claim "current".
-      if (!reg.waiting) return 'unavailable'
-      break
+  if (workerAppeared) {
+    const deadline = Date.now() + 8000
+    while (Date.now() < deadline) {
+      if (reg.waiting) return activateWaitingWorker({ reason: 'manual-waiting' })
+      if (!reg.installing) {
+        // A worker appeared but is neither installing nor waiting anymore:
+        // the install failed (worker went redundant). Don't claim "current".
+        return 'unavailable'
+      }
+      await new Promise((resolve) => setTimeout(resolve, 200))
     }
-    await new Promise((resolve) => setTimeout(resolve, 200))
+    if (reg.waiting) return activateWaitingWorker({ reason: 'manual-waiting' })
+    if (reg.installing) return 'downloading'
   }
-  if (reg.waiting) return applyAndReload(apply)
-  if (reg.installing) return 'downloading'
+
+  const deployed = await deployedPromise
+  if (isRunningStale(deployed)) {
+    return activateWaitingWorker({ reason: 'manual-stale-shell', forcePurge: true })
+  }
   return 'current'
 }
 
@@ -88,18 +141,22 @@ export async function checkForUpdates(): Promise<UpdateCheckResult> {
  * Quietly ask the service worker whether a newer version exists. Does not
  * apply the update — when one is found, vite-plugin-pwa's `onNeedRefresh`
  * shows the existing toast so the user can choose when to reload.
+ * A /version.json mismatch also raises the toast: the worker can look
+ * "current" while this tab is still running a retired bundle.
  */
 export function probeForUpdates(): void {
   const reg = registration
   if (!reg || quietProbeInFlight) return
   quietProbeInFlight = true
   lastQuietProbeAt = Date.now()
-  void reg
-    .update()
-    .catch(() => undefined)
-    .finally(() => {
-      quietProbeInFlight = false
-    })
+  void Promise.all([
+    reg.update().catch(() => undefined),
+    fetchDeployedVersion().then((deployed) => {
+      if (isRunningStale(deployed)) notifyNeedRefresh?.()
+    }),
+  ]).finally(() => {
+    quietProbeInFlight = false
+  })
 }
 
 function shouldProbeOnResume(): boolean {
@@ -131,27 +188,215 @@ function attachResumeUpdateChecks(): void {
   window.addEventListener('pageshow', onAppResume)
 }
 
-async function applyAndReload(
-  apply: (reloadPage?: boolean) => Promise<void>,
-): Promise<UpdateCheckResult> {
+/** User tapped Update on the toast (or About already decided to apply). */
+export async function applyWaitingUpdate(): Promise<UpdateCheckResult> {
+  return activateWaitingWorker({ reason: 'toast' })
+}
+
+async function activateWaitingWorker(options: {
+  reason: string
+  forcePurge?: boolean
+}): Promise<UpdateCheckResult> {
+  const reg = registration
+  const waiting = reg?.waiting ?? null
+  const installing = reg?.installing ?? null
+  const worker = waiting ?? installing
+  const deployed = await fetchDeployedVersion()
+
+  recordDiag({
+    phase: 'apply-start',
+    reason: options.reason,
+    running: testHooks.runningSha ?? COMMIT_SHA,
+    deployed: deployed?.commit ?? null,
+    waiting: Boolean(waiting),
+    installing: Boolean(installing),
+    hasController: Boolean(navigator.serviceWorker?.controller),
+  })
+
+  // Best-effort: tell workbox-window too. It no-ops when its own
+  // registration.waiting is stale; we still postMessage on `worker` below.
+  if (applyUpdate && worker) {
+    void applyUpdate(true).catch(() => undefined)
+  }
+
+  if (worker && !options.forcePurge) {
+    const claimed = await skipWaitingAndAwaitClaim(worker)
+    recordDiag({
+      phase: 'claim',
+      reason: options.reason,
+      claimed,
+      waiting: Boolean(reg?.waiting),
+      installing: Boolean(reg?.installing),
+      hasController: Boolean(navigator.serviceWorker?.controller),
+    })
+    if (claimed) {
+      hardNavigate()
+      return 'updated'
+    }
+  }
+
   try {
-    await apply(true)
+    if (testHooks.purge) await testHooks.purge()
+    else await purgeWorkersAndCaches()
   } catch {
+    recordDiag({ phase: 'purge-failed', reason: options.reason })
     return 'unavailable'
   }
-  // Normally clientsClaim + controllerchange reload the page before this
-  // fires; service workers deployed before clientsClaim never emit
-  // controllerchange, which left the button looking dead. The new worker
-  // has been told to activate either way — reload under it.
-  window.setTimeout(() => {
-    window.location.reload()
-  }, 1500)
+  recordDiag({ phase: 'purged-reload', reason: options.reason })
+  hardNavigate()
   return 'updated'
+}
+
+function skipWaitingAndAwaitClaim(worker: ServiceWorker): Promise<boolean> {
+  return new Promise((resolve) => {
+    const serviceWorker = navigator.serviceWorker
+    if (!serviceWorker) {
+      resolve(false)
+      return
+    }
+    if (serviceWorker.controller === worker) {
+      resolve(true)
+      return
+    }
+    let settled = false
+    const finish = (claimed: boolean) => {
+      if (settled) return
+      settled = true
+      serviceWorker.removeEventListener('controllerchange', onChange)
+      window.clearTimeout(timer)
+      resolve(claimed)
+    }
+    const onChange = () => finish(true)
+    const timer = window.setTimeout(() => finish(false), claimTimeoutMs)
+    serviceWorker.addEventListener('controllerchange', onChange)
+    try {
+      worker.postMessage({ type: 'SKIP_WAITING' })
+    } catch {
+      finish(false)
+    }
+  })
+}
+
+async function purgeWorkersAndCaches(): Promise<void> {
+  const regs = await (navigator.serviceWorker?.getRegistrations?.() ?? [])
+  await Promise.all(regs.map((reg) => reg.unregister()))
+  const keys = await (self.caches?.keys?.() ?? [])
+  await Promise.all(keys.map((key) => caches.delete(key)))
+  const urls = new Set([location.pathname || '/', '/'])
+  await Promise.allSettled(
+    [...urls].map((url) => fetch(url, { cache: 'reload', credentials: 'same-origin' })),
+  )
+}
+
+function hardNavigate(): void {
+  const url = new URL(location.href)
+  url.searchParams.delete(UPDATE_NAV_PARAM)
+  url.searchParams.set(UPDATE_NAV_PARAM, String(Date.now()))
+  const next = `${url.pathname}${url.search}${url.hash}`
+  if (testHooks.navigate) {
+    testHooks.navigate(next)
+    return
+  }
+  location.replace(next)
+}
+
+/** Drop the one-shot navigation mark so the address bar / router stay clean. */
+export function stripUpdateNavigationMark(): void {
+  if (typeof location === 'undefined' || typeof history === 'undefined') return
+  const url = new URL(location.href)
+  if (!url.searchParams.has(UPDATE_NAV_PARAM)) return
+  url.searchParams.delete(UPDATE_NAV_PARAM)
+  history.replaceState(history.state, '', `${url.pathname}${url.search}${url.hash}`)
+}
+
+export function isRunningStale(deployed: DeployedVersion | null | undefined): boolean {
+  if (!deployed) return false
+  const running = testHooks.runningSha ?? COMMIT_SHA
+  if (running === 'dev') return false
+  return deployed.commit !== running
+}
+
+export function fetchDeployedVersion(): Promise<DeployedVersion | null> {
+  if (testHooks.fetchDeployed) return testHooks.fetchDeployed()
+  if (deployedCache && Date.now() - deployedCache.at < DEPLOYED_CACHE_MS) {
+    return Promise.resolve(deployedCache.value)
+  }
+  if (deployedInFlight) return deployedInFlight
+  deployedInFlight = (async () => {
+    try {
+      const res = await fetch('/version.json', {
+        cache: 'no-store',
+        headers: { accept: 'application/json' },
+      })
+      if (!res.ok) return null
+      const data = (await res.json()) as { commit?: unknown }
+      if (typeof data.commit !== 'string' || data.commit.length === 0) return null
+      const value = { commit: data.commit }
+      deployedCache = { at: Date.now(), value }
+      return value
+    } catch {
+      return null
+    } finally {
+      deployedInFlight = null
+    }
+  })()
+  return deployedInFlight
+}
+
+function recordDiag(event: Omit<UpdateDiagEvent, 'at'>): void {
+  const next: UpdateDiagEvent = { at: Date.now(), ...event }
+  try {
+    const prev = readDiagEvents()
+    prev.push(next)
+    sessionStorage.setItem(DIAG_KEY, JSON.stringify(prev.slice(-DIAG_MAX_EVENTS)))
+  } catch {
+    // private mode / blocked storage
+  }
+}
+
+function readDiagEvents(): UpdateDiagEvent[] {
+  try {
+    const raw = sessionStorage.getItem(DIAG_KEY)
+    if (!raw) return []
+    const parsed = JSON.parse(raw) as unknown
+    if (!Array.isArray(parsed)) return []
+    return parsed.filter(isDiagEvent)
+  } catch {
+    return []
+  }
+}
+
+function isDiagEvent(value: unknown): value is UpdateDiagEvent {
+  if (value == null || typeof value !== 'object') return false
+  const event = value as UpdateDiagEvent
+  return typeof event.at === 'number' && typeof event.phase === 'string'
+}
+
+/** Last apply attempts + worker snapshot, for the About diagnostics panel. */
+export function getUpdateDiagnostics(): {
+  events: UpdateDiagEvent[]
+  waiting: boolean
+  installing: boolean
+  hasController: boolean
+} {
+  return {
+    events: readDiagEvents(),
+    waiting: Boolean(registration?.waiting),
+    installing: Boolean(registration?.installing),
+    hasController: Boolean(
+      typeof navigator !== 'undefined' && navigator.serviceWorker?.controller,
+    ),
+  }
 }
 
 /** Test-only: reset module listeners/state between Vitest cases. */
 export function resetAppUpdateForTests(options?: {
   minIntervalMs?: number
+  claimTimeoutMs?: number
+  navigate?: (url: string) => void
+  fetchDeployed?: () => Promise<DeployedVersion | null>
+  purge?: () => Promise<void>
+  runningSha?: string
 }): void {
   if (resumeChecksAttached && typeof document !== 'undefined') {
     document.removeEventListener('visibilitychange', onVisibilityChange)
@@ -162,8 +407,23 @@ export function resetAppUpdateForTests(options?: {
   }
   registration = null
   applyUpdate = null
+  notifyNeedRefresh = null
   resumeChecksAttached = false
   lastQuietProbeAt = 0
   quietProbeInFlight = false
   resumeMinIntervalMs = options?.minIntervalMs ?? DEFAULT_RESUME_MIN_INTERVAL_MS
+  claimTimeoutMs = options?.claimTimeoutMs ?? DEFAULT_CLAIM_TIMEOUT_MS
+  deployedInFlight = null
+  deployedCache = null
+  testHooks = {
+    navigate: options?.navigate,
+    fetchDeployed: options?.fetchDeployed,
+    purge: options?.purge,
+    runningSha: options?.runningSha,
+  }
+  try {
+    sessionStorage.removeItem(DIAG_KEY)
+  } catch {
+    // ignore
+  }
 }

--- a/src/lib/app-update.ts
+++ b/src/lib/app-update.ts
@@ -22,6 +22,7 @@ let notifyNeedRefresh: (() => void) | null = null
 const DEFAULT_RESUME_MIN_INTERVAL_MS = 30_000
 const DEFAULT_CLAIM_TIMEOUT_MS = 2_500
 const DEPLOYED_CACHE_MS = 10_000
+const FETCH_TIMEOUT_MS = 4_000
 const DIAG_KEY = 'kody:update-diag'
 const DIAG_MAX_EVENTS = 12
 /** Query mark so iOS standalone cannot recycle the in-memory document. */
@@ -157,9 +158,11 @@ export function probeForUpdates(): void {
   lastQuietProbeAt = Date.now()
   void Promise.all([
     reg.update().catch(() => undefined),
-    fetchDeployedVersion().then((deployed) => {
-      if (isRunningStale(deployed)) notifyNeedRefresh?.()
-    }),
+    fetchDeployedVersion()
+      .then((deployed) => {
+        if (isRunningStale(deployed)) notifyNeedRefresh?.()
+      })
+      .catch(() => undefined),
   ]).finally(() => {
     quietProbeInFlight = false
   })
@@ -207,13 +210,15 @@ async function activateWaitingWorker(options: {
   const waiting = reg?.waiting ?? null
   const installing = reg?.installing ?? null
   const worker = waiting ?? installing
-  const deployed = await fetchDeployedVersion()
+  // Do not block SKIP_WAITING on /version.json — a hung probe used to
+  // leave the toast looking dead. Claim first; the stamp is only needed
+  // to decide whether a no-worker tap should purge.
+  const deployedPromise = fetchDeployedVersion()
 
   recordDiag({
     phase: 'apply-start',
     reason: options.reason,
     running: testHooks.runningSha ?? COMMIT_SHA,
-    deployed: deployed?.commit ?? null,
     waiting: Boolean(waiting),
     installing: Boolean(installing),
     hasController: Boolean(navigator.serviceWorker?.controller),
@@ -239,6 +244,16 @@ async function activateWaitingWorker(options: {
       hardNavigate()
       return 'updated'
     }
+  }
+
+  const deployed = await deployedPromise
+  if (!worker && !options.forcePurge && !isRunningStale(deployed)) {
+    recordDiag({
+      phase: 'no-worker',
+      reason: options.reason,
+      deployed: deployed?.commit ?? null,
+    })
+    return 'unavailable'
   }
 
   try {
@@ -290,7 +305,9 @@ async function purgeWorkersAndCaches(): Promise<void> {
   await Promise.all(keys.map((key) => caches.delete(key)))
   const urls = new Set([location.pathname || '/', '/'])
   await Promise.allSettled(
-    [...urls].map((url) => fetch(url, { cache: 'reload', credentials: 'same-origin' })),
+    [...urls].map((url) =>
+      fetchWithTimeout(url, { cache: 'reload', credentials: 'same-origin' }, FETCH_TIMEOUT_MS),
+    ),
   )
 }
 
@@ -328,12 +345,13 @@ export function fetchDeployedVersion(): Promise<DeployedVersion | null> {
     return Promise.resolve(deployedCache.value)
   }
   if (deployedInFlight) return deployedInFlight
-  deployedInFlight = (async () => {
+  const request = (async () => {
     try {
-      const res = await fetch('/version.json', {
-        cache: 'no-store',
-        headers: { accept: 'application/json' },
-      })
+      const res = await fetchWithTimeout(
+        '/version.json',
+        { cache: 'no-store', headers: { accept: 'application/json' } },
+        FETCH_TIMEOUT_MS,
+      )
       if (!res.ok) return null
       const data = (await res.json()) as { commit?: unknown }
       if (typeof data.commit !== 'string' || data.commit.length === 0) return null
@@ -342,11 +360,30 @@ export function fetchDeployedVersion(): Promise<DeployedVersion | null> {
       return value
     } catch {
       return null
-    } finally {
-      deployedInFlight = null
     }
   })()
-  return deployedInFlight
+  deployedInFlight = request
+  void request.finally(() => {
+    if (deployedInFlight === request) deployedInFlight = null
+  })
+  return request
+}
+
+/** setTimeout-based so a hung fetch cannot stall apply on older WebKit. */
+function fetchWithTimeout(url: string, init: RequestInit, ms: number): Promise<Response> {
+  return new Promise((resolve, reject) => {
+    const timer = window.setTimeout(() => reject(new Error(`Timed out fetching ${url}`)), ms)
+    void fetch(url, init).then(
+      (res) => {
+        window.clearTimeout(timer)
+        resolve(res)
+      },
+      (err: unknown) => {
+        window.clearTimeout(timer)
+        reject(err)
+      },
+    )
+  })
 }
 
 function recordDiag(event: Omit<UpdateDiagEvent, 'at'>): void {

--- a/src/lib/app-update.ts
+++ b/src/lib/app-update.ts
@@ -216,7 +216,7 @@ async function activateWaitingWorker(options: {
   // Best-effort: tell workbox-window too. It no-ops when its own
   // registration.waiting is stale; we still postMessage on `worker` below.
   if (applyUpdate && worker) {
-    void applyUpdate(true).catch(() => undefined)
+    void Promise.resolve(applyUpdate(true)).catch(() => undefined)
   }
 
   if (worker && !options.forcePurge) {

--- a/src/lib/app-update.ts
+++ b/src/lib/app-update.ts
@@ -209,10 +209,9 @@ async function activateWaitingWorker(options: {
   const reg = registration
   const waiting = reg?.waiting ?? null
   const installing = reg?.installing ?? null
-  const worker = waiting ?? installing
-  // Do not block SKIP_WAITING on /version.json — a hung probe used to
-  // leave the toast looking dead. Claim first; the stamp is only needed
-  // to decide whether a no-worker tap should purge.
+  // Only a waiting worker can skipWaiting. An installing worker is still
+  // downloading — posting SKIP_WAITING and then purging on a 2.5s miss
+  // wipes the working shell (Bugbot). Leave it alone and report downloading.
   const deployedPromise = fetchDeployedVersion()
 
   recordDiag({
@@ -225,13 +224,13 @@ async function activateWaitingWorker(options: {
   })
 
   // Best-effort: tell workbox-window too. It no-ops when its own
-  // registration.waiting is stale; we still postMessage on `worker` below.
-  if (applyUpdate && worker) {
+  // registration.waiting is stale; we still postMessage on `waiting` below.
+  if (applyUpdate && waiting) {
     void Promise.resolve(applyUpdate(true)).catch(() => undefined)
   }
 
-  if (worker && !options.forcePurge) {
-    const claimed = await skipWaitingAndAwaitClaim(worker)
+  if (waiting && !options.forcePurge) {
+    const claimed = await skipWaitingAndAwaitClaim(waiting)
     recordDiag({
       phase: 'claim',
       reason: options.reason,
@@ -247,7 +246,15 @@ async function activateWaitingWorker(options: {
   }
 
   const deployed = await deployedPromise
-  if (!worker && !options.forcePurge && !isRunningStale(deployed)) {
+  if (!waiting && installing && !options.forcePurge) {
+    recordDiag({
+      phase: 'installing',
+      reason: options.reason,
+      deployed: deployed?.commit ?? null,
+    })
+    return 'downloading'
+  }
+  if (!waiting && !options.forcePurge && !isRunningStale(deployed)) {
     recordDiag({
       phase: 'no-worker',
       reason: options.reason,

--- a/src/lib/app-update.ts
+++ b/src/lib/app-update.ts
@@ -98,9 +98,17 @@ export async function checkForUpdates(): Promise<UpdateCheckResult> {
   try {
     await reg.update()
   } catch {
-    if (reg.waiting || reg.installing) {
+    // update() failing (offline, SW script 404) is not "you're current".
+    // Still honor a waiting worker, and still force-purge a known-stale
+    // shell — About already compared SHAs and the user asked to apply.
+    if (reg.waiting) {
       return activateWaitingWorker({ reason: 'manual-offline-waiting' })
     }
+    const deployed = await deployedPromise
+    if (isRunningStale(deployed)) {
+      return activateWaitingWorker({ reason: 'manual-stale-shell', forcePurge: true })
+    }
+    if (reg.installing) return 'downloading'
     return 'unavailable'
   }
   // update() can resolve before a found worker shows up on `installing` —
@@ -344,6 +352,19 @@ export function isRunningStale(deployed: DeployedVersion | null | undefined): bo
   const running = testHooks.runningSha ?? COMMIT_SHA
   if (running === 'dev') return false
   return deployed.commit !== running
+}
+
+/**
+ * About may already know the deployed SHA from an earlier /version.json
+ * fetch. A later check can miss that file (cache window expired, brief
+ * offline) and report `current` — don't let that contradict the stale banner.
+ */
+export function reconcileUpdateCheckResult(
+  result: UpdateCheckResult,
+  knownDeployed: DeployedVersion | null | undefined,
+): UpdateCheckResult {
+  if (result === 'current' && isRunningStale(knownDeployed)) return 'unavailable'
+  return result
 }
 
 export function fetchDeployedVersion(): Promise<DeployedVersion | null> {

--- a/src/lib/app-update.ts
+++ b/src/lib/app-update.ts
@@ -70,6 +70,12 @@ export function registerUpdateHandles(
   // don't fire again from the first focus/pageshow burst after load.
   lastQuietProbeAt = Date.now()
   attachResumeUpdateChecks()
+  // registerSW({ immediate: true }) already called registration.update().
+  // Still compare /version.json on boot: a failed apply can leave this
+  // tab on a retired bundle while the worker looks "current".
+  void fetchDeployedVersion().then((deployed) => {
+    if (isRunningStale(deployed)) notifyNeedRefresh?.()
+  })
 }
 
 export type UpdateCheckResult = 'updated' | 'current' | 'downloading' | 'unavailable'

--- a/src/lib/app-update.ts
+++ b/src/lib/app-update.ts
@@ -99,16 +99,18 @@ export async function checkForUpdates(): Promise<UpdateCheckResult> {
     await reg.update()
   } catch {
     // update() failing (offline, SW script 404) is not "you're current".
-    // Still honor a waiting worker, and still force-purge a known-stale
-    // shell — About already compared SHAs and the user asked to apply.
+    // Honor a waiting worker first. An installing worker is still
+    // downloading — do not force-purge under it (that tears down the
+    // working offline shell). Only purge a known-stale shell when no
+    // worker is in flight.
     if (reg.waiting) {
       return activateWaitingWorker({ reason: 'manual-offline-waiting' })
     }
+    if (reg.installing) return 'downloading'
     const deployed = await deployedPromise
     if (isRunningStale(deployed)) {
       return activateWaitingWorker({ reason: 'manual-stale-shell', forcePurge: true })
     }
-    if (reg.installing) return 'downloading'
     return 'unavailable'
   }
   // update() can resolve before a found worker shows up on `installing` —

--- a/src/lib/sync-peer.test.ts
+++ b/src/lib/sync-peer.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { normalizeSdp, receiveBackupOnChannel, sendBackupOnChannel } from './sync-peer'
 import { encodeSyncHeader, STUN_ICE_SERVERS } from './sync-protocol'
 
@@ -101,11 +101,17 @@ describe('sync DataChannel transfer', () => {
     const payload = new Uint8Array(1200)
     for (let i = 0; i < payload.length; i += 1) payload[i] = i % 199
     const signal = new AbortController().signal
-    const received = receiveBackupOnChannel(pair.receiver, signal)
+    let gotAllBytes = false
+    const received = receiveBackupOnChannel(pair.receiver, signal, (got, total) => {
+      if (got === total) gotAllBytes = true
+    })
     pair.sender.send(
       encodeSyncHeader({ v: 1, byteLength: payload.byteLength, filename: 'no-eof.kodyvideo' }),
     )
     pair.sender.send(payload.buffer)
+    // Close only after the payload is on the receiver. Immediate close can
+    // beat the last message on a loaded CI runner and fail this as a flake.
+    await vi.waitFor(() => expect(gotAllBytes).toBe(true))
     pair.sender.close()
     const result = await received
     expect(result.filename).toBe('no-eof.kodyvideo')

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,11 +2,13 @@
 import './lib/array-at-polyfill'
 import { createRoot } from 'remix/ui'
 import { App } from './app'
+import { stripUpdateNavigationMark } from './lib/app-update'
 import { initErrorReporting, reportComponentError } from './lib/error-reporting'
 import { sweepExportCache } from './lib/export/export-cache'
 import { onNavigate } from './router'
 import './lib/install-prompt'
 
+stripUpdateNavigationMark()
 initErrorReporting()
 // Export temp files and zip scratch can be gigabytes; reclaim anything no
 // longer referenced. No export can be running at boot, so this is safe.

--- a/src/pages/about-page.tsx
+++ b/src/pages/about-page.tsx
@@ -54,13 +54,15 @@ function updateDiagnosticsReport(
 ): string | null {
   const diag = getUpdateDiagnostics()
   const stale = isRunningStale(deployedCommit ? { commit: deployedCommit } : null)
-  if (!stale && diag.events.length === 0) return null
-  if (!deployedKnown && diag.events.length === 0) return null
+  const activeWorker = diag.waiting || diag.installing
+  if (!stale && diag.events.length === 0 && !activeWorker) return null
+  if (!deployedKnown && diag.events.length === 0 && !activeWorker) return null
   return [
     `Running: ${shortSha(COMMIT_SHA)}`,
     `Deployed: ${shortSha(deployedCommit)}`,
     `Controller: ${diag.hasController ? 'yes' : 'no'}`,
     `Waiting worker: ${diag.waiting ? 'yes' : 'no'}`,
+    `Installing worker: ${diag.installing ? 'yes' : 'no'}`,
     ...diag.events.map(formatDiagEvent),
   ].join('\n')
 }

--- a/src/pages/about-page.tsx
+++ b/src/pages/about-page.tsx
@@ -7,6 +7,7 @@ import {
   fetchDeployedVersion,
   getUpdateDiagnostics,
   isRunningStale,
+  reconcileUpdateCheckResult,
   type UpdateDiagEvent,
 } from '../lib/app-update'
 import { buildDateLabel, COMMIT_SHA, commitUrl, shortVersion } from '../lib/build-info'
@@ -216,7 +217,11 @@ export function AboutPage(handle: Handle) {
     void handle.update()
     void checkForUpdates()
       .then((result) => {
-        switch (result) {
+        const resolved = reconcileUpdateCheckResult(
+          result,
+          deployedCommit ? { commit: deployedCommit } : null,
+        )
+        switch (resolved) {
           case 'updated':
             // checkForUpdates already applied it; the page is about to reload.
             updateStatus = 'updating'
@@ -231,7 +236,7 @@ export function AboutPage(handle: Handle) {
             updateStatus = 'unavailable'
             return
           default: {
-            const exhaustive: never = result
+            const exhaustive: never = resolved
             throw new Error(`Unhandled update result: ${String(exhaustive)}`)
           }
         }

--- a/src/pages/about-page.tsx
+++ b/src/pages/about-page.tsx
@@ -2,8 +2,14 @@ import type { Handle } from 'remix/ui'
 import { on } from 'remix/ui'
 import { IconBack } from '../components/icons'
 import { BrandMark } from '../components/brand-mark'
-import { checkForUpdates } from '../lib/app-update'
-import { buildDateLabel, commitUrl, shortVersion } from '../lib/build-info'
+import {
+  checkForUpdates,
+  fetchDeployedVersion,
+  getUpdateDiagnostics,
+  isRunningStale,
+  type UpdateDiagEvent,
+} from '../lib/app-update'
+import { buildDateLabel, COMMIT_SHA, commitUrl, shortVersion } from '../lib/build-info'
 import { reportError } from '../lib/error-reporting'
 import { clearExportCache, estimateExportCacheBytes } from '../lib/export/export-cache'
 import { listRearCameras } from '../lib/media'
@@ -27,6 +33,36 @@ function reportProblemUrl(): string {
   ].join('\n')
   const params = new URLSearchParams({ labels: 'bug', body })
   return `https://github.com/kentcdodds/kody-video/issues/new?${params}`
+}
+
+function shortSha(sha: string | null): string {
+  if (!sha) return 'unknown'
+  return sha === 'dev' ? 'dev' : sha.slice(0, 7)
+}
+
+function formatDiagEvent(event: UpdateDiagEvent): string {
+  const time = new Date(event.at).toLocaleTimeString()
+  const bits = [time, event.phase]
+  if (event.reason) bits.push(event.reason)
+  if (event.claimed !== undefined) bits.push(event.claimed ? 'claimed' : 'no-claim')
+  return bits.join(' · ')
+}
+
+function updateDiagnosticsReport(
+  deployedCommit: string | null,
+  deployedKnown: boolean,
+): string | null {
+  const diag = getUpdateDiagnostics()
+  const stale = isRunningStale(deployedCommit ? { commit: deployedCommit } : null)
+  if (!stale && diag.events.length === 0) return null
+  if (!deployedKnown && diag.events.length === 0) return null
+  return [
+    `Running: ${shortSha(COMMIT_SHA)}`,
+    `Deployed: ${shortSha(deployedCommit)}`,
+    `Controller: ${diag.hasController ? 'yes' : 'no'}`,
+    `Waiting worker: ${diag.waiting ? 'yes' : 'no'}`,
+    ...diag.events.map(formatDiagEvent),
+  ].join('\n')
 }
 
 interface AboutData {
@@ -63,6 +99,8 @@ export function AboutPage(handle: Handle) {
   let importing = false
   let importProgress: string | null = null
   let importError: string | null = null
+  let deployedCommit: string | null = null
+  let deployedKnown = false
 
   const refresh = async () => {
     data = await loadAboutData()
@@ -70,6 +108,12 @@ export function AboutPage(handle: Handle) {
     void handle.update()
   }
   void refresh()
+  void fetchDeployedVersion().then((deployed) => {
+    if (handle.signal.aborted) return
+    deployedCommit = deployed?.commit ?? null
+    deployedKnown = true
+    void handle.update()
+  })
 
   /**
    * On-device camera diagnostic: what the browser exposes varies wildly by
@@ -200,6 +244,7 @@ export function AboutPage(handle: Handle) {
     const { storage, exportCacheBytes } = data
     const version = <code>{shortVersion()}</code>
     const versionUrl = commitUrl()
+    const diagReport = updateDiagnosticsReport(deployedCommit, deployedKnown)
     return (
       <div className="screen about-screen">
         <div className="about-top">
@@ -433,6 +478,17 @@ export function AboutPage(handle: Handle) {
               <p role="status" aria-live="polite">
                 {UPDATE_STATUS_LABEL[updateStatus]}
               </p>
+            ) : null}
+            {deployedKnown && isRunningStale(deployedCommit ? { commit: deployedCommit } : null) ? (
+              <p role="status" aria-live="polite">
+                This screen is still on an older build than the server. Tap Check for updates.
+              </p>
+            ) : null}
+            {diagReport ? (
+              <details className="about-update-diag">
+                <summary>Update details</summary>
+                <pre className="camera-report">{diagReport}</pre>
+              </details>
             ) : null}
           </section>
 

--- a/src/styles/home.css
+++ b/src/styles/home.css
@@ -688,6 +688,17 @@
   pointer-events: none;
 }
 
+.about-update-diag {
+  margin-top: 10px;
+  color: var(--ink-muted);
+  font-size: 0.85rem;
+}
+
+.about-update-diag summary {
+  cursor: pointer;
+  font-weight: 600;
+}
+
 .camera-report {
   margin: 10px 0 0;
   padding: 10px 12px;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,4 +1,4 @@
-import { copyFile } from 'node:fs/promises'
+import { copyFile, writeFile } from 'node:fs/promises'
 import { defineConfig } from 'vite'
 import { VitePWA } from 'vite-plugin-pwa'
 import { sentryVitePlugin } from '@sentry/vite-plugin'
@@ -172,7 +172,14 @@ export default defineConfig({
         // Not part of the app shell: the social card is for link scrapers
         // and the icon master is only the source for generated icons.
         // Source maps are served on demand for debugging — do not precache.
-        globIgnores: ['**/og-image.png', '**/art/kody-video-icon.png', '**/*.map'],
+        globIgnores: [
+          '**/og-image.png',
+          '**/art/kody-video-icon.png',
+          '**/*.map',
+          // Network-only: About / resume probes compare this to the running
+          // bundle SHA. Precaching it would make a stale shell look current.
+          '**/version.json',
+        ],
         navigateFallback: '/index.html',
         // Never SPA-fallback these: opening the social card in a tab with an
         // active service worker was "redirecting" to the app, and the API
@@ -183,6 +190,7 @@ export default defineConfig({
           /^\/robots\.txt$/,
           /^\/sitemap\.xml$/,
           /^\/llms\.txt$/,
+          /^\/version\.json$/,
           /^\/assets\//,
           /\.map$/,
         ],
@@ -195,12 +203,17 @@ export default defineConfig({
     {
       // _redirects rewrites deep links to /app (see public/_redirects):
       // Cloudflare Pages 308-normalizes rewrites that target /index.html,
-      // so the shell needs a second name. Written after the service worker
-      // generation so it stays out of the precache (navigateFallback keeps
-      // using /index.html).
+      // so the shell needs a second name. version.json is the network-only
+      // commit stamp About / resume probes compare to the running bundle.
+      // Written after the service worker generation so both stay out of the
+      // precache (navigateFallback keeps using /index.html).
       name: 'spa-shell-copy',
       closeBundle: async () => {
         await copyFile('dist/index.html', 'dist/app.html')
+        await writeFile(
+          'dist/version.json',
+          `${JSON.stringify({ commit: commitSha, builtAt: new Date().toISOString() })}\n`,
+        )
       },
     },
   ],


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Tapping **Update** (or About → Check for updates) paused, refreshed, then offered the same update again. About could eventually say the app was current while the running bundle was still the old commit. Only force-quitting the installed PWA actually booted the new build.

Apply was `SKIP_WAITING` + a 1.5s `location.reload()`. That reload often ran while the **old** service worker still controlled the page (or iOS standalone recycled the in-memory document). Workbox then served the old precache.

## Fix

- Wait for `controllerchange`, then force-navigate with a one-shot `_sw` query so the new worker actually controls the next document.
- If claim fails: unregister service workers, drop Cache Storage (never IndexedDB), reprime HTTP cache, navigate — same idea as `/api/recover`.
- Publish network-only `version.json` and compare it to the running `__COMMIT_SHA__`. A mismatch raises the toast and will not claim “latest.”
- Do not purge when Update is tapped and no worker is waiting, unless `version.json` says the shell is stale.
- Do not treat an **installing** worker like a waiting one (`skipWaiting` cannot apply yet; a timed-out claim + purge wiped the working shell).
- If `registration.update()` throws (offline / SW script miss), still honor a waiting worker and still force-purge a known-stale shell — but not while a worker is still installing.
- About will not show “You're on the latest version” when a prior deployed SHA is still stale.

## Test plan

- Unit: claim-then-navigate, purge-on-failed-claim, no-worker unavailable, stale no-worker purge, installing → downloading (including `update()` throw + stale + installing), `update()` throw + stale purge, `update()` throw + unknown version → unavailable, boot/resume stale toast, About reconcile of a stale “current” result, `_sw` strip.
- Existing e2e / smoke stay green.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9c535c63-53b4-48e2-a60f-52dd23dd4656?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9c535c63-53b4-48e2-a60f-52dd23dd4656&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved update handling so new versions apply more reliably without requiring a manual refresh.
  - Added automatic detection and recovery when an outdated app version is running.
  - Added update status and diagnostic details to the About page, including build freshness and update activity.
  - Added version metadata to help identify the deployed build.

- **Bug Fixes**
  - Reduced issues caused by stale cached pages and service-worker updates.
  - Improved navigation after updates and prevented outdated update markers from persisting.
  - Improved reliability when receiving the final data payload during peer connections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->