### PR TITLE
Allowlist Cursor Cloud Agent authors on the CLA check

### DIFF
--- a/.github/cla-signers.json
+++ b/.github/cla-signers.json
@@ -2,8 +2,15 @@
 	"version": 1,
 	"document": "docs/legal/individual-cla.md",
 	"allowlist": {
-		"github": ["kentcdodds", "kody-bot"],
-		"email": ["me@kentcdodds.com", "me+github@kentcdodds.com"]
+		"github": [
+			"kentcdodds",
+			"kody-bot",
+			"cursoragent"
+		],
+		"email": [
+			"me@kentcdodds.com",
+			"me+github@kentcdodds.com"
+		]
 	},
 	"signers": []
 }

--- a/docs/contribute/inbound-cla.md
+++ b/docs/contribute/inbound-cla.md
@@ -36,7 +36,7 @@ How it works:
 
 - **Scope.** This git repository only.
 - **Who signs.** Every GitHub identity that authors a commit on the pull
-  request, unless that identity is `kentcdodds`, `kody-bot`, a `*[bot]`
+  request, unless that identity is `kentcdodds`, `kody-bot`, `cursoragent`, a `*[bot]`
   or `app/*` account, or an email listed as Licensor-owned in
   [`.github/cla-signers.json`](../../.github/cla-signers.json).
 - **Which form.** [Individual CLA](../legal/individual-cla.md) by default.

--- a/docs/contribute/inbound-contributions.md
+++ b/docs/contribute/inbound-contributions.md
@@ -59,11 +59,12 @@ sign:
 
 - `kentcdodds` (Licensor)
 - `kody-bot` and other logins listed in that file
+- `cursoragent` (Cursor Cloud Agent commit author)
 - Licensor-owned commit emails listed in that file
 - GitHub accounts whose login ends in `[bot]` or starts with `app/`
 
-Cursor Cloud Agent pull requests that GitHub authors as `kentcdodds` follow
-the Licensor path.
+Cursor Cloud Agent pull requests follow the Licensor path even when GitHub
+authors the pull request as `kentcdodds` and the commits as `cursoragent`.
 
 ## Maintainer steps
 


### PR DESCRIPTION
Cloud Agent PRs are opened as `kentcdodds` but commits are authored as `cursoragent`. That identity is Licensor automation, not an outside contributor.

Matches kentcdodds/kody#1463.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and allowlist-only change for Licensor-owned automation; no runtime or security logic changes beyond skipping CLA for one GitHub login.
> 
> **Overview**
> **Adds `cursoragent` to the CLA GitHub allowlist** in `.github/cla-signers.json` so Cursor Cloud Agent commits no longer fail the inbound CLA check.
> 
> Contributor docs now list `cursoragent` among identities that do not sign and clarify that Cloud Agent PRs are treated as Licensor automation when commits are authored as `cursoragent` even if the PR is opened as `kentcdodds`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6658b769b567c2e91dba9fc7f12cb5e535d87a03. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->