### PR TITLE
Record individual CLA signatures from the signing comment

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -137,7 +137,7 @@ jobs:
     if: >
       github.event_name == 'issue_comment' && github.event.issue.pull_request &&
       github.event.comment.user.type == 'User' &&
-      contains(github.event.comment.body, 'I have read the CLA and I hereby sign the CLA')
+      contains(github.event.comment.body, 'I hereby sign the CLA')
     runs-on: ubuntu-latest
     name: 📝 Record CLA
     timeout-minutes: 5

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,4 +1,4 @@
-name: CLA
+name: ✍️ CLA
 
 on:
   pull_request:
@@ -8,29 +8,36 @@ on:
       - opened
       - reopened
       - synchronize
+  issue_comment:
+    types:
+      - created
+      - edited
 
 permissions:
   contents: read
-  pull-requests: write
 
 jobs:
   cla:
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
-    name: CLA
+    name: ✍️ CLA
     timeout-minutes: 5
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
-      - name: Checkout base
+      - name: 📦 Checkout base
         uses: actions/checkout@v6.0.2
         with:
           ref: ${{ github.event.pull_request.base.ref }}
           persist-credentials: false
 
-      - name: Setup Node
+      - name: 🟢 Setup Node
         uses: actions/setup-node@v6
         with:
           node-version: 24
 
-      - name: Collect identities
+      - name: 🧾 Collect identities
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
           script: |
@@ -63,7 +70,7 @@ jobs:
               `${JSON.stringify(identities, null, '\t')}\n`,
             )
 
-      - name: Check CLA
+      - name: ✍️ Check CLA
         id: check
         run: |
           if [ ! -f tools/ci/check-cla.mjs ] || [ ! -f .github/cla-signers.json ]; then
@@ -80,7 +87,7 @@ jobs:
             exit "$code"
           fi
 
-      - name: Comment when unsigned
+      - name: 💬 Comment when unsigned
         if: steps.check.outputs.exit_code == '1'
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
@@ -91,7 +98,7 @@ jobs:
 
             1. Read the [Individual CLA](https://github.com/${{ github.repository }}/blob/main/docs/legal/individual-cla.md) (or the [Entity CLA](https://github.com/${{ github.repository }}/blob/main/docs/legal/entity-cla.md) if an organization owns the work).
             2. Comment exactly: \`I have read the CLA and I hereby sign the CLA\`
-            3. A maintainer records your GitHub username on \`main\`. See [Inbound contributions](https://github.com/${{ github.repository }}/blob/main/docs/contribute/inbound-contributions.md).
+            3. The CLA workflow records your GitHub username on \`main\` and re-runs this check. See [Inbound contributions](https://github.com/${{ github.repository }}/blob/main/docs/contribute/inbound-contributions.md).
 
             Adding your own username on this branch does not pass the check.`
             const comments = await github.paginate(
@@ -122,6 +129,156 @@ jobs:
               })
             }
 
-      - name: Fail when unsigned
+      - name: ❌ Fail when unsigned
         if: steps.check.outputs.exit_code == '1'
         run: exit 1
+
+  record:
+    if: >
+      github.event_name == 'issue_comment' && github.event.issue.pull_request &&
+      github.event.comment.user.type == 'User' &&
+      contains(github.event.comment.body, 'I have read the CLA and I hereby sign the CLA')
+    runs-on: ubuntu-latest
+    name: 📝 Record CLA
+    timeout-minutes: 5
+    concurrency:
+      group: cla-signers-main
+      cancel-in-progress: false
+    permissions:
+      contents: write
+      pull-requests: write
+      actions: write
+    steps:
+      - name: 📦 Checkout main
+        uses: actions/checkout@v6.0.2
+        with:
+          ref: main
+
+      - name: 🟢 Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
+      - name: 📝 Record signer
+        id: record
+        env:
+          CLA_COMMENT: ${{ github.event.comment.body }}
+          CLA_LOGIN: ${{ github.event.comment.user.login }}
+          CLA_SIGNED_AT: ${{ github.event.comment.created_at }}
+        run: |
+          if [ ! -f tools/ci/check-cla.mjs ] || [ ! -f .github/cla-signers.json ]; then
+            echo "skipped=true" >> "$GITHUB_OUTPUT"
+            echo "added=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          printf '%s' "$CLA_COMMENT" > cla-comment.txt
+          node tools/ci/check-cla.mjs \
+            --signers .github/cla-signers.json \
+            --record-signer "$CLA_LOGIN" \
+            --signed-at "${CLA_SIGNED_AT%%T*}" \
+            --comment-file cla-comment.txt > cla-record-output.txt
+          cat cla-record-output.txt
+          grep -E '^(skipped|added|github)=' cla-record-output.txt >> "$GITHUB_OUTPUT"
+
+      - name: 💾 Commit signer on main
+        if: steps.record.outputs.added == 'true'
+        env:
+          CLA_GITHUB: ${{ steps.record.outputs.github }}
+        run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git add .github/cla-signers.json
+          git commit -m "Record @${CLA_GITHUB} as an individual CLA signer"
+          git pull --rebase origin main
+          git push origin HEAD:main
+
+      - name: 💬 Comment and re-run CLA
+        if: steps.record.outputs.skipped == 'false'
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        env:
+          CLA_ADDED: ${{ steps.record.outputs.added }}
+          CLA_GITHUB: ${{ steps.record.outputs.github }}
+        with:
+          script: |
+            const login = process.env.CLA_GITHUB
+            const added = process.env.CLA_ADDED === 'true'
+            const marker = '<!-- kody-cla-recorded -->'
+            const owner = context.repo.owner
+            const repo = context.repo.repo
+            const pull = await github.rest.pulls.get({
+              owner,
+              repo,
+              pull_number: context.payload.issue.number,
+            })
+            const headSha = pull.data.head.sha
+
+            async function latestClaRun() {
+              const runs = await github.rest.actions.listWorkflowRuns({
+                owner,
+                repo,
+                workflow_id: 'cla.yml',
+                event: 'pull_request',
+                head_sha: headSha,
+                per_page: 5,
+              })
+              return runs.data.workflow_runs[0] ?? null
+            }
+
+            const deadline = Date.now() + 180_000
+            let latest = await latestClaRun()
+            while (latest && latest.status !== 'completed' && Date.now() < deadline) {
+              await new Promise((resolve) => setTimeout(resolve, 10_000))
+              latest = await latestClaRun()
+            }
+
+            let reran = false
+            if (latest?.status === 'completed') {
+              try {
+                await github.rest.actions.reRunWorkflow({
+                  owner,
+                  repo,
+                  run_id: latest.id,
+                })
+                reran = true
+              } catch (error) {
+                core.warning(
+                  `Could not re-run CLA: ${error instanceof Error ? error.message : String(error)}`,
+                )
+              }
+            }
+
+            const followUp = reran
+              ? 'The CLA check will re-run.'
+              : 'The next CLA check will read the updated signers file.'
+            const body = added
+              ? `${marker}
+            Recorded @${login} as an individual CLA signer on \`main\`. ${followUp}`
+              : `${marker}
+            @${login} is already recorded as an individual CLA signer. ${followUp}`
+            const comments = await github.paginate(
+              github.rest.issues.listComments,
+              {
+                owner,
+                repo,
+                issue_number: context.payload.issue.number,
+                per_page: 100,
+              },
+            )
+            const existing = comments.find((comment) =>
+              comment.body?.includes(marker),
+            )
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner,
+                repo,
+                comment_id: existing.id,
+                body,
+              })
+            } else {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number: context.payload.issue.number,
+                body,
+              })
+            }

--- a/docs/contribute/inbound-cla.md
+++ b/docs/contribute/inbound-cla.md
@@ -42,8 +42,9 @@ How it works:
 - **Which form.** [Individual CLA](../legal/individual-cla.md) by default.
   [Entity CLA](../legal/entity-cla.md) when an organization owns the work.
 - **How they sign.** Read the CLA, then comment:
-  `I have read the CLA and I hereby sign the CLA`. A maintainer records the
-  GitHub username in `.github/cla-signers.json` on `main`.
+  `I have read the CLA and I hereby sign the CLA`. The `CLA` workflow,
+  running from `main` on that comment, records the commenter's GitHub
+  username in `.github/cla-signers.json` on `main` and re-runs the check.
 - **Enforcement.** The `CLA` workflow reads signers from `main` (never
   from the pull request head) and fails closed. No trivial-contribution
   exception.
@@ -52,7 +53,7 @@ How it works:
 
 - The Licensor stays one party for FSL, the Apache conversion, relicensing,
   and enforcement.
-- Outside pull requests take one extra maintainer step (record the signer on
-  `main`).
+- Individual signatures do not need a maintainer to edit the signers file.
+  The recorder is a first-party `issue_comment` job that writes `main` only.
 - Revisit if the Licensor becomes a company, if counsel revises the CLA
   text, or if contribution volume justifies hosted click-to-sign.

--- a/docs/contribute/inbound-contributions.md
+++ b/docs/contribute/inbound-contributions.md
@@ -28,15 +28,15 @@ There is no exception for docs-only or one-line patches.
    I have read the CLA and I hereby sign the CLA
    ```
 
-4. Wait for a maintainer to record your GitHub username in
-   [`.github/cla-signers.json`](../../.github/cla-signers.json) on `main`.
-5. Re-run the `CLA` check, or push another commit.
+4. The `CLA` workflow records your GitHub username in
+   [`.github/cla-signers.json`](../../.github/cla-signers.json) on `main` and
+   re-runs the check.
 
 Signing once covers past, present, and future contributions from that GitHub
 identity. People who contributed before this process sign the same way before
-their next merge. The `CLA` workflow reads signers from `main`, not from
-the pull request branch, so adding your own username on the branch does not
-pass the check.
+their next merge. The workflow reads signers from `main`, not from the pull
+request branch, so adding your own username on the branch does not pass the
+check. Only the commenter is recorded, and only from the exact phrase.
 
 ## How to sign (entity)
 
@@ -70,10 +70,10 @@ authors the pull request as `kentcdodds` and the commits as `cursoragent`.
 
 Do not merge a pull request while the `CLA` check is red.
 
-After a valid individual signing comment, add a `signers` entry on `main`
-(GitHub login, `signedAt` as an ISO date, `cla` of `individual`) and
-re-run the check. After an accepted Entity CLA, add each authorized username
-with `cla` of `entity`.
+Individual signatures are recorded automatically from the signing comment.
+After an accepted Entity CLA, add each authorized username to
+`.github/cla-signers.json` on `main` with `signedAt` as an ISO date
+(`YYYY-MM-DD`) and `cla` of `entity`.
 
 Make the `CLA` check required for `main` in GitHub branch protection so a
 green review cannot skip it.

--- a/tools/ci/check-cla.mjs
+++ b/tools/ci/check-cla.mjs
@@ -42,9 +42,11 @@ export function parseClaSignersFile(raw) {
 	return parsed
 }
 
+function compactStringArray(values) {
+	return `[${values.map((value) => JSON.stringify(value)).join(', ')}]`
+}
+
 export function serializeClaSignersFile(file) {
-	const compactStringArray = (values) =>
-		`[${values.map((value) => JSON.stringify(value)).join(', ')}]`
 	const placeholderGithub = '__CLA_ALLOWLIST_GITHUB__'
 	const placeholderEmail = '__CLA_ALLOWLIST_EMAIL__'
 	const indented = JSON.stringify(

--- a/tools/ci/check-cla.mjs
+++ b/tools/ci/check-cla.mjs
@@ -1,6 +1,9 @@
-import { readFile } from 'node:fs/promises'
-import { pathToFileURL } from 'node:url'
+import { readFile, writeFile } from 'node:fs/promises'
 import path from 'node:path'
+import { pathToFileURL } from 'node:url'
+
+export const individualClaSigningPhrase =
+	'I have read the CLA and I hereby sign the CLA'
 
 const githubBotLoginPattern = /\[bot\]$/i
 
@@ -23,11 +26,7 @@ function identityLabel(identity) {
 
 export function parseClaSignersFile(raw) {
 	const parsed = JSON.parse(raw)
-	if (
-		typeof parsed !== 'object' ||
-		parsed === null ||
-		parsed.version !== 1
-	) {
+	if (typeof parsed !== 'object' || parsed === null || parsed.version !== 1) {
 		throw new Error('CLA signers file must be version 1 JSON')
 	}
 	if (
@@ -41,6 +40,73 @@ export function parseClaSignersFile(raw) {
 		throw new Error('CLA signers file is missing allowlist or signers')
 	}
 	return parsed
+}
+
+export function serializeClaSignersFile(file) {
+	const compactStringArray = (values) =>
+		`[${values.map((value) => JSON.stringify(value)).join(', ')}]`
+	const placeholderGithub = '__CLA_ALLOWLIST_GITHUB__'
+	const placeholderEmail = '__CLA_ALLOWLIST_EMAIL__'
+	const indented = JSON.stringify(
+		{
+			...file,
+			allowlist: { github: placeholderGithub, email: placeholderEmail },
+		},
+		null,
+		'\t',
+	)
+		.replace(
+			JSON.stringify(placeholderGithub),
+			compactStringArray(file.allowlist.github),
+		)
+		.replace(
+			JSON.stringify(placeholderEmail),
+			compactStringArray(file.allowlist.email),
+		)
+	return `${indented}\n`
+}
+
+export function isIndividualClaSigningComment(body) {
+	return body.trim() === individualClaSigningPhrase
+}
+
+export function applyIndividualClaSigningComment(input) {
+	if (!isIndividualClaSigningComment(input.comment)) {
+		return {
+			file: input.file,
+			status: 'ignored',
+			reason: 'not_signing_comment',
+		}
+	}
+
+	const login = input.github.trim()
+	if (!login) {
+		return { file: input.file, status: 'ignored', reason: 'missing_login' }
+	}
+
+	if (
+		input.file.signers.some(
+			(signer) => normalize(signer.github) === normalize(login),
+		)
+	) {
+		return { file: input.file, status: 'already_signed', github: login }
+	}
+
+	return {
+		file: {
+			...input.file,
+			signers: [
+				...input.file.signers,
+				{
+					github: login,
+					signedAt: input.signedAt,
+					cla: 'individual',
+				},
+			],
+		},
+		status: 'recorded',
+		github: login,
+	}
 }
 
 export function isAllowlistedIdentity(identity, signersFile) {
@@ -60,7 +126,7 @@ export function isAllowlistedIdentity(identity, signersFile) {
 	const email = identity.email ? normalize(identity.email) : null
 	return Boolean(
 		email &&
-			signersFile.allowlist.email.some((entry) => normalize(entry) === email),
+		signersFile.allowlist.email.some((entry) => normalize(entry) === email),
 	)
 }
 
@@ -104,29 +170,38 @@ export function formatClaFailure(result) {
 		'Unsigned contributions cannot merge.',
 		'Read docs/legal/individual-cla.md (or the Entity CLA if an organization owns the work).',
 		'Comment on the pull request: I have read the CLA and I hereby sign the CLA',
-		'A maintainer then records your GitHub username on main. See the inbound contributions doc.',
+		'The CLA workflow records that GitHub username on main. See the inbound contributions doc.',
 		'',
 		'Missing signatures:',
 		...result.missing.map((entry) => `- ${entry.reason}`),
 	].join('\n')
 }
 
-function runSelfTest() {
-	const file = {
+function fixtureSignersFile() {
+	return {
 		version: 1,
 		document: 'docs/legal/individual-cla.md',
 		allowlist: {
-			github: ['kentcdodds', 'kody-bot'],
+			github: ['kentcdodds', 'kody-bot', 'cursoragent'],
 			email: ['me@kentcdodds.com', 'me+github@kentcdodds.com'],
 		},
 		signers: [
-			{ github: 'VojtaHolik', signedAt: '2026-08-16', cla: 'individual' },
+			{ github: 'ExampleSigner', signedAt: '2026-08-16', cla: 'individual' },
 		],
 	}
+}
+
+function runSelfTest() {
+	const file = fixtureSignersFile()
 	const passing = checkClaIdentities(
 		[
 			{ githubLogin: 'kentcdodds', name: 'Kent', email: null },
 			{ githubLogin: 'kody-bot', name: 'Kody', email: null },
+			{
+				githubLogin: 'cursoragent',
+				name: 'Cursor Agent',
+				email: 'cursoragent@cursor.com',
+			},
 			{ githubLogin: 'cursor[bot]', name: 'cursor[bot]', email: null },
 			{ githubLogin: 'app/imgbot', name: 'ImgBot', email: null },
 			{
@@ -135,9 +210,9 @@ function runSelfTest() {
 				email: 'me+github@kentcdodds.com',
 			},
 			{
-				githubLogin: 'vojtaholik',
-				name: 'Vojta Holik',
-				email: 'vojta@egghead.io',
+				githubLogin: 'examplesigner',
+				name: 'Example Signer',
+				email: 'signer@example.com',
 			},
 		],
 		file,
@@ -145,6 +220,7 @@ function runSelfTest() {
 	if (!passing.ok) {
 		throw new Error('expected allowlisted and signed identities to pass')
 	}
+
 	const failing = checkClaIdentities(
 		[
 			{ githubLogin: 'kentcdodds', name: 'Kent', email: null },
@@ -172,19 +248,88 @@ function runSelfTest() {
 	) {
 		throw new Error(`unexpected failure reasons: ${reasons.join('; ')}`)
 	}
+
+	const empty = { ...file, signers: [] }
+	const recorded = applyIndividualClaSigningComment({
+		file: empty,
+		github: 'ExampleSigner',
+		signedAt: '2026-08-16',
+		comment: individualClaSigningPhrase,
+	})
+	if (recorded.status !== 'recorded') {
+		throw new Error('expected the signing comment to record a signer')
+	}
+	const again = applyIndividualClaSigningComment({
+		file: recorded.file,
+		github: 'examplesigner',
+		signedAt: '2026-08-17',
+		comment: individualClaSigningPhrase,
+	})
+	if (again.status !== 'already_signed') {
+		throw new Error('expected a second signing comment to be idempotent')
+	}
 	console.log('CLA self-test passed')
 }
 
-async function runCli(args) {
-	if (args.includes('--self-test')) {
-		runSelfTest()
-		return
+function readFlag(args, flag) {
+	const index = args.indexOf(flag)
+	if (index === -1) {
+		return null
 	}
-	const signersFlag = args.indexOf('--signers')
-	const identitiesFlag = args.indexOf('--identities-json')
-	const signersPath = signersFlag === -1 ? null : args[signersFlag + 1]
-	const identitiesPath =
-		identitiesFlag === -1 ? null : args[identitiesFlag + 1]
+	const value = args[index + 1]
+	if (!value || value.startsWith('--')) {
+		return null
+	}
+	return value
+}
+
+async function runRecordCli(args) {
+	const signersPath = readFlag(args, '--signers')
+	const github = readFlag(args, '--record-signer')
+	const signedAt = readFlag(args, '--signed-at')
+	const commentPath = readFlag(args, '--comment-file')
+	if (!signersPath || !github || !signedAt || !commentPath) {
+		throw new Error(
+			'Usage: node tools/ci/check-cla.mjs --signers <file> --record-signer <login> --signed-at <YYYY-MM-DD> --comment-file <file>',
+		)
+	}
+
+	const current = parseClaSignersFile(await readFile(signersPath, 'utf8'))
+	const recorded = applyIndividualClaSigningComment({
+		file: current,
+		github,
+		signedAt,
+		comment: await readFile(commentPath, 'utf8'),
+	})
+
+	switch (recorded.status) {
+		case 'ignored':
+			console.log('skipped=true')
+			console.log('added=false')
+			break
+		case 'already_signed':
+			console.log('skipped=false')
+			console.log('added=false')
+			console.log(`github=${recorded.github}`)
+			break
+		case 'recorded':
+			await writeFile(
+				signersPath,
+				serializeClaSignersFile(recorded.file),
+				'utf8',
+			)
+			console.log('skipped=false')
+			console.log('added=true')
+			console.log(`github=${recorded.github}`)
+			break
+		default:
+			throw new Error(`Unhandled CLA record status: ${recorded.status}`)
+	}
+}
+
+async function runCheckCli(args) {
+	const signersPath = readFlag(args, '--signers')
+	const identitiesPath = readFlag(args, '--identities-json')
 	if (!signersPath || !identitiesPath) {
 		throw new Error(
 			'Usage: node tools/ci/check-cla.mjs --signers <file> --identities-json <file>',
@@ -200,6 +345,18 @@ async function runCli(args) {
 		console.error(formatClaFailure(result))
 		process.exitCode = 1
 	}
+}
+
+async function runCli(args) {
+	if (args.includes('--self-test')) {
+		runSelfTest()
+		return
+	}
+	if (args.includes('--record-signer')) {
+		await runRecordCli(args)
+		return
+	}
+	await runCheckCli(args)
 }
 
 const entryPoint = process.argv[1]


### PR DESCRIPTION
The exact PR comment now writes the commenter onto `main` and re-runs the check. Jobs use glanceable emoji (`✍️ CLA`, `📝 Record CLA`) to match Validate/Preview.

Matches kentcdodds/kody#1468.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> The new job can push commits to `main` and re-run Actions, but it is gated on the exact signing phrase and human `User` commenters with serialized writes via concurrency.
> 
> **Overview**
> **Individual CLA signing is automated:** posting the exact phrase `I have read the CLA and I hereby sign the CLA` on a PR now triggers a new **`record`** job (on `issue_comment`) that validates the comment, appends the commenter to `.github/cla-signers.json` on **`main`**, commits via `github-actions[bot]`, posts a status comment, and **re-runs** the PR `CLA` check when possible.
> 
> The existing **`cla`** job is unchanged in behavior but only runs on `pull_request`; workflow/step names get emoji labels, and `pull-requests: write` moves to the job level. Contributor docs and failure/unsigned PR comments now describe workflow recording instead of a maintainer editing the signers file (entity CLAs remain manual).
> 
> **`tools/ci/check-cla.mjs`** gains `--record-signer` (with `--signed-at` and `--comment-file`), exports for the signing phrase and `applyIndividualClaSigningComment`, and stable serialization when writing the signers JSON; self-tests cover record/idempotency.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2374bb48fb0e20171e361e27a17f80cf4bb18c57. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->