### PR TITLE
Select a neighbor clip after delete instead of jumping to the last

### DIFF
--- a/src/components/editor-screen.tsx
+++ b/src/components/editor-screen.tsx
@@ -16,6 +16,7 @@ import {
 } from '../lib/project-actions'
 import { downloadClipFile } from '../lib/media'
 import { resolveSplitMs } from '../lib/clip-edit'
+import { clipIdAfterDelete } from '../lib/clip-selection'
 import {
   effectiveDurationMs,
   formatDuration,
@@ -230,11 +231,16 @@ export function EditorScreen(handle: Handle<EditorScreenProps>) {
   }
 
   const handleDelete = () => {
-    const id = resolveSelectedId()
+    const clips = visibleClips(props.clips)
+    const id = resolveSelectedId(clips)
     if (!id) return
+    const nextSelectedId = clipIdAfterDelete(
+      clips.map((clip) => clip.id),
+      id,
+    )
     void (async () => {
       await removeClip(id)
-      selectedClipId = null
+      selectedClipId = nextSelectedId
       trimming = false
       splitting = false
       void handle.update()

--- a/src/lib/clip-selection.test.ts
+++ b/src/lib/clip-selection.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest'
+import { clipIdAfterDelete } from './clip-selection'
+
+describe('clipIdAfterDelete', () => {
+  it('selects the next clip when one remains after the deleted one', () => {
+    expect(clipIdAfterDelete(['a', 'b', 'c'], 'b')).toBe('c')
+    expect(clipIdAfterDelete(['a', 'b', 'c'], 'a')).toBe('b')
+  })
+
+  it('selects the previous clip when the last clip is deleted', () => {
+    expect(clipIdAfterDelete(['a', 'b', 'c'], 'c')).toBe('b')
+  })
+
+  it('returns null when the only clip is deleted', () => {
+    expect(clipIdAfterDelete(['a'], 'a')).toBeNull()
+  })
+
+  it('falls back to the last clip when the deleted id is already gone', () => {
+    expect(clipIdAfterDelete(['a', 'b'], 'missing')).toBe('b')
+    expect(clipIdAfterDelete([], 'a')).toBeNull()
+  })
+})

--- a/src/lib/clip-selection.ts
+++ b/src/lib/clip-selection.ts
@@ -1,0 +1,10 @@
+/** After a delete, keep the playhead on a neighbor instead of jumping to the end. */
+
+export function clipIdAfterDelete<T extends string>(
+  clipIds: readonly T[],
+  deletedId: T,
+): T | null {
+  const index = clipIds.indexOf(deletedId)
+  if (index < 0) return clipIds.at(-1) ?? null
+  return clipIds[index + 1] ?? clipIds[index - 1] ?? null
+}

--- a/tests/e2e/editor-playback.spec.ts
+++ b/tests/e2e/editor-playback.spec.ts
@@ -47,6 +47,23 @@ test.describe('editor', () => {
     await expect(tiles).toHaveCount(2)
   })
 
+  test('delete selects the next clip, or the previous when it was last', async ({ page }) => {
+    await openEditorWithClips(page, 3)
+    const tiles = page.locator('.clip-thumb')
+    const secondId = await tiles.nth(1).getAttribute('data-clip-id')
+    await tiles.nth(0).click()
+    await page.getByRole('button', { name: 'Delete clip' }).click()
+    await expect(tiles).toHaveCount(2)
+    await expect(tiles.nth(0)).toHaveAttribute('data-clip-id', secondId!)
+    await expect(tiles.nth(0)).toHaveClass(/selected/)
+
+    await tiles.nth(1).click()
+    await page.getByRole('button', { name: 'Delete clip' }).click()
+    await expect(tiles).toHaveCount(1)
+    await expect(tiles.nth(0)).toHaveAttribute('data-clip-id', secondId!)
+    await expect(tiles.nth(0)).toHaveClass(/selected/)
+  })
+
   test('trim opens the strip; dragging a handle and Done persists', async ({ page }) => {
     await openEditorWithClips(page, 1)
     const durBefore = (await page.locator('.clip-thumb .clip-dur').first().textContent()) ?? ''


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
After deleting a clip, the editor kept falling back to the last remaining clip. That felt like the playhead jumped away.

## Why

Jakub reported it: delete should land on the clip after the one you removed, or the one before if you deleted the last clip.

## What lands

- `clipIdAfterDelete` picks the next id, else the previous
- Editor delete uses that instead of clearing selection (which resolved to the tail)
- Undo still restores the deleted clip and reselects it

## Tests

- Unit: next / previous / only-clip / missing-id
- E2E: delete the first of three, then the last remaining neighbor

Risk: **low**

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-04283985-9019-4c2b-bbfb-f5e85da7eb55?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-04283985-9019-4c2b-bbfb-f5e85da7eb55&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved clip deletion behavior in the editor.
  * After deleting a clip, selection now moves to the next available clip, or the previous clip when deleting the final clip.
  * Selection is cleared only when no clips remain.

* **Tests**
  * Added coverage for clip selection after deletion, including edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->