### PR TITLE
Select the previous clip after delete, like backspace

### DIFF
--- a/src/lib/clip-selection.test.ts
+++ b/src/lib/clip-selection.test.ts
@@ -2,13 +2,13 @@ import { describe, expect, it } from 'vitest'
 import { clipIdAfterDelete } from './clip-selection'
 
 describe('clipIdAfterDelete', () => {
-  it('selects the next clip when one remains after the deleted one', () => {
-    expect(clipIdAfterDelete(['a', 'b', 'c'], 'b')).toBe('c')
-    expect(clipIdAfterDelete(['a', 'b', 'c'], 'a')).toBe('b')
+  it('selects the previous clip when one remains before the deleted one', () => {
+    expect(clipIdAfterDelete(['a', 'b', 'c'], 'b')).toBe('a')
+    expect(clipIdAfterDelete(['a', 'b', 'c'], 'c')).toBe('b')
   })
 
-  it('selects the previous clip when the last clip is deleted', () => {
-    expect(clipIdAfterDelete(['a', 'b', 'c'], 'c')).toBe('b')
+  it('selects the next clip when the first clip is deleted', () => {
+    expect(clipIdAfterDelete(['a', 'b', 'c'], 'a')).toBe('b')
   })
 
   it('returns null when the only clip is deleted', () => {

--- a/src/lib/clip-selection.ts
+++ b/src/lib/clip-selection.ts
@@ -1,4 +1,4 @@
-/** After a delete, keep the playhead on a neighbor instead of jumping to the end. */
+/** After a delete, keep the playhead on the previous clip (backspace-style). */
 
 export function clipIdAfterDelete<T extends string>(
   clipIds: readonly T[],
@@ -6,5 +6,5 @@ export function clipIdAfterDelete<T extends string>(
 ): T | null {
   const index = clipIds.indexOf(deletedId)
   if (index < 0) return clipIds.at(-1) ?? null
-  return clipIds[index + 1] ?? clipIds[index - 1] ?? null
+  return clipIds[index - 1] ?? clipIds[index + 1] ?? null
 }

--- a/tests/e2e/editor-playback.spec.ts
+++ b/tests/e2e/editor-playback.spec.ts
@@ -47,20 +47,20 @@ test.describe('editor', () => {
     await expect(tiles).toHaveCount(2)
   })
 
-  test('delete selects the next clip, or the previous when it was last', async ({ page }) => {
+  test('delete selects the previous clip, or the next when it was first', async ({ page }) => {
     await openEditorWithClips(page, 3)
     const tiles = page.locator('.clip-thumb')
-    const secondId = await tiles.nth(1).getAttribute('data-clip-id')
-    await tiles.nth(0).click()
-    await page.getByRole('button', { name: 'Delete clip' }).click()
-    await expect(tiles).toHaveCount(2)
-    await expect(tiles.nth(0)).toHaveAttribute('data-clip-id', secondId!)
-    await expect(tiles.nth(0)).toHaveClass(/selected/)
-
+    const firstId = await tiles.nth(0).getAttribute('data-clip-id')
+    const thirdId = await tiles.nth(2).getAttribute('data-clip-id')
     await tiles.nth(1).click()
     await page.getByRole('button', { name: 'Delete clip' }).click()
+    await expect(tiles).toHaveCount(2)
+    await expect(tiles.nth(0)).toHaveAttribute('data-clip-id', firstId!)
+    await expect(tiles.nth(0)).toHaveClass(/selected/)
+
+    await page.getByRole('button', { name: 'Delete clip' }).click()
     await expect(tiles).toHaveCount(1)
-    await expect(tiles.nth(0)).toHaveAttribute('data-clip-id', secondId!)
+    await expect(tiles.nth(0)).toHaveAttribute('data-clip-id', thirdId!)
     await expect(tiles.nth(0)).toHaveClass(/selected/)
   })
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

Jakub asked for neighbor selection after delete. We shipped next-clip-first. Kent wants backspace semantics instead: land on the clip before the deleted one, and only move forward when the first clip is deleted.

## What

`clipIdAfterDelete` now prefers `index - 1`, then `index + 1`. Unit and e2e coverage match that order.

## Test plan

- Unit: previous for middle/last, next for first, null for only clip
- E2E: delete the middle clip → first selected; delete that first remaining clip → last remaining selected

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-04283985-9019-4c2b-bbfb-f5e85da7eb55?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-04283985-9019-4c2b-bbfb-f5e85da7eb55&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved clip selection after deletion: the previous clip is now selected when available.
  * When deleting the first clip, the next available clip is selected instead.
  * Preserved expected behavior when no neighboring clip exists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->