### PR TITLE
docs: always enable Cursor Cloud PR tools

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,11 @@ rate-limits do not block. Follow `.cursor/skills/ship-pr/SKILL.md`.
 
 ## Cursor Cloud specific instructions
 
+Code-changing agents push their branch and create or update the pull request
+with Cursor Cloud `ManagePullRequest` (Kent C. Dodds account) before finishing.
+`@kentcdodds/cursor` `createAgent` always enables those tools. Never have
+Kody/workflows/GitHub create the initial PR as a substitute.
+
 Contributor and cloud-agent docs live in `docs/contribute/`:
 
 - [`environment.md`](docs/contribute/environment.md) — required Node version (`>=24.3.0`) and dependency/install caveats.


### PR DESCRIPTION
Add the same Cursor Cloud PR-ownership note as kody: agents open their own PRs via ManagePullRequest, and `createAgent` always enables those tools.

Low-risk docs only.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to agent workflow; no application or runtime behavior.
> 
> **Overview**
> Adds **Cursor Cloud** guidance under `AGENTS.md` so code-changing agents open their own PRs with **`ManagePullRequest`** (Kent C. Dodds account) before finishing, and states that **`@kentcdodds/cursor` `createAgent`** always enables those tools.
> 
> Agents must **not** rely on Kody, workflows, or GitHub to create the initial PR instead.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c363bb3b1da7311912a159bf37b05e619a52f4a3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->