### PR TITLE
Show the export cover-crop in camera, editor, and playback

### DIFF
--- a/src/components/editor-clip-preview.tsx
+++ b/src/components/editor-clip-preview.tsx
@@ -96,8 +96,8 @@ export function EditorClipPreview(handle: Handle<EditorClipPreviewProps>) {
             alt="Selected photo"
             mix={ref(bindImage)}
           />
+          {props.onInfoClick ? <PreviewInfoButton onClick={props.onInfoClick} /> : null}
         </div>
-        {props.onInfoClick ? <PreviewInfoButton onClick={props.onInfoClick} /> : null}
       </div>
     )
   }
@@ -574,7 +574,6 @@ export function EditorClipPreview(handle: Handle<EditorClipPreviewProps>) {
             on('click', togglePlayback),
           ]}
         />
-        </div>
         <button
           type="button"
           className="editor-preview-affordance"
@@ -584,6 +583,7 @@ export function EditorClipPreview(handle: Handle<EditorClipPreviewProps>) {
           {playing ? <IconPause size={18} /> : <IconPlay size={18} />}
         </button>
         {props.onInfoClick ? <PreviewInfoButton onClick={props.onInfoClick} /> : null}
+        </div>
       </div>
     )
   }

--- a/src/components/editor-clip-preview.tsx
+++ b/src/components/editor-clip-preview.tsx
@@ -89,12 +89,14 @@ export function EditorClipPreview(handle: Handle<EditorClipPreviewProps>) {
     }
     return () => (
       <div className="editor-clip-preview-wrap">
-        <BlobImage
-          blob={props.clip.blob}
-          className="editor-clip-preview editor-clip-preview-image"
-          alt="Selected photo"
-          mix={ref(bindImage)}
-        />
+        <div className="film-frame">
+          <BlobImage
+            blob={props.clip.blob}
+            className="editor-clip-preview editor-clip-preview-image"
+            alt="Selected photo"
+            mix={ref(bindImage)}
+          />
+        </div>
         {props.onInfoClick ? <PreviewInfoButton onClick={props.onInfoClick} /> : null}
       </div>
     )
@@ -520,6 +522,7 @@ export function EditorClipPreview(handle: Handle<EditorClipPreviewProps>) {
             ]}
           />
         ) : null}
+        <div className="film-frame">
         <BlobVideo
           key={remountKey}
           blob={clip.blob}
@@ -571,6 +574,7 @@ export function EditorClipPreview(handle: Handle<EditorClipPreviewProps>) {
             on('click', togglePlayback),
           ]}
         />
+        </div>
         <button
           type="button"
           className="editor-preview-affordance"

--- a/src/components/playback-overlay.tsx
+++ b/src/components/playback-overlay.tsx
@@ -713,6 +713,7 @@ export function PlaybackOverlay(handle: Handle<PlaybackOverlayProps>) {
           />
         ) : null}
 
+        <div className="film-frame">
         {isPhoto ? (
           <BlobImage
             key={`${segment.clip.id}:${index}`}
@@ -749,6 +750,7 @@ export function PlaybackOverlay(handle: Handle<PlaybackOverlayProps>) {
             }),
           ]}
         />
+        </div>
 
         <div className="playback-tap-zones">
           <button

--- a/src/components/record-screen.tsx
+++ b/src/components/record-screen.tsx
@@ -1013,13 +1013,15 @@ export function RecordScreen(handle: Handle<RecordScreenProps>) {
             on('contextmenu', (event) => event.preventDefault()),
           ]}
         >
-          <video
-            className={`camera-video${camera.facing === 'user' ? ' mirror' : ''}`}
-            muted
-            playsInline
-            autoPlay
-            mix={ref((node, signal) => bindCameraVideo(node as HTMLVideoElement, signal))}
-          />
+          <div className="film-frame">
+            <video
+              className={`camera-video${camera.facing === 'user' ? ' mirror' : ''}`}
+              muted
+              playsInline
+              autoPlay
+              mix={ref((node, signal) => bindCameraVideo(node as HTMLVideoElement, signal))}
+            />
+          </div>
 
           {/* aria-live sits on the LABEL, not the pill: the elapsed readout
               rewrites its text 10×/s, and a live region around it would make

--- a/src/lib/testing/make-test-clip.ts
+++ b/src/lib/testing/make-test-clip.ts
@@ -92,3 +92,46 @@ export async function makeTestClipBlob(durationMs: number, toneHz?: number): Pro
   if (!target.buffer) throw new Error('Test clip encode produced no bytes')
   return new Blob([target.buffer], { type: 'video/webm' })
 }
+
+/** Landscape (or any size) fixture with labeled edges so cover-crop is visible. */
+export async function makeLabeledClipBlob(
+  width: number,
+  height: number,
+  durationMs = 1200,
+): Promise<Blob> {
+  const codec = await getFirstEncodableVideoCodec(['vp8', 'vp9'], { width, height })
+  if (!codec) throw new Error('No encodable test codec')
+  const canvas = document.createElement('canvas')
+  canvas.width = width
+  canvas.height = height
+  const ctx = canvas.getContext('2d')
+  if (!ctx) throw new Error('Canvas not available')
+  ctx.fillStyle = '#1a7a4c'
+  ctx.fillRect(0, 0, width, height)
+  ctx.fillStyle = '#c62828'
+  ctx.fillRect(0, 0, width * 0.22, height)
+  ctx.fillStyle = '#1565c0'
+  ctx.fillRect(width * 0.78, 0, width * 0.22, height)
+  ctx.fillStyle = '#f9a825'
+  ctx.fillRect(0, 0, width, 36)
+  ctx.fillRect(0, height - 36, width, 36)
+  ctx.fillStyle = '#fff'
+  ctx.font = `bold ${Math.round(height / 8)}px sans-serif`
+  ctx.fillText('LEFT', 16, height / 2)
+  ctx.fillText('RIGHT', width * 0.8, height / 2)
+  ctx.fillText('WIDE', width / 2 - 50, height / 2)
+
+  const target = new BufferTarget()
+  const output = new Output({ format: new WebMOutputFormat(), target })
+  const source = new CanvasSource(canvas, {
+    codec,
+    quality: new Quality({ bitrate: 600_000 }),
+  })
+  output.addVideoTrack(source, { frameRate: 12 })
+  await output.start()
+  await source.add(0, durationMs / 1000)
+  source.close()
+  await output.finalize()
+  if (!target.buffer) throw new Error('Test clip encode produced no bytes')
+  return new Blob([target.buffer], { type: 'video/webm' })
+}

--- a/src/lib/testing/make-test-clip.ts
+++ b/src/lib/testing/make-test-clip.ts
@@ -121,15 +121,21 @@ export async function makeLabeledClipBlob(
   ctx.fillText('RIGHT', width * 0.8, height / 2)
   ctx.fillText('WIDE', width / 2 - 50, height / 2)
 
+  const fps = 12
   const target = new BufferTarget()
   const output = new Output({ format: new WebMOutputFormat(), target })
   const source = new CanvasSource(canvas, {
     codec,
     quality: new Quality({ bitrate: 600_000 }),
   })
-  output.addVideoTrack(source, { frameRate: 12 })
+  output.addVideoTrack(source, { frameRate: fps })
   await output.start()
-  await source.add(0, durationMs / 1000)
+  const totalSec = durationMs / 1000
+  const frames = Math.max(2, Math.ceil(totalSec * fps))
+  for (let i = 0; i < frames; i += 1) {
+    const duration = Math.max(0.001, Math.min(1 / fps, totalSec - i / fps))
+    await source.add(i / fps, duration)
+  }
   source.close()
   await output.finalize()
   if (!target.buffer) throw new Error('Test clip encode produced no bytes')

--- a/src/pages/project-page.tsx
+++ b/src/pages/project-page.tsx
@@ -688,11 +688,17 @@ export function ProjectPage(handle: Handle<ProjectPageProps>) {
     const captureTimeMs = lastCaptureTimeMs(clips) ?? undefined
     const orientation = effectiveOrientation()
     const unlocked = orientationUnlocked()
+    // Phones lock a film shape; show that shape (cover-cropped) so the
+    // camera, editor, and playback match export. Desktop never locks a
+    // portrait film, so it keeps filling the pane. Landscape projects
+    // always frame 16:9 (the Plus lock).
+    const filmFramed =
+      !unlocked && (orientation === 'landscape' || isCoarsePointerDevice())
     syncShellOrientation(orientation, unlocked)
 
     return (
       <div
-        className={`screen project-screen${orientation === 'landscape' ? ' orientation-landscape' : ''}`}
+        className={`screen project-screen${orientation === 'landscape' ? ' orientation-landscape' : ''}${filmFramed ? ' is-film-framed' : ''}`}
       >
         {/* While exporting, the screens unmount entirely: the camera is
             released (no dead preview burning battery behind the overlay) and

--- a/src/styles/editor.css
+++ b/src/styles/editor.css
@@ -76,6 +76,8 @@
 
 .editor-clip-preview-wrap {
   position: relative;
+  display: grid;
+  place-items: center;
   width: 100%;
   height: 100%;
   min-height: 120px;
@@ -84,7 +86,7 @@
 .editor-clip-preview {
   width: 100%;
   height: 100%;
-  object-fit: contain;
+  object-fit: cover;
   display: block;
   background: #000;
 }
@@ -116,7 +118,7 @@
 }
 
 .editor-clip-preview-image {
-  object-fit: contain;
+  object-fit: cover;
 }
 
 .editor-empty-preview {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -169,6 +169,80 @@ a {
   animation: none;
 }
 
+/* Export is cover-fit into the film's aspect. Preview hosts size a
+   `.film-frame` to that aspect (when `.is-film-framed`) and the media
+   cover-crops inside it — same crop the encoder will keep. */
+.film-frame {
+  position: relative;
+  overflow: hidden;
+  background: #000;
+}
+
+.film-frame > .camera-video,
+.film-frame > .editor-clip-preview,
+.film-frame > .playback-video,
+.film-frame > .playback-image {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.record-stage,
+.editor-clip-preview-wrap,
+.playback-overlay {
+  container-type: size;
+}
+
+.record-stage > .film-frame {
+  width: 100%;
+  height: 100%;
+  min-width: 0;
+  min-height: 0;
+}
+
+.editor-clip-preview-wrap {
+  display: grid;
+  place-items: center;
+}
+
+.editor-clip-preview-wrap > .film-frame {
+  width: 100%;
+  height: 100%;
+  min-width: 0;
+  min-height: 0;
+}
+
+.playback-overlay > .film-frame {
+  position: absolute;
+  inset: 0;
+}
+
+.project-screen.is-film-framed:not(.orientation-landscape) .record-stage > .film-frame,
+.project-screen.is-film-framed:not(.orientation-landscape) .editor-clip-preview-wrap > .film-frame,
+.project-screen.is-film-framed:not(.orientation-landscape) .playback-overlay > .film-frame {
+  width: min(100cqw, calc(100cqh * 9 / 16));
+  height: auto;
+  aspect-ratio: 9 / 16;
+  max-height: 100%;
+  inset: auto;
+}
+
+.project-screen.is-film-framed.orientation-landscape .record-stage > .film-frame,
+.project-screen.is-film-framed.orientation-landscape .editor-clip-preview-wrap > .film-frame,
+.project-screen.is-film-framed.orientation-landscape .playback-overlay > .film-frame {
+  width: min(100cqw, calc(100cqh * 16 / 9));
+  height: auto;
+  aspect-ratio: 16 / 9;
+  max-height: 100%;
+  inset: auto;
+}
+
+.project-screen.is-film-framed .playback-overlay > .film-frame {
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+}
+
 @keyframes rise-in {
   from {
     opacity: 0;
@@ -917,7 +991,7 @@ a {
 .playback-video {
   width: 100%;
   height: 100%;
-  object-fit: contain;
+  object-fit: cover;
   background: #000;
 }
 
@@ -930,7 +1004,7 @@ a {
 .playback-image {
   width: 100%;
   height: 100%;
-  object-fit: contain;
+  object-fit: cover;
   background: #000;
 }
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -238,9 +238,11 @@ a {
 }
 
 .project-screen.is-film-framed .playback-overlay > .film-frame {
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
+  /* The framed size rules set `inset: auto` at higher specificity than
+     `top/left: 50%` would win, so drop out of absolute fill and let the
+     overlay's flex centering place the film. */
+  position: relative;
+  inset: auto;
 }
 
 @keyframes rise-in {

--- a/src/styles/record.css
+++ b/src/styles/record.css
@@ -15,6 +15,8 @@
 .record-stage {
   position: absolute;
   inset: 0;
+  display: grid;
+  place-items: center;
   background:
     radial-gradient(80% 60% at 50% 20%, var(--accent-soft), transparent 60%),
     var(--stage-bg);

--- a/tests/e2e/orientation-touch.spec.ts
+++ b/tests/e2e/orientation-touch.spec.ts
@@ -172,6 +172,15 @@ test.describe('export-cover preview (touch)', () => {
 
     await page.getByRole('button', { name: 'Play project preview' }).click()
     await expect(page.locator('.playback-overlay')).toBeVisible()
+    const overlay = page.locator('.playback-overlay')
+    const playFilm = overlay.locator('> .film-frame')
+    const overlayBox = await overlay.boundingBox()
+    const playBox = await playFilm.boundingBox()
+    expect(overlayBox).not.toBeNull()
+    expect(playBox).not.toBeNull()
+    expect(playBox!.width / playBox!.height).toBeCloseTo(9 / 16, 2)
+    expect(Math.abs(playBox!.x + playBox!.width / 2 - (overlayBox!.x + overlayBox!.width / 2))).toBeLessThan(4)
+    expect(Math.abs(playBox!.y + playBox!.height / 2 - (overlayBox!.y + overlayBox!.height / 2))).toBeLessThan(4)
     await shot('playback_portrait_film')
   })
 

--- a/tests/e2e/orientation-touch.spec.ts
+++ b/tests/e2e/orientation-touch.spec.ts
@@ -1,5 +1,11 @@
 import { test, expect, type Page } from '@playwright/test'
-import { openNewProject, recordClip, totalClipCount, unlockPlus } from './helpers'
+import {
+  openNewProject,
+  recordClip,
+  totalClipCount,
+  unlockPlus,
+  waitForCameraReady,
+} from './helpers'
 
 // Runs under the `touch` Playwright project (real touch emulation, so
 // `pointer: coarse` matches): the rotate-to-choose flow only exists on
@@ -71,6 +77,10 @@ test.describe('rotate-to-choose orientation (touch)', () => {
     // The first take decides: recording sideways locks the project landscape.
     await recordClip(page)
     await expect.poll(() => storedOrientation(page)).toBe('landscape')
+    await expect(page.locator('.project-screen')).toHaveClass(/is-film-framed/)
+    const landscapeFilm = await page.locator('.record-stage > .film-frame').boundingBox()
+    expect(landscapeFilm).not.toBeNull()
+    expect(landscapeFilm!.width / landscapeFilm!.height).toBeCloseTo(16 / 9, 2)
 
     // From now on the interface is stuck landscape — turning the phone back
     // upright keeps the landscape layout and asks for a turn instead.
@@ -120,11 +130,119 @@ test.describe('rotate-to-choose orientation (touch)', () => {
     await expect(page.locator('.orientation-gate-pill')).toBeHidden()
     await recordClip(page)
     expect(await storedOrientation(page)).toBeUndefined()
+    await expect(page.locator('.project-screen')).toHaveClass(/is-film-framed/)
+    const film = page.locator('.record-stage > .film-frame')
+    const box = await film.boundingBox()
+    expect(box).not.toBeNull()
+    expect(box!.width / box!.height).toBeCloseTo(9 / 16, 2)
     expect(
       await page.evaluate(async () => {
         const storage = await import('/src/lib/storage.ts')
         return (await storage.listProjects()).length
       }),
     ).toBe(1)
+  })
+})
+
+test.describe('export-cover preview (touch)', () => {
+  test('camera, editor, and playback show the film-shaped cover crop', async ({
+    page,
+  }, testInfo) => {
+    const shot = async (name: string) => {
+      const file = testInfo.outputPath(`${name}.png`)
+      await page.screenshot({ path: file, fullPage: false })
+      await page.screenshot({ path: `/opt/cursor/artifacts/${name}.png`, fullPage: false })
+    }
+
+    await openNewProject(page)
+    await recordClip(page)
+    await waitForCameraReady(page)
+    await expect(page.locator('.project-screen')).toHaveClass(/is-film-framed/)
+    await shot('camera_portrait_locked')
+
+    await rotate(page)
+    await expect(page.locator('.orientation-hint')).toBeVisible()
+    await shot('camera_held_wrong')
+
+    await rotate(page)
+    await page.getByRole('button', { name: 'Open editor' }).click()
+    await expect(page.locator('.editor-screen')).toBeVisible()
+    await shot('editor_portrait_film')
+
+    await page.getByRole('button', { name: 'Play project preview' }).click()
+    await expect(page.locator('.playback-overlay')).toBeVisible()
+    await shot('playback_portrait_film')
+  })
+
+  test('a landscape clip is side-cropped in a portrait film', async ({ page }, testInfo) => {
+    await page.goto('/')
+    await page.evaluate(async () => {
+      const storage = await import('/src/lib/storage.ts')
+      const thumbs = await import('/src/lib/thumbs.ts')
+      const {
+        BufferTarget,
+        CanvasSource,
+        Output,
+        Quality,
+        WebMOutputFormat,
+        getFirstEncodableVideoCodec,
+      } = await import('mediabunny')
+      const width = 640
+      const height = 360
+      const canvas = document.createElement('canvas')
+      canvas.width = width
+      canvas.height = height
+      const ctx = canvas.getContext('2d')
+      if (!ctx) throw new Error('canvas')
+      ctx.fillStyle = '#1a7a4c'
+      ctx.fillRect(0, 0, width, height)
+      ctx.fillStyle = '#c62828'
+      ctx.fillRect(0, 0, width * 0.22, height)
+      ctx.fillStyle = '#1565c0'
+      ctx.fillRect(width * 0.78, 0, width * 0.22, height)
+      ctx.fillStyle = '#f9a825'
+      ctx.fillRect(0, 0, width, 36)
+      ctx.fillRect(0, height - 36, width, 36)
+      ctx.fillStyle = '#fff'
+      ctx.font = 'bold 42px sans-serif'
+      ctx.fillText('LEFT', 16, height / 2)
+      ctx.fillText('RIGHT', width - 170, height / 2)
+      ctx.fillText('WIDE SHOT', width / 2 - 120, height / 2)
+      const codec = await getFirstEncodableVideoCodec(['vp8', 'vp9'], { width, height })
+      if (!codec) throw new Error('codec')
+      const target = new BufferTarget()
+      const output = new Output({ format: new WebMOutputFormat(), target })
+      const source = new CanvasSource(canvas, {
+        codec,
+        quality: new Quality({ bitrate: 600_000 }),
+      })
+      output.addVideoTrack(source, { frameRate: 12 })
+      await output.start()
+      await source.add(0, 1.2)
+      source.close()
+      await output.finalize()
+      if (!target.buffer) throw new Error('encode')
+      const project = await storage.createProject('Wide in tall')
+      const clip = await storage.addClip({
+        projectId: project.id,
+        blob: new Blob([target.buffer], { type: 'video/webm' }),
+        mimeType: 'video/webm',
+        durationMs: 1200,
+        width,
+        height,
+      })
+      await thumbs.ensureClipThumbs(clip)
+    })
+    await page.goto('/')
+    await page.locator('.project-slot:not(.empty)').first().click()
+    await page.getByRole('button', { name: 'Open editor' }).click()
+    await expect(page.locator('.editor-screen')).toBeVisible()
+    await expect(page.locator('.project-screen')).toHaveClass(/is-film-framed/)
+    const file = testInfo.outputPath('editor_landscape_clip_cropped.png')
+    await page.screenshot({ path: file, fullPage: false })
+    await page.screenshot({
+      path: '/opt/cursor/artifacts/editor_landscape_clip_cropped.png',
+      fullPage: false,
+    })
   })
 })

--- a/tests/e2e/orientation-touch.spec.ts
+++ b/tests/e2e/orientation-touch.spec.ts
@@ -202,8 +202,8 @@ test.describe('export-cover preview (touch)', () => {
     await expect(page.locator('.project-screen')).toHaveClass(/is-film-framed/)
     const preview = page.locator('.editor-clip-preview')
     await expect
-      .poll(() => preview.evaluate((el) => (el as HTMLVideoElement).readyState >= 2))
-      .toBe(true)
+      .poll(() => preview.evaluate((el) => (el as HTMLVideoElement).videoWidth))
+      .toBeGreaterThan(0)
     const file = testInfo.outputPath('editor_landscape_clip_cropped.png')
     await page.screenshot({ path: file, fullPage: false })
     await page.screenshot({

--- a/tests/e2e/orientation-touch.spec.ts
+++ b/tests/e2e/orientation-touch.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect, type Page } from '@playwright/test'
 import {
+  gotoHome,
   openNewProject,
   recordClip,
   totalClipCount,
@@ -175,57 +176,18 @@ test.describe('export-cover preview (touch)', () => {
   })
 
   test('a landscape clip is side-cropped in a portrait film', async ({ page }, testInfo) => {
-    await page.goto('/')
+    await gotoHome(page)
     await page.evaluate(async () => {
       const storage = await import('/src/lib/storage.ts')
       const thumbs = await import('/src/lib/thumbs.ts')
-      const {
-        BufferTarget,
-        CanvasSource,
-        Output,
-        Quality,
-        WebMOutputFormat,
-        getFirstEncodableVideoCodec,
-      } = await import('mediabunny')
+      const { makeLabeledClipBlob } = await import('/src/lib/testing/make-test-clip.ts')
       const width = 640
       const height = 360
-      const canvas = document.createElement('canvas')
-      canvas.width = width
-      canvas.height = height
-      const ctx = canvas.getContext('2d')
-      if (!ctx) throw new Error('canvas')
-      ctx.fillStyle = '#1a7a4c'
-      ctx.fillRect(0, 0, width, height)
-      ctx.fillStyle = '#c62828'
-      ctx.fillRect(0, 0, width * 0.22, height)
-      ctx.fillStyle = '#1565c0'
-      ctx.fillRect(width * 0.78, 0, width * 0.22, height)
-      ctx.fillStyle = '#f9a825'
-      ctx.fillRect(0, 0, width, 36)
-      ctx.fillRect(0, height - 36, width, 36)
-      ctx.fillStyle = '#fff'
-      ctx.font = 'bold 42px sans-serif'
-      ctx.fillText('LEFT', 16, height / 2)
-      ctx.fillText('RIGHT', width - 170, height / 2)
-      ctx.fillText('WIDE SHOT', width / 2 - 120, height / 2)
-      const codec = await getFirstEncodableVideoCodec(['vp8', 'vp9'], { width, height })
-      if (!codec) throw new Error('codec')
-      const target = new BufferTarget()
-      const output = new Output({ format: new WebMOutputFormat(), target })
-      const source = new CanvasSource(canvas, {
-        codec,
-        quality: new Quality({ bitrate: 600_000 }),
-      })
-      output.addVideoTrack(source, { frameRate: 12 })
-      await output.start()
-      await source.add(0, 1.2)
-      source.close()
-      await output.finalize()
-      if (!target.buffer) throw new Error('encode')
+      const blob = await makeLabeledClipBlob(width, height)
       const project = await storage.createProject('Wide in tall')
       const clip = await storage.addClip({
         projectId: project.id,
-        blob: new Blob([target.buffer], { type: 'video/webm' }),
+        blob,
         mimeType: 'video/webm',
         durationMs: 1200,
         width,
@@ -238,6 +200,10 @@ test.describe('export-cover preview (touch)', () => {
     await page.getByRole('button', { name: 'Open editor' }).click()
     await expect(page.locator('.editor-screen')).toBeVisible()
     await expect(page.locator('.project-screen')).toHaveClass(/is-film-framed/)
+    const preview = page.locator('.editor-clip-preview')
+    await expect
+      .poll(() => preview.evaluate((el) => (el as HTMLVideoElement).readyState >= 2))
+      .toBe(true)
     const file = testInfo.outputPath('editor_landscape_clip_cropped.png')
     await page.screenshot({ path: file, fullPage: false })
     await page.screenshot({


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

Holding the phone the "wrong" way (or importing a mismatched clip) recorded the full sensor, then export center-cropped. Previews used `object-fit: contain` or covered the *stage*, so they showed more than the finished film.

## What

Locked projects now size a film frame to 9:16 (portrait) or 16:9 (landscape) and cover-crop the camera, editor, and playback into it. Unlocked empty projects stay full-bleed so rotate-to-choose still works. Desktop portrait projects still fill the pane (they never lock a film shape). The saved recording is unchanged.

Editor play/info buttons sit on the film, not the letterbox.

## Test plan

- Touch e2e: after a portrait lock the camera film is 9:16; after a landscape lock it is 16:9
- Playback film is centered in the overlay
- Screenshots: camera upright, camera held sideways, editor, playback, and a landscape clip in a portrait film

## Preview

Camera held sideways on a locked portrait project (clearest view of the 9:16 film):

![Camera held sideways shows a 9:16 film frame](https://cursor.com/artifacts/c/art-a59ff79a-cfeb-4582-8e2b-4986ae045869)

Editor after a portrait take:

![Editor portrait film frame](https://cursor.com/artifacts/c/art-3a6bfcfe-db94-46d3-a75c-a278ae8b47bb)

Playback (centered 9:16 film):

![Playback portrait film frame](https://cursor.com/artifacts/c/art-a19fe289-87e5-4930-9457-c62bff43d8d4)

Landscape clip dropped into a portrait film — sides cropped, center kept (same as export):

![Landscape clip cover-cropped in a portrait editor film](https://cursor.com/artifacts/c/art-d6244464-3744-4b2b-8083-f6f2bc57cef9)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-04283985-9019-4c2b-bbfb-f5e85da7eb55?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-04283985-9019-4c2b-bbfb-f5e85da7eb55&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added film-framed previews for portrait and landscape projects across recording, editing, playback, and export views.
  - Media previews now use cover fitting and maintain appropriate aspect ratios for each project orientation.
  - Improved preview alignment and centered camera, clip, and playback content.

- **Tests**
  - Added coverage for orientation-specific framing, export previews, and landscape video cropping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->