### PR TITLE
Record any orientation; crop or letterbox mismatched clips

### DIFF
--- a/src/components/clip-info-sheet.tsx
+++ b/src/components/clip-info-sheet.tsx
@@ -2,15 +2,24 @@ import type { Handle } from 'remix/ui'
 import { on, ref } from 'remix/ui'
 import { canSplitClip, clipHasUnusedMedia } from '../lib/clip-edit'
 import { buildClipFacts } from '../lib/clip-facts'
+import { clipFit, clipMismatchesFilm } from '../lib/clip-fit'
 import { attachSheetModal } from '../lib/sheet-modal'
-import { effectiveDurationMs, isImageClip, type ClipRecord } from '../lib/types'
-import { IconDownload, IconSplit, IconTrim } from './icons'
+import {
+  effectiveDurationMs,
+  isImageClip,
+  type ClipFit,
+  type ClipRecord,
+  type ProjectOrientation,
+} from '../lib/types'
+import { IconCrop, IconDownload, IconLetterbox, IconSplit, IconTrim } from './icons'
 
 interface ClipInfoSheetProps {
   clip: ClipRecord
   clips: ClipRecord[]
   index: number
   projectName: string
+  filmOrientation: ProjectOrientation
+  onSetFit: (fit: ClipFit) => Promise<void>
   onPermanentlyTrim: () => Promise<void>
   onStartSplit: () => void
   onDownload: () => Promise<void>
@@ -84,6 +93,33 @@ export function ClipInfoSheet(handle: Handle<ClipInfoSheetProps>) {
               </div>
             ))}
           </dl>
+
+          {clipMismatchesFilm(clip, handle.props.filmOrientation) ? (
+            <div className="clip-info-fit" role="group" aria-label="Fit in film">
+              <p className="clip-info-fit-label">This clip does not match the film</p>
+              <div className="clip-info-fit-toggles">
+                {(['crop', 'letterbox'] as const).map((choice) => {
+                  const active = clipFit(clip) === choice
+                  return (
+                    <button
+                      type="button"
+                      key={choice}
+                      className={`btn btn-ghost clip-info-fit-btn${active ? ' is-active' : ''}`}
+                      aria-pressed={active}
+                      disabled={working}
+                      mix={on('click', () => {
+                        if (active || working) return
+                        void handle.props.onSetFit(choice)
+                      })}
+                    >
+                      {choice === 'crop' ? <IconCrop size={16} /> : <IconLetterbox size={16} />}
+                      {choice === 'crop' ? 'Crop' : 'Letterbox'}
+                    </button>
+                  )
+                })}
+              </div>
+            </div>
+          ) : null}
 
           {error ? <p className="sheet-message is-error">{error}</p> : null}
 

--- a/src/components/editor-clip-preview.tsx
+++ b/src/components/editor-clip-preview.tsx
@@ -15,6 +15,7 @@ import {
   trackMediaSec,
   trackMusicGain,
 } from '../lib/preview-music-bed'
+import { clipCanvasFit } from '../lib/clip-fit'
 import { BlobImage } from './blob-image'
 import { BlobVideo } from './blob-video'
 import { IconInfo, IconPause, IconPlay } from './icons'
@@ -89,7 +90,7 @@ export function EditorClipPreview(handle: Handle<EditorClipPreviewProps>) {
     }
     return () => (
       <div className="editor-clip-preview-wrap">
-        <div className="film-frame">
+        <div className={`film-frame${clipCanvasFit(props.clip) === 'contain' ? ' is-letterbox' : ''}`}>
           <BlobImage
             blob={props.clip.blob}
             className="editor-clip-preview editor-clip-preview-image"
@@ -522,7 +523,7 @@ export function EditorClipPreview(handle: Handle<EditorClipPreviewProps>) {
             ]}
           />
         ) : null}
-        <div className="film-frame">
+        <div className={`film-frame${clipCanvasFit(clip) === 'contain' ? ' is-letterbox' : ''}`}>
         <BlobVideo
           key={remountKey}
           blob={clip.blob}

--- a/src/components/editor-screen.tsx
+++ b/src/components/editor-screen.tsx
@@ -10,10 +10,13 @@ import {
   removeClip,
   setAudioTrackSettings,
   setClipDuration,
+  setClipFit,
+  setFilmOrientation,
   splitSelectedClip,
   trimClip,
   undoLastDelete,
 } from '../lib/project-actions'
+import { PlusRequiredError } from '../lib/storage'
 import { downloadClipFile } from '../lib/media'
 import { resolveSplitMs } from '../lib/clip-edit'
 import { clipIdAfterDelete } from '../lib/clip-selection'
@@ -21,11 +24,13 @@ import {
   effectiveDurationMs,
   formatDuration,
   isImageClip,
+  projectOrientation,
   type ClipId,
   type ClipRecord,
   type Project,
   type ProjectAudioRecord,
   type ProjectId,
+  type ProjectOrientation,
 } from '../lib/types'
 import { AudioDetailStrip } from './audio-detail-strip'
 import { AudioStrip } from './audio-strip'
@@ -91,6 +96,24 @@ export function EditorScreen(handle: Handle<EditorScreenProps>) {
   let ghostAfterId: ClipId | null = null
   const fileInputRef: { current: HTMLInputElement | null } = { current: null }
   const previewApi: { current: EditorClipPreviewHandle | null } = { current: null }
+
+  const chooseFilmOrientation = async (orientation: ProjectOrientation) => {
+    if (orientation === 'landscape' && !props.plus) {
+      props.onUpsell()
+      return
+    }
+    try {
+      const projectId = await props.ensureProjectId()
+      await setFilmOrientation(projectId, orientation)
+      await props.refresh()
+    } catch (error) {
+      if (error instanceof PlusRequiredError) {
+        props.onUpsell()
+        return
+      }
+      throw error
+    }
+  }
 
   const visibleClips = (loaded: ClipRecord[]): ClipRecord[] => {
     let next = loaded
@@ -445,6 +468,27 @@ export function EditorScreen(handle: Handle<EditorScreenProps>) {
             <small>
               {clips.length} clip{clips.length === 1 ? '' : 's'} · {formatDuration(totalDurationMs)}
             </small>
+            <div className="editor-film-orientation" role="group" aria-label="Export orientation">
+              {(['portrait', 'landscape'] as const).map((choice) => {
+                const film = projectOrientation(project)
+                const active = film === choice
+                return (
+                  <button
+                    type="button"
+                    key={choice}
+                    className={active ? 'is-active' : undefined}
+                    aria-pressed={active}
+                    disabled={importing}
+                    mix={on('click', () => {
+                      if (active || importing) return
+                      void chooseFilmOrientation(choice)
+                    })}
+                  >
+                    {choice === 'portrait' ? 'Portrait' : 'Landscape'}
+                  </button>
+                )
+              })}
+            </div>
           </div>
           <button
             type="button"
@@ -575,6 +619,7 @@ export function EditorScreen(handle: Handle<EditorScreenProps>) {
               pendingGhostCount={pendingGhostCount}
               pendingGhostAfterId={ghostAfterId}
               showAudioBadges={props.audio !== null}
+              filmOrientation={projectOrientation(project)}
               refresh={props.refresh}
             />
           )}
@@ -713,6 +758,11 @@ export function EditorScreen(handle: Handle<EditorScreenProps>) {
             clips={clips}
             index={selectedIndex}
             projectName={project.name}
+            filmOrientation={projectOrientation(project)}
+            onSetFit={async (fit) => {
+              await setClipFit(selected.id, fit)
+              await props.refresh()
+            }}
             onPermanentlyTrim={async () => {
               const updated = await permanentlyTrimClip(selected.id)
               clipInfoOpen = false

--- a/src/components/icons.tsx
+++ b/src/components/icons.tsx
@@ -258,6 +258,27 @@ export function IconLens(handle: Handle<IconProps>) {
   )
 }
 
+/** Crop: a frame with inward corners, like a crop overlay. */
+export function IconCrop(handle: Handle<IconProps>) {
+  return () => (
+    <svg {...baseProps(handle.props.size ?? 22)}>
+      <path d="M6 3v15h15" />
+      <path d="M3 6h15v15" />
+    </svg>
+  )
+}
+
+/** Letterbox: a wide frame with bars above and below. */
+export function IconLetterbox(handle: Handle<IconProps>) {
+  return () => (
+    <svg {...baseProps(handle.props.size ?? 22)}>
+      <rect x="3" y="6" width="18" height="12" rx="2" />
+      <path d="M6 9h12" />
+      <path d="M6 15h12" />
+    </svg>
+  )
+}
+
 /** Project orientation: the frame the film is shaped for, portrait or
  * landscape, with a rotate arrow suggesting the switch. */
 export function IconOrientation(handle: Handle<IconProps & { landscape?: boolean }>) {

--- a/src/components/playback-overlay.tsx
+++ b/src/components/playback-overlay.tsx
@@ -23,6 +23,7 @@ import {
   type ClipRecord,
   type ProjectAudioRecord,
 } from '../lib/types'
+import { clipCanvasFit } from '../lib/clip-fit'
 import { BlobImage } from './blob-image'
 import { IconPlay } from './icons'
 import { isInteractiveTarget } from '../lib/keyboard'
@@ -713,7 +714,7 @@ export function PlaybackOverlay(handle: Handle<PlaybackOverlayProps>) {
           />
         ) : null}
 
-        <div className="film-frame">
+        <div className={`film-frame${clipCanvasFit(segment.clip) === 'contain' ? ' is-letterbox' : ''}`}>
         {isPhoto ? (
           <BlobImage
             key={`${segment.clip.id}:${index}`}

--- a/src/components/record-screen.tsx
+++ b/src/components/record-screen.tsx
@@ -41,7 +41,6 @@ import {
   IconFlip,
   IconLens,
   IconLocation,
-  IconLock,
   IconMic,
   IconOrientation,
   IconPlay,
@@ -83,7 +82,7 @@ interface RecordScreenProps {
   orientationUnlocked: boolean
   /** Kody Video Plus unlocked (landscape projects are a Plus perk). */
   plus: boolean
-  /** Open the Plus upsell sheet (landscape takes on the free plan). */
+  /** Open the Plus upsell sheet (location tagging and other Plus perks). */
   onUpsell: () => void
   onOpenEditor: () => void
   onOpenExport: () => void
@@ -345,12 +344,6 @@ export function RecordScreen(handle: Handle<RecordScreenProps>) {
       ) {
         return
       }
-      // Touch-primary devices with getDisplayMedia (ChromeOS tablets): a
-      // screen take is a first clip like any other — same landscape gate.
-      if (landscapeTakeGated()) {
-        props.onUpsell()
-        return
-      }
       screenBusy = true
       try {
         const session = await startScreenRecording()
@@ -371,13 +364,6 @@ export function RecordScreen(handle: Handle<RecordScreenProps>) {
     })()
   }
 
-  /** Free plan, empty project, device held sideways: the landscape
-   * interface is on screen as a preview, but the take that would lock the
-   * project landscape is a Plus perk — recording waits for an upgrade (or
-   * for the device to turn back upright). */
-  const landscapeTakeGated = () =>
-    props.orientationUnlocked && props.orientation === 'landscape' && !props.plus
-
   const beginRecord = async (
     nextPointerId: number | null,
     nextRecordingMode: RecordingMode,
@@ -389,10 +375,6 @@ export function RecordScreen(handle: Handle<RecordScreenProps>) {
       props.interactionLocked ||
       countdown !== null
     ) {
-      return false
-    }
-    if (landscapeTakeGated()) {
-      props.onUpsell()
       return false
     }
     if (screenSession) {
@@ -587,10 +569,6 @@ export function RecordScreen(handle: Handle<RecordScreenProps>) {
   const startSelfTimer = () => {
     if (recording || props.interactionLocked || countdown !== null) return
     if (screenSession) return
-    if (landscapeTakeGated()) {
-      props.onUpsell()
-      return
-    }
     if (!camera.getStream() || !camera.isReady) {
       props.showToast('Camera not ready')
       return
@@ -1056,32 +1034,30 @@ export function RecordScreen(handle: Handle<RecordScreenProps>) {
             </div>
           ) : null}
 
-          {/* The gate pill replaces the hold hint — "hold anywhere" would
-              contradict a blocked take. */}
           {!recording &&
           !screenRecording &&
           countdown === null &&
-          camera.isReady &&
-          !landscapeTakeGated() ? (
+          camera.isReady ? (
             <div className={`hold-hint${clips.length > 0 ? ' hold-hint-subtle' : ''}`}>
               <strong>Hold anywhere</strong>
               <span>release to stop</span>
             </div>
           ) : null}
 
-          {/* Locked projects are stuck with their first take's orientation;
-              when the device is held the other way, say so. Visibility is
-              CSS-driven (each hint shows only on the mismatching viewport,
-              and the portrait one only where rotating means anything —
-              coarse pointers). */}
+          {/* Locked films keep a compact hold hint when the device is
+              turned the other way. Visibility is CSS-driven (each hint
+              shows only on the mismatching viewport, and the portrait
+              one only where rotating means anything — coarse pointers). */}
           {!props.orientationUnlocked &&
           props.orientation === 'landscape' &&
           !recording &&
           !screenRecording ? (
             <div className="orientation-hint" role="status">
-              <IconOrientation size={28} landscape />
-              <strong>Turn your device sideways</strong>
-              <span>this is a landscape project</span>
+              <IconOrientation size={16} landscape />
+              <span>
+                <strong>Hold sideways</strong>
+                <span>or crop this take</span>
+              </span>
             </div>
           ) : null}
           {!props.orientationUnlocked &&
@@ -1089,28 +1065,12 @@ export function RecordScreen(handle: Handle<RecordScreenProps>) {
           !recording &&
           !screenRecording ? (
             <div className="orientation-hint orientation-hint-portrait" role="status">
-              <IconOrientation size={28} />
-              <strong>Turn your device upright</strong>
-              <span>this is a portrait project</span>
+              <IconOrientation size={16} />
+              <span>
+                <strong>Hold upright</strong>
+                <span>or crop this take</span>
+              </span>
             </div>
-          ) : null}
-
-          {/* The rotate-to-choose upsell: the free user is LOOKING at the
-              landscape interface — recording in it is the Plus perk. */}
-          {landscapeTakeGated() && !recording && !screenRecording && countdown === null ? (
-            <button
-              type="button"
-              className="orientation-gate-pill"
-              mix={[
-                // The stage records on pointerdown — the pill must not
-                // double as a (gated) hold-to-record press.
-                on('pointerdown', (event) => event.stopPropagation()),
-                on('click', () => props.onUpsell()),
-              ]}
-            >
-              <IconLock size={14} />
-              Landscape projects are a Plus perk — unlock to record
-            </button>
           ) : null}
 
           <div

--- a/src/components/record-screen.tsx
+++ b/src/components/record-screen.tsx
@@ -999,6 +999,35 @@ export function RecordScreen(handle: Handle<RecordScreenProps>) {
               autoPlay
               mix={ref((node, signal) => bindCameraVideo(node as HTMLVideoElement, signal))}
             />
+            {/* Locked films keep a compact hold hint when the device is
+                turned the other way. Visibility is CSS-driven (each hint
+                shows only on the mismatching viewport, and the portrait
+                one only where rotating means anything — coarse pointers).
+                Sits on the film so it does not collide with the title. */}
+            {!props.orientationUnlocked &&
+            props.orientation === 'landscape' &&
+            !recording &&
+            !screenRecording ? (
+              <div className="orientation-hint" role="status">
+                <IconOrientation size={16} landscape />
+                <span>
+                  <strong>Hold sideways</strong>
+                  <span>or crop this take</span>
+                </span>
+              </div>
+            ) : null}
+            {!props.orientationUnlocked &&
+            props.orientation === 'portrait' &&
+            !recording &&
+            !screenRecording ? (
+              <div className="orientation-hint orientation-hint-portrait" role="status">
+                <IconOrientation size={16} />
+                <span>
+                  <strong>Hold upright</strong>
+                  <span>or crop this take</span>
+                </span>
+              </div>
+            ) : null}
           </div>
 
           {/* aria-live sits on the LABEL, not the pill: the elapsed readout
@@ -1041,35 +1070,6 @@ export function RecordScreen(handle: Handle<RecordScreenProps>) {
             <div className={`hold-hint${clips.length > 0 ? ' hold-hint-subtle' : ''}`}>
               <strong>Hold anywhere</strong>
               <span>release to stop</span>
-            </div>
-          ) : null}
-
-          {/* Locked films keep a compact hold hint when the device is
-              turned the other way. Visibility is CSS-driven (each hint
-              shows only on the mismatching viewport, and the portrait
-              one only where rotating means anything — coarse pointers). */}
-          {!props.orientationUnlocked &&
-          props.orientation === 'landscape' &&
-          !recording &&
-          !screenRecording ? (
-            <div className="orientation-hint" role="status">
-              <IconOrientation size={16} landscape />
-              <span>
-                <strong>Hold sideways</strong>
-                <span>or crop this take</span>
-              </span>
-            </div>
-          ) : null}
-          {!props.orientationUnlocked &&
-          props.orientation === 'portrait' &&
-          !recording &&
-          !screenRecording ? (
-            <div className="orientation-hint orientation-hint-portrait" role="status">
-              <IconOrientation size={16} />
-              <span>
-                <strong>Hold upright</strong>
-                <span>or crop this take</span>
-              </span>
             </div>
           ) : null}
 

--- a/src/components/timeline.tsx
+++ b/src/components/timeline.tsx
@@ -1,5 +1,6 @@
 import type { Handle } from 'remix/ui'
 import { on, ref } from 'remix/ui'
+import { clipFitBadge } from '../lib/clip-fit'
 import { reorderClips } from '../lib/storage'
 import {
   clipMusicVolume,
@@ -10,8 +11,9 @@ import {
   type ClipId,
   type ClipRecord,
   type ProjectId,
+  type ProjectOrientation,
 } from '../lib/types'
-import { IconPhoto } from './icons'
+import { IconCrop, IconLetterbox, IconPhoto } from './icons'
 import { TimelineThumbImage } from './timeline-thumb-image'
 
 const PX_PER_SECOND = 26
@@ -41,6 +43,8 @@ interface TimelineProps {
   pendingGhostAfterId?: ClipId | null
   /** Show per-clip music-volume badges (project has a background track). */
   showAudioBadges?: boolean
+  /** Film shape — used for the crop / letterbox badge. */
+  filmOrientation: ProjectOrientation
   refresh: () => void
 }
 
@@ -397,6 +401,7 @@ export function Timeline(handle: Handle<TimelineProps>) {
           const isDragging = draggingId === clip.id
           const showDropBefore = draggingId !== null && gapIndex === index
           const isPhoto = isImageClip(clip)
+          const fitBadge = clipFitBadge(clip, props.filmOrientation)
           const showGhostsAfter =
             pendingGhostCount > 0 &&
             draggingId === null &&
@@ -411,6 +416,12 @@ export function Timeline(handle: Handle<TimelineProps>) {
                 role="option"
                 aria-selected={selected}
                 aria-label={`${isPhoto ? 'Photo' : 'Clip'} ${index + 1}, ${formatDuration(effectiveDurationMs(clip))}${
+                  fitBadge === 'crop'
+                    ? ', cropped'
+                    : fitBadge === 'letterbox'
+                      ? ', letterboxed'
+                      : ''
+                }${
                   // Presence checks stay on the raw fields (override vs
                   // default); displayed values go through the clamped
                   // accessors playback uses.
@@ -460,6 +471,19 @@ export function Timeline(handle: Handle<TimelineProps>) {
                   )}
                 </div>
                 <span className="clip-dur">{formatDuration(effectiveDurationMs(clip))}</span>
+                {fitBadge ? (
+                  <span
+                    className="clip-fit-badge"
+                    aria-hidden="true"
+                    title={fitBadge === 'letterbox' ? 'Letterboxed' : 'Cropped'}
+                  >
+                    {fitBadge === 'letterbox' ? (
+                      <IconLetterbox size={12} />
+                    ) : (
+                      <IconCrop size={12} />
+                    )}
+                  </span>
+                ) : null}
                 {isPhoto ? (
                   <span className="clip-photo-badge" aria-hidden="true">
                     <IconPhoto size={12} />

--- a/src/lib/clip-fit.test.ts
+++ b/src/lib/clip-fit.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest'
+import {
+  clipCanvasFit,
+  clipFit,
+  clipFitBadge,
+  clipMismatchesFilm,
+  orientationFromSize,
+} from './clip-fit'
+
+describe('clipFit', () => {
+  it('defaults to crop when unset', () => {
+    expect(clipFit({})).toBe('crop')
+    expect(clipFit({ fit: 'crop' })).toBe('crop')
+    expect(clipFit({ fit: 'letterbox' })).toBe('letterbox')
+  })
+
+  it('maps crop to cover and letterbox to contain', () => {
+    expect(clipCanvasFit({})).toBe('cover')
+    expect(clipCanvasFit({ fit: 'letterbox' })).toBe('contain')
+  })
+})
+
+describe('orientationFromSize', () => {
+  it('returns null for missing or square sizes', () => {
+    expect(orientationFromSize()).toBeNull()
+    expect(orientationFromSize(0, 1080)).toBeNull()
+    expect(orientationFromSize(1000, 1000)).toBeNull()
+  })
+
+  it('reads landscape and portrait from pixels', () => {
+    expect(orientationFromSize(1920, 1080)).toBe('landscape')
+    expect(orientationFromSize(1080, 1920)).toBe('portrait')
+  })
+})
+
+describe('clipMismatchesFilm', () => {
+  it('is false when size is unknown, square, or already matching', () => {
+    expect(clipMismatchesFilm({}, 'portrait')).toBe(false)
+    expect(clipMismatchesFilm({ width: 800, height: 800 }, 'landscape')).toBe(false)
+    expect(clipMismatchesFilm({ width: 1080, height: 1920 }, 'portrait')).toBe(false)
+    expect(clipMismatchesFilm({ width: 1920, height: 1080 }, 'landscape')).toBe(false)
+  })
+
+  it('is true when the clip and film disagree', () => {
+    expect(clipMismatchesFilm({ width: 1920, height: 1080 }, 'portrait')).toBe(true)
+    expect(clipMismatchesFilm({ width: 1080, height: 1920 }, 'landscape')).toBe(true)
+  })
+})
+
+describe('clipFitBadge', () => {
+  it('is hidden when the clip already matches the film', () => {
+    expect(clipFitBadge({ width: 1080, height: 1920 }, 'portrait')).toBeNull()
+    expect(clipFitBadge({ width: 1920, height: 1080, fit: 'letterbox' }, 'landscape')).toBeNull()
+  })
+
+  it('shows crop by default and letterbox when chosen', () => {
+    expect(clipFitBadge({ width: 1920, height: 1080 }, 'portrait')).toBe('crop')
+    expect(clipFitBadge({ width: 1920, height: 1080, fit: 'letterbox' }, 'portrait')).toBe(
+      'letterbox',
+    )
+  })
+})

--- a/src/lib/clip-fit.ts
+++ b/src/lib/clip-fit.ts
@@ -1,0 +1,41 @@
+import type { ClipFit, ProjectOrientation } from './types'
+
+/** Stored override, or crop when the clip has never been toggled. */
+export function clipFit(clip: { fit?: ClipFit }): ClipFit {
+  return clip.fit === 'letterbox' ? 'letterbox' : 'crop'
+}
+
+/** Canvas / CSS object-fit for a clip (crop covers, letterbox contains). */
+export function clipCanvasFit(clip: { fit?: ClipFit }): 'cover' | 'contain' {
+  return clipFit(clip) === 'letterbox' ? 'contain' : 'cover'
+}
+
+/** Pixel orientation of a clip. Null when size is missing or square. */
+export function orientationFromSize(
+  width?: number,
+  height?: number,
+): ProjectOrientation | null {
+  if (!(width && height) || width === height) return null
+  return width > height ? 'landscape' : 'portrait'
+}
+
+/**
+ * True when the clip's pixels disagree with the film, so crop or letterbox
+ * will actually change what is kept. Square / unknown size matches both.
+ */
+export function clipMismatchesFilm(
+  clip: { width?: number; height?: number },
+  film: ProjectOrientation,
+): boolean {
+  const clipOrientation = orientationFromSize(clip.width, clip.height)
+  return clipOrientation !== null && clipOrientation !== film
+}
+
+/** Which timeline badge to show, if any. */
+export function clipFitBadge(
+  clip: { width?: number; height?: number; fit?: ClipFit },
+  film: ProjectOrientation,
+): ClipFit | null {
+  if (!clipMismatchesFilm(clip, film)) return null
+  return clipFit(clip)
+}

--- a/src/lib/export/encode-realtime.ts
+++ b/src/lib/export/encode-realtime.ts
@@ -1,3 +1,4 @@
+import { clipCanvasFit } from '../clip-fit'
 import { pickRecorderMimeType } from '../media'
 import { isIosBrowser } from '../platform'
 import { videoBitrateFor } from '../video-quality'
@@ -22,8 +23,7 @@ import {
   blitPreview,
   decodeBackgroundAudio,
   decodeClipAudio,
-  drawCover,
-  drawCoverFrom,
+  drawFitFrom,
   drawWatermark,
   loadClipImage,
   loadClipVideo,
@@ -369,6 +369,7 @@ export async function exportRealtime(
           getPreviewCanvas: encodingIntoPreview ? undefined : options.getPreviewCanvas,
           watermarkImage: options.watermarkImage ?? null,
           signal: options.signal,
+          fit: clipCanvasFit(segment.clip),
           onElapsedMs: (elapsed: number) => {
             if (plan.totalMs > 0) {
               options.onProgress?.(Math.min(1, (paintedTotalMs + elapsed) / plan.totalMs))
@@ -453,6 +454,7 @@ interface PaintSharedArgs {
   getPreviewCanvas?: () => HTMLCanvasElement | null
   watermarkImage: HTMLImageElement | null
   signal?: AbortSignal
+  fit: 'cover' | 'contain'
   onElapsedMs: (elapsedMs: number) => void
 }
 
@@ -490,6 +492,7 @@ async function paintImageSegment({
   getPreviewCanvas,
   watermarkImage,
   signal,
+  fit,
   onElapsedMs,
 }: PaintImageSegmentArgs): Promise<number> {
   const segmentSec = endSec - startSec
@@ -498,7 +501,7 @@ async function paintImageSegment({
   const bitmap = await loadClipImage(blob)
   try {
     const paintFrame = () => {
-      drawCoverFrom(ctx, bitmap, bitmap.width, bitmap.height, canvas.width, canvas.height)
+      drawFitFrom(ctx, bitmap, bitmap.width, bitmap.height, canvas.width, canvas.height, fit)
       if (watermarkImage) {
         drawWatermark(ctx, watermarkImage, canvas.width, canvas.height)
       }
@@ -553,6 +556,7 @@ async function paintSegment({
   getPreviewCanvas,
   watermarkImage,
   signal,
+  fit,
   onElapsedMs,
 }: PaintSegmentArgs): Promise<number> {
   const segmentSec = endSec - startSec
@@ -575,7 +579,15 @@ async function paintSegment({
     }
 
     const paintFrame = () => {
-      drawCover(ctx, video, canvas.width, canvas.height)
+      drawFitFrom(
+        ctx,
+        video,
+        video.videoWidth || canvas.width,
+        video.videoHeight || canvas.height,
+        canvas.width,
+        canvas.height,
+        fit,
+      )
       if (watermarkImage) {
         drawWatermark(ctx, watermarkImage, canvas.width, canvas.height)
       }

--- a/src/lib/export/encode-webcodecs.ts
+++ b/src/lib/export/encode-webcodecs.ts
@@ -17,6 +17,7 @@ import {
   type VideoCodec,
 } from 'mediabunny'
 import { isIosBrowser } from '../platform'
+import { clipCanvasFit } from '../clip-fit'
 import {
   clipMusicVolume,
   clipSoundVolume,
@@ -45,7 +46,7 @@ import {
   blitPreview,
   decodeBackgroundAudio,
   decodeClipAudio,
-  drawCoverFrom,
+  drawFitFrom,
   drawWatermark,
   loadClipImage,
   loadClipVideo,
@@ -455,6 +456,7 @@ export async function exportWithWebCodecs(
           getPreviewCanvas: encodingIntoPreview ? undefined : getPreviewCanvas,
           watermarkImage,
           signal,
+          fit: clipCanvasFit(segment.clip),
           onElapsedMs: (elapsed: number) => {
             if (plan.totalMs > 0) {
               onProgress?.(Math.min(1, (state.doneMs + elapsed) / plan.totalMs))
@@ -677,6 +679,7 @@ interface PumpSharedArgs {
   getPreviewCanvas?: () => HTMLCanvasElement | null
   watermarkImage?: HTMLImageElement | null
   signal?: AbortSignal
+  fit: 'cover' | 'contain'
   onElapsedMs: (elapsedMs: number) => void
 }
 
@@ -778,7 +781,7 @@ async function pumpSegmentVideoDecoded(
   const sink = new CanvasSink(track, {
     width: canvas.width,
     height: canvas.height,
-    fit: 'cover',
+    fit: args.fit,
     poolSize: 2,
   })
 
@@ -826,7 +829,7 @@ async function pumpSegmentImage({ blob, ...shared }: ImagePumpArgs): Promise<voi
   const bitmap = await loadClipImage(blob)
   try {
     const draw = (ctx: CanvasRenderingContext2D, width: number, height: number) =>
-      drawCoverFrom(ctx, bitmap, bitmap.width, bitmap.height, width, height)
+      drawFitFrom(ctx, bitmap, bitmap.width, bitmap.height, width, height, shared.fit)
     // The epsilon keeps float accumulation from emitting one tick past the
     // segment's end (the sink would clamp it onto the same timestamp).
     for (let tsSec = startSec, first = true; tsSec < endSec - 1e-6; tsSec += EXPORT_FRAME_INTERVAL_SEC) {
@@ -862,17 +865,14 @@ async function pumpSegmentVideo({
   const emitAt = (mediaTimeSec: number, options?: { force?: boolean }): Promise<void> =>
     emit(
       (ctx, width, height) => {
-        const vw = video.videoWidth || width
-        const vh = video.videoHeight || height
-        const scale = Math.max(width / vw, height / vh)
-        ctx.fillStyle = '#000'
-        ctx.fillRect(0, 0, width, height)
-        ctx.drawImage(
+        drawFitFrom(
+          ctx,
           video,
-          (width - vw * scale) / 2,
-          (height - vh * scale) / 2,
-          vw * scale,
-          vh * scale,
+          video.videoWidth || width,
+          video.videoHeight || height,
+          width,
+          height,
+          shared.fit,
         )
       },
       mediaTimeSec,

--- a/src/lib/export/index.ts
+++ b/src/lib/export/index.ts
@@ -49,8 +49,8 @@ export interface ExportOptions {
   /** Background-music playlist mixed under the clips at their per-clip
    * volumes; tracks play one after the other until the film ends. */
   background?: BackgroundAudio | null
-  /** Force the output into the project's orientation. Absent = follow the
-   * first clip's aspect (how every project exported before the setting). */
+  /** Force the output into the project's orientation. Portrait and
+   * landscape both pin the canvas; absent still follows the first clip. */
   orientation?: ProjectOrientation
   /**
    * Fired once when the export enters the realtime canvas + MediaRecorder

--- a/src/lib/export/last-export.test.ts
+++ b/src/lib/export/last-export.test.ts
@@ -24,6 +24,9 @@ describe('exportSignature', () => {
     expect(exportSignature(clips, true, null, undefined)).toBe(
       exportSignature(clips, true, null),
     )
+    expect(JSON.parse(exportSignature(clips, true, null, 'portrait')).orientation).toBe(
+      'portrait',
+    )
   })
 
   it('signs landscape differently so the cached export re-renders', () => {

--- a/src/lib/export/last-export.test.ts
+++ b/src/lib/export/last-export.test.ts
@@ -46,4 +46,12 @@ describe('exportSignature', () => {
       exportSignature(clips, false, null, 'portrait', false, 'Road trip'),
     )
   })
+
+  it('signs letterbox so a fit change cannot reuse a cropped export', () => {
+    const cropped = [fakeClip('clip_a')]
+    const letterboxed = [{ ...fakeClip('clip_a'), fit: 'letterbox' as const }]
+    expect(exportSignature(letterboxed, false, null, 'portrait')).not.toBe(
+      exportSignature(cropped, false, null, 'portrait'),
+    )
+  })
 })

--- a/src/lib/export/last-export.ts
+++ b/src/lib/export/last-export.ts
@@ -7,6 +7,7 @@
  */
 
 import { getDb, getSettings } from '../storage'
+import { clipFit } from '../clip-fit'
 import {
   audioTrackLevel,
   clipMusicVolume,
@@ -40,15 +41,20 @@ export function exportSignature(
     projectName,
     // Only landscape signs (JSON drops undefined).
     orientation: orientation === 'landscape' ? 'landscape' : undefined,
-    clips: clips.map((clip) => [
-      clip.id,
-      clip.trimStartMs,
-      clip.trimEndMs,
-      // Per-clip levels, resolved so an explicit value equal to the
-      // default signs identically to no value.
-      clipSoundVolume(clip),
-      clipMusicVolume(clip),
-    ]),
+    clips: clips.map((clip) => {
+      const row: Array<string | number> = [
+        clip.id,
+        clip.trimStartMs,
+        clip.trimEndMs,
+        // Per-clip levels, resolved so an explicit value equal to the
+        // default signs identically to no value.
+        clipSoundVolume(clip),
+        clipMusicVolume(clip),
+      ]
+      // Crop is the default; only letterbox changes the pixels.
+      if (clipFit(clip) === 'letterbox') row.push('letterbox')
+      return row
+    }),
     audio: audio
       ? {
           tracks: audio.tracks.map((track) => [

--- a/src/lib/export/last-export.ts
+++ b/src/lib/export/last-export.ts
@@ -39,8 +39,9 @@ export function exportSignature(
     includeLocation,
     // Title is written into the file; a rename must not reuse the old MP4.
     projectName,
-    // Only landscape signs (JSON drops undefined).
-    orientation: orientation === 'landscape' ? 'landscape' : undefined,
+    // Portrait signs explicitly so pre-pin caches (that followed the
+    // first clip's aspect) cannot be reused as a 9:16 film.
+    orientation: orientation === 'landscape' ? 'landscape' : 'portrait',
     clips: clips.map((clip) => {
       const row: Array<string | number> = [
         clip.id,

--- a/src/lib/export/shared.test.ts
+++ b/src/lib/export/shared.test.ts
@@ -13,6 +13,8 @@ import {
   decodeClipAudio,
   isAutoplayBlockedError,
   isWebKitAudioDecoderNotFoundError,
+  drawContainFrom,
+  drawCoverFrom,
   pickOutputSize,
   playExportVideo,
   prepareExportVideoElement,
@@ -22,6 +24,50 @@ import {
   unlockExportMediaPlayback,
   waitForPreviewCanvas,
 } from './shared'
+
+describe('drawContainFrom', () => {
+  it('letterboxes a landscape source onto a portrait canvas', () => {
+    const canvas = document.createElement('canvas')
+    canvas.width = 90
+    canvas.height = 160
+    const ctx = canvas.getContext('2d')
+    if (!ctx) throw new Error('canvas 2d missing')
+    const source = document.createElement('canvas')
+    source.width = 160
+    source.height = 90
+    const sourceCtx = source.getContext('2d')
+    if (!sourceCtx) throw new Error('source canvas 2d missing')
+    sourceCtx.fillStyle = '#fff'
+    sourceCtx.fillRect(0, 0, 160, 90)
+
+    drawContainFrom(ctx, source, 160, 90, 90, 160)
+    const top = ctx.getImageData(45, 2, 1, 1).data
+    const mid = ctx.getImageData(45, 80, 1, 1).data
+    expect(top[0]).toBe(0)
+    expect(mid[0]).toBe(255)
+  })
+})
+
+describe('drawCoverFrom', () => {
+  it('crops a landscape source onto a portrait canvas', () => {
+    const canvas = document.createElement('canvas')
+    canvas.width = 90
+    canvas.height = 160
+    const ctx = canvas.getContext('2d')
+    if (!ctx) throw new Error('canvas 2d missing')
+    const source = document.createElement('canvas')
+    source.width = 160
+    source.height = 90
+    const sourceCtx = source.getContext('2d')
+    if (!sourceCtx) throw new Error('source canvas 2d missing')
+    sourceCtx.fillStyle = '#fff'
+    sourceCtx.fillRect(0, 0, 160, 90)
+
+    drawCoverFrom(ctx, source, 160, 90, 90, 160)
+    const mid = ctx.getImageData(45, 80, 1, 1).data
+    expect(mid[0]).toBe(255)
+  })
+})
 
 describe('pickOutputSize', () => {
   it('follows the source aspect, capped at 1920 on the long edge', () => {

--- a/src/lib/export/shared.ts
+++ b/src/lib/export/shared.ts
@@ -322,17 +322,59 @@ export function drawCoverFrom(
   ctx.drawImage(source, (width - dw) / 2, (height - dh) / 2, dw, dh)
 }
 
+/** Letterbox `source` onto the destination so the whole frame is visible. */
+export function drawContainFrom(
+  ctx: CanvasRenderingContext2D,
+  source: CanvasImageSource,
+  sourceWidth: number,
+  sourceHeight: number,
+  width: number,
+  height: number,
+): void {
+  const vw = sourceWidth || width
+  const vh = sourceHeight || height
+  const scale = Math.min(width / vw, height / vh)
+  const dw = vw * scale
+  const dh = vh * scale
+  ctx.fillStyle = '#000'
+  ctx.fillRect(0, 0, width, height)
+  ctx.drawImage(source, (width - dw) / 2, (height - dh) / 2, dw, dh)
+}
+
+/** Cover-crop or letterbox `source` onto the destination. */
+export function drawFitFrom(
+  ctx: CanvasRenderingContext2D,
+  source: CanvasImageSource,
+  sourceWidth: number,
+  sourceHeight: number,
+  width: number,
+  height: number,
+  fit: 'cover' | 'contain',
+): void {
+  switch (fit) {
+    case 'contain':
+      drawContainFrom(ctx, source, sourceWidth, sourceHeight, width, height)
+      return
+    case 'cover':
+      drawCoverFrom(ctx, source, sourceWidth, sourceHeight, width, height)
+      return
+    default: {
+      const _exhaustive: never = fit
+      throw new Error(`Unhandled clip fit: ${_exhaustive}`)
+    }
+  }
+}
+
 /**
  * Pick output dimensions from the first clip's real pixel size: preserve its
  * aspect ratio, cap the long edge at 1920 (1080p), never upscale, keep dims even.
  *
  * When the project carries an explicit `orientation`, the output must match
  * it regardless of what the first clip happens to be: a mismatched source
- * has its dimensions swapped (the same cover-fit draw that letterboxes
- * nothing then center-crops every frame into the rotated canvas). A square
- * source is deliberately left square — it already satisfies either
- * orientation, and inventing a non-square target would crop pixels for no
- * reason.
+ * has its dimensions swapped. Each clip then cover-crops or letterboxes
+ * into that canvas. A square source is deliberately left square — it
+ * already satisfies either orientation, and inventing a non-square target
+ * would crop pixels for no reason.
  */
 export function pickOutputSize(
   sourceWidth: number,

--- a/src/lib/import-device-clips.ts
+++ b/src/lib/import-device-clips.ts
@@ -1,3 +1,4 @@
+import { lockOrientationFromFirstClip } from './orientation-lock'
 import { addClip, clearUndo } from './storage'
 import {
   DEFAULT_IMAGE_DURATION_MS,
@@ -303,6 +304,7 @@ export async function importDeviceClips(
       const probed = await probeDeviceClip(file)
       projectId ??= await options.ensureProjectId()
       const clip = await addClip(addClipInputFor(projectId, probed, afterClipId))
+      await lockOrientationFromFirstClip(projectId, clip)
       added.push(clip)
       afterClipId = clip.id
       options.onAdded?.(clip)

--- a/src/lib/orientation-lock.test.ts
+++ b/src/lib/orientation-lock.test.ts
@@ -1,0 +1,52 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { markWatermarkRemoved } from './entitlement'
+import { lockOrientationFromFirstClip } from './orientation-lock'
+import { setPlatformOverridesForTests } from './platform'
+import { __resetDbForTests, addClip, createProject, getProject } from './storage'
+
+function fakeBlob(label: string): Blob {
+  return new Blob([label], { type: 'video/webm' })
+}
+
+describe('lockOrientationFromFirstClip', () => {
+  beforeEach(async () => {
+    await __resetDbForTests()
+    await markWatermarkRemoved('cs_test_lock')
+  })
+
+  afterEach(() => {
+    setPlatformOverridesForTests({})
+  })
+
+  it('prefers how the phone is held when recording, even if pixels disagree', async () => {
+    setPlatformOverridesForTests({ coarsePointer: true, viewportLandscape: false })
+    const project = await createProject('Held upright')
+    const clip = await addClip({
+      projectId: project.id,
+      blob: fakeBlob('wide-sensor'),
+      mimeType: 'video/webm',
+      durationMs: 800,
+      width: 1920,
+      height: 1080,
+    })
+
+    await lockOrientationFromFirstClip(project.id, clip, { preferHeldOrientation: true })
+    expect((await getProject(project.id))?.orientation).toBeUndefined()
+  })
+
+  it('uses clip pixels for imports, ignoring how the device is held', async () => {
+    setPlatformOverridesForTests({ coarsePointer: true, viewportLandscape: false })
+    const project = await createProject('Import wide')
+    const clip = await addClip({
+      projectId: project.id,
+      blob: fakeBlob('import'),
+      mimeType: 'video/webm',
+      durationMs: 800,
+      width: 1920,
+      height: 1080,
+    })
+
+    await lockOrientationFromFirstClip(project.id, clip)
+    expect((await getProject(project.id))?.orientation).toBe('landscape')
+  })
+})

--- a/src/lib/orientation-lock.ts
+++ b/src/lib/orientation-lock.ts
@@ -1,0 +1,32 @@
+import { orientationFromSize } from './clip-fit'
+import { isCoarsePointerDevice, viewportIsLandscape } from './platform'
+import { getProject, setProjectOrientation } from './storage'
+import type { ClipRecord, ProjectId, ProjectOrientation } from './types'
+
+/**
+ * The first clip sets the film's orientation. On a phone, how the device
+ * is held wins: camera tracks are often landscape pixels even when the
+ * user is recording upright. Imports and desktop use the clip's pixels
+ * (viewport only when size is unknown on a held device). Later clips
+ * never overwrite a choice. Landscape still requires Plus — a gated
+ * write leaves the project portrait and the take is kept.
+ */
+export async function lockOrientationFromFirstClip(
+  projectId: ProjectId,
+  clip: Pick<ClipRecord, 'width' | 'height'>,
+  options?: { preferHeldOrientation?: boolean },
+): Promise<void> {
+  const project = await getProject(projectId)
+  if (!project || project.clipIds.length !== 1) return
+  const fromClip = orientationFromSize(clip.width, clip.height)
+  const held: ProjectOrientation | null = isCoarsePointerDevice()
+    ? viewportIsLandscape()
+      ? 'landscape'
+      : 'portrait'
+    : null
+  const chosen = options?.preferHeldOrientation
+    ? (held ?? fromClip)
+    : (fromClip ?? held)
+  if (!chosen) return
+  await setProjectOrientation(projectId, chosen).catch(() => undefined)
+}

--- a/src/lib/project-actions.test.ts
+++ b/src/lib/project-actions.test.ts
@@ -93,7 +93,7 @@ describe('appendRecording orientation lock', () => {
     expect((await getProject(project.id))?.orientation).toBeUndefined()
   })
 
-  it('never locks on fine-pointer (desktop) devices', async () => {
+  it('never locks on fine-pointer (desktop) devices without clip size', async () => {
     setPlatformOverridesForTests({ coarsePointer: false, viewportLandscape: true })
     const project = await createProject('Desk')
 
@@ -101,10 +101,24 @@ describe('appendRecording orientation lock', () => {
     expect((await getProject(project.id))?.orientation).toBeUndefined()
   })
 
+  it('locks desktop from the first clip\'s pixels when size is known', async () => {
+    await markWatermarkRemoved('cs_test_actions')
+    setPlatformOverridesForTests({ coarsePointer: false, viewportLandscape: false })
+    const project = await createProject('Desk wide')
+
+    await appendRecording(project.id, {
+      blob: fakeBlob('webcam'),
+      mimeType: 'video/webm',
+      durationMs: 900,
+      width: 1920,
+      height: 1080,
+    })
+    expect((await getProject(project.id))?.orientation).toBe('landscape')
+  })
+
   it('saves the take even when the landscape lock is entitlement-gated', async () => {
-    // Free plan: the record screen blocks landscape takes up front, but if
-    // one ever reaches the save path the clip must land and the project
-    // simply stays unlocked.
+    // Free plan: recording is allowed sideways; the take lands and the
+    // project stays portrait when the landscape lock is Plus-gated.
     setPlatformOverridesForTests({ coarsePointer: true, viewportLandscape: true })
     const project = await createProject('Free wide')
 

--- a/src/lib/project-actions.ts
+++ b/src/lib/project-actions.ts
@@ -20,6 +20,7 @@ import {
   setProjectOrientation,
   undoDeleteLastClip,
   updateClipDuration,
+  updateClipFit,
   updateClipThumbs,
   updateClipTrim,
   updateClipVolumes,
@@ -27,7 +28,7 @@ import {
   type ClipVolumeSettings,
   type ProjectAudioTrackSettings,
 } from './storage'
-import { isCoarsePointerDevice, viewportIsLandscape } from './platform'
+import { lockOrientationFromFirstClip } from './orientation-lock'
 import { probeAudioFile } from './audio-import'
 import { estimateExportCacheBytes } from './export/export-cache'
 import { estimateStorageSpace, type StorageSpace } from './storage-space'
@@ -37,11 +38,13 @@ import {
   NEW_PROJECT_ID,
   effectiveDurationMs,
   isImageClip,
+  type ClipFit,
   type ClipId,
   type ClipRecord,
   type Project,
   type ProjectAudioRecord,
   type ProjectId,
+  type ProjectOrientation,
 } from './types'
 
 export interface ProjectSummary extends Project {
@@ -264,14 +267,6 @@ export async function appendRecording(
     capturedThumbs?: GeneratedThumbs | null
   },
 ): Promise<ClipRecord> {
-  // The FIRST recording locks the project's orientation to how the device
-  // is held — but only where holding it a way is a deliberate choice
-  // (phones/tablets). Desktop cameras and screen shares are landscape media
-  // regardless of intent, so desktop projects stay unlocked (their exports
-  // follow the clips, as always). Checked before the write so the lock
-  // below can never mistake this very clip for an existing one.
-  const project = await getProject(projectId)
-  const locksOrientation = project?.clipIds.length === 0 && isCoarsePointerDevice()
   const clip = await addClip({
     projectId,
     blob: input.blob,
@@ -285,16 +280,7 @@ export async function appendRecording(
     lng: input.lng,
     locationAccuracyM: input.locationAccuracyM,
   })
-  if (locksOrientation) {
-    // Best-effort, after the clip is safely stored: a lock failure (e.g.
-    // the landscape Plus gate racing an entitlement change — the record
-    // screen blocks free landscape takes before they start) must never
-    // lose a recorded take. An unlocked project just stays portrait.
-    await setProjectOrientation(
-      projectId,
-      viewportIsLandscape() ? 'landscape' : 'portrait',
-    ).catch(() => undefined)
-  }
+  await lockOrientationFromFirstClip(projectId, clip, { preferHeldOrientation: true })
   if (options?.capturedThumbs) {
     // Best-effort: on a (rare) persistence failure the loader backfill
     // still generates thumbs — one black flash beats missing artwork. The
@@ -472,6 +458,19 @@ export async function setClipVolumes(
   volumes: ClipVolumeSettings,
 ): Promise<void> {
   await updateClipVolumes(clipId, volumes)
+}
+
+/** Crop is the default; letterbox is the stored override. */
+export async function setClipFit(clipId: ClipId, fit: ClipFit): Promise<void> {
+  await updateClipFit(clipId, fit)
+}
+
+/** Change the film's export orientation. Landscape requires Plus. */
+export async function setFilmOrientation(
+  projectId: ProjectId,
+  orientation: ProjectOrientation,
+): Promise<void> {
+  await setProjectOrientation(projectId, orientation)
 }
 
 export {

--- a/src/lib/storage.test.ts
+++ b/src/lib/storage.test.ts
@@ -35,6 +35,7 @@ import {
   undoDeleteLastClip,
   updateClipAudioPeak,
   updateClipDuration,
+  updateClipFit,
   updateClipThumbs,
   updateClipVolumes,
   updateProjectAudioTrack,
@@ -346,6 +347,27 @@ describe('storage layer', () => {
     const portrait = await setProjectOrientation(project.id, 'portrait')
     expect(portrait.orientation).toBeUndefined()
     expect('orientation' in ((await listProjects())[0] ?? {})).toBe(false)
+  })
+
+  it('stores letterbox as a clip override and clears it for crop', async () => {
+    const project = await createProject('Fit')
+    const clip = await addClip({
+      projectId: project.id,
+      blob: fakeBlob('take'),
+      mimeType: 'video/webm',
+      durationMs: 900,
+      width: 1920,
+      height: 1080,
+    })
+    expect(clip.fit).toBeUndefined()
+
+    const letterboxed = await updateClipFit(clip.id, 'letterbox')
+    expect(letterboxed.fit).toBe('letterbox')
+    expect((await getClip(clip.id))?.fit).toBe('letterbox')
+
+    const cropped = await updateClipFit(clip.id, 'crop')
+    expect(cropped.fit).toBeUndefined()
+    expect('fit' in ((await getClip(clip.id)) ?? {})).toBe(false)
   })
 
   it('creates landscape projects when asked (Plus only)', async () => {

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -7,6 +7,7 @@ import {
   clampVolume,
   newId,
   type AppMeta,
+  type ClipFit,
   type ClipId,
   type ClipKind,
   type ClipMeta,
@@ -778,6 +779,19 @@ export async function updateClipTrim(
   const start = Math.max(0, Math.min(trimStartMs, clip.durationMs))
   const end = Math.max(start, Math.min(trimEndMs, clip.durationMs))
   const updated: ClipRecord = { ...clip, trimStartMs: start, trimEndMs: end }
+  await db.put('clips', updated)
+  await touchProject(clip.projectId)
+  return toMeta(updated)
+}
+
+/** Crop is the default, so it clears the stored override. */
+export async function updateClipFit(clipId: ClipId, fit: ClipFit): Promise<ClipMeta> {
+  const db = await getDb()
+  const clip = await db.get('clips', clipId)
+  if (!clip) throw new Error('Clip not found')
+  const updated: ClipRecord = { ...clip }
+  if (fit === 'letterbox') updated.fit = 'letterbox'
+  else delete updated.fit
   await db.put('clips', updated)
   await touchProject(clip.projectId)
   return toMeta(updated)

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -2,9 +2,12 @@ export type ProjectId = string
 export type ClipId = string
 
 /** The film's shape: portrait (the default, phone-style) or landscape.
- * Landscape is a Kody Video Plus perk. Chosen by how the device is held
- * when the first clip is recorded (phones/tablets), not by a setting. */
+ * Landscape is a Kody Video Plus perk. Defaults to the first clip's
+ * orientation; the user can change it later as a project setting. */
 export type ProjectOrientation = 'portrait' | 'landscape'
+
+/** How a mismatched clip is fitted into the film. Absent = crop. */
+export type ClipFit = 'crop' | 'letterbox'
 
 export interface Project {
   id: ProjectId
@@ -16,11 +19,8 @@ export interface Project {
    * rename, and never set for caller-chosen names, so a deliberate name
    * (even one shaped like "Project 2") is never mistaken for the default. */
   nameIsDefault?: boolean
-  /** The film's orientation, locked in by the first clip recorded on a
-   * touch device (how the device was held). Absent = portrait: projects
-   * made before this existed, desktop projects, and portrait locks all
-   * store nothing. A project with no clips is UNLOCKED — its interface
-   * follows the device until the first take decides. */
+  /** The film's export orientation. Absent = portrait. The first clip
+   * sets this when the project is still empty; the user can change it. */
   orientation?: ProjectOrientation
 }
 
@@ -47,6 +47,8 @@ export interface ClipMeta {
   createdAt: number
   width?: number
   height?: number
+  /** Fit into a mismatched film. Absent = crop (the default). */
+  fit?: ClipFit
   thumbWidth?: number
   thumbHeight?: number
   /** Opt-in geolocation captured at recording time (absent on older clips

--- a/src/pages/project-page.tsx
+++ b/src/pages/project-page.tsx
@@ -225,17 +225,18 @@ export function ProjectPage(handle: Handle<ProjectPageProps>) {
 
   /**
    * The film's orientation this page renders for. Locked projects (any with
-   * clips) are stuck with what their first take chose, wherever they open.
-   * Unlocked projects on phones/tablets follow how the device is held right
-   * now — rotating IS the orientation picker. Desktop keeps the classic
-   * column for unlocked projects (its cameras are landscape media without
-   * that being a choice).
+   * clips) use the stored film. Unlocked Plus projects on phones follow
+   * how the device is held — rotating is the orientation picker. Free
+   * unlocked projects stay portrait: landscape films are Plus, so a
+   * sideways preview would not match the take they can actually lock.
+   * Desktop keeps the classic column for unlocked projects.
    */
   const effectiveOrientation = (): ProjectOrientation => {
     const project = data?.project
     if (!project) return 'portrait'
     if (orientationUnlocked() && isCoarsePointerDevice()) {
-      return viewportIsLandscape() ? 'landscape' : 'portrait'
+      if (viewportIsLandscape() && data?.watermarkRemoved) return 'landscape'
+      return 'portrait'
     }
     return projectOrientation(project)
   }

--- a/src/pages/project-page.tsx
+++ b/src/pages/project-page.tsx
@@ -247,12 +247,9 @@ export function ProjectPage(handle: Handle<ProjectPageProps>) {
    * data-shell attribute so the CSS can reach the shell (#root) above the
    * app tree ('wide' vs 'narrow' — main.tsx resets it to 'adaptive' when
    * navigating to non-project routes).
-   * Installed PWAs additionally get best-effort screen-orientation pins
-   * (the manifest allows every orientation so rotation can happen at all):
-   * a LOCKED project pins the screen to its orientation, native-camera
-   * style; an unlocked project frees rotation so turning the phone can make
-   * the choice. In a browser tab every lock call rejects silently and the
-   * OS's own auto-rotate does the job.
+   * Recording is allowed in any hold, so the screen is never pinned —
+   * unlocking lets people rotate freely. In a browser tab lock/unlock
+   * reject silently and the OS's own auto-rotate does the job.
    */
   let appliedShellState: string | null = null
   const syncShellOrientation = (orientation: ProjectOrientation, unlocked: boolean) => {
@@ -261,16 +258,9 @@ export function ProjectPage(handle: Handle<ProjectPageProps>) {
     appliedShellState = nextState
     document.documentElement.dataset.shell = orientation === 'landscape' ? 'wide' : 'narrow'
     try {
-      const lockable = screen.orientation as ScreenOrientation & {
-        lock?: (lock: string) => Promise<void>
-      }
-      if (unlocked) {
-        screen.orientation.unlock()
-      } else {
-        void lockable.lock?.(orientation).catch(() => undefined)
-      }
+      screen.orientation.unlock()
     } catch {
-      // Orientation API missing or lock not allowed here — rotation stays manual.
+      // Orientation API missing or unlock not allowed here — rotation stays manual.
     }
   }
   handle.signal.addEventListener('abort', () => {
@@ -283,21 +273,9 @@ export function ProjectPage(handle: Handle<ProjectPageProps>) {
     }
   })
 
-  // Rotating the device re-renders (the unlocked layout follows it), and on
-  // the free plan, turning an unlocked project sideways is the moment to
-  // pitch Plus: the landscape interface is on screen — the gate (recording
-  // is blocked until upgrade or rotating back) needs explaining.
+  // Rotating the device re-renders (an unlocked layout follows it).
   const landscapeMedia = window.matchMedia('(orientation: landscape)')
   const onDeviceOrientationChange = () => {
-    if (
-      landscapeMedia.matches &&
-      isCoarsePointerDevice() &&
-      orientationUnlocked() &&
-      data &&
-      !data.watermarkRemoved
-    ) {
-      upselling = true
-    }
     void handle.update()
   }
   landscapeMedia.addEventListener('change', onDeviceOrientationChange)
@@ -375,11 +353,9 @@ export function ProjectPage(handle: Handle<ProjectPageProps>) {
     )
     const includeLocation =
       data.watermarkRemoved && data.includeLocationInExports && hasLocation
-    // Only an explicit landscape choice forces the output shape; portrait
-    // projects keep following their first clip (desktop and screen
-    // recordings are landscape media in "portrait" projects — cropping
-    // those would be a regression, not a feature).
-    const orientation = effectiveOrientation() === 'landscape' ? 'landscape' : undefined
+    // Always pin the canvas to the film so mismatched clips crop or
+    // letterbox instead of stretching the output to the first take.
+    const orientation = projectOrientation(project ?? { orientation: undefined })
     const signature = exportSignature(
       clips,
       watermarked,
@@ -688,12 +664,8 @@ export function ProjectPage(handle: Handle<ProjectPageProps>) {
     const captureTimeMs = lastCaptureTimeMs(clips) ?? undefined
     const orientation = effectiveOrientation()
     const unlocked = orientationUnlocked()
-    // Phones lock a film shape; show that shape (cover-cropped) so the
-    // camera, editor, and playback match export. Desktop never locks a
-    // portrait film, so it keeps filling the pane. Landscape projects
-    // always frame 16:9 (the Plus lock).
-    const filmFramed =
-      !unlocked && (orientation === 'landscape' || isCoarsePointerDevice())
+    // Always frame to the film so crop / letterbox previews match export.
+    const filmFramed = true
     syncShellOrientation(orientation, unlocked)
 
     return (

--- a/src/styles/editor.css
+++ b/src/styles/editor.css
@@ -44,6 +44,34 @@
   font-size: 0.78rem;
 }
 
+.editor-film-orientation {
+  display: inline-flex;
+  margin-top: 4px;
+  padding: 2px;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--ink) 8%, transparent);
+  border: 1px solid var(--line);
+}
+
+.editor-film-orientation button {
+  appearance: none;
+  border: 0;
+  background: transparent;
+  color: var(--ink-muted);
+  font: inherit;
+  font-size: 0.68rem;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  padding: 3px 8px;
+  border-radius: 999px;
+  line-height: 1.2;
+}
+
+.editor-film-orientation button.is-active {
+  color: var(--ink);
+  background: color-mix(in srgb, var(--stage-bg) 88%, var(--ink));
+}
+
 .editor-stage {
   flex: 1 1 auto;
   min-height: 0;
@@ -332,6 +360,21 @@
   padding: 2px 5px;
   border-radius: 999px;
   font-variant-numeric: tabular-nums;
+  pointer-events: none;
+}
+
+/* Mismatched clips show crop or letterbox in the top-left. */
+.clip-thumb .clip-fit-badge {
+  position: absolute;
+  left: 4px;
+  top: 4px;
+  display: grid;
+  place-items: center;
+  width: 18px;
+  height: 18px;
+  border-radius: 6px;
+  color: #fff;
+  background: rgba(0, 0, 0, 0.55);
   pointer-events: none;
 }
 
@@ -1086,6 +1129,32 @@
   text-align: right;
   font-variant-numeric: tabular-nums;
   font-size: 0.9rem;
+}
+
+.clip-info-fit {
+  margin-top: 14px;
+}
+
+.clip-info-fit-label {
+  margin: 0 0 8px;
+  font-size: 0.82rem;
+  color: var(--ink-muted);
+}
+
+.clip-info-fit-toggles {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 8px;
+}
+
+.clip-info-fit-btn {
+  justify-content: center;
+  gap: 8px;
+}
+
+.clip-info-fit-btn.is-active {
+  border-color: var(--accent);
+  color: var(--ink);
 }
 
 .clip-info-actions {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -187,6 +187,12 @@ a {
   object-fit: cover;
 }
 
+.film-frame.is-letterbox > .editor-clip-preview,
+.film-frame.is-letterbox > .playback-video,
+.film-frame.is-letterbox > .playback-image {
+  object-fit: contain;
+}
+
 .record-stage,
 .editor-clip-preview-wrap,
 .playback-overlay {

--- a/src/styles/record.css
+++ b/src/styles/record.css
@@ -447,7 +447,7 @@
 .orientation-hint {
   position: absolute;
   left: 50%;
-  top: calc(12px + var(--safe-top, 0px));
+  top: calc(48px + var(--safe-top, 0px));
   transform: translateX(-50%);
   z-index: 2;
   display: none;

--- a/src/styles/record.css
+++ b/src/styles/record.css
@@ -440,40 +440,47 @@
   pointer-events: none;
 }
 
-/* Locked-project mismatch hints: a landscape project held upright (shown on
-   portrait viewports), and a portrait project held sideways (shown on
+/* Locked-film mismatch hints: a landscape film held upright (shown on
+   portrait viewports), and a portrait film held sideways (shown on
    landscape viewports, coarse pointers only — desktop windows aren't
-   "held"). Each is rendered only on its project kind. */
+   "held"). Compact top pill — obvious, not a centered modal. */
 .orientation-hint {
   position: absolute;
   left: 50%;
-  top: 50%;
-  transform: translate(-50%, -50%);
+  top: calc(12px + var(--safe-top, 0px));
+  transform: translateX(-50%);
   z-index: 2;
   display: none;
-  flex-direction: column;
+  flex-direction: row;
   align-items: center;
-  gap: 4px;
-  padding: 16px 22px;
-  border-radius: 18px;
+  gap: 8px;
+  padding: 7px 12px;
+  border-radius: 999px;
   color: #fff;
-  background: rgba(8, 12, 14, 0.66);
-  border: 1px solid rgba(255, 255, 255, 0.18);
+  background: rgba(8, 12, 14, 0.72);
+  border: 1px solid rgba(255, 255, 255, 0.22);
   backdrop-filter: blur(10px);
-  box-shadow: 0 8px 28px rgba(0, 0, 0, 0.35);
-  text-align: center;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.28);
+  text-align: left;
   pointer-events: none;
-  max-width: min(300px, 84vw);
+  max-width: min(360px, 88vw);
+}
+
+.orientation-hint > span {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  min-width: 0;
 }
 
 .orientation-hint strong {
   font-family: var(--font-display);
-  font-size: 1.15rem;
+  font-size: 0.82rem;
   line-height: 1.15;
 }
 
-.orientation-hint span {
-  font-size: 0.82rem;
+.orientation-hint > span span {
+  font-size: 0.72rem;
   opacity: 0.82;
 }
 
@@ -491,29 +498,6 @@
   .orientation-hint-portrait {
     display: flex;
   }
-}
-
-/* Rotate-to-choose upsell (free plan, empty project, device sideways): the
-   landscape interface is visible as a preview; this explains why recording
-   waits. Sits where the hold-hint would be. */
-.orientation-gate-pill {
-  position: absolute;
-  left: 50%;
-  bottom: 22%;
-  transform: translateX(-50%);
-  z-index: 2;
-  display: inline-flex;
-  align-items: center;
-  gap: 8px;
-  padding: 10px 16px;
-  border-radius: 999px;
-  color: #10171a;
-  background: var(--accent);
-  border: 1px solid color-mix(in srgb, var(--accent) 65%, #fff);
-  font-weight: 700;
-  font-size: 0.85rem;
-  box-shadow: 0 8px 28px rgba(0, 0, 0, 0.35);
-  max-width: min(420px, 88vw);
 }
 
 /* The landscape interface: with the project (and viewport) sideways, the

--- a/tests/e2e/orientation-touch.spec.ts
+++ b/tests/e2e/orientation-touch.spec.ts
@@ -88,7 +88,7 @@ test.describe('rotate-to-choose orientation (touch)', () => {
     await rotate(page)
     await expect.poll(() => shellLayout(page)).toBe('wide')
     await expect(page.locator('.orientation-hint')).toBeVisible()
-    await expect(page.locator('.orientation-hint')).toContainText(/turn your device sideways/i)
+    await expect(page.locator('.orientation-hint')).toContainText(/hold sideways/i)
 
     // Survives a reload.
     await page.reload()
@@ -96,40 +96,22 @@ test.describe('rotate-to-choose orientation (touch)', () => {
     await expect.poll(() => shellLayout(page)).toBe('wide')
   })
 
-  test('free plan: rotating previews landscape but the take is gated behind Plus', async ({
+  test('free plan: rotating previews landscape and recording is allowed', async ({
     page,
   }) => {
     await openNewProject(page)
     await expect.poll(() => shellLayout(page)).toBe('narrow')
 
-    // Turn the phone: the layout shifts (the preview IS the pitch) and the
-    // upsell opens to explain the gate.
+    // Turn the phone: the layout follows. Recording is allowed; Plus is
+    // only required to lock the film landscape.
     await rotate(page)
     await expect.poll(() => shellLayout(page)).toBe('wide')
-    const upsell = page.locator('.sheet[aria-label="Kody Video Plus"]')
-    await expect(upsell).toBeVisible()
-    await expect(upsell).toContainText(/landscape projects/i)
-    await upsell.getByRole('button', { name: 'Not now' }).click()
-    await expect(upsell).toBeHidden()
+    await expect(page.locator('.sheet[aria-label="Kody Video Plus"]')).toBeHidden()
+    await expect(page.locator('.orientation-gate-pill')).toHaveCount(0)
 
-    // The standing gate pill explains why recording waits; pressing the
-    // stage re-opens the upsell instead of starting a take.
-    await expect(page.locator('.orientation-gate-pill')).toBeVisible()
-    const stage = await page.locator('.record-stage').boundingBox()
-    await page.mouse.move(stage!.x + stage!.width / 2, stage!.y + stage!.height / 2)
-    await page.mouse.down()
-    await page.waitForTimeout(800)
-    await page.mouse.up()
-    await expect(upsell).toBeVisible()
-    expect(await totalClipCount(page)).toBe(0)
-    await upsell.getByRole('button', { name: 'Not now' }).click()
-
-    // Turning back upright: everything works free, and the first take locks
-    // portrait (stored as nothing — the default).
-    await rotate(page)
-    await expect.poll(() => shellLayout(page)).toBe('narrow')
-    await expect(page.locator('.orientation-gate-pill')).toBeHidden()
     await recordClip(page)
+    expect(await totalClipCount(page)).toBe(1)
+    // Free plan cannot lock landscape, so the film stays portrait.
     expect(await storedOrientation(page)).toBeUndefined()
     await expect(page.locator('.project-screen')).toHaveClass(/is-film-framed/)
     const film = page.locator('.record-stage > .film-frame')
@@ -209,14 +191,28 @@ test.describe('export-cover preview (touch)', () => {
     await page.getByRole('button', { name: 'Open editor' }).click()
     await expect(page.locator('.editor-screen')).toBeVisible()
     await expect(page.locator('.project-screen')).toHaveClass(/is-film-framed/)
+    await expect(page.locator('.clip-fit-badge')).toBeVisible()
+    await expect(page.getByRole('option', { name: /cropped/i })).toBeVisible()
     const preview = page.locator('.editor-clip-preview')
     await expect
       .poll(() => preview.evaluate((el) => (el as HTMLVideoElement).videoWidth))
       .toBeGreaterThan(0)
+    await expect(page.locator('.film-frame.is-letterbox')).toHaveCount(0)
     const file = testInfo.outputPath('editor_landscape_clip_cropped.png')
     await page.screenshot({ path: file, fullPage: false })
     await page.screenshot({
       path: '/opt/cursor/artifacts/editor_landscape_clip_cropped.png',
+      fullPage: false,
+    })
+
+    await page.getByRole('button', { name: 'Clip info' }).click()
+    await expect(page.locator('.clip-info-sheet')).toBeVisible()
+    await page.getByRole('button', { name: 'Letterbox' }).click()
+    await page.getByRole('button', { name: 'Close' }).click()
+    await expect(page.locator('.film-frame.is-letterbox')).toBeVisible()
+    await expect(page.getByRole('option', { name: /letterboxed/i })).toBeVisible()
+    await page.screenshot({
+      path: '/opt/cursor/artifacts/editor_landscape_clip_letterboxed.png',
       fullPage: false,
     })
   })

--- a/tests/e2e/orientation-touch.spec.ts
+++ b/tests/e2e/orientation-touch.spec.ts
@@ -96,18 +96,19 @@ test.describe('rotate-to-choose orientation (touch)', () => {
     await expect.poll(() => shellLayout(page)).toBe('wide')
   })
 
-  test('free plan: rotating previews landscape and recording is allowed', async ({
+  test('free plan: rotating stays portrait and recording is allowed', async ({
     page,
   }) => {
     await openNewProject(page)
     await expect.poll(() => shellLayout(page)).toBe('narrow')
 
-    // Turn the phone: the layout follows. Recording is allowed; Plus is
-    // only required to lock the film landscape.
+    // Turn the phone: the film stays portrait (landscape lock is Plus),
+    // recording is still allowed, and there is no gate or upsell.
     await rotate(page)
-    await expect.poll(() => shellLayout(page)).toBe('wide')
+    await expect.poll(() => shellLayout(page)).toBe('narrow')
     await expect(page.locator('.sheet[aria-label="Kody Video Plus"]')).toBeHidden()
     await expect(page.locator('.orientation-gate-pill')).toHaveCount(0)
+    await expect(page.locator('.project-screen.orientation-landscape')).toHaveCount(0)
 
     await recordClip(page)
     expect(await totalClipCount(page)).toBe(1)

--- a/tests/e2e/project-orientation.spec.ts
+++ b/tests/e2e/project-orientation.spec.ts
@@ -35,7 +35,7 @@ test.describe('project orientation', () => {
 
     // Held upright (portrait viewport), the app asks for a turn.
     await expect(page.locator('.orientation-hint')).toBeVisible()
-    await expect(page.locator('.orientation-hint')).toContainText(/turn your device/i)
+    await expect(page.locator('.orientation-hint')).toContainText(/hold sideways/i)
 
     // A reload keeps the landscape interface — the lock is on the project.
     await page.reload()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
People can record in whatever orientation they like. The film’s export orientation is a project setting (Portrait / Landscape in the editor). The first clip still sets the default — on a phone, from how the device is held; on desktop or import, from the clip’s pixels. Landscape films remain a Plus perk; a free-plan landscape take is kept and the project stays portrait.

**Per-clip fit**
- Crop is the default when a clip disagrees with the film
- Letterbox is a clip-info choice
- Timeline shows a small crop / letterbox badge only when the clip is actually fitted (no icon when it already matches)

**Record**
- No more landscape record gate or giant centered warning
- A compact pill on the film hints to hold the device the film’s way (or crop the take)
- The screen is no longer orientation-locked, so rotation stays free
- Empty free projects stay portrait when held sideways, so the preview matches the film they can lock. Plus still rotate-to-choose.

**Preview & export**
- Editor and playback use `object-fit: contain` for letterboxed clips
- Both export engines cover-crop or letterbox per clip
- Export always pins the canvas to the film orientation (including portrait)
- Portrait now signs in the export cache key so older follow-the-first-clip files are not reused

![Compact hold hint when the device does not match the film](https://cursor.com/artifacts/c/art-a59ff79a-cfeb-4582-8e2b-4986ae045869)
![Landscape clip cropped into a portrait film, with crop badge](https://cursor.com/artifacts/c/art-d6244464-3744-4b2b-8083-f6f2bc57cef9)
![Same clip letterboxed, with letterbox badge](https://cursor.com/artifacts/c/art-76795417-28ff-4a56-b9e9-b34bdad67eb1)

Tests cover fit helpers, first-clip lock, letterbox cache invalidation, and the free-plan “record while sideways” path.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-04283985-9019-4c2b-bbfb-f5e85da7eb55?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-04283985-9019-4c2b-bbfb-f5e85da7eb55&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

