### PR TITLE
Fix orientation switcher, landscape chrome, and per-clip size

### DIFF
--- a/index.html
+++ b/index.html
@@ -177,7 +177,9 @@
       /* Shell width by layout mode — must mirror global.css (the attribute
          is set by the pre-paint script below, so the frame never jumps when
          the full stylesheet arrives). 'adaptive' (home/static pages) widens
-         on landscape viewports; 'wide' (landscape projects) always. */
+         on landscape viewports; 'wide' (landscape projects) always;
+         'narrow' (portrait projects) widens when the viewport is landscape
+         so chrome can use the side gutters. */
       html[data-shell='wide'] #root,
       html[data-shell='wide'] .app-shell {
         width: 100%;
@@ -185,14 +187,17 @@
       }
       @media (orientation: landscape) {
         html[data-shell='adaptive'] #root,
-        html[data-shell='adaptive'] .app-shell {
+        html[data-shell='adaptive'] .app-shell,
+        html[data-shell='narrow'] #root,
+        html[data-shell='narrow'] .app-shell {
           width: 100%;
           max-width: none;
         }
       }
       @media (min-width: 720px) and (orientation: landscape) and (pointer: fine) {
         html[data-shell='adaptive'] #root,
-        html[data-shell='wide'] #root {
+        html[data-shell='wide'] #root,
+        html[data-shell='narrow'] #root {
           width: min(1200px, calc(100% - 48px));
         }
       }

--- a/src/lib/clip-media.test.ts
+++ b/src/lib/clip-media.test.ts
@@ -1,8 +1,8 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 import { permanentlyTrimClip, splitSelectedClip } from './project-actions'
 import { __resetDbForTests, addClip, createProject, getClip, getClipsForProject, updateClipTrim } from './storage'
-import { makeTestClipBlob } from './testing/make-test-clip'
-import { outputMimeForClipMedia, sliceClipMedia } from './clip-media'
+import { makeLabeledClipBlob, makeTestClipBlob } from './testing/make-test-clip'
+import { outputMimeForClipMedia, probeVideoDisplaySize, sliceClipMedia } from './clip-media'
 import { measureBlobDuration } from './media'
 
 describe('outputMimeForClipMedia', () => {
@@ -12,6 +12,22 @@ describe('outputMimeForClipMedia', () => {
     expect(outputMimeForClipMedia('video/x-m4v')).toBe('video/mp4')
     expect(outputMimeForClipMedia('video/webm')).toBe('video/webm')
     expect(outputMimeForClipMedia('')).toBe('video/webm')
+  })
+})
+
+describe('probeVideoDisplaySize', () => {
+  it('reads landscape pixels from the file, not a caller-supplied fallback', async () => {
+    const blob = await makeLabeledClipBlob(640, 360)
+    await expect(probeVideoDisplaySize(blob)).resolves.toEqual({ width: 640, height: 360 })
+  })
+
+  it('reads portrait pixels from the file', async () => {
+    const blob = await makeTestClipBlob(400)
+    await expect(probeVideoDisplaySize(blob)).resolves.toEqual({ width: 320, height: 568 })
+  })
+
+  it('returns null for a non-video blob', async () => {
+    await expect(probeVideoDisplaySize(new Blob(['nope'], { type: 'text/plain' }))).resolves.toBeNull()
   })
 })
 

--- a/src/lib/clip-media.ts
+++ b/src/lib/clip-media.ts
@@ -85,6 +85,11 @@ async function measureSlicedDuration(blob: Blob, fallbackMs: number): Promise<nu
   return Math.round(fallbackMs)
 }
 
+export interface VideoDisplaySize {
+  width: number
+  height: number
+}
+
 async function probeSlicedSize(
   input: { getPrimaryVideoTrack: () => Promise<{ displayWidth: number; displayHeight: number; codedWidth: number; codedHeight: number } | null> },
 ): Promise<{ width?: number; height?: number }> {
@@ -94,4 +99,39 @@ async function probeSlicedSize(
   const height = track.displayHeight > 0 ? track.displayHeight : track.codedHeight
   if (!(width > 0) || !(height > 0)) return {}
   return { width, height }
+}
+
+/**
+ * Pixel size the file actually displays, including rotation / display
+ * matrices. Camera `getSettings()` often stays at the sensor size from
+ * when the session started, so a sideways take can be stored as 9:16
+ * even when the encoded frames are 16:9.
+ */
+export async function probeVideoDisplaySize(blob: Blob): Promise<VideoDisplaySize | null> {
+  try {
+    const { ALL_FORMATS, BlobSource, Input } = await import('mediabunny')
+    const input = new Input({ source: new BlobSource(blob), formats: ALL_FORMATS })
+    try {
+      const size = await probeSlicedSize(input)
+      if (size.width && size.height) return { width: size.width, height: size.height }
+    } finally {
+      input.dispose()
+    }
+  } catch {
+    // Unparseable container — let the element path judge it.
+  }
+  try {
+    const { loadClipVideo } = await import('./export/shared')
+    const loaded = await loadClipVideo(blob)
+    try {
+      const width = loaded.video.videoWidth
+      const height = loaded.video.videoHeight
+      if (width > 0 && height > 0) return { width, height }
+    } finally {
+      loaded.release()
+    }
+  } catch {
+    return null
+  }
+  return null
 }

--- a/src/lib/project-actions.test.ts
+++ b/src/lib/project-actions.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
-import { appendRecording, loadHomeProjects } from './project-actions'
-import { __resetDbForTests, addClip, createProject, deleteClip, getProject, listProjects, renameProject } from './storage'
+import { appendRecording, hydrateProjectClips, loadHomeProjects } from './project-actions'
+import { __resetDbForTests, addClip, createProject, deleteClip, getClip, getProject, listProjects, renameProject } from './storage'
+import { makeLabeledClipBlob } from './testing/make-test-clip'
 import { markWatermarkRemoved } from './entitlement'
 import { setPlatformOverridesForTests } from './platform'
 
@@ -127,5 +128,46 @@ describe('appendRecording orientation lock', () => {
     const stored = await getProject(project.id)
     expect(stored?.clipIds).toHaveLength(1)
     expect(stored?.orientation).toBeUndefined()
+  })
+
+  it('stores the encoded display size instead of the camera-track fallback', async () => {
+    const project = await createProject('Track lie')
+    const blob = await makeLabeledClipBlob(640, 360)
+    const clip = await appendRecording(project.id, {
+      blob,
+      mimeType: 'video/webm',
+      durationMs: 1200,
+      width: 360,
+      height: 640,
+    })
+    expect(clip.width).toBe(640)
+    expect(clip.height).toBe(360)
+    expect((await getClip(clip.id))?.width).toBe(640)
+    expect((await getClip(clip.id))?.height).toBe(360)
+  })
+})
+
+describe('hydrateProjectClips display size', () => {
+  beforeEach(async () => {
+    await __resetDbForTests()
+  })
+
+  it('corrects a stored size that disagrees with the file', async () => {
+    const project = await createProject('Backfill')
+    const blob = await makeLabeledClipBlob(640, 360)
+    const clip = await addClip({
+      projectId: project.id,
+      blob,
+      mimeType: 'video/webm',
+      durationMs: 1200,
+      width: 360,
+      height: 640,
+    })
+
+    const [hydrated] = await hydrateProjectClips([clip])
+    expect(hydrated.width).toBe(640)
+    expect(hydrated.height).toBe(360)
+    expect((await getClip(clip.id))?.width).toBe(640)
+    expect((await getClip(clip.id))?.height).toBe(360)
   })
 })

--- a/src/lib/project-actions.ts
+++ b/src/lib/project-actions.ts
@@ -21,6 +21,7 @@ import {
   undoDeleteLastClip,
   updateClipDuration,
   updateClipFit,
+  updateClipSize,
   updateClipThumbs,
   updateClipTrim,
   updateClipVolumes,
@@ -28,6 +29,7 @@ import {
   type ClipVolumeSettings,
   type ProjectAudioTrackSettings,
 } from './storage'
+import { probeVideoDisplaySize } from './clip-media'
 import { lockOrientationFromFirstClip } from './orientation-lock'
 import { probeAudioFile } from './audio-import'
 import { estimateExportCacheBytes } from './export/export-cache'
@@ -229,18 +231,31 @@ export async function loadProjectPage(projectId: ProjectId): Promise<ProjectLoad
   }
 }
 
-/** Generate missing filmstrip thumbs and audio-peak measurements. Serial
- * because Android caps concurrent video decoders. Safe to call after the
- * first paint — tiles already render with placeholders. */
+/** Generate missing filmstrip thumbs and audio-peak measurements, and
+ * correct stored pixel size from the file (camera track settings often
+ * stay at the session-start sensor size). Serial because Android caps
+ * concurrent video decoders. Safe to call after the first paint — tiles
+ * already render with placeholders. */
 export async function hydrateProjectClips(clips: ClipRecord[]): Promise<ClipRecord[]> {
   if (clips.length === 0) return clips
   const { ensureClipThumbs } = await import('./thumbs')
   const { ensureClipAudioPeak } = await import('./clip-audio-peak')
   const hydrated: ClipRecord[] = []
   for (const clip of clips) {
-    hydrated.push(await ensureClipAudioPeak(await ensureClipThumbs(clip)))
+    hydrated.push(await ensureClipAudioPeak(await ensureClipThumbs(await ensureClipDisplaySize(clip))))
   }
   return hydrated
+}
+
+/** Reconcile stored width/height with the file's display size. Photos
+ * already come from a bitmap decode, so they are left alone. */
+export async function ensureClipDisplaySize(clip: ClipRecord): Promise<ClipRecord> {
+  if (isImageClip(clip)) return clip
+  const probed = await probeVideoDisplaySize(clip.blob).catch(() => null)
+  if (!probed) return clip
+  if (clip.width === probed.width && clip.height === probed.height) return clip
+  await updateClipSize(clip.id, probed.width, probed.height).catch(() => undefined)
+  return { ...clip, width: probed.width, height: probed.height }
 }
 
 export async function appendRecording(
@@ -267,6 +282,12 @@ export async function appendRecording(
     capturedThumbs?: GeneratedThumbs | null
   },
 ): Promise<ClipRecord> {
+  // Prefer the encoded file's display size. Phone camera tracks often keep
+  // reporting the session-start sensor size after the device is rotated,
+  // which made landscape takes look like portrait (and vice versa).
+  const probed = await probeVideoDisplaySize(input.blob).catch(() => null)
+  const width = probed?.width ?? input.width
+  const height = probed?.height ?? input.height
   const clip = await addClip({
     projectId,
     blob: input.blob,
@@ -274,8 +295,8 @@ export async function appendRecording(
     durationMs: input.durationMs,
     trimStartMs: input.trimStartMs,
     trimEndMs: input.trimEndMs,
-    width: input.width,
-    height: input.height,
+    width,
+    height,
     lat: input.lat,
     lng: input.lng,
     locationAccuracyM: input.locationAccuracyM,

--- a/src/lib/storage.test.ts
+++ b/src/lib/storage.test.ts
@@ -36,6 +36,7 @@ import {
   updateClipAudioPeak,
   updateClipDuration,
   updateClipFit,
+  updateClipSize,
   updateClipThumbs,
   updateClipVolumes,
   updateProjectAudioTrack,
@@ -368,6 +369,23 @@ describe('storage layer', () => {
     const cropped = await updateClipFit(clip.id, 'crop')
     expect(cropped.fit).toBeUndefined()
     expect('fit' in ((await getClip(clip.id)) ?? {})).toBe(false)
+  })
+
+  it('updates stored clip display size without touching other fields', async () => {
+    const project = await createProject('Size')
+    const clip = await addClip({
+      projectId: project.id,
+      blob: fakeBlob('take'),
+      mimeType: 'video/webm',
+      durationMs: 900,
+      width: 1080,
+      height: 1920,
+    })
+    await updateClipSize(clip.id, 1920, 1080)
+    const stored = await getClip(clip.id)
+    expect(stored?.width).toBe(1920)
+    expect(stored?.height).toBe(1080)
+    expect(stored?.durationMs).toBe(900)
   })
 
   it('creates landscape projects when asked (Plus only)', async () => {

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -969,6 +969,28 @@ async function writeClipVolumes(
   return toMeta(updated)
 }
 
+/** Persist the file's display size (rotation-aware). Not a user edit —
+ * the project's updatedAt is deliberately untouched. */
+export async function updateClipSize(
+  clipId: ClipId,
+  width: number,
+  height: number,
+): Promise<void> {
+  if (!(width > 0) || !(height > 0)) return
+  const db = await getDb()
+  const tx = db.transaction('clips', 'readwrite')
+  const clip = await tx.store.get(clipId)
+  if (!clip) {
+    await tx.done
+    return
+  }
+  if (clip.width === width && clip.height === height) {
+    await tx.done
+    return
+  }
+  await completeTransaction([tx.store.put({ ...clip, width, height })], tx)
+}
+
 /** Persist a clip's measured audio peak (the normalization measurement).
  * Not a user edit — the project's updatedAt is deliberately untouched. */
 export async function updateClipAudioPeak(clipId: ClipId, peak: number): Promise<void> {

--- a/src/styles/editor.css
+++ b/src/styles/editor.css
@@ -68,8 +68,10 @@
 }
 
 .editor-film-orientation button.is-active {
-  color: var(--ink);
-  background: color-mix(in srgb, var(--stage-bg) 88%, var(--ink));
+  /* Light text on a dark fill in both themes: --ink and --stage-bg are
+     both dark in light mode, so mixing them made the label unreadable. */
+  color: #f3f5f4;
+  background: var(--ink-strong);
 }
 
 .editor-stage {
@@ -1069,33 +1071,33 @@
   flex: 0 1 auto;
 }
 
-/* The landscape interface: with the project (and viewport) sideways there
-   is no room for a player stacked over a tall panel — the stage takes the
-   left, and the timeline/tools panel becomes a right-hand column. */
+/* Landscape viewport: the stage takes the left and the timeline/tools
+   panel becomes a right-hand column. Follows the viewport, not the film
+   — a portrait project held sideways has room beside the 9:16 preview. */
 @media (orientation: landscape) {
-  .orientation-landscape .editor-screen {
+  .editor-screen {
     display: grid;
     grid-template-columns: minmax(0, 1fr) minmax(320px, 44%);
     grid-template-rows: auto minmax(0, 1fr);
   }
 
-  .orientation-landscape .editor-top {
+  .editor-top {
     grid-column: 1 / -1;
   }
 
-  .orientation-landscape .editor-stage {
+  .editor-stage {
     grid-row: 2;
     grid-column: 1;
     margin: 2px 0 calc(12px + var(--safe-bottom)) 14px;
   }
 
-  .orientation-landscape .editor-screen.is-trimming .editor-stage,
-  .orientation-landscape .editor-screen.is-splitting .editor-stage,
-  .orientation-landscape .editor-screen.is-audio-editing .editor-stage {
+  .editor-screen.is-trimming .editor-stage,
+  .editor-screen.is-splitting .editor-stage,
+  .editor-screen.is-audio-editing .editor-stage {
     flex: none;
   }
 
-  .orientation-landscape .editor-panel {
+  .editor-panel {
     grid-row: 2;
     grid-column: 2;
     min-height: 0;

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1167,7 +1167,9 @@ a {
      viewports, which includes desktop windows by default.
    - 'wide' (locked-landscape projects, set by the project page): always
      widens — the layout is stuck sideways wherever it opens.
-   - 'narrow' / absent (portrait projects): the classic column.
+   - 'narrow' / absent (portrait projects): the classic column on portrait
+     viewports; widens when the device is held sideways so chrome can use
+     the side gutters around a 9:16 film.
    Must sit after the base #root / .app-shell rules AND the min-width
    desktop block so it wins in both. */
 html[data-shell='wide'] #root,
@@ -1178,7 +1180,9 @@ html[data-shell='wide'] .app-shell {
 
 @media (orientation: landscape) {
   html[data-shell='adaptive'] #root,
-  html[data-shell='adaptive'] .app-shell {
+  html[data-shell='adaptive'] .app-shell,
+  html[data-shell='narrow'] #root,
+  html[data-shell='narrow'] .app-shell {
     width: 100%;
     max-width: none;
   }
@@ -1186,7 +1190,8 @@ html[data-shell='wide'] .app-shell {
 
 @media (min-width: 720px) and (orientation: landscape) and (pointer: fine) {
   html[data-shell='adaptive'] #root,
-  html[data-shell='wide'] #root {
+  html[data-shell='wide'] #root,
+  html[data-shell='narrow'] #root {
     width: min(1200px, calc(100% - 48px));
   }
 }

--- a/src/styles/record.css
+++ b/src/styles/record.css
@@ -500,12 +500,13 @@
   }
 }
 
-/* The landscape interface: with the project (and viewport) sideways, the
-   dock leaves the bottom edge and becomes a right-hand rail — Go under the
-   thumb, tools stacked above it, native-camera style. The zoom cluster
-   drops to the freed bottom edge. */
+/* Landscape viewport chrome: the dock leaves the bottom edge and becomes
+   a right-hand rail — Go under the thumb, tools stacked above it,
+   native-camera style. Follows the *viewport*, not the film: a portrait
+   project held sideways still has empty side gutters to put chrome in.
+   The zoom cluster drops to the freed bottom edge. */
 @media (orientation: landscape) {
-  .orientation-landscape .record-dock {
+  .record-dock {
     top: 0;
     bottom: 0;
     left: auto;
@@ -533,11 +534,11 @@
     );
   }
 
-  .orientation-landscape .record-dock::-webkit-scrollbar {
+  .record-dock::-webkit-scrollbar {
     display: none;
   }
 
-  .orientation-landscape .record-tools {
+  .record-tools {
     flex-direction: column;
     gap: 10px;
     flex-shrink: 0;
@@ -545,7 +546,7 @@
   }
 
   /* Compact Go so the whole rail fits common landscape phone heights. */
-  .orientation-landscape .record-dock .go-button {
+  .record-dock .go-button {
     width: 68px;
     height: 68px;
     min-width: 68px;
@@ -556,12 +557,12 @@
 
   /* Keep the title/meta clear of the rail (which grows with the right
      inset); pad the back button away from the notch side. */
-  .orientation-landscape .record-top {
+  .record-top {
     right: calc(108px + env(safe-area-inset-right, 0px));
     padding-left: calc(12px + env(safe-area-inset-left, 0px));
   }
 
-  .orientation-landscape .record-zoom {
+  .record-zoom {
     bottom: calc(16px + var(--safe-bottom));
   }
 }

--- a/tests/e2e/project-orientation.spec.ts
+++ b/tests/e2e/project-orientation.spec.ts
@@ -69,6 +69,39 @@ test.describe('project orientation', () => {
       .toBe(true)
   })
 
+  test('a portrait project uses the side chrome when the viewport is landscape', async ({
+    page,
+  }) => {
+    const projectId = await seedProject(page, { clips: 1 })
+    await page.goto(`/project/${projectId}`)
+    await waitForCameraReady(page)
+
+    // Film stays portrait, so the document shell attribute stays narrow —
+    // CSS still widens the frame on a landscape viewport.
+    await expect.poll(() => shellLayout(page)).toBe('narrow')
+
+    const viewport = page.viewportSize()!
+    await page.setViewportSize({ width: viewport.height, height: viewport.width })
+    await expect.poll(() => shellLayout(page)).toBe('narrow')
+
+    const dock = await page.locator('.record-dock').boundingBox()
+    const shell = await page.locator('.project-screen').boundingBox()
+    expect(dock).not.toBeNull()
+    expect(shell).not.toBeNull()
+    expect(dock!.height).toBeGreaterThan(dock!.width)
+    expect(dock!.x + dock!.width).toBeGreaterThan(shell!.x + shell!.width - 8)
+
+    await page.locator('[aria-label="Open editor"]').click()
+    await expect
+      .poll(async () => {
+        const stage = await page.locator('.editor-stage').boundingBox()
+        const panel = await page.locator('.editor-panel').boundingBox()
+        if (!stage || !panel) return false
+        return panel.x >= stage.x + stage.width - 2
+      })
+      .toBe(true)
+  })
+
   test('fine-pointer (desktop-like) recording never locks an orientation', async ({ page }) => {
     // Webcams and screen shares are landscape media without that being a
     // choice — desktop projects stay unlocked and keep the classic column.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes three bugs from a mixed-orientation test project:

1. **Light-mode Portrait/Landscape contrast** — the active pill used `--ink` on a `--stage-bg` mix. Both tokens are dark in light mode, so the label was unreadable. Active state is now light text (`#f3f5f4`) on `--ink-strong`.

2. **Crowded landscape chrome** — a portrait film kept the 480px column even when the phone was sideways, so header/tools sat on the 9:16 preview while the side gutters stayed empty. Landscape viewports now widen a `narrow` shell and use the existing side-rail record dock + side-by-side editor, regardless of film orientation.

3. **Wrong per-clip orientation** — camera `getSettings()` stayed at the session-start sensor size (1080×1920) after rotating. The second take in the test project is encoded 1920×1080 but was stored as 9:16, so both clips badged in landscape and neither in portrait. New recordings and hydrate now probe the file’s display size (Mediabunny, then `<video>`).

Existing projects correct themselves on the next open.

![Light-mode switcher after contrast fix](https://cursor.com/artifacts/c/art-226a8c04-bb87-43e0-9779-cdbfa1aad21a)
![Portrait film: only the landscape clip is badged](https://cursor.com/artifacts/c/art-226a8c04-bb87-43e0-9779-cdbfa1aad21a)
![Landscape record chrome uses the side rail](https://cursor.com/artifacts/c/art-90123915-27d7-4c93-b4c4-4c648bdc19db)
![Landscape editor is side-by-side](https://cursor.com/artifacts/c/art-105d58c7-9fad-4be4-82e0-32747014dc56)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-04283985-9019-4c2b-bbfb-f5e85da7eb55?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-04283985-9019-4c2b-bbfb-f5e85da7eb55&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Video clips now use their encoded display dimensions for more accurate sizing during recording and project loading.
  - Updated clip dimensions are saved automatically when needed.

- **Bug Fixes**
  - Improved landscape layouts for narrow, adaptive, and wide shells.
  - Landscape editor and recording controls now position consistently when rotating the device.
  - Active film-orientation controls have improved contrast and visibility.

- **Tests**
  - Added coverage for video sizing, clip persistence, and portrait-to-landscape transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->