### PR TITLE
Move crop/letterbox timeline badges to the bottom-left

### DIFF
--- a/src/styles/editor.css
+++ b/src/styles/editor.css
@@ -365,11 +365,12 @@
   pointer-events: none;
 }
 
-/* Mismatched clips show crop or letterbox in the top-left. */
+/* Mismatched clips show crop or letterbox in the bottom-left — top-left
+   is the music-volume pill. Duration stays bottom-right. */
 .clip-thumb .clip-fit-badge {
   position: absolute;
   left: 4px;
-  top: 4px;
+  bottom: 4px;
   display: grid;
   place-items: center;
   width: 18px;
@@ -380,7 +381,8 @@
   pointer-events: none;
 }
 
-/* Photo tiles carry a small camera badge so stills read at a glance. */
+/* Photo tiles carry a small camera badge so stills read at a glance.
+   When a fit badge is also present, sit beside it instead of stacking. */
 .clip-thumb .clip-photo-badge {
   position: absolute;
   left: 4px;
@@ -393,6 +395,10 @@
   color: #fff;
   background: rgba(0, 0, 0, 0.55);
   pointer-events: none;
+}
+
+.clip-thumb:has(.clip-fit-badge) .clip-photo-badge {
+  left: 24px;
 }
 
 /* In-timeline trim mode */

--- a/tests/e2e/orientation-touch.spec.ts
+++ b/tests/e2e/orientation-touch.spec.ts
@@ -194,6 +194,13 @@ test.describe('export-cover preview (touch)', () => {
     await expect(page.locator('.project-screen')).toHaveClass(/is-film-framed/)
     await expect(page.locator('.clip-fit-badge')).toBeVisible()
     await expect(page.getByRole('option', { name: /cropped/i })).toBeVisible()
+    // Bottom-left, clear of the top-left music pill and the duration.
+    const tileBox = await page.locator('.clip-thumb').first().boundingBox()
+    const badgeBox = await page.locator('.clip-fit-badge').boundingBox()
+    expect(tileBox).not.toBeNull()
+    expect(badgeBox).not.toBeNull()
+    expect(badgeBox!.x).toBeLessThan(tileBox!.x + tileBox!.width / 2)
+    expect(badgeBox!.y).toBeGreaterThan(tileBox!.y + tileBox!.height / 2)
     const preview = page.locator('.editor-clip-preview')
     await expect
       .poll(() => preview.evaluate((el) => (el as HTMLVideoElement).videoWidth))


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The crop/letterbox icon sat in the top-left of each timeline tile, on top of the music-volume pill (`♪ 60%`).

Move it to the bottom-left. That corner is empty on video clips. Duration stays bottom-right. The photo camera badge (stills only) shifts 20px right when both icons are present so they sit side by side instead of stacking.

On a minimum-width 0.5s photo tile the two left badges and the duration get tight, but that is an edge case; default photos are 3s / ~78px.

![Crop badge in the bottom-left of a timeline tile](https://cursor.com/artifacts/c/art-1aceb6a4-e9bf-4494-bf64-56bbf0b873d4)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-04283985-9019-4c2b-bbfb-f5e85da7eb55?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-04283985-9019-4c2b-bbfb-f5e85da7eb55&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

