### PR TITLE
Make public pages agent-readable without accounts or llms.txt

### DIFF
--- a/functions/_middleware.ts
+++ b/functions/_middleware.ts
@@ -1,0 +1,15 @@
+/**
+ * Serve markdown when an agent asks for it (Accept: text/markdown).
+ * Cloudflare's zone-level Markdown for Agents converter is Pro+ only;
+ * kody.video is on the Free plan, so this Function is the equivalent.
+ */
+import { agentMarkdownResponse } from './lib/agent-markdown'
+
+interface PagesContext {
+  request: Request
+  next: () => Promise<Response>
+}
+
+export async function onRequest(context: PagesContext): Promise<Response> {
+  return agentMarkdownResponse(context.request) ?? context.next()
+}

--- a/functions/lib/agent-markdown.ts
+++ b/functions/lib/agent-markdown.ts
@@ -217,7 +217,7 @@ Kody Video has **no accounts**.
 
 ## Kody Video Plus
 
-Plus is a one-time $0.99 [Stripe Payment Link](https://kody.video/). After checkout, Stripe redirects to \`/unlocked?session_id=…\`. \`/api/verify-purchase\` checks that session server-side; the entitlement is then stored on the device. 100%-off promotion codes use the same verification.
+Plus is a one-time $0.99 [Stripe Payment Link](https://buy.stripe.com/00wfZi71ibU30rk9hU2Ry07). After checkout, Stripe redirects to \`/unlocked?session_id=<CHECKOUT_SESSION_ID>\`. \`/api/verify-purchase\` checks that session server-side; the entitlement is then stored on the device. 100%-off promotion codes use the same verification.
 
 Restore on another device with **Already paid?** (export sheet or a locked slot). That is the same Stripe session, not a password.
 

--- a/functions/lib/agent-markdown.ts
+++ b/functions/lib/agent-markdown.ts
@@ -257,8 +257,24 @@ export function pageIdForPath(pathname: string): AgentPageId | null {
   }
 }
 
+function acceptQuality(accept: string | null, type: string): number {
+  if (!accept) return 0
+  let best = 0
+  for (const part of accept.split(',')) {
+    const [media, ...params] = part.split(';').map((token) => token.trim())
+    if (media?.toLowerCase() !== type) continue
+    const qParam = params.find((param) => param.toLowerCase().startsWith('q='))
+    const quality = qParam ? Number(qParam.slice(2)) : 1
+    if (Number.isFinite(quality) && quality > 0) best = Math.max(best, quality)
+  }
+  return best
+}
+
+/** True when text/markdown is present with q>0 and is not outranked by text/html. */
 export function prefersMarkdown(accept: string | null): boolean {
-  return Boolean(accept && /\btext\/markdown\b/i.test(accept))
+  const markdown = acceptQuality(accept, 'text/markdown')
+  if (markdown <= 0) return false
+  return markdown >= acceptQuality(accept, 'text/html')
 }
 
 export function renderAgentMarkdown(id: AgentPageId): string {

--- a/functions/lib/agent-markdown.ts
+++ b/functions/lib/agent-markdown.ts
@@ -1,0 +1,309 @@
+/**
+ * Markdown-for-agents responses for the public pages. The kody.video zone
+ * is on Cloudflare's Free plan, so the hosted Markdown for Agents converter
+ * cannot be enabled (`content_converter` is not editable). This module is
+ * the same Accept: text/markdown negotiation that converter would do.
+ */
+
+export const CONTENT_SIGNAL = 'search=yes, ai-input=yes, ai-train=yes'
+
+export type AgentPageId = 'home' | 'about' | 'privacy' | 'terms' | 'receive' | 'auth'
+
+type AgentPage = {
+  title: string
+  description: string
+  canonical: string
+  body: string
+}
+
+const PAGES: Record<AgentPageId, AgentPage> = {
+  home: {
+    title: 'Kody Video',
+    description:
+      'Hold anywhere to record clips. Privacy-first camera for the web. Record shot by shot, trim on a filmstrip, export one video.',
+    canonical: 'https://kody.video/',
+    body: `# Kody Video
+
+Privacy-first clips camera for the web. Hold anywhere on the preview to record, arrange clips on a filmstrip timeline, then tap **Go** to export or share one video — all on your device.
+
+## What it is
+
+- Free and open source: [github.com/kentcdodds/kody-video](https://github.com/kentcdodds/kody-video)
+- No accounts, no clip uploads, no cross-site tracking
+- Projects live in this browser's IndexedDB until you export, back up, or send them
+- Installable PWA (Chromium, especially Android, is the primary target)
+
+## How to use it
+
+1. Open [kody.video](https://kody.video/) and allow the camera
+2. Hold anywhere on the preview to record a clip; release to stop
+3. Arrange, duplicate, delete, and trim clips on the filmstrip
+4. Tap **Go** to export one video, then Share or Save
+
+Photos can be added to the timeline as still clips. Desktop can record a screen or window as a regular clip.
+
+## Kody Video Plus
+
+A one-time $0.99 Stripe Payment Link. It removes the export watermark and unlocks six project slots, background music, landscape projects, optional location tagging, and send-to-another-device. Restore with **Already paid?** using the Stripe receipt — there is no login.
+
+## Support
+
+Email [team@kody.video](mailto:team@kody.video) or [open a GitHub issue](https://github.com/kentcdodds/kody-video/issues/new).
+
+See [About](/about), [Privacy](/privacy), [Terms](/terms), and [auth.md](/auth.md).
+`,
+  },
+  about: {
+    title: 'About — Kody Video',
+    description:
+      'Kody Video is a free, open-source, on-device clips camera for the web.',
+    canonical: 'https://kody.video/about',
+    body: `# About Kody Video
+
+Kody Video is a free and open source clips camera. The whole app, including the export engine, lives at [github.com/kentcdodds/kody-video](https://github.com/kentcdodds/kody-video).
+
+## See it in action
+
+Kent demos record, arrange, and share in a minute and a half: [YouTube tour](https://youtube.com/shorts/JaUdPTHHk7A). [A video Kent made with Kody Video](https://x.com/kentcdodds/status/2084891368724533456).
+
+## Inspired by OK Video
+
+The hold-to-record interaction model is inspired by [OK Video](https://okvideo.app) by Pim Coumans. Kody Video is an independent project and is not affiliated with OK Video. The koala mascot comes from the KCD community: [kentcdodds.com/kody](https://kentcdodds.com/kody).
+
+## Private by design
+
+No accounts, no uploads, no cross-site tracking. Clips live in this browser's storage until you export and share them yourself.
+
+The app's only own network traffic:
+
+- Stripe checkout and purchase verification if you buy Plus
+- Anonymous Sentry crash reports (error and stack trace — never media)
+- Cookieless Fathom page-view counts
+- The home-screen tour video from \`media.kody.video\` if you tap play
+- A short-lived \`/api/sync\` matchmaking room if you tap Send to device (code + WebRTC descriptions, never clips)
+
+## Made for phones
+
+Designed as a mobile camera app. Desktop has keyboard support (hold Space to record, F flip, T timer, E editor, P play).
+
+## Backups
+
+Every project can be saved as a \`.kodyvideo\` file (⋯ → Save backup). Plus can also Send to device; the other device opens [kody.video/receive](/receive). Restore a backup from the About page in the app, or drop the file anywhere.
+
+## Support
+
+[Open a GitHub issue](https://github.com/kentcdodds/kody-video/issues/new) or email [team@kody.video](mailto:team@kody.video).
+
+A poisoned or stale app shell (hero with no project slots) can be diagnosed at [/api/diag](/api/diag) and repaired at [/api/recover](/api/recover). Recover never touches IndexedDB.
+
+## Legal
+
+[Privacy](/privacy) · [Terms](/terms) · [auth.md](/auth.md)
+`,
+  },
+  privacy: {
+    title: 'Privacy — Kody Video',
+    description:
+      'Kody Video keeps recordings on your device. No accounts, no uploads, no cross-site tracking.',
+    canonical: 'https://kody.video/privacy',
+    body: `# Privacy
+
+Last updated: August 2026
+
+## Everything stays on your device
+
+All recordings, projects, and edits live in this browser's on-device storage (IndexedDB). Nothing is uploaded. There are no accounts, no cookies, and no cross-site tracking.
+
+## Anonymous page-view counts
+
+The app counts page views with [Fathom Analytics](https://usefathom.com), a privacy-first service: no cookies, no personal identifiers, no cross-site tracking, and nothing that requires a consent banner. We only ever see aggregate numbers like "how many people opened the app today".
+
+## Anonymous crash reports
+
+When the app itself breaks, an error report (the error message, a stack trace, browser and OS names, and which step failed) is sent to Sentry so bugs get found and fixed. Crash reports never contain your clips, audio, location, or any account identifier, and no IP-based user profile is kept.
+
+## Send to another device
+
+Kody Video Plus can send a project to another phone or computer that has the app open. A Cloudflare matchmaker introduces the two browsers (a short code plus the WebRTC connection description, which includes network addresses). Your clips never go to our servers — they travel device-to-device, encrypted. Rooms expire in minutes and are not stored as a library. Receiving a project is free and is the same as importing a backup.
+
+## Camera and microphone
+
+The camera and microphone are used only while the app is open, on the camera view. Nothing is ever streamed anywhere.
+
+## Optional location tagging
+
+Location tagging is an optional Plus feature and is off by default. When it is on, each new clip stores device coordinates locally. Exported videos omit location by default; Plus users can explicitly include it in MP4 metadata from the export sheet.
+
+## Watermark removal purchase
+
+The one-time Plus purchase is processed by Stripe on Stripe's pages — their privacy policy applies. The app's verification endpoint sees only the checkout session id, never your media or location.
+
+## Exports and sharing
+
+Exported or shared files leave the device only when you share or save them yourself.
+
+## Deleting your data
+
+Delete projects in the app, or clear this site's browsing data / uninstall the PWA. There is no server copy to delete.
+
+## Questions
+
+Email [team@kody.video](mailto:team@kody.video) or open an issue at [github.com/kentcdodds/kody-video](https://github.com/kentcdodds/kody-video).
+
+See also [Terms](/terms) and [About](/about).
+`,
+  },
+  terms: {
+    title: 'Terms — Kody Video',
+    description: 'Terms of use for the on-device Kody Video clips camera.',
+    canonical: 'https://kody.video/terms',
+    body: `# Terms
+
+Last updated: July 2026
+
+## Free to use, as is
+
+Kody Video is free to use and runs entirely on your device. It is provided "as is" without warranty of any kind. Use it at your own risk — always keep copies of recordings you care about. Device storage can be cleared by the browser or OS.
+
+## Your recordings are yours
+
+You own your recordings entirely. The app claims no rights to any of your content.
+
+## Kody Video Plus
+
+Kody Video Plus is a one-time $0.99 purchase that unlocks watermark-free exports, optional location tagging, sending a project to another device, and up to six project slots (the free plan includes one project) for the browser profile where it is verified. You can restore the purchase on another device via the Stripe receipt link. Payments are handled by Stripe. For refunds or purchase trouble, email [team@kody.video](mailto:team@kody.video).
+
+## Recording responsibly
+
+Don't use the app to record people unlawfully. You are responsible for complying with local recording and consent laws.
+
+## Liability
+
+Liability is limited to the amount you paid for the app — at most $0.99.
+
+## Changes and affiliation
+
+These terms may change with the app; they are versioned in the [open-source repo](https://github.com/kentcdodds/kody-video). Kody Video is not affiliated with OK Video.
+
+See also [Privacy](/privacy) and [About](/about).
+`,
+  },
+  receive: {
+    title: 'Receive a project — Kody Video',
+    description:
+      'Accept a Kody Video project sent from another device. Free. Clips never upload.',
+    canonical: 'https://kody.video/receive',
+    body: `# Receive a project
+
+Open this page on the receiving device when someone taps **Send to device** (Plus). The two browsers pair with a short code or QR and the \`.kodyvideo\` project travels over a WebRTC DataChannel.
+
+Receiving is free. Clips never land on Kody Video servers. If the devices cannot connect, use **Save backup** and import the \`.kodyvideo\` file instead.
+
+There is no account. See [auth.md](/auth.md) and [About](/about).
+`,
+  },
+  auth: {
+    title: 'Authentication — Kody Video',
+    description: 'Kody Video has no accounts. Plus is a one-time Stripe Payment Link.',
+    canonical: 'https://kody.video/auth.md',
+    body: `# Authentication
+
+Kody Video has **no accounts**.
+
+- No login, passwords, cookies, sessions, or OAuth
+- Do not invent a sign-in flow, password reset, or "create an account" step
+- Projects and clips live in this browser's IndexedDB (\`kody-video\`)
+- There is no clip upload API and no user cloud library
+
+## Kody Video Plus
+
+Plus is a one-time $0.99 [Stripe Payment Link](https://kody.video/). After checkout, Stripe redirects to \`/unlocked?session_id=…\`. \`/api/verify-purchase\` checks that session server-side; the entitlement is then stored on the device. 100%-off promotion codes use the same verification.
+
+Restore on another device with **Already paid?** (export sheet or a locked slot). That is the same Stripe session, not a password.
+
+## Other network calls
+
+- \`/api/sync\` — short-lived send-to-device matchmaking (room code + WebRTC descriptions). Never media.
+- \`/api/diag\` and \`/api/recover\` — on-device shell repair. Recover never touches IndexedDB.
+
+See [Privacy](/privacy) and [About](/about).
+`,
+  },
+}
+
+export function pageIdForPath(pathname: string): AgentPageId | null {
+  const path = pathname.replace(/\/+$/, '') || '/'
+  switch (path) {
+    case '/':
+    case '/index.html':
+    case '/app':
+    case '/app.html':
+      return 'home'
+    case '/about':
+    case '/about.html':
+      return 'about'
+    case '/privacy':
+    case '/privacy.html':
+      return 'privacy'
+    case '/terms':
+    case '/terms.html':
+      return 'terms'
+    case '/receive':
+      return 'receive'
+    case '/auth.md':
+      return 'auth'
+    default:
+      return null
+  }
+}
+
+export function prefersMarkdown(accept: string | null): boolean {
+  return Boolean(accept && /\btext\/markdown\b/i.test(accept))
+}
+
+export function renderAgentMarkdown(id: AgentPageId): string {
+  const page = PAGES[id]
+  switch (id) {
+    case 'home':
+    case 'about':
+    case 'privacy':
+    case 'terms':
+    case 'receive':
+    case 'auth':
+      return `---
+title: ${page.title}
+description: ${page.description}
+url: ${page.canonical}
+---
+
+${page.body.trim()}\n`
+    default: {
+      const exhaustive: never = id
+      throw new Error(`Unhandled agent page: ${String(exhaustive)}`)
+    }
+  }
+}
+
+export function agentMarkdownResponse(request: Request): Response | null {
+  const method = request.method.toUpperCase()
+  if (method !== 'GET' && method !== 'HEAD') return null
+
+  const url = new URL(request.url)
+  const id = pageIdForPath(url.pathname)
+  if (!id) return null
+
+  const accept = request.headers.get('accept')
+  if (id !== 'auth' && !prefersMarkdown(accept)) return null
+
+  const body = renderAgentMarkdown(id)
+  const headers = {
+    'content-type': 'text/markdown; charset=utf-8',
+    vary: 'Accept',
+    'cache-control': 'public, max-age=3600',
+    'x-markdown-tokens': String(Math.ceil(body.length / 4)),
+    'content-signal': CONTENT_SIGNAL,
+  }
+
+  if (method === 'HEAD') return new Response(null, { status: 200, headers })
+  return new Response(body, { status: 200, headers })
+}

--- a/index.html
+++ b/index.html
@@ -51,7 +51,10 @@
         "url": "https://kody.video/",
         "applicationCategory": "MultimediaApplication",
         "operatingSystem": "Any",
-        "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" },
+        "offers": [
+          { "@type": "Offer", "name": "Kody Video", "price": "0", "priceCurrency": "USD" },
+          { "@type": "Offer", "name": "Kody Video Plus", "price": "0.99", "priceCurrency": "USD" }
+        ],
         "description": "A private, on-device clips camera for the web. Record shot by shot, trim on a filmstrip, export one video. Free and open source. No accounts and no clip uploads."
       }
     </script>

--- a/index.html
+++ b/index.html
@@ -43,6 +43,18 @@
       content="A private, on-device clips camera for the web. Free & open source."
     />
     <meta name="twitter:image" content="https://kody.video/og-image.png" />
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "WebApplication",
+        "name": "Kody Video",
+        "url": "https://kody.video/",
+        "applicationCategory": "MultimediaApplication",
+        "operatingSystem": "Any",
+        "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" },
+        "description": "A private, on-device clips camera for the web. Record shot by shot, trim on a filmstrip, export one video. Free and open source. No accounts and no clip uploads."
+      }
+    </script>
     <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
     <link
       rel="preload"

--- a/public/_headers
+++ b/public/_headers
@@ -1,5 +1,8 @@
 # Service worker + version must revalidate. A cached sw.js is how a phone
 # can sit on a retired shell while About says it is already up to date.
+/
+  Link: </sitemap.xml>; rel="describedby"; type="application/xml", </about>; rel="about", </auth.md>; rel="describedby"; type="text/markdown"
+
 /sw.js
   Cache-Control: public, max-age=0, must-revalidate
 

--- a/public/auth.md
+++ b/public/auth.md
@@ -15,7 +15,7 @@ Kody Video has **no accounts**.
 
 ## Kody Video Plus
 
-Plus is a one-time $0.99 [Stripe Payment Link](https://kody.video/). After checkout, Stripe redirects to `/unlocked?session_id=…`. `/api/verify-purchase` checks that session server-side; the entitlement is then stored on the device. 100%-off promotion codes use the same verification.
+Plus is a one-time $0.99 [Stripe Payment Link](https://buy.stripe.com/00wfZi71ibU30rk9hU2Ry07). After checkout, Stripe redirects to `/unlocked?session_id=<CHECKOUT_SESSION_ID>`. `/api/verify-purchase` checks that session server-side; the entitlement is then stored on the device. 100%-off promotion codes use the same verification.
 
 Restore on another device with **Already paid?** (export sheet or a locked slot). That is the same Stripe session, not a password.
 

--- a/public/auth.md
+++ b/public/auth.md
@@ -1,0 +1,27 @@
+---
+title: Authentication — Kody Video
+description: Kody Video has no accounts. Plus is a one-time Stripe Payment Link.
+url: https://kody.video/auth.md
+---
+
+# Authentication
+
+Kody Video has **no accounts**.
+
+- No login, passwords, cookies, sessions, or OAuth
+- Do not invent a sign-in flow, password reset, or "create an account" step
+- Projects and clips live in this browser's IndexedDB (`kody-video`)
+- There is no clip upload API and no user cloud library
+
+## Kody Video Plus
+
+Plus is a one-time $0.99 [Stripe Payment Link](https://kody.video/). After checkout, Stripe redirects to `/unlocked?session_id=…`. `/api/verify-purchase` checks that session server-side; the entitlement is then stored on the device. 100%-off promotion codes use the same verification.
+
+Restore on another device with **Already paid?** (export sheet or a locked slot). That is the same Stripe session, not a password.
+
+## Other network calls
+
+- `/api/sync` — short-lived send-to-device matchmaking (room code + WebRTC descriptions). Never media.
+- `/api/diag` and `/api/recover` — on-device shell repair. Recover never touches IndexedDB.
+
+See [Privacy](/privacy) and [About](/about).

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,4 +1,32 @@
+# As a condition of accessing this website, you agree to
+# abide by the following content signals:
+# (a)  If a content-signal = yes, you may collect content
+#      for the corresponding use.
+# (b)  If a content-signal = no, you may not collect content
+#      for the corresponding use.
+# (c)  If the website operator does not include a content
+#      signal for a corresponding use, the website operator
+#      neither grants nor restricts permission via content signal
+#      with respect to the corresponding use.
+# The content signals and their meanings are:
+# search: building a search index and providing search
+# results (e.g., returning hyperlinks and short excerpts
+# from your website's contents).  Search does not include
+# providing AI-generated search summaries.
+# ai-input: inputting content into one or more AI models
+# (e.g., retrieval augmented generation, grounding, or other
+# real-time taking of content for generative AI search
+# answers).
+# ai-train: training or fine-tuning AI models.
+# ANY RESTRICTIONS EXPRESSED VIA CONTENT SIGNALS ARE EXPRESS
+# RESERVATIONS OF RIGHTS UNDER ARTICLE 4 OF THE EUROPEAN
+# UNION DIRECTIVE 2019/790 ON COPYRIGHT AND RELATED RIGHTS
+# IN THE DIGITAL SINGLE MARKET.
+
 User-agent: *
+Content-Signal: search=yes, ai-input=yes, ai-train=yes
 Allow: /
+Disallow: /project/
+Disallow: /api/
 
 Sitemap: https://kody.video/sitemap.xml

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -15,4 +15,7 @@
   <url>
     <loc>https://kody.video/receive</loc>
   </url>
+  <url>
+    <loc>https://kody.video/auth.md</loc>
+  </url>
 </urlset>

--- a/src/lib/agent-markdown.test.ts
+++ b/src/lib/agent-markdown.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from 'vitest'
+import { onRequest } from '../../functions/_middleware'
+import {
+  agentMarkdownResponse,
+  pageIdForPath,
+  prefersMarkdown,
+  renderAgentMarkdown,
+} from '../../functions/lib/agent-markdown'
+
+function request(path: string, init?: RequestInit) {
+  return new Request(`https://kody.video${path}`, init)
+}
+
+describe('pageIdForPath', () => {
+  it('maps public pages and ignores project/api routes', () => {
+    expect(pageIdForPath('/')).toBe('home')
+    expect(pageIdForPath('/about')).toBe('about')
+    expect(pageIdForPath('/privacy/')).toBe('privacy')
+    expect(pageIdForPath('/terms')).toBe('terms')
+    expect(pageIdForPath('/receive')).toBe('receive')
+    expect(pageIdForPath('/auth.md')).toBe('auth')
+    expect(pageIdForPath('/project/abc')).toBeNull()
+    expect(pageIdForPath('/api/diag')).toBeNull()
+    expect(pageIdForPath('/assets/app.js')).toBeNull()
+  })
+})
+
+describe('prefersMarkdown', () => {
+  it('requires an explicit text/markdown type', () => {
+    expect(prefersMarkdown('text/markdown')).toBe(true)
+    expect(prefersMarkdown('text/markdown, text/html')).toBe(true)
+    expect(prefersMarkdown('text/html')).toBe(false)
+    expect(prefersMarkdown('*/*')).toBe(false)
+    expect(prefersMarkdown(null)).toBe(false)
+  })
+})
+
+describe('renderAgentMarkdown', () => {
+  it('emits frontmatter and the no-account rule', () => {
+    const home = renderAgentMarkdown('home')
+    expect(home.startsWith('---\n')).toBe(true)
+    expect(home).toContain('title: Kody Video')
+    expect(home).toContain('No accounts')
+
+    const auth = renderAgentMarkdown('auth')
+    expect(auth).toContain('no accounts')
+    expect(auth).toContain('/api/verify-purchase')
+    expect(auth).toContain('Do not invent a sign-in flow')
+  })
+})
+
+describe('agentMarkdownResponse', () => {
+  it('returns markdown for public pages when asked', async () => {
+    const response = agentMarkdownResponse(
+      request('/about', { headers: { accept: 'text/markdown' } }),
+    )
+    expect(response).not.toBeNull()
+    expect(response?.headers.get('content-type')).toBe('text/markdown; charset=utf-8')
+    expect(response?.headers.get('content-signal')).toContain('search=yes')
+    expect(response?.headers.get('vary')).toBe('Accept')
+    const body = await response!.text()
+    expect(body).toContain('# About Kody Video')
+    expect(body).toContain('Private by design')
+  })
+
+  it('leaves HTML browsers on the SPA', () => {
+    expect(agentMarkdownResponse(request('/about'))).toBeNull()
+    expect(
+      agentMarkdownResponse(request('/about', { headers: { accept: 'text/html' } })),
+    ).toBeNull()
+    expect(agentMarkdownResponse(request('/project/new'))).toBeNull()
+    expect(
+      agentMarkdownResponse(
+        request('/api/diag', { headers: { accept: 'text/markdown' } }),
+      ),
+    ).toBeNull()
+  })
+
+  it('always serves /auth.md as markdown', async () => {
+    const response = agentMarkdownResponse(request('/auth.md'))
+    expect(response?.headers.get('content-type')).toBe('text/markdown; charset=utf-8')
+    expect(await response!.text()).toContain('# Authentication')
+  })
+})
+
+describe('pages middleware', () => {
+  it('passes unrelated requests through', async () => {
+    const next = async () => new Response('spa', { status: 200 })
+    const passed = await onRequest({
+      request: request('/project/abc'),
+      next,
+    })
+    expect(await passed.text()).toBe('spa')
+
+    const markdown = await onRequest({
+      request: request('/privacy', { headers: { accept: 'text/markdown' } }),
+      next,
+    })
+    expect(markdown.headers.get('content-type')).toContain('text/markdown')
+    expect(await markdown.text()).toContain('# Privacy')
+  })
+})

--- a/src/lib/agent-markdown.test.ts
+++ b/src/lib/agent-markdown.test.ts
@@ -26,9 +26,12 @@ describe('pageIdForPath', () => {
 })
 
 describe('prefersMarkdown', () => {
-  it('requires an explicit text/markdown type', () => {
+  it('requires an explicit text/markdown type and honors q-values', () => {
     expect(prefersMarkdown('text/markdown')).toBe(true)
     expect(prefersMarkdown('text/markdown, text/html')).toBe(true)
+    expect(prefersMarkdown('text/html;q=0.9, text/markdown')).toBe(true)
+    expect(prefersMarkdown('text/html, text/markdown;q=0.1')).toBe(false)
+    expect(prefersMarkdown('text/markdown;q=0')).toBe(false)
     expect(prefersMarkdown('text/html')).toBe(false)
     expect(prefersMarkdown('*/*')).toBe(false)
     expect(prefersMarkdown(null)).toBe(false)

--- a/src/lib/agent-markdown.test.ts
+++ b/src/lib/agent-markdown.test.ts
@@ -48,6 +48,8 @@ describe('renderAgentMarkdown', () => {
     const auth = renderAgentMarkdown('auth')
     expect(auth).toContain('no accounts')
     expect(auth).toContain('/api/verify-purchase')
+    expect(auth).toContain('session_id=<CHECKOUT_SESSION_ID>')
+    expect(auth).toContain('https://buy.stripe.com/00wfZi71ibU30rk9hU2Ry07')
     expect(auth).toContain('Do not invent a sign-in flow')
   })
 })

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -21,5 +21,5 @@
     "noUncheckedSideEffectImports": true,
     "types": ["vite/client"]
   },
-  "include": ["src"]
+  "include": ["src", "functions"]
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -128,6 +128,7 @@ export default defineConfig({
         'robots.txt',
         'sitemap.xml',
         'llms.txt',
+        'auth.md',
       ],
       manifest: {
         name: 'Kody Video',
@@ -190,6 +191,7 @@ export default defineConfig({
           /^\/robots\.txt$/,
           /^\/sitemap\.xml$/,
           /^\/llms\.txt$/,
+          /^\/auth\.md$/,
           /^\/version\.json$/,
           /^\/assets\//,
           /\.map$/,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Cloudflare’s hosted [Markdown for Agents](https://developers.cloudflare.com/fundamentals/reference/markdown-for-agents/) converter is Pro-only. `kody.video` is on the Free plan (`content_converter` is not editable), so this PR implements the same `Accept: text/markdown` negotiation in a Pages Function and makes the public facts agents need explicit.

## What changed

- **Content Signals** in `robots.txt` (`search=yes, ai-input=yes, ai-train=yes`) so we can leave Level 1. `/project/` and `/api/` are disallowed — those are the app and diagnostics, not docs.
- **Markdown negotiation** for `/`, `/about`, `/privacy`, `/terms`, and `/receive` when the client prefers `text/markdown` (q-values honored; `q=0` or HTML-outranked stays on the SPA).
- **`/auth.md`** states there is no login: Plus is a one-time Stripe Payment Link; entitlement lives in IndexedDB; do not invent an account flow.
- **Homepage `Link` headers** point at the sitemap, About, and `auth.md` (not `llms.txt`).
- **JSON-LD** `WebApplication` on the homepage so a later zone-level converter still has structured product facts.

## Out of scope

- `llms.txt` / `llms-full.txt` (unused; left as-is)
- OAuth, MCP, A2A, WebMCP, x402 / UCP / ACP — they fight the no-account, on-device product
- Upgrading the zone to Pro just to flip Cloudflare’s converter

## Risk

Medium: a new `functions/_middleware.ts` runs on every request. It only rewrites the public pages above, and only when `Accept` prefers `text/markdown` (plus always-on `/auth.md`). Everything else calls `next()`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9d842e9b-a888-417d-ad5c-ce2d135e3f2b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9d842e9b-a888-417d-ad5c-ce2d135e3f2b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Markdown versions of key pages, including Home, About, Privacy, Terms, Receive, and Authentication.
  * Added authentication documentation covering local storage, Plus purchases, and device restoration.
* **Documentation**
  * Added sitemap, robots guidance, page links, and structured metadata for improved site discovery.
* **Improvements**
  * Markdown responses now support content negotiation and efficient `GET`/`HEAD` requests.
  * Protected project and API paths from crawling while keeping public pages discoverable.
  * Added authentication documentation to the built app and sitemap.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->