### PR TITLE
Scroll the home grid on short phones instead of crushing slots

### DIFF
--- a/src/styles/home.css
+++ b/src/styles/home.css
@@ -4,6 +4,11 @@
   gap: 0;
   /* Anchor for the corner buttons. */
   position: relative;
+  /* Floor for each slot tile: empty/locked copy (plus + two lines) still
+     fits, and a 3×2 / 2×3 grid won't crush into untappable chips on a
+     short phone (iPhone 13 mini, in-app browsers). `.home-main` scrolls
+     once this floor no longer fits under the hero. */
+  --home-slot-min-h: 7.75rem;
 }
 
 /* Install (left) / About (right) corner buttons: full 44px tap targets in
@@ -78,10 +83,20 @@
   }
 }
 
-/* Portrait: .home-main is invisible to layout — its children stay direct
-   flex items of the .home-screen column, exactly the classic layout. */
+/* Banners, slots, and the privacy line. A real box (not display:contents)
+   so this column can scroll on short viewports while the hero — and the
+   static #boot-hero that paints over its spacer — stay put. Tall phones
+   still fill: slots grow with leftover height and nothing scrolls. */
 .home-main {
-  display: contents;
+  display: flex;
+  flex-direction: column;
+  flex: 1 1 auto;
+  min-height: 0;
+  min-width: 0;
+  overflow-x: hidden;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  -webkit-overflow-scrolling: touch;
 }
 
 /* The landscape home: a deliberate two-pane layout instead of a squeezed
@@ -123,18 +138,15 @@
   }
 
   .home-main {
-    display: flex;
-    flex-direction: column;
     grid-column: 2;
     grid-row: 1;
-    min-height: 0;
-    min-width: 0;
   }
 
   /* Six slots read as 3×2 in a wide pane (2×3 is the portrait shape). */
   .home-main .project-slots {
     grid-template-columns: repeat(3, minmax(0, 1fr));
-    grid-template-rows: repeat(2, minmax(0, 1fr));
+    grid-template-rows: repeat(2, minmax(var(--home-slot-min-h), 1fr));
+    min-height: calc(2 * var(--home-slot-min-h) + 8px);
   }
 
   /* Top-right would sit on the first slot row's ⋯ button; the install
@@ -188,17 +200,19 @@
   margin: 10px 0 0;
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
-  grid-template-rows: repeat(3, minmax(0, 1fr));
+  grid-template-rows: repeat(3, minmax(var(--home-slot-min-h), 1fr));
   gap: 8px;
-  flex: 1;
-  min-height: 0;
+  /* Grow to fill leftover height; don't shrink below the tile floor —
+     overflow:hidden would otherwise let flex min-height:auto collapse to 0. */
+  flex: 1 0 auto;
+  min-height: calc(3 * var(--home-slot-min-h) + 16px);
   overflow: hidden;
   padding: 0;
 }
 
 .project-slot {
   position: relative;
-  min-height: 0;
+  min-height: var(--home-slot-min-h);
   border-radius: 20px;
   border: 1px solid var(--line);
   background:
@@ -956,5 +970,19 @@
   .slot-plus {
     width: 40px;
     height: 40px;
+  }
+
+  .tour-card {
+    padding: 6px 40px 6px 6px;
+  }
+
+  .tour-card-teaser {
+    grid-template-columns: 36px 1fr 24px;
+    gap: 10px;
+  }
+
+  .tour-card-teaser img {
+    width: 36px;
+    height: 64px;
   }
 }

--- a/tests/e2e/home.spec.ts
+++ b/tests/e2e/home.spec.ts
@@ -50,6 +50,47 @@ test.describe('home & app shell', () => {
     expect(about!.width).toBeLessThanOrEqual(760)
   })
 
+  test('short viewports scroll the home column instead of crushing slots', async ({
+    page,
+  }) => {
+    // iPhone 13 mini (375×812) minus Safari / in-app-browser chrome — the
+    // viewport that crushed the 2×3 grid when overflow was hidden.
+    await page.setViewportSize({ width: 375, height: 560 })
+    await page.goto('/')
+
+    const main = page.locator('.home-main')
+    const slots = page.locator('.project-slots')
+    const lastSlot = page.locator('.project-slot').last()
+    const footer = page.locator('.home-privacy')
+    await expect(slots).toBeVisible()
+
+    const slotBox = await page.locator('.project-slot').first().boundingBox()
+    expect(slotBox).not.toBeNull()
+    expect(slotBox!.height).toBeGreaterThanOrEqual(120)
+
+    expect(
+      await main.evaluate((el) => el.scrollHeight > el.clientHeight + 1),
+    ).toBe(true)
+
+    // The LCP boot hero stays pinned with the spacer; only `.home-main`
+    // (banners, slots, footer) scrolls.
+    const bootBefore = await page.locator('#boot-hero').boundingBox()
+    const spacerBefore = await page.locator('.home-hero').boundingBox()
+    expect(bootBefore).not.toBeNull()
+    expect(spacerBefore).not.toBeNull()
+    expect(Math.abs(bootBefore!.y - spacerBefore!.y)).toBeLessThan(8)
+
+    await lastSlot.scrollIntoViewIfNeeded()
+    await expect(lastSlot).toBeInViewport()
+    await footer.scrollIntoViewIfNeeded()
+    await expect(footer).toBeInViewport()
+
+    const bootAfter = await page.locator('#boot-hero').boundingBox()
+    const spacerAfter = await page.locator('.home-hero').boundingBox()
+    expect(bootAfter!.y).toBe(bootBefore!.y)
+    expect(spacerAfter!.y).toBe(spacerBefore!.y)
+  })
+
   test('onboarding shows on first camera open, dismisses for good', async ({ page }) => {
     await page.goto('/')
     await page.locator('.project-slot.empty').first().click()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

[iPhone 13 mini screenshot](https://x.com/zxcodes/status/2090353891028373885): the home screen’s 2×3 slot grid was getting crushed (and the privacy line clipped) because `.screen` / `.project-slots` hid overflow and tiles could shrink to 0. Browser chrome and the tour card make that viewport even shorter.

## What

Yes — scroll at a min-height, not the whole app.

- Slot tiles keep a floor (`--home-slot-min-h`) so empty/locked copy stays tappable.
- `.home-main` (banners, slots, footer) becomes a real column that `overflow-y: auto`s once that floor no longer fits.
- The brand hero — and the static `#boot-hero` LCP paint over its spacer — stay pinned. Tall phones still fill leftover height with no scrollbar.
- Landscape 3×2 uses a two-row floor; short landscape panes scroll the same way.
- Tour card compact on `max-height: 720px`.

E2E covers a 375×560 “mini + chrome” viewport: tiles stay ≥120px, the column scrolls to the last slot and footer, boot-hero does not move.

Preview: https://cursor-home-min-height-scrol.kody-video.pages.dev
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d9262711-0ab0-45e1-8d04-4e6f6eee5d98?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d9262711-0ab0-45e1-8d04-4e6f6eee5d98&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved home page behavior on short screens by enabling scrolling without shrinking project areas.
  * Preserved hero positioning while allowing project slots and the footer to scroll into view.
  * Adjusted mobile spacing, thumbnails, and tour cards for compact layouts.
  * Ensured project tiles maintain usable minimum heights across portrait and landscape orientations.

* **Tests**
  * Added end-to-end coverage for short mobile viewport behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->