### PR TITLE
Let Plus devices share a short restore code or QR

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,8 +254,11 @@ Stripe redirects back to `/unlocked?session_id=…`, and a single Cloudflare
 Pages Function (`functions/api/verify-purchase.ts`) verifies the session
 server-side before the entitlement is stored in IndexedDB. 100%-off
 promotion codes (friends / the developer) flow through the exact same
-verification. Restore on another device: "Already paid?" on the export
-sheet or a locked slot's upsell.
+verification. Restore on another device: on the phone or computer that
+already has Plus, open About and tap "Use Plus on another
+device" — type the short code or scan the QR. "Already paid?"
+on the export sheet still accepts that code (or a checkout
+session id).
 
 Projects are also created lazily — "New project" opens the camera at
 `/project/new` and nothing is persisted until the first clip is recorded, so

--- a/functions/api/restore-codes.ts
+++ b/functions/api/restore-codes.ts
@@ -1,0 +1,16 @@
+/**
+ * Cloudflare Pages Function: mint a short-lived restore code for a verified
+ * Plus checkout session. The subscribed device shows the code / QR; the new
+ * device redeems it via /api/verify-purchase?code=.
+ */
+
+import { handleRestoreCodesRequest, type PurchaseHttpEnv } from '../../src/lib/purchase-http'
+
+interface PagesContext {
+  request: Request
+  env: PurchaseHttpEnv
+}
+
+export async function onRequestPost(context: PagesContext): Promise<Response> {
+  return handleRestoreCodesRequest(context.request, context.env)
+}

--- a/functions/api/verify-purchase.ts
+++ b/functions/api/verify-purchase.ts
@@ -1,78 +1,16 @@
 /**
  * Cloudflare Pages Function: verify a Stripe Checkout session for the
- * Kody Video Plus purchase. The only backend surface in the app — it
- * never stores anything and never sees media; it just asks Stripe whether
- * the session really completed (including 100%-off promo checkouts).
- *
- * Requires the STRIPE_SECRET_KEY environment variable on the Pages project
- * (a restricted key with Checkout Sessions read access is enough).
+ * Kody Video Plus purchase. Accepts a checkout session id or a short
+ * restore code minted by the device that already has Plus.
  */
 
-interface Env {
-  STRIPE_SECRET_KEY?: string
-  /** Optional override; defaults to the production payment link. */
-  STRIPE_PAYMENT_LINK_ID?: string
-}
+import { handleVerifyPurchaseRequest, type PurchaseHttpEnv } from '../../src/lib/purchase-http'
 
 interface PagesContext {
   request: Request
-  env: Env
-}
-
-const PRODUCTION_PAYMENT_LINK_ID = 'plink_1TxcxULAQpAnsYszr2bLuqOl'
-const SESSION_ID_PATTERN = /^cs_[a-zA-Z0-9_]+$/
-
-function json(body: unknown, status: number): Response {
-  return new Response(JSON.stringify(body), {
-    status,
-    headers: {
-      'content-type': 'application/json',
-      'cache-control': 'no-store',
-    },
-  })
+  env: PurchaseHttpEnv
 }
 
 export async function onRequestGet(context: PagesContext): Promise<Response> {
-  const { request, env } = context
-  const secretKey = env.STRIPE_SECRET_KEY
-  if (!secretKey) {
-    return json({ unlocked: false, error: 'Purchase verification is not configured yet.' }, 503)
-  }
-
-  const sessionId = new URL(request.url).searchParams.get('session_id') ?? ''
-  if (!SESSION_ID_PATTERN.test(sessionId)) {
-    return json({ unlocked: false, error: 'Invalid session id.' }, 400)
-  }
-
-  const response = await fetch(
-    `https://api.stripe.com/v1/checkout/sessions/${encodeURIComponent(sessionId)}`,
-    { headers: { authorization: `Bearer ${secretKey}` } },
-  )
-  if (response.status === 404) {
-    return json({ unlocked: false, error: 'No such purchase.' }, 404)
-  }
-  if (!response.ok) {
-    return json({ unlocked: false, error: 'Could not reach Stripe. Try again shortly.' }, 502)
-  }
-
-  const session = (await response.json()) as {
-    status?: string
-    payment_status?: string
-    payment_link?: string
-  }
-
-  const expectedLink = env.STRIPE_PAYMENT_LINK_ID ?? PRODUCTION_PAYMENT_LINK_ID
-  const complete = session.status === 'complete'
-  // 100%-off promotion-code checkouts complete with 'no_payment_required'.
-  const paid =
-    session.payment_status === 'paid' || session.payment_status === 'no_payment_required'
-  const rightProduct = session.payment_link === expectedLink
-
-  if (complete && paid && rightProduct) {
-    return json({ unlocked: true }, 200)
-  }
-  return json(
-    { unlocked: false, error: 'This checkout session is not a completed watermark purchase.' },
-    403,
-  )
+  return handleVerifyPurchaseRequest(context.request, context.env)
 }

--- a/functions/lib/agent-markdown.ts
+++ b/functions/lib/agent-markdown.ts
@@ -44,7 +44,7 @@ Photos can be added to the timeline as still clips. Desktop can record a screen 
 
 ## Kody Video Plus
 
-A one-time $0.99 Stripe Payment Link. It removes the export watermark and unlocks six project slots, background music, landscape projects, optional location tagging, and send-to-another-device. Restore with **Already paid?** using the Stripe receipt — there is no login.
+A one-time $0.99 Stripe Payment Link. It removes the export watermark and unlocks six project slots, background music, landscape projects, optional location tagging, and send-to-another-device. Restore from the device that already has Plus (About → Use Plus on another device) with a short code or QR — there is no login.
 
 ## Support
 
@@ -81,6 +81,7 @@ The app's only own network traffic:
 - Cookieless Fathom page-view counts
 - The home-screen tour video from \`media.kody.video\` if you tap play
 - A short-lived \`/api/sync\` matchmaking room if you tap Send to device (code + WebRTC descriptions, never clips)
+- A short-lived Plus restore code if you share Plus with another device (session id only)
 
 ## Made for phones
 
@@ -136,7 +137,7 @@ Location tagging is an optional Plus feature and is off by default. When it is o
 
 ## Watermark removal purchase
 
-The one-time Plus purchase is processed by Stripe on Stripe's pages — their privacy policy applies. The app's verification endpoint sees only the checkout session id, never your media or location.
+The one-time Plus purchase is processed by Stripe on Stripe's pages — their privacy policy applies. The app's verification endpoint sees only the checkout session id, never your media or location. Sharing Plus with another device mints a short-lived restore code that maps to that same session id and expires in minutes.
 
 ## Exports and sharing
 
@@ -171,7 +172,7 @@ You own your recordings entirely. The app claims no rights to any of your conten
 
 ## Kody Video Plus
 
-Kody Video Plus is a one-time $0.99 purchase that unlocks watermark-free exports, optional location tagging, sending a project to another device, and up to six project slots (the free plan includes one project) for the browser profile where it is verified. You can restore the purchase on another device via the Stripe receipt link. Payments are handled by Stripe. For refunds or purchase trouble, email [team@kody.video](mailto:team@kody.video).
+Kody Video Plus is a one-time $0.99 purchase that unlocks watermark-free exports, optional location tagging, sending a project to another device, and up to six project slots (the free plan includes one project) for the browser profile where it is verified. You can restore the purchase on another device with a short code or QR from the device that already has Plus. Payments are handled by Stripe. For refunds or purchase trouble, email [team@kody.video](mailto:team@kody.video).
 
 ## Recording responsibly
 
@@ -219,11 +220,13 @@ Kody Video has **no accounts**.
 
 Plus is a one-time $0.99 [Stripe Payment Link](https://buy.stripe.com/00wfZi71ibU30rk9hU2Ry07). After checkout, Stripe redirects to \`/unlocked?session_id=<CHECKOUT_SESSION_ID>\`. \`/api/verify-purchase\` checks that session server-side; the entitlement is then stored on the device. 100%-off promotion codes use the same verification.
 
-Restore on another device with **Already paid?** (export sheet or a locked slot). That is the same Stripe session, not a password.
+Restore on another device from the device that already has Plus: About → **Use Plus on another device** shows a short code and QR. The new device types the code under **Already paid?** or opens \`/unlocked?code=\`. That mints a short-lived mapping to the same Stripe session — not a password. A checkout session id still works if you have one. Stripe receipt URLs do not include that session id.
 
 ## Other network calls
 
 - \`/api/sync\` — short-lived send-to-device matchmaking (room code + WebRTC descriptions). Never media.
+- \`/api/restore-codes\` — short-lived Plus restore codes (session id only, 30 minutes).
+- \`/api/verify-purchase\` — Stripe session or restore-code check. Never media.
 - \`/api/diag\` and \`/api/recover\` — on-device shell repair. Recover never touches IndexedDB.
 
 See [Privacy](/privacy) and [About](/about).

--- a/public/auth.md
+++ b/public/auth.md
@@ -17,11 +17,13 @@ Kody Video has **no accounts**.
 
 Plus is a one-time $0.99 [Stripe Payment Link](https://buy.stripe.com/00wfZi71ibU30rk9hU2Ry07). After checkout, Stripe redirects to `/unlocked?session_id=<CHECKOUT_SESSION_ID>`. `/api/verify-purchase` checks that session server-side; the entitlement is then stored on the device. 100%-off promotion codes use the same verification.
 
-Restore on another device with **Already paid?** (export sheet or a locked slot). That is the same Stripe session, not a password.
+Restore on another device from the device that already has Plus: About → **Use Plus on another device** shows a short code and QR. The new device types the code under **Already paid?** or opens `/unlocked?code=`. That mints a short-lived mapping to the same Stripe session — not a password. A checkout session id still works if you have one. Stripe receipt URLs do not include that session id.
 
 ## Other network calls
 
 - `/api/sync` — short-lived send-to-device matchmaking (room code + WebRTC descriptions). Never media.
+- `/api/restore-codes` — short-lived Plus restore codes (session id only, 30 minutes).
+- `/api/verify-purchase` — Stripe session or restore-code check. Never media.
 - `/api/diag` and `/api/recover` — on-device shell repair. Recover never touches IndexedDB.
 
 See [Privacy](/privacy) and [About](/about).

--- a/scripts/vite-sync-api-plugin.ts
+++ b/scripts/vite-sync-api-plugin.ts
@@ -1,8 +1,10 @@
 import type { IncomingMessage, ServerResponse } from 'node:http'
 import type { Plugin } from 'vite'
-import { handleSyncRequest, memorySyncKv } from '../src/lib/sync-rooms'
+import { createRestoreCode, getRestoreSessionId } from '../src/lib/restore-codes'
+import { jsonResponse, handleSyncRequest, memorySyncKv, SyncRoomError } from '../src/lib/sync-rooms'
 
 const kv = memorySyncKv()
+const LOCAL_TEST_SESSION = /^cs_test_[a-zA-Z0-9]+$/
 
 async function nodeToRequest(req: IncomingMessage): Promise<Request> {
   const host = req.headers.host ?? '127.0.0.1'
@@ -34,18 +36,63 @@ async function writeResponse(res: ServerResponse, response: Response): Promise<v
   res.end(bytes)
 }
 
-/** In-memory /api/sync/* so Vite and Playwright can exercise send-to-device. */
+/** Local-only: accept cs_test_* sessions so Playwright can pair devices without Stripe. */
+async function handleLocalPurchase(request: Request): Promise<Response> {
+  const url = new URL(request.url)
+  try {
+    if (url.pathname === '/api/restore-codes') {
+      if (request.method !== 'POST') return jsonResponse({ error: 'Method not allowed.' }, 405)
+      const posted = (await request.json().catch(() => null)) as { session_id?: unknown } | null
+      const sessionId = typeof posted?.session_id === 'string' ? posted.session_id : ''
+      if (!LOCAL_TEST_SESSION.test(sessionId)) {
+        return jsonResponse({ error: 'Local restore codes only accept cs_test_ sessions.' }, 400)
+      }
+      const code = await createRestoreCode(kv, sessionId, 'local')
+      return jsonResponse({ code }, 201)
+    }
+
+    if (url.pathname === '/api/verify-purchase') {
+      if (request.method !== 'GET') return jsonResponse({ unlocked: false, error: 'Method not allowed.' }, 405)
+      let sessionId = url.searchParams.get('session_id') ?? ''
+      const code = url.searchParams.get('code') ?? ''
+      if (code) sessionId = await getRestoreSessionId(kv, code)
+      if (!LOCAL_TEST_SESSION.test(sessionId)) {
+        return jsonResponse({ unlocked: false, error: 'No such purchase.' }, 404)
+      }
+      return jsonResponse({ unlocked: true, sessionId }, 200)
+    }
+  } catch (error) {
+    if (error instanceof SyncRoomError) {
+      const payload =
+        url.pathname === '/api/verify-purchase'
+          ? { unlocked: false, error: error.message }
+          : { error: error.message }
+      return jsonResponse(payload, error.status)
+    }
+    throw error
+  }
+  return jsonResponse({ error: 'Not found.' }, 404)
+}
+
+/** In-memory /api/sync/* and Plus restore-code endpoints for Vite and Playwright. */
 export function syncApiPlugin(): Plugin {
   return {
     name: 'kody-sync-api',
     configureServer(server) {
       server.middlewares.use((req, res, next) => {
-        if (!req.url?.startsWith('/api/sync/')) {
+        const path = req.url?.split('?')[0] ?? ''
+        const purchase =
+          path === '/api/restore-codes' || path === '/api/verify-purchase'
+        if (!path.startsWith('/api/sync/') && !purchase) {
           next()
           return
         }
         void nodeToRequest(req)
-          .then((request) => handleSyncRequest(request, { SYNC_ROOMS: kv }))
+          .then((request) =>
+            purchase
+              ? handleLocalPurchase(request)
+              : handleSyncRequest(request, { SYNC_ROOMS: kv }),
+          )
           .then((response) => writeResponse(res, response))
           .catch((error: unknown) => {
             res.statusCode = 500

--- a/src/components/restore-sheet.tsx
+++ b/src/components/restore-sheet.tsx
@@ -70,8 +70,8 @@ export function RestoreSheet(handle: Handle<RestoreSheetProps>) {
           <h3>Restore purchase</h3>
           <p className="muted sheet-lede">
             On the device that already has Plus, open About and tap{' '}
-            <strong>Use Plus on another device</strong>. Type that short code here, or scan its QR.
-            A checkout session id starting with “cs_” still works too.
+            <strong>Use Plus on another device</strong>. Type that short code here, paste its unlock
+            link, or scan the QR. A checkout session id starting with “cs_” still works too.
           </p>
           <div className="field">
             <label htmlFor="restore-input">Restore code or session id</label>

--- a/src/components/restore-sheet.tsx
+++ b/src/components/restore-sheet.tsx
@@ -1,7 +1,11 @@
 import type { Handle } from 'remix/ui'
 import { on, ref } from 'remix/ui'
 import { attachSheetModal } from '../lib/sheet-modal'
-import { extractSessionId, verifyPurchaseSession } from '../lib/entitlement'
+import {
+  extractRestoreToken,
+  looksLikeStripeReceipt,
+  verifyPurchase,
+} from '../lib/entitlement'
 
 interface RestoreSheetProps {
   onRestored: () => void
@@ -9,8 +13,9 @@ interface RestoreSheetProps {
 }
 
 /**
- * Restore the Kody Video Plus purchase on a new device: paste the link
- * from the Stripe receipt email (or the checkout session id) and re-verify.
+ * Restore Kody Video Plus on a new device: paste a short code from the
+ * device that already has Plus, scan its QR (opens /unlocked?code=), or
+ * paste a checkout session id.
  */
 export function RestoreSheet(handle: Handle<RestoreSheetProps>) {
   let value = ''
@@ -18,12 +23,18 @@ export function RestoreSheet(handle: Handle<RestoreSheetProps>) {
   let error: string | null = null
 
   const restore = async () => {
-    const sessionId = extractSessionId(value)
-    if (!sessionId) return
+    const token = extractRestoreToken(value)
+    if (!token) {
+      error = looksLikeStripeReceipt(value)
+        ? 'Stripe receipt links do not include a restore handle. On the device that already has Plus, open About and tap Use Plus on another device.'
+        : 'Enter the short code from the other device, or a checkout session id starting with “cs_”.'
+      void handle.update()
+      return
+    }
     busy = true
     error = null
     void handle.update()
-    const result = await verifyPurchaseSession(sessionId)
+    const result = await verifyPurchase(token)
     busy = false
     if (result.unlocked) {
       handle.props.onRestored()
@@ -58,16 +69,21 @@ export function RestoreSheet(handle: Handle<RestoreSheetProps>) {
         >
           <h3>Restore purchase</h3>
           <p className="muted sheet-lede">
-            Paste the confirmation link from your Stripe receipt email (or the checkout session id
-            starting with “cs_”). We’ll verify it and remove the watermark on this device.
+            On the device that already has Plus, open About and tap{' '}
+            <strong>Use Plus on another device</strong>. Type that short code here, or scan its QR.
+            A checkout session id starting with “cs_” still works too.
           </p>
           <div className="field">
-            <label htmlFor="restore-input">Receipt link or session id</label>
+            <label htmlFor="restore-input">Restore code or session id</label>
             <input
               id="restore-input"
               type="text"
+              inputMode="text"
+              autoCapitalize="characters"
+              autoCorrect="off"
+              spellCheck={false}
               value={value}
-              placeholder="https://… or cs_live_…"
+              placeholder="ABC-234 or cs_live_…"
               mix={[
                 ref((node) => (node as HTMLInputElement).focus()),
                 on('input', (event) => {
@@ -90,7 +106,7 @@ export function RestoreSheet(handle: Handle<RestoreSheetProps>) {
             <button
               type="button"
               className="btn btn-primary"
-              disabled={busy || !extractSessionId(value)}
+              disabled={busy || !extractRestoreToken(value)}
               mix={on('click', () => void restore())}
             >
               {busy ? 'Verifying…' : 'Restore'}

--- a/src/components/restore-sheet.tsx
+++ b/src/components/restore-sheet.tsx
@@ -79,7 +79,7 @@ export function RestoreSheet(handle: Handle<RestoreSheetProps>) {
               id="restore-input"
               type="text"
               inputMode="text"
-              autoCapitalize="characters"
+              autoCapitalize="none"
               autoCorrect="off"
               spellCheck={false}
               value={value}

--- a/src/components/share-plus-sheet.tsx
+++ b/src/components/share-plus-sheet.tsx
@@ -1,0 +1,117 @@
+import type { Handle } from 'remix/ui'
+import { on, ref } from 'remix/ui'
+import { attachSheetModal } from '../lib/sheet-modal'
+import { formatRoomCode } from '../lib/sync-protocol'
+import { getPurchaseSessionId, mintRestoreCode } from '../lib/entitlement'
+import { SyncQr } from './sync-qr'
+
+interface SharePlusSheetProps {
+  onClose: () => void
+}
+
+/**
+ * Plus device: show a short-lived code + QR so another device can unlock.
+ */
+export function SharePlusSheet(handle: Handle<SharePlusSheetProps>) {
+  let code: string | null = null
+  let error: string | null = null
+  let busy = true
+  let copied = false
+
+  const load = async () => {
+    busy = true
+    error = null
+    code = null
+    void handle.update()
+    const sessionId = await getPurchaseSessionId()
+    if (!sessionId) {
+      busy = false
+      error =
+        'This device has Plus, but no restore handle is saved. Open the checkout confirmation link, or write team@kody.video.'
+      void handle.update()
+      return
+    }
+    const minted = await mintRestoreCode(sessionId)
+    busy = false
+    if ('error' in minted) {
+      error = minted.error
+    } else {
+      code = minted.code
+    }
+    if (!handle.signal.aborted) void handle.update()
+  }
+
+  void load()
+
+  const unlockHref = () => {
+    const origin = window.location.origin
+    return code ? `${origin}/unlocked?code=${encodeURIComponent(code)}` : `${origin}/unlocked`
+  }
+
+  return () => {
+    const { onClose } = handle.props
+    return (
+      <>
+        <div
+          className="sheet-backdrop"
+          mix={on('click', () => {
+            if (!busy) onClose()
+          })}
+        />
+        <div
+          className="sheet send-sheet"
+          role="dialog"
+          aria-modal="true"
+          aria-label="Use Plus on another device"
+          mix={ref((node, signal) =>
+            attachSheetModal(node as HTMLElement, signal, {
+              onDismiss: () => handle.props.onClose(),
+              busy: () => busy,
+            }),
+          )}
+        >
+          <h3>Use Plus on another device</h3>
+          <p className={error ? 'sheet-lede is-error' : 'sheet-lede muted'}>
+            {error ??
+              (busy
+                ? 'Making a short code…'
+                : 'On the new device, open kody.video and tap Already paid? Type this code, or scan the QR. It expires in 30 minutes.')}
+          </p>
+          {code ? (
+            <div className="sync-code-block">
+              <p className="sync-code" aria-label={`Restore code ${formatRoomCode(code)}`}>
+                {formatRoomCode(code)}
+              </p>
+              <SyncQr href={unlockHref()} label="QR code to unlock Plus on another device" />
+              <button
+                type="button"
+                className="link-button"
+                mix={on('click', () => {
+                  void navigator.clipboard?.writeText(unlockHref()).then(
+                    () => {
+                      copied = true
+                      void handle.update()
+                    },
+                    () => undefined,
+                  )
+                })}
+              >
+                {copied ? 'Link copied' : 'Copy unlock link'}
+              </button>
+            </div>
+          ) : null}
+          <div className="sheet-actions">
+            {error ? (
+              <button type="button" className="btn btn-primary" mix={on('click', () => void load())}>
+                Try again
+              </button>
+            ) : null}
+            <button type="button" className="btn btn-ghost" mix={on('click', () => onClose())}>
+              Done
+            </button>
+          </div>
+        </div>
+      </>
+    )
+  }
+}

--- a/src/components/sync-qr.tsx
+++ b/src/components/sync-qr.tsx
@@ -4,9 +4,10 @@ import { renderSVG } from 'uqr'
 
 interface SyncQrProps {
   href: string
+  label?: string
 }
 
-/** QR for the receive URL — scanned on the other device. */
+/** QR for a pairing URL — scanned on the other device. */
 export function SyncQr(handle: Handle<SyncQrProps>) {
   return () => {
     const svg = renderSVG(handle.props.href, {
@@ -19,7 +20,7 @@ export function SyncQr(handle: Handle<SyncQrProps>) {
       <div
         className="sync-qr"
         role="img"
-        aria-label="QR code to receive this project"
+        aria-label={handle.props.label ?? 'QR code to receive this project'}
         mix={ref((node) => {
           ;(node as HTMLElement).innerHTML = svg
         })}

--- a/src/components/upsell-sheet.tsx
+++ b/src/components/upsell-sheet.tsx
@@ -43,8 +43,9 @@ export function UpsellSheet(handle: Handle<UpsellSheetProps>) {
               type="button"
               className="btn btn-primary"
               mix={on('click', () => {
-                window.open(REMOVE_WATERMARK_LINK, '_blank', 'noopener')
-                handle.props.onClose()
+                // Same tab so Stripe's redirect lands in this browser profile
+                // (a popup can pay successfully and still leave this device locked).
+                window.location.assign(REMOVE_WATERMARK_LINK)
               })}
             >
               Get Plus — $0.99

--- a/src/lib/entitlement.test.ts
+++ b/src/lib/entitlement.test.ts
@@ -18,6 +18,21 @@ describe('extractRestoreToken', () => {
     expect(extractRestoreToken('abc234')).toEqual({ kind: 'code', value: 'ABC234' })
   })
 
+  it('pulls a restore code out of a copied unlock URL', () => {
+    expect(extractRestoreToken('https://kody.video/unlocked?code=ABC234')).toEqual({
+      kind: 'code',
+      value: 'ABC234',
+    })
+    expect(extractRestoreToken('https://kody.video/unlocked?code=ABC-234')).toEqual({
+      kind: 'code',
+      value: 'ABC234',
+    })
+    expect(extractRestoreToken('kody.video/unlocked?code=ABC234')).toEqual({
+      kind: 'code',
+      value: 'ABC234',
+    })
+  })
+
   it('does not treat a Stripe receipt URL as a session id', () => {
     const receipt =
       'https://pay.stripe.com/receipts/invoices/CAcQARoXChVhY2N0XzFQT2hYV0xBUXBBbnNZc3o'

--- a/src/lib/entitlement.test.ts
+++ b/src/lib/entitlement.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+import {
+  extractRestoreToken,
+  extractSessionId,
+  looksLikeStripeReceipt,
+} from './entitlement'
+
+describe('extractRestoreToken', () => {
+  it('pulls a checkout session id out of a success URL', () => {
+    expect(
+      extractSessionId('https://kody.video/unlocked?session_id=cs_live_b1tCTabc123'),
+    ).toBe('cs_live_b1tCTabc123')
+    expect(extractRestoreToken('cs_test_e2e')).toEqual({ kind: 'session', value: 'cs_test_e2e' })
+  })
+
+  it('accepts a 6-character restore code with or without a hyphen', () => {
+    expect(extractRestoreToken('ABC-234')).toEqual({ kind: 'code', value: 'ABC234' })
+    expect(extractRestoreToken('abc234')).toEqual({ kind: 'code', value: 'ABC234' })
+  })
+
+  it('does not treat a Stripe receipt URL as a session id', () => {
+    const receipt =
+      'https://pay.stripe.com/receipts/invoices/CAcQARoXChVhY2N0XzFQT2hYV0xBUXBBbnNZc3o'
+    expect(extractSessionId(receipt)).toBeNull()
+    expect(extractRestoreToken(receipt)).toBeNull()
+    expect(looksLikeStripeReceipt(receipt)).toBe(true)
+  })
+})

--- a/src/lib/entitlement.ts
+++ b/src/lib/entitlement.ts
@@ -115,10 +115,27 @@ export function looksLikeStripeReceipt(text: string): boolean {
   return /pay\.stripe\.com\/receipts|dashboard\.stripe\.com/i.test(text)
 }
 
+function extractCodeFromText(text: string): string | null {
+  const trimmed = text.trim()
+  try {
+    const url = new URL(trimmed)
+    const fromQuery = normalizeRoomCode(url.searchParams.get('code') ?? '')
+    if (fromQuery) return fromQuery
+  } catch {
+    // Pasted text is often a bare code, not an absolute URL.
+  }
+  const queryMatch = trimmed.match(/[?&]code=([A-Za-z0-9-]+)/i)
+  if (queryMatch?.[1]) {
+    const fromQuery = normalizeRoomCode(queryMatch[1])
+    if (fromQuery) return fromQuery
+  }
+  return normalizeRoomCode(trimmed)
+}
+
 /** Session id, or the 6-character code from the device that already has Plus. */
 export function extractRestoreToken(text: string): RestoreToken | null {
   const sessionId = extractSessionId(text)
   if (sessionId) return { kind: 'session', value: sessionId }
-  const code = normalizeRoomCode(text)
+  const code = extractCodeFromText(text)
   return code ? { kind: 'code', value: code } : null
 }

--- a/src/lib/entitlement.ts
+++ b/src/lib/entitlement.ts
@@ -1,5 +1,6 @@
 import { getDb, getSettings } from './storage'
 import type { AppMeta } from './types'
+import { normalizeRoomCode } from './sync-protocol'
 
 /** Stripe Payment Link for the one-time Kody Video Plus unlock ($0.99). */
 export const REMOVE_WATERMARK_LINK = 'https://buy.stripe.com/00wfZi71ibU30rk9hU2Ry07'
@@ -9,6 +10,11 @@ const SESSION_ID_PATTERN = /cs_(?:live|test)_[a-zA-Z0-9]+/
 export async function isWatermarkRemoved(): Promise<boolean> {
   const settings = await getSettings()
   return settings.watermarkRemoved === true
+}
+
+export async function getPurchaseSessionId(): Promise<string | null> {
+  const settings = await getSettings()
+  return settings.purchaseSessionId ?? null
 }
 
 export async function markWatermarkRemoved(sessionId: string): Promise<void> {
@@ -31,22 +37,41 @@ export function shouldWatermarkExports(
 export interface VerifyResult {
   unlocked: boolean
   error?: string
+  sessionId?: string
 }
 
+export type RestoreToken =
+  | { kind: 'session'; value: string }
+  | { kind: 'code'; value: string }
+
 /**
- * Ask the Pages Function to confirm a Stripe Checkout session, and persist
- * the entitlement when it checks out.
+ * Ask the Pages Function to confirm a Stripe Checkout session or a short
+ * restore code, and persist the entitlement when it checks out.
  */
-export async function verifyPurchaseSession(sessionId: string): Promise<VerifyResult> {
+export async function verifyPurchaseSession(
+  sessionId: string,
+  fetchImpl: typeof fetch = fetch,
+): Promise<VerifyResult> {
+  return verifyPurchase({ kind: 'session', value: sessionId }, fetchImpl)
+}
+
+export async function verifyPurchase(
+  token: RestoreToken,
+  fetchImpl: typeof fetch = fetch,
+): Promise<VerifyResult> {
+  const query =
+    token.kind === 'session'
+      ? `session_id=${encodeURIComponent(token.value)}`
+      : `code=${encodeURIComponent(token.value)}`
   try {
-    const response = await fetch(
-      `/api/verify-purchase?session_id=${encodeURIComponent(sessionId)}`,
-      { headers: { accept: 'application/json' } },
-    )
+    const response = await fetchImpl(`/api/verify-purchase?${query}`, {
+      headers: { accept: 'application/json' },
+    })
     const body = (await response.json().catch(() => null)) as VerifyResult | null
     if (response.ok && body?.unlocked) {
-      await markWatermarkRemoved(sessionId)
-      return { unlocked: true }
+      const sessionId = body.sessionId ?? (token.kind === 'session' ? token.value : '')
+      if (sessionId) await markWatermarkRemoved(sessionId)
+      return { unlocked: true, sessionId }
     }
     return {
       unlocked: false,
@@ -57,8 +82,43 @@ export async function verifyPurchaseSession(sessionId: string): Promise<VerifyRe
   }
 }
 
+export async function mintRestoreCode(
+  sessionId: string,
+  fetchImpl: typeof fetch = fetch,
+): Promise<{ code: string } | { error: string }> {
+  try {
+    const response = await fetchImpl('/api/restore-codes', {
+      method: 'POST',
+      headers: { accept: 'application/json', 'content-type': 'application/json' },
+      body: JSON.stringify({ session_id: sessionId }),
+    })
+    const body = (await response.json().catch(() => null)) as {
+      code?: string
+      error?: string
+    } | null
+    if (response.ok && typeof body?.code === 'string') {
+      return { code: body.code }
+    }
+    return { error: body?.error ?? 'Could not create a restore code. Try again shortly.' }
+  } catch {
+    return { error: 'Could not create a restore code — are you offline?' }
+  }
+}
+
 /** Pull a checkout session id out of pasted text (receipt URL, session id, …). */
 export function extractSessionId(text: string): string | null {
   const match = text.match(SESSION_ID_PATTERN)
   return match ? match[0] : null
+}
+
+export function looksLikeStripeReceipt(text: string): boolean {
+  return /pay\.stripe\.com\/receipts|dashboard\.stripe\.com/i.test(text)
+}
+
+/** Session id, or the 6-character code from the device that already has Plus. */
+export function extractRestoreToken(text: string): RestoreToken | null {
+  const sessionId = extractSessionId(text)
+  if (sessionId) return { kind: 'session', value: sessionId }
+  const code = normalizeRoomCode(text)
+  return code ? { kind: 'code', value: code } : null
 }

--- a/src/lib/purchase-http.ts
+++ b/src/lib/purchase-http.ts
@@ -1,0 +1,75 @@
+import { checkPurchaseSession, normalizeSessionId, type PurchaseEnv } from './purchase-session'
+import { createRestoreCode, getRestoreSessionId, clientIp, requireRestoreKv } from './restore-codes'
+import { jsonResponse, SyncRoomError, type SyncRoomsEnv } from './sync-rooms'
+
+export type PurchaseHttpEnv = PurchaseEnv & SyncRoomsEnv
+
+/**
+ * GET /api/verify-purchase?session_id=cs_…  or  ?code=ABC123
+ */
+export async function handleVerifyPurchaseRequest(
+  request: Request,
+  env: PurchaseHttpEnv,
+  fetchImpl: typeof fetch = fetch,
+): Promise<Response> {
+  if (request.method !== 'GET') {
+    return jsonResponse({ unlocked: false, error: 'Method not allowed.' }, 405)
+  }
+
+  const url = new URL(request.url)
+  const rawSession = url.searchParams.get('session_id') ?? ''
+  const rawCode = url.searchParams.get('code') ?? ''
+
+  let sessionId = rawSession
+  if (rawCode) {
+    try {
+      sessionId = await getRestoreSessionId(requireRestoreKv(env), rawCode)
+    } catch (error) {
+      if (error instanceof SyncRoomError) {
+        return jsonResponse({ unlocked: false, error: error.message }, error.status)
+      }
+      return jsonResponse({ unlocked: false, error: 'Could not look up that restore code.' }, 500)
+    }
+  }
+
+  const result = await checkPurchaseSession(sessionId, env, fetchImpl)
+  if (!result.ok) {
+    return jsonResponse({ unlocked: false, error: result.error }, result.status)
+  }
+  return jsonResponse({ unlocked: true, sessionId: result.sessionId }, 200)
+}
+
+/**
+ * POST /api/restore-codes  { session_id }
+ * Mints a short-lived code after confirming the session is a real Plus purchase.
+ */
+export async function handleRestoreCodesRequest(
+  request: Request,
+  env: PurchaseHttpEnv,
+  fetchImpl: typeof fetch = fetch,
+): Promise<Response> {
+  if (request.method !== 'POST') {
+    return jsonResponse({ error: 'Method not allowed.' }, 405)
+  }
+
+  const body = (await request.json().catch(() => null)) as { session_id?: unknown } | null
+  const sessionId = typeof body?.session_id === 'string' ? normalizeSessionId(body.session_id) : null
+  if (!sessionId) {
+    return jsonResponse({ error: 'Invalid session id.' }, 400)
+  }
+
+  const result = await checkPurchaseSession(sessionId, env, fetchImpl)
+  if (!result.ok) {
+    return jsonResponse({ error: result.error }, result.status)
+  }
+
+  try {
+    const code = await createRestoreCode(requireRestoreKv(env), result.sessionId, clientIp(request))
+    return jsonResponse({ code }, 201)
+  } catch (error) {
+    if (error instanceof SyncRoomError) {
+      return jsonResponse({ error: error.message }, error.status)
+    }
+    return jsonResponse({ error: 'Could not create a restore code.' }, 500)
+  }
+}

--- a/src/lib/purchase-session.ts
+++ b/src/lib/purchase-session.ts
@@ -1,0 +1,72 @@
+/**
+ * Shared Stripe Checkout session check used by purchase verification and
+ * restore-code minting. Never stores media; it only asks Stripe whether a
+ * session is a completed Kody Video Plus purchase.
+ */
+
+export const PRODUCTION_PAYMENT_LINK_ID = 'plink_1TxcxULAQpAnsYszr2bLuqOl'
+export const SESSION_ID_PATTERN = /^cs_[a-zA-Z0-9_]+$/
+
+export interface PurchaseEnv {
+  STRIPE_SECRET_KEY?: string
+  /** Optional override; defaults to the production payment link. */
+  STRIPE_PAYMENT_LINK_ID?: string
+}
+
+export type PurchaseCheck =
+  | { ok: true; sessionId: string }
+  | { ok: false; error: string; status: number }
+
+export function normalizeSessionId(value: string): string | null {
+  const sessionId = value.trim()
+  return SESSION_ID_PATTERN.test(sessionId) ? sessionId : null
+}
+
+export async function checkPurchaseSession(
+  sessionId: string,
+  env: PurchaseEnv,
+  fetchImpl: typeof fetch = fetch,
+): Promise<PurchaseCheck> {
+  const normalized = normalizeSessionId(sessionId)
+  if (!normalized) {
+    return { ok: false, error: 'Invalid session id.', status: 400 }
+  }
+
+  const secretKey = env.STRIPE_SECRET_KEY
+  if (!secretKey) {
+    return { ok: false, error: 'Purchase verification is not configured yet.', status: 503 }
+  }
+
+  const response = await fetchImpl(
+    `https://api.stripe.com/v1/checkout/sessions/${encodeURIComponent(normalized)}`,
+    { headers: { authorization: `Bearer ${secretKey}` } },
+  )
+  if (response.status === 404) {
+    return { ok: false, error: 'No such purchase.', status: 404 }
+  }
+  if (!response.ok) {
+    return { ok: false, error: 'Could not reach Stripe. Try again shortly.', status: 502 }
+  }
+
+  const session = (await response.json()) as {
+    status?: string
+    payment_status?: string
+    payment_link?: string
+  }
+
+  const expectedLink = env.STRIPE_PAYMENT_LINK_ID ?? PRODUCTION_PAYMENT_LINK_ID
+  const complete = session.status === 'complete'
+  // 100%-off promotion-code checkouts complete with 'no_payment_required'.
+  const paid =
+    session.payment_status === 'paid' || session.payment_status === 'no_payment_required'
+  const rightProduct = session.payment_link === expectedLink
+
+  if (complete && paid && rightProduct) {
+    return { ok: true, sessionId: normalized }
+  }
+  return {
+    ok: false,
+    error: 'This checkout session is not a completed watermark purchase.',
+    status: 403,
+  }
+}

--- a/src/lib/purchase-session.ts
+++ b/src/lib/purchase-session.ts
@@ -17,6 +17,12 @@ export type PurchaseCheck =
   | { ok: true; sessionId: string }
   | { ok: false; error: string; status: number }
 
+interface StripeCheckoutSession {
+  status?: string
+  payment_status?: string
+  payment_link?: string
+}
+
 export function normalizeSessionId(value: string): string | null {
   const sessionId = value.trim()
   return SESSION_ID_PATTERN.test(sessionId) ? sessionId : null
@@ -37,10 +43,15 @@ export async function checkPurchaseSession(
     return { ok: false, error: 'Purchase verification is not configured yet.', status: 503 }
   }
 
-  const response = await fetchImpl(
-    `https://api.stripe.com/v1/checkout/sessions/${encodeURIComponent(normalized)}`,
-    { headers: { authorization: `Bearer ${secretKey}` } },
-  )
+  let response: Response
+  try {
+    response = await fetchImpl(
+      `https://api.stripe.com/v1/checkout/sessions/${encodeURIComponent(normalized)}`,
+      { headers: { authorization: `Bearer ${secretKey}` } },
+    )
+  } catch {
+    return { ok: false, error: 'Could not reach Stripe. Try again shortly.', status: 502 }
+  }
   if (response.status === 404) {
     return { ok: false, error: 'No such purchase.', status: 404 }
   }
@@ -48,10 +59,11 @@ export async function checkPurchaseSession(
     return { ok: false, error: 'Could not reach Stripe. Try again shortly.', status: 502 }
   }
 
-  const session = (await response.json()) as {
-    status?: string
-    payment_status?: string
-    payment_link?: string
+  let session: StripeCheckoutSession
+  try {
+    session = (await response.json()) as StripeCheckoutSession
+  } catch {
+    return { ok: false, error: 'Could not reach Stripe. Try again shortly.', status: 502 }
   }
 
   const expectedLink = env.STRIPE_PAYMENT_LINK_ID ?? PRODUCTION_PAYMENT_LINK_ID

--- a/src/lib/restore-codes.ts
+++ b/src/lib/restore-codes.ts
@@ -1,0 +1,99 @@
+import { normalizeRoomCode, randomRoomCode, ROOM_CODE_PATTERN } from './sync-protocol'
+import { SyncRoomError, type SyncKv, type SyncRoomsEnv } from './sync-rooms'
+
+export const RESTORE_CODE_TTL_MS = 30 * 60 * 1000
+const RESTORE_KEY_PREFIX = 'restore:'
+const RATE_KEY_PREFIX = 'restore-rate:'
+const CREATE_RATE_LIMIT = 30
+const RATE_WINDOW_SEC = 10 * 60
+
+export interface RestoreCodeRecord {
+  code: string
+  sessionId: string
+  createdAt: number
+  expiresAt: number
+}
+
+function restoreKey(code: string): string {
+  return `${RESTORE_KEY_PREFIX}${code}`
+}
+
+async function readRestoreCode(kv: SyncKv, code: string): Promise<RestoreCodeRecord | null> {
+  const raw = await kv.get(restoreKey(code), 'text')
+  if (!raw) return null
+  try {
+    const parsed = JSON.parse(raw) as RestoreCodeRecord
+    if (parsed.expiresAt <= Date.now()) {
+      await kv.delete(restoreKey(code))
+      return null
+    }
+    if (typeof parsed.sessionId !== 'string' || !ROOM_CODE_PATTERN.test(parsed.code)) {
+      await kv.delete(restoreKey(code))
+      return null
+    }
+    return parsed
+  } catch {
+    await kv.delete(restoreKey(code))
+    return null
+  }
+}
+
+async function writeRestoreCode(kv: SyncKv, record: RestoreCodeRecord): Promise<void> {
+  const ttlSec = Math.max(30, Math.ceil((record.expiresAt - Date.now()) / 1000))
+  await kv.put(restoreKey(record.code), JSON.stringify(record), { expirationTtl: ttlSec })
+}
+
+async function enforceCreateRateLimit(kv: SyncKv, ip: string): Promise<void> {
+  const key = `${RATE_KEY_PREFIX}${ip}`
+  const raw = await kv.get(key, 'text')
+  let count = 0
+  if (raw) {
+    const parsed = Number(raw)
+    if (Number.isFinite(parsed)) count = parsed
+  }
+  if (count >= CREATE_RATE_LIMIT) {
+    throw new SyncRoomError('Too many restore codes from this network. Try again in a few minutes.', 429)
+  }
+  await kv.put(key, String(count + 1), { expirationTtl: RATE_WINDOW_SEC })
+}
+
+export async function createRestoreCode(
+  kv: SyncKv,
+  sessionId: string,
+  ip: string,
+): Promise<string> {
+  await enforceCreateRateLimit(kv, ip)
+  const createdAt = Date.now()
+  const expiresAt = createdAt + RESTORE_CODE_TTL_MS
+  for (let attempt = 0; attempt < 8; attempt += 1) {
+    const code = randomRoomCode()
+    if (await readRestoreCode(kv, code)) continue
+    await writeRestoreCode(kv, { code, sessionId, createdAt, expiresAt })
+    return code
+  }
+  throw new SyncRoomError('Could not allocate a restore code. Try again.', 503)
+}
+
+export async function getRestoreSessionId(kv: SyncKv, code: string): Promise<string> {
+  const normalized = normalizeRoomCode(code)
+  if (!normalized) throw new SyncRoomError('That is not a valid restore code.', 400)
+  const record = await readRestoreCode(kv, normalized)
+  if (!record) {
+    throw new SyncRoomError('That code is not valid or has expired.', 404)
+  }
+  return record.sessionId
+}
+
+export function clientIp(request: Request): string {
+  return request.headers.get('CF-Connecting-IP') ?? request.headers.get('x-forwarded-for') ?? 'local'
+}
+
+export function requireRestoreKv(env: SyncRoomsEnv): SyncKv {
+  if (!env.SYNC_ROOMS) {
+    throw new SyncRoomError(
+      'Device restore codes are not configured on this deployment (missing SYNC_ROOMS).',
+      503,
+    )
+  }
+  return env.SYNC_ROOMS
+}

--- a/src/lib/verify-purchase.test.ts
+++ b/src/lib/verify-purchase.test.ts
@@ -1,21 +1,20 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { onRequestGet } from '../../functions/api/verify-purchase'
+import { handleVerifyPurchaseRequest, handleRestoreCodesRequest } from './purchase-http'
+import { PRODUCTION_PAYMENT_LINK_ID } from './purchase-session'
+import { memorySyncKv } from './sync-rooms'
 
-const PLINK = 'plink_1TxcxULAQpAnsYszr2bLuqOl'
-
-function makeContext(url: string, env: Record<string, string> = {}) {
-  return { request: new Request(url), env }
-}
+const PLINK = PRODUCTION_PAYMENT_LINK_ID
 
 function stripeResponds(session: unknown, status = 200) {
-  vi.stubGlobal(
-    'fetch',
-    vi.fn(async () => new Response(JSON.stringify(session), { status })),
-  )
+  return vi.fn(async () => new Response(JSON.stringify(session), { status }))
 }
 
 async function body(response: Response) {
-  return (await response.json()) as { unlocked: boolean; error?: string }
+  return (await response.json()) as { unlocked?: boolean; error?: string; code?: string; sessionId?: string }
+}
+
+function env(kv = memorySyncKv()) {
+  return { STRIPE_SECRET_KEY: 'rk_test_x', SYNC_ROOMS: kv }
 }
 
 afterEach(() => {
@@ -24,57 +23,133 @@ afterEach(() => {
 
 describe('verify-purchase function', () => {
   const url = 'https://kody.video/api/verify-purchase?session_id=cs_live_abc123'
-  const env = { STRIPE_SECRET_KEY: 'rk_test_x' }
 
   it('returns 503 when the secret is not configured', async () => {
-    const response = await onRequestGet(makeContext(url, {}))
+    const response = await handleVerifyPurchaseRequest(new Request(url), {})
     expect(response.status).toBe(503)
     expect((await body(response)).unlocked).toBe(false)
   })
 
   it('rejects malformed session ids without calling Stripe', async () => {
     const fetchSpy = vi.fn()
-    vi.stubGlobal('fetch', fetchSpy)
-    const response = await onRequestGet(
-      makeContext('https://x.dev/api/verify-purchase?session_id=<script>', env),
+    const response = await handleVerifyPurchaseRequest(
+      new Request('https://x.dev/api/verify-purchase?session_id=<script>'),
+      env(),
+      fetchSpy,
     )
     expect(response.status).toBe(400)
     expect(fetchSpy).not.toHaveBeenCalled()
   })
 
   it('unlocks a paid completed session for our payment link', async () => {
-    stripeResponds({ status: 'complete', payment_status: 'paid', payment_link: PLINK })
-    const response = await onRequestGet(makeContext(url, env))
+    const fetchSpy = stripeResponds({
+      status: 'complete',
+      payment_status: 'paid',
+      payment_link: PLINK,
+    })
+    const response = await handleVerifyPurchaseRequest(new Request(url), env(), fetchSpy)
     expect(response.status).toBe(200)
-    expect((await body(response)).unlocked).toBe(true)
+    const json = await body(response)
+    expect(json.unlocked).toBe(true)
+    expect(json.sessionId).toBe('cs_live_abc123')
   })
 
   it('unlocks a 100%-off promo checkout (no_payment_required)', async () => {
-    stripeResponds({
+    const fetchSpy = stripeResponds({
       status: 'complete',
       payment_status: 'no_payment_required',
       payment_link: PLINK,
     })
-    const response = await onRequestGet(makeContext(url, env))
+    const response = await handleVerifyPurchaseRequest(new Request(url), env(), fetchSpy)
     expect((await body(response)).unlocked).toBe(true)
   })
 
   it('rejects sessions from other payment links', async () => {
-    stripeResponds({ status: 'complete', payment_status: 'paid', payment_link: 'plink_other' })
-    const response = await onRequestGet(makeContext(url, env))
+    const fetchSpy = stripeResponds({
+      status: 'complete',
+      payment_status: 'paid',
+      payment_link: 'plink_other',
+    })
+    const response = await handleVerifyPurchaseRequest(new Request(url), env(), fetchSpy)
     expect(response.status).toBe(403)
     expect((await body(response)).unlocked).toBe(false)
   })
 
   it('rejects incomplete or unpaid sessions', async () => {
-    stripeResponds({ status: 'open', payment_status: 'unpaid', payment_link: PLINK })
-    const response = await onRequestGet(makeContext(url, env))
+    const fetchSpy = stripeResponds({
+      status: 'open',
+      payment_status: 'unpaid',
+      payment_link: PLINK,
+    })
+    const response = await handleVerifyPurchaseRequest(new Request(url), env(), fetchSpy)
     expect(response.status).toBe(403)
   })
 
   it('maps unknown sessions to 404', async () => {
-    stripeResponds({ error: { type: 'invalid_request_error' } }, 404)
-    const response = await onRequestGet(makeContext(url, env))
+    const fetchSpy = stripeResponds({ error: { type: 'invalid_request_error' } }, 404)
+    const response = await handleVerifyPurchaseRequest(new Request(url), env(), fetchSpy)
     expect(response.status).toBe(404)
+  })
+})
+
+describe('restore codes', () => {
+  it('mints a code for a verified session and redeems it', async () => {
+    const kv = memorySyncKv()
+    const rooms = env(kv)
+    const fetchSpy = stripeResponds({
+      status: 'complete',
+      payment_status: 'paid',
+      payment_link: PLINK,
+    })
+    const minted = await handleRestoreCodesRequest(
+      new Request('https://kody.video/api/restore-codes', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ session_id: 'cs_live_abc123' }),
+      }),
+      rooms,
+      fetchSpy,
+    )
+    expect(minted.status).toBe(201)
+    const code = (await body(minted)).code
+    expect(code).toMatch(/^[A-Z2-9]{6}$/)
+
+    const redeemed = await handleVerifyPurchaseRequest(
+      new Request(`https://kody.video/api/verify-purchase?code=${code}`),
+      rooms,
+      fetchSpy,
+    )
+    expect(redeemed.status).toBe(200)
+    const json = await body(redeemed)
+    expect(json.unlocked).toBe(true)
+    expect(json.sessionId).toBe('cs_live_abc123')
+  })
+
+  it('rejects an unknown or expired code', async () => {
+    const response = await handleVerifyPurchaseRequest(
+      new Request('https://kody.video/api/verify-purchase?code=ABCDEF'),
+      env(),
+    )
+    expect(response.status).toBe(404)
+    expect((await body(response)).unlocked).toBe(false)
+  })
+
+  it('does not mint a code for an unverified session', async () => {
+    const fetchSpy = stripeResponds({
+      status: 'open',
+      payment_status: 'unpaid',
+      payment_link: PLINK,
+    })
+    const response = await handleRestoreCodesRequest(
+      new Request('https://kody.video/api/restore-codes', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ session_id: 'cs_live_abc123' }),
+      }),
+      env(),
+      fetchSpy,
+    )
+    expect(response.status).toBe(403)
+    expect((await body(response)).code).toBeUndefined()
   })
 })

--- a/src/lib/verify-purchase.test.ts
+++ b/src/lib/verify-purchase.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { handleVerifyPurchaseRequest, handleRestoreCodesRequest } from './purchase-http'
 import { PRODUCTION_PAYMENT_LINK_ID } from './purchase-session'
+import { RESTORE_CODE_TTL_MS } from './restore-codes'
 import { memorySyncKv } from './sync-rooms'
 
 const PLINK = PRODUCTION_PAYMENT_LINK_ID
@@ -19,6 +20,7 @@ function env(kv = memorySyncKv()) {
 
 afterEach(() => {
   vi.unstubAllGlobals()
+  vi.restoreAllMocks()
 })
 
 describe('verify-purchase function', () => {
@@ -90,6 +92,28 @@ describe('verify-purchase function', () => {
     const response = await handleVerifyPurchaseRequest(new Request(url), env(), fetchSpy)
     expect(response.status).toBe(404)
   })
+
+  it('maps Stripe transport failures to 502', async () => {
+    const fetchSpy = vi.fn(async () => {
+      throw new Error('network down')
+    })
+    const response = await handleVerifyPurchaseRequest(new Request(url), env(), fetchSpy)
+    expect(response.status).toBe(502)
+    expect((await body(response)).unlocked).toBe(false)
+  })
+
+  it('maps unreadable Stripe JSON to 502', async () => {
+    const fetchSpy = vi.fn(
+      async () =>
+        new Response('not-json', {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        }),
+    )
+    const response = await handleVerifyPurchaseRequest(new Request(url), env(), fetchSpy)
+    expect(response.status).toBe(502)
+    expect((await body(response)).unlocked).toBe(false)
+  })
 })
 
 describe('restore codes', () => {
@@ -132,6 +156,37 @@ describe('restore codes', () => {
     )
     expect(response.status).toBe(404)
     expect((await body(response)).unlocked).toBe(false)
+  })
+
+  it('rejects a minted code after it expires', async () => {
+    const kv = memorySyncKv()
+    const rooms = env(kv)
+    const fetchSpy = stripeResponds({
+      status: 'complete',
+      payment_status: 'paid',
+      payment_link: PLINK,
+    })
+    const minted = await handleRestoreCodesRequest(
+      new Request('https://kody.video/api/restore-codes', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ session_id: 'cs_live_abc123' }),
+      }),
+      rooms,
+      fetchSpy,
+    )
+    const code = (await body(minted)).code
+    expect(code).toBeTruthy()
+
+    const now = Date.now()
+    vi.spyOn(Date, 'now').mockReturnValue(now + RESTORE_CODE_TTL_MS + 1)
+    const redeemed = await handleVerifyPurchaseRequest(
+      new Request(`https://kody.video/api/verify-purchase?code=${code}`),
+      rooms,
+      fetchSpy,
+    )
+    expect(redeemed.status).toBe(404)
+    expect((await body(redeemed)).unlocked).toBe(false)
   })
 
   it('does not mint a code for an unverified session', async () => {

--- a/src/pages/about-page.tsx
+++ b/src/pages/about-page.tsx
@@ -2,6 +2,7 @@ import type { Handle } from 'remix/ui'
 import { on } from 'remix/ui'
 import { IconBack } from '../components/icons'
 import { BrandMark } from '../components/brand-mark'
+import { SharePlusSheet } from '../components/share-plus-sheet'
 import {
   checkForUpdates,
   fetchDeployedVersion,
@@ -16,6 +17,7 @@ import { clearExportCache, estimateExportCacheBytes } from '../lib/export/export
 import { listRearCameras } from '../lib/media'
 import { BackupFormatError, importKodyVideoBackupFile } from '../lib/project-transfer'
 import { estimateStorageSpace, formatBytes, type StorageSpace } from '../lib/storage-space'
+import { getSettings } from '../lib/storage'
 import { navigate } from '../router'
 
 /** Prefilled GitHub issue so bug reports arrive with device context attached. */
@@ -71,14 +73,16 @@ function updateDiagnosticsReport(
 interface AboutData {
   storage: StorageSpace | null
   exportCacheBytes: number
+  plus: boolean
 }
 
 async function loadAboutData(): Promise<AboutData> {
-  const [storage, exportCacheBytes] = await Promise.all([
+  const [storage, exportCacheBytes, settings] = await Promise.all([
     estimateStorageSpace(),
     estimateExportCacheBytes(),
+    getSettings(),
   ])
-  return { storage, exportCacheBytes }
+  return { storage, exportCacheBytes, plus: settings.watermarkRemoved === true }
 }
 
 type UpdateStatus = 'idle' | 'checking' | 'current' | 'updating' | 'downloading' | 'unavailable'
@@ -93,7 +97,8 @@ const UPDATE_STATUS_LABEL: Record<Exclude<UpdateStatus, 'idle'>, string> = {
 
 /** Credits, inspiration, and the open-source pointer. */
 export function AboutPage(handle: Handle) {
-  let data: AboutData = { storage: null, exportCacheBytes: 0 }
+  let data: AboutData = { storage: null, exportCacheBytes: 0, plus: false }
+  let sharingPlus = false
   let updateStatus: UpdateStatus = 'idle'
   let cacheStatus: string | null = null
   let clearingCache = false
@@ -248,7 +253,7 @@ export function AboutPage(handle: Handle) {
   }
 
   return () => {
-    const { storage, exportCacheBytes } = data
+    const { storage, exportCacheBytes, plus } = data
     const version = <code>{shortVersion()}</code>
     const versionUrl = commitUrl()
     const diagReport = updateDiagnosticsReport(deployedCommit, deployedKnown)
@@ -269,6 +274,26 @@ export function AboutPage(handle: Handle) {
           <h1>
             Kody <span>Video</span>
           </h1>
+
+          {plus ? (
+            <section className="about-section">
+              <h2>Kody Video Plus</h2>
+              <p>
+                This device is unlocked. To use Plus on a second phone or computer, show a short
+                code and QR the new device can type or scan — no Stripe receipt required.
+              </p>
+              <button
+                type="button"
+                className="btn btn-ghost"
+                mix={on('click', () => {
+                  sharingPlus = true
+                  void handle.update()
+                })}
+              >
+                Use Plus on another device
+              </button>
+            </section>
+          ) : null}
 
           <section className="about-section">
             <h2>Free &amp; open source</h2>
@@ -344,7 +369,8 @@ export function AboutPage(handle: Handle) {
               something breaks, cookieless page-view counts via Fathom Analytics, the tour video
               streaming from this app&rsquo;s own domain if you tap play on it, and — only if you
               tap Send to device — a short-lived matchmaking room so two browsers can find each
-              other. Clips still never upload.
+              other, and a short-lived restore code if you share Plus with another device. Clips
+              still never upload.
             </p>
           </section>
 
@@ -508,6 +534,14 @@ export function AboutPage(handle: Handle) {
             </p>
           </section>
         </div>
+        {sharingPlus ? (
+          <SharePlusSheet
+            onClose={() => {
+              sharingPlus = false
+              void handle.update()
+            }}
+          />
+        ) : null}
       </div>
     )
   }

--- a/src/pages/privacy-page.tsx
+++ b/src/pages/privacy-page.tsx
@@ -92,7 +92,9 @@ export function PrivacyPage() {
           <p>
             The one-time watermark-removal purchase is processed by Stripe on Stripe&rsquo;s pages
             — their privacy policy applies. The app&rsquo;s verification endpoint sees only the
-            checkout session id, never your media or location.
+            checkout session id, never your media or location. Sharing Plus with another device
+            mints a short-lived restore code that maps to that same session id and expires in
+            minutes.
           </p>
         </section>
 

--- a/src/pages/terms-page.tsx
+++ b/src/pages/terms-page.tsx
@@ -14,7 +14,7 @@ export function TermsPage() {
 
       <div className="about-body">
         <h1>Terms</h1>
-        <p className="legal-updated">Last updated: July 2026</p>
+        <p className="legal-updated">Last updated: August 2026</p>
 
         <section className="about-section">
           <h2>Free to use, as is</h2>

--- a/src/pages/terms-page.tsx
+++ b/src/pages/terms-page.tsx
@@ -39,7 +39,8 @@ export function TermsPage() {
             optional location tagging, sending a project to another device, and up to six project
             slots (the free plan includes one project) for the browser profile where it&rsquo;s
             verified. You can restore the
-            purchase on another device via the Stripe receipt link. Payments are handled by Stripe.
+            purchase on another device with a short code or QR from the device that already has
+            Plus. Payments are handled by Stripe.
             For refunds or purchase trouble, email{' '}
             <a href="mailto:team@kody.video">team@kody.video</a>.
           </p>

--- a/src/pages/unlocked-page.tsx
+++ b/src/pages/unlocked-page.tsx
@@ -1,22 +1,35 @@
 import type { Handle } from 'remix/ui'
+import { on } from 'remix/ui'
 import { BrandMark } from '../components/brand-mark'
-import { verifyPurchaseSession, type VerifyResult } from '../lib/entitlement'
+import { SharePlusSheet } from '../components/share-plus-sheet'
+import {
+  extractRestoreToken,
+  verifyPurchase,
+  type VerifyResult,
+} from '../lib/entitlement'
 
 /**
  * Stripe's Payment Link redirects here after checkout with
- * ?session_id={CHECKOUT_SESSION_ID}; setup verifies it server-side and
+ * ?session_id={CHECKOUT_SESSION_ID}. A Plus device can also mint a short
+ * code whose QR opens ?code=ABC123. Setup verifies server-side and
  * persists the entitlement before rendering the result.
  */
 async function verifyFromLocation(): Promise<VerifyResult> {
-  const sessionId = new URL(window.location.href).searchParams.get('session_id')
-  if (!sessionId) {
-    return { unlocked: false, error: 'Missing checkout session. Use the link from your receipt.' }
+  const params = new URL(window.location.href).searchParams
+  const raw = params.get('session_id') ?? params.get('code') ?? ''
+  const token = extractRestoreToken(raw)
+  if (!token) {
+    return {
+      unlocked: false,
+      error: 'Missing checkout session or restore code. Use the code from the other device.',
+    }
   }
-  return verifyPurchaseSession(sessionId)
+  return verifyPurchase(token)
 }
 
 export function UnlockedPage(handle: Handle) {
   let result: VerifyResult | null = null
+  let sharing = false
 
   void verifyFromLocation().then((verified) => {
     if (handle.signal.aborted) return
@@ -40,8 +53,8 @@ export function UnlockedPage(handle: Handle) {
             <p className="muted">
               Thank you for supporting Kody Video. Every export from this device is now
               watermark-free, all six project slots are open, optional location tagging is
-              available, and you can send a project to another device. Keep your Stripe receipt
-              email — its link restores the purchase on another device.
+              available, and you can send a project to another device. To unlock a second
+              phone or computer, tap Add another device and scan or type the short code.
             </p>
           </>
         ) : (
@@ -50,16 +63,41 @@ export function UnlockedPage(handle: Handle) {
             <h1>Hmm, that didn’t check out</h1>
             <p className="muted">
               {result.error ?? 'Could not verify this purchase.'} If you paid and keep seeing
-              this, retry from the link in your Stripe receipt email.
+              this, restore from the device that already has Plus (About → Use Plus on another
+              device).
             </p>
           </>
         )}
-        {result === null ? null : (
+        {result === null ? null : result.unlocked ? (
+          <div className="sheet-actions">
+            <button
+              type="button"
+              className="btn btn-ghost"
+              mix={on('click', () => {
+                sharing = true
+                void handle.update()
+              })}
+            >
+              Add another device
+            </button>
+            <a className="btn btn-primary" href="/">
+              Start creating
+            </a>
+          </div>
+        ) : (
           <a className="btn btn-primary" href="/">
-            {result.unlocked ? 'Start creating' : 'Back to Kody Video'}
+            Back to Kody Video
           </a>
         )}
       </div>
+      {sharing ? (
+        <SharePlusSheet
+          onClose={() => {
+            sharing = false
+            void handle.update()
+          }}
+        />
+      ) : null}
     </div>
   )
 }

--- a/tests/e2e/restore.spec.ts
+++ b/tests/e2e/restore.spec.ts
@@ -1,0 +1,35 @@
+import { test, expect } from '@playwright/test'
+import { unlockPlus } from './helpers'
+
+test.describe('Plus restore codes', () => {
+  test('the Plus device shows a code the other browser can redeem', async ({
+    page,
+    browser,
+    baseURL,
+  }) => {
+    const receiverContext = await browser.newContext({ baseURL })
+    const receiver = await receiverContext.newPage()
+    try {
+      await unlockPlus(page)
+      await page.goto('/about')
+      await page.getByRole('button', { name: 'Use Plus on another device' }).click()
+      const sheet = page.getByRole('dialog', { name: 'Use Plus on another device' })
+      await expect(sheet).toBeVisible()
+      const code = (await sheet.locator('.sync-code').innerText()).replace(/[^A-Z0-9]/g, '')
+      expect(code).toHaveLength(6)
+
+      await receiver.goto(`/unlocked?code=${code}`)
+      await expect(receiver.getByRole('heading', { name: /Plus unlocked/ })).toBeVisible({
+        timeout: 15_000,
+      })
+      const unlocked = await receiver.evaluate(async () => {
+        const storage = await import('/src/lib/storage.ts')
+        const settings = await storage.getSettings()
+        return settings.watermarkRemoved === true
+      })
+      expect(unlocked).toBe(true)
+    } finally {
+      await receiverContext.close()
+    }
+  })
+})

--- a/tests/e2e/restore.spec.ts
+++ b/tests/e2e/restore.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test'
-import { unlockPlus } from './helpers'
+import { gotoHome, unlockPlus } from './helpers'
 
 test.describe('Plus restore codes', () => {
   test('the Plus device shows a code the other browser can redeem', async ({
@@ -10,6 +10,7 @@ test.describe('Plus restore codes', () => {
     const receiverContext = await browser.newContext({ baseURL })
     const receiver = await receiverContext.newPage()
     try {
+      await gotoHome(page)
       await unlockPlus(page)
       await page.goto('/about')
       await page.getByRole('button', { name: 'Use Plus on another device' }).click()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Plus restore now works without a Stripe checkout session id (the thing receipts never show).

**Customer (already handled):** Jon Hilton bought Plus on iPhone, could not restore on Mac (receipt has no `cs_live_…`), bought again, refunded the $0.99 duplicate (`re_3U6UPQLAQpAnsYsz1TZ5kzTA`). Reply sent from `me@kentcdodds.com` with the original session unlock link.

**Product:**
- Subscribed device: **Use Plus on another device** — 6-character code + QR (`/unlocked?code=`).
- New device: type the code, scan the QR, or paste a checkout/unlock URL.
- Checkout stays in the same tab (Safari PWA).
- Codes live 30 minutes in existing `SYNC_ROOMS` KV (`restore:` prefix). Production still verifies via Stripe.

**Review follow-ups:**
- Bugbot: pasted `/unlocked?code=…` links now extract the code.
- CodeRabbit: restore input no longer forces uppercase (session ids stay `cs_live_…`); Stripe fetch/JSON failures return 502; terms date bumped; expired-code test added. Skipped a Durable Object rate limiter — same KV counter pattern as send-to-device rooms.

## Test plan

- [x] `npm test` — purchase + entitlement cases including unlock URLs, Stripe outages, expired codes
- [x] `npm run test:e2e -- tests/e2e/restore.spec.ts`
- [ ] CI on this commit
- [ ] Preview: share sheet on a Plus device, type/scan/paste on a second device
- [ ] Confirm Stripe receipt paste still shows the receipt hint (no false unlock)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3547232c-34d4-469c-a9c2-0bc6e68a609b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3547232c-34d4-469c-a9c2-0bc6e68a609b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Restore Plus on another device using a short code or QR scan.
  * Generate and share short-lived restore codes from the About page.
  * Restore using checkout session IDs alongside restore codes.
  * Add clearer restore guidance and device-sharing actions.

* **Bug Fixes**
  * Improved validation and error messages for invalid restore inputs.
  * Purchase redirects now open in the current browser tab.

* **Documentation**
  * Updated authentication, privacy, and terms documentation for the new restoration flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->