### PR TITLE
Filter Chromium IndexedDB backing-store open noise (KODY-VIDEO-Y)

### DIFF
--- a/src/lib/error-reporting.test.ts
+++ b/src/lib/error-reporting.test.ts
@@ -181,6 +181,28 @@ describe('isIndexedDbBackingStoreOpenEvent', () => {
     ).toBe(true)
   })
 
+  it('drops UnknownError wrappers that only say opening backing store', () => {
+    expect(
+      isIndexedDbBackingStoreOpenEvent({
+        exception: {
+          values: [
+            {
+              type: 'UnknownError',
+              value: 'Failed opening backing store for this profile',
+            },
+          ],
+        },
+      }),
+    ).toBe(true)
+    expect(
+      isExpectedUserError(
+        Object.assign(new Error('Failed opening backing store for this profile'), {
+          name: 'UnknownError',
+        }),
+      ),
+    ).toBe(true)
+  })
+
   it('keeps unrelated IndexedDB UnknownErrors', () => {
     expect(
       isIndexedDbBackingStoreOpenEvent({

--- a/src/lib/error-reporting.test.ts
+++ b/src/lib/error-reporting.test.ts
@@ -4,6 +4,7 @@ import {
   isChunkLoadErrorEvent,
   isCloudflareInsightsBeaconEvent,
   isExpectedUserError,
+  isIndexedDbBackingStoreOpenEvent,
   isMonitoringSelfTestEvent,
   isProjectLimitEvent,
   isReportingHostname,
@@ -13,7 +14,7 @@ import {
   reportComponentError,
   reportError,
 } from './error-reporting'
-import { ProjectLimitError } from './storage'
+import { IndexedDbUnavailableError, ProjectLimitError } from './storage'
 
 describe('isMonitoringSelfTestEvent', () => {
   it('drops the setup-agent synthetic exception signature', () => {
@@ -124,6 +125,75 @@ describe('isExpectedUserError / reportError', () => {
     expect(() =>
       reportError(new ProjectLimitError('The free plan includes 1 project'), 'save-clip'),
     ).not.toThrow()
+  })
+
+  it('recognizes IndexedDbUnavailableError and raw Chromium open failures', () => {
+    expect(isExpectedUserError(new IndexedDbUnavailableError())).toBe(true)
+    expect(
+      isExpectedUserError(
+        new DOMException(
+          'Internal error opening backing store for indexedDB.open.',
+          'UnknownError',
+        ),
+      ),
+    ).toBe(true)
+    expect(
+      isExpectedUserError(
+        new Error('UnknownError: Internal error opening backing store for indexedDB.open.'),
+      ),
+    ).toBe(true)
+  })
+
+  it('reportError stays silent for IndexedDbUnavailableError', () => {
+    expect(() => reportError(new IndexedDbUnavailableError(), 'load-home')).not.toThrow()
+  })
+})
+
+describe('isIndexedDbBackingStoreOpenEvent', () => {
+  it('drops IndexedDbUnavailableError by exception type', () => {
+    expect(
+      isIndexedDbBackingStoreOpenEvent({
+        exception: {
+          values: [
+            {
+              type: 'IndexedDbUnavailableError',
+              value:
+                'This browser can’t open on-device storage right now. Free some disk space, close other kody.video tabs, or restart the browser — then reload.',
+            },
+          ],
+        },
+      }),
+    ).toBe(true)
+  })
+
+  it('drops the raw Chromium backing-store open signature (KODY-VIDEO-Y)', () => {
+    expect(
+      isIndexedDbBackingStoreOpenEvent({
+        exception: {
+          values: [
+            {
+              type: 'Error',
+              value: 'UnknownError: Internal error opening backing store for indexedDB.open.',
+            },
+          ],
+        },
+      }),
+    ).toBe(true)
+  })
+
+  it('keeps unrelated IndexedDB UnknownErrors', () => {
+    expect(
+      isIndexedDbBackingStoreOpenEvent({
+        exception: {
+          values: [
+            {
+              type: 'Error',
+              value: 'UnknownError: Error preparing Blob/File data to be stored in object store',
+            },
+          ],
+        },
+      }),
+    ).toBe(false)
   })
 })
 

--- a/src/lib/error-reporting.ts
+++ b/src/lib/error-reporting.ts
@@ -94,6 +94,20 @@ export function isProjectLimitEvent(event: FilterableSentryEvent): boolean {
 const IDB_BACKING_STORE_OPEN =
   /Internal error opening backing store for indexedDB\.open/i
 
+/** Shared text matcher for raw Chromium / wrapper open failures. */
+function isIndexedDbBackingStoreOpenText(
+  type: string | undefined,
+  text: string,
+): boolean {
+  if (IDB_BACKING_STORE_OPEN.test(text)) return true
+  // storage.ts also accepts UnknownError + "opening backing store" without the
+  // exact Chromium sentence (alternate wrappers / localized paraphrases).
+  return (
+    (type === 'UnknownError' || /^UnknownError:/i.test(text)) &&
+    /opening backing store/i.test(text)
+  )
+}
+
 /**
  * Environmental IndexedDB.open noise: Chromium cannot open the profile's
  * LevelDB backing store (disk/profile/AV). After one retry, storage throws
@@ -105,11 +119,11 @@ export function isIndexedDbBackingStoreOpenEvent(
   const exceptionValues = event.exception?.values ?? []
   for (const value of exceptionValues) {
     if (value.type === 'IndexedDbUnavailableError') return true
-    const text = value.value ?? ''
-    if (IDB_BACKING_STORE_OPEN.test(text)) return true
+    if (isIndexedDbBackingStoreOpenText(value.type, value.value ?? '')) return true
   }
   return (
-    typeof event.message === 'string' && IDB_BACKING_STORE_OPEN.test(event.message)
+    typeof event.message === 'string' &&
+    isIndexedDbBackingStoreOpenText(undefined, event.message)
   )
 }
 
@@ -447,7 +461,7 @@ export function isExpectedUserError(error: unknown): boolean {
   if (error.name === 'ProjectLimitError') return true
   if (error.name === 'IndexedDbUnavailableError') return true
   // Raw Chromium open failure if something reports before storage wraps it.
-  return IDB_BACKING_STORE_OPEN.test(error.message)
+  return isIndexedDbBackingStoreOpenText(error.name, error.message)
 }
 
 /**

--- a/src/lib/error-reporting.ts
+++ b/src/lib/error-reporting.ts
@@ -87,6 +87,33 @@ export function isProjectLimitEvent(event: FilterableSentryEvent): boolean {
 }
 
 /**
+ * Chromium LevelDB open failure (KODY-VIDEO-Y). Keep in sync with
+ * `isIndexedDbBackingStoreOpenFailure` in storage.ts — message-only here so
+ * this module stays free of an idb import.
+ */
+const IDB_BACKING_STORE_OPEN =
+  /Internal error opening backing store for indexedDB\.open/i
+
+/**
+ * Environmental IndexedDB.open noise: Chromium cannot open the profile's
+ * LevelDB backing store (disk/profile/AV). After one retry, storage throws
+ * IndexedDbUnavailableError for in-app guidance — not a triage-worthy bug.
+ */
+export function isIndexedDbBackingStoreOpenEvent(
+  event: FilterableSentryEvent,
+): boolean {
+  const exceptionValues = event.exception?.values ?? []
+  for (const value of exceptionValues) {
+    if (value.type === 'IndexedDbUnavailableError') return true
+    const text = value.value ?? ''
+    if (IDB_BACKING_STORE_OPEN.test(text)) return true
+  }
+  return (
+    typeof event.message === 'string' && IDB_BACKING_STORE_OPEN.test(event.message)
+  )
+}
+
+/**
  * Browser-extension / host-bridge noise (often Edge/Chrome on Windows).
  * Rejects a non-Error string like
  * "Object Not Found Matching Id:1, MethodName:update, ParamCount:4" with no
@@ -373,6 +400,7 @@ function loadSentry(): Promise<SentryLike> | null {
         if (isMonitoringSelfTestEvent(event)) return null
         if (isCloudflareInsightsBeaconEvent(event)) return null
         if (isProjectLimitEvent(event)) return null
+        if (isIndexedDbBackingStoreOpenEvent(event)) return null
         if (isBrowserExtensionHostObjectNoiseEvent(event)) return null
         if (isViteCssPreloadError(event)) return null
         if (isChunkLoadErrorEvent(event)) return null
@@ -409,12 +437,17 @@ export function initErrorReporting(): void {
 }
 
 /**
- * True for expected product gates that must never become crash reports.
- * Matched by `error.name` so this module stays free of a storage import
+ * True for expected product gates / environmental storage failures that must
+ * never become crash reports. Matched by `error.name` (and a narrow Chromium
+ * IndexedDB.open signature) so this module stays free of a storage import
  * (storage pulls idb/OPFS; reportError is on the idle-deferred Sentry path).
  */
 export function isExpectedUserError(error: unknown): boolean {
-  return error instanceof Error && error.name === 'ProjectLimitError'
+  if (!(error instanceof Error)) return false
+  if (error.name === 'ProjectLimitError') return true
+  if (error.name === 'IndexedDbUnavailableError') return true
+  // Raw Chromium open failure if something reports before storage wraps it.
+  return IDB_BACKING_STORE_OPEN.test(error.message)
 }
 
 /**

--- a/src/lib/storage.test.ts
+++ b/src/lib/storage.test.ts
@@ -20,6 +20,8 @@ import {
   getUndoSnapshot,
   isRetriableIdbFailure,
   isStaleConnectionError,
+  isIndexedDbBackingStoreOpenFailure,
+  IndexedDbUnavailableError,
   listProjects,
   moveClip,
   PlusRequiredError,
@@ -131,6 +133,29 @@ describe('storage layer', () => {
       false,
     )
     expect(isStaleConnectionError(new Error('nope'))).toBe(false)
+  })
+
+  it('recognizes Chromium IndexedDB backing-store open failures (KODY-VIDEO-Y)', () => {
+    expect(
+      isIndexedDbBackingStoreOpenFailure(
+        new DOMException(
+          'Internal error opening backing store for indexedDB.open.',
+          'UnknownError',
+        ),
+      ),
+    ).toBe(true)
+    expect(
+      isIndexedDbBackingStoreOpenFailure(
+        new Error('UnknownError: Internal error opening backing store for indexedDB.open.'),
+      ),
+    ).toBe(true)
+    expect(
+      isIndexedDbBackingStoreOpenFailure(
+        new DOMException('Error preparing Blob/File data to be stored', 'UnknownError'),
+      ),
+    ).toBe(false)
+    expect(isIndexedDbBackingStoreOpenFailure(new Error('Clip not found'))).toBe(false)
+    expect(new IndexedDbUnavailableError().name).toBe('IndexedDbUnavailableError')
   })
 
   it('heals a DB left empty by a version-less open (diag-style)', async () => {
@@ -980,6 +1005,14 @@ describe('storage layer', () => {
     expect(
       isRetriableIdbFailure(
         new DOMException('Error preparing Blob/File data to be stored', 'UnknownError'),
+      ),
+    ).toBe(true)
+    expect(
+      isRetriableIdbFailure(
+        new DOMException(
+          'Internal error opening backing store for indexedDB.open.',
+          'UnknownError',
+        ),
       ),
     ).toBe(true)
     expect(isRetriableIdbFailure(new DOMException('Transaction aborted', 'AbortError'))).toBe(true)

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -106,6 +106,40 @@ export function isStaleConnectionError(error: unknown): boolean {
 }
 
 /**
+ * Chromium LevelDB open failure (KODY-VIDEO-Y): the profile's IndexedDB
+ * backing store will not open — disk pressure, profile corruption, AV locks,
+ * or enterprise storage policy. Not an app logic bug; keep in sync with the
+ * beforeSend matcher in error-reporting.ts.
+ */
+const IDB_BACKING_STORE_OPEN =
+  /Internal error opening backing store for indexedDB\.open/i
+
+/** True when IndexedDB.open failed because Chromium could not open LevelDB. */
+export function isIndexedDbBackingStoreOpenFailure(error: unknown): boolean {
+  if (!(error instanceof DOMException) && !(error instanceof Error)) return false
+  if (IDB_BACKING_STORE_OPEN.test(error.message)) return true
+  // Some wrappers put the DOMException name in the message ("UnknownError: …").
+  return (
+    error.name === 'UnknownError' &&
+    /opening backing store/i.test(error.message)
+  )
+}
+
+/**
+ * Soft storage-unavailable gate after IndexedDB.open fails environmentally.
+ * Surfaced in-app as guidance; expected platform noise, never a crash report.
+ */
+export class IndexedDbUnavailableError extends Error {
+  override readonly name = 'IndexedDbUnavailableError'
+
+  constructor(
+    message = 'This browser can’t open on-device storage right now. Free some disk space, close other kody.video tabs, or restart the browser — then reload.',
+  ) {
+    super(message)
+  }
+}
+
+/**
  * True when an IndexedDB failure looks environmental — the connection or the
  * backing store gave out mid-operation (iOS Safari closing IDB under memory
  * pressure, Chromium's "Error preparing Blob/File data to be stored") — so an
@@ -115,6 +149,7 @@ export function isStaleConnectionError(error: unknown): boolean {
  */
 export function isRetriableIdbFailure(error: unknown): boolean {
   if (isStaleConnectionError(error)) return true
+  if (isIndexedDbBackingStoreOpenFailure(error)) return true
   if (!(error instanceof DOMException)) return false
   return (
     error.name === 'AbortError' ||
@@ -168,7 +203,8 @@ function discardStaleDb(stale: IDBPDatabase<ClipsDB> | null, pending: Promise<ID
  * The handle is cached, but browsers — especially iOS Safari — may close it
  * out from under us. getDb() clears the cache on close and, if a caller still
  * holds a closing handle, probes and reopens once so getSettings/load-home
- * does not surface InvalidStateError.
+ * does not surface InvalidStateError. Chromium LevelDB open failures
+ * (KODY-VIDEO-Y) get the same one-shot retry, then a clear IndexedDbUnavailableError.
  */
 export async function getDb(): Promise<IDBPDatabase<ClipsDB>> {
   for (let attempt = 0; attempt < 2; attempt += 1) {
@@ -186,7 +222,14 @@ export async function getDb(): Promise<IDBPDatabase<ClipsDB>> {
       db.transaction('meta')
       return db
     } catch (error) {
-      if (!isStaleConnectionError(error) || attempt === 1) throw error
+      const retriable =
+        isStaleConnectionError(error) || isIndexedDbBackingStoreOpenFailure(error)
+      if (!retriable || attempt === 1) {
+        if (isIndexedDbBackingStoreOpenFailure(error)) {
+          throw new IndexedDbUnavailableError()
+        }
+        throw error
+      }
       discardStaleDb(activeDb, pending)
     }
   }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sentry [KODY-VIDEO-Y](https://kent-c-dodds-tech-llc.sentry.io/issues/7683914052/) reports `UnknownError: Internal error opening backing store for indexedDB.open.` during `load-home` on Chrome/Windows. That is Chromium failing to open the profile LevelDB store (disk pressure, profile corruption, AV locks) — not an app logic bug. Four events arrived in ~7 minutes from the same client (refresh spam).

## Changes

- Detect the Chromium backing-store open signature and retry `getDb()` once (same path as stale-connection reconnect).
- After retry exhaustion, throw `IndexedDbUnavailableError` with actionable in-app copy instead of the raw DOMException text.
- Skip `reportError` for this class and drop matching events in `beforeSend` (narrow signature only — blob-store UnknownErrors like KODY-VIDEO-3 stay reportable).
- Follow-up: aligned the Sentry text matcher with storage’s `UnknownError` + “opening backing store” fallback (CodeRabbit).

## Risk

**Low** — isolated storage open path + Sentry filter; no auth/billing/export changes.

## Outcome

Squash-merged as `1eec5b06`. Sentry issue ignored; triage outcome `filtered`. Cloudflare Pages deploy on main succeeded.

## Test plan

- [x] `npx vitest run` (local) / CI Lint, unit, e2e
- [x] `npm run lint` / `npm run build`
- [x] Bugbot + CodeRabbit cleared
- [x] `node scripts/manual-smoke.mjs` — 32/33; unrelated flake on “export overlay shows encoded frames” (export still completes to ready)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4da333fb-e8b6-4d28-8e22-931ec0d5a1be?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4da333fb-e8b6-4d28-8e22-931ec0d5a1be&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of Chromium IndexedDB backing-store failures.
  * Automatically retries affected storage operations once using a fresh connection.
  * Reports a clear IndexedDB unavailable error when recovery is unsuccessful.
  * Prevents expected IndexedDB availability errors from being reported as application errors.

* **Tests**
  * Added coverage for recognized, unrelated, and retriable IndexedDB failure scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->