### PR TITLE
Fix SharePlusSheet scheduleUpdate rejection on open

### DIFF
--- a/src/components/share-plus-sheet.test.ts
+++ b/src/components/share-plus-sheet.test.ts
@@ -1,0 +1,94 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { createElement, createRoot, type Handle } from 'remix/ui'
+
+/**
+ * Regression for Sentry 7685051724: Remix only wires scheduleUpdate after the
+ * first render commits. A sync handle.update() kicked from setup (before any
+ * await) rejects with "scheduleUpdate not implemented".
+ *
+ * Mirrors SharePlusSheet's mount load: start busy=true, skip the sync busy
+ * paint, then update after the first await when the runtime is connected.
+ */
+function SheetSetupLoad(handle: Handle) {
+  let busy = true
+  let error: string | null = null
+  let code: string | null = null
+
+  const load = async () => {
+    const needsBusyPaint = !busy || error !== null || code !== null
+    busy = true
+    error = null
+    code = null
+    if (needsBusyPaint) void handle.update()
+    await Promise.resolve()
+    busy = false
+    code = 'ABC234'
+    if (!handle.signal.aborted) void handle.update()
+  }
+
+  void load()
+
+  return () =>
+    createElement(
+      'div',
+      { role: 'dialog' },
+      busy ? 'Making a short code…' : null,
+      code ? createElement('p', { className: 'sync-code' }, code) : null,
+    )
+}
+
+describe('SharePlusSheet setup load', () => {
+  let dispose: (() => void) | undefined
+
+  afterEach(() => {
+    dispose?.()
+    dispose = undefined
+  })
+
+  it('does not reject scheduleUpdate when load starts during setup', async () => {
+    const rejections: string[] = []
+    const onRejection = (event: PromiseRejectionEvent) => {
+      const msg =
+        event.reason instanceof Error ? event.reason.message : String(event.reason ?? '')
+      if (msg.includes('scheduleUpdate')) {
+        rejections.push(msg)
+        event.preventDefault()
+      }
+    }
+    window.addEventListener('unhandledrejection', onRejection)
+
+    const host = document.createElement('div')
+    document.body.appendChild(host)
+    const root = createRoot(host)
+    dispose = () => {
+      window.removeEventListener('unhandledrejection', onRejection)
+      root.dispose()
+      host.remove()
+    }
+
+    root.render(createElement(SheetSetupLoad))
+    root.flush()
+
+    await waitFor(() => {
+      root.flush()
+      expect(host.querySelector('.sync-code')?.textContent).toBe('ABC234')
+    })
+
+    expect(rejections).toEqual([])
+  })
+})
+
+async function waitFor(assert: () => void, timeoutMs = 2000): Promise<void> {
+  const start = Date.now()
+  let last: unknown
+  while (Date.now() - start < timeoutMs) {
+    try {
+      assert()
+      return
+    } catch (err) {
+      last = err
+      await new Promise((r) => setTimeout(r, 20))
+    }
+  }
+  throw last instanceof Error ? last : new Error(String(last))
+}

--- a/src/components/share-plus-sheet.tsx
+++ b/src/components/share-plus-sheet.tsx
@@ -19,10 +19,16 @@ export function SharePlusSheet(handle: Handle<SharePlusSheetProps>) {
   let copied = false
 
   const load = async () => {
+    // Remix wires scheduleUpdate only after the first render commits. Calling
+    // handle.update() synchronously from setup (before any await) rejects with
+    // "scheduleUpdate not implemented" — an unhandledrejection on every open.
+    // Initial state is already busy=true / empty, so skip that paint; on retry
+    // (mounted) we do need a busy paint when leaving an error/code state.
+    const needsBusyPaint = !busy || error !== null || code !== null
     busy = true
     error = null
     code = null
-    void handle.update()
+    if (needsBusyPaint) void handle.update()
     const sessionId = await getPurchaseSessionId()
     if (!sessionId) {
       busy = false

--- a/tests/e2e/restore.spec.ts
+++ b/tests/e2e/restore.spec.ts
@@ -10,6 +10,17 @@ test.describe('Plus restore codes', () => {
     const receiverContext = await browser.newContext({ baseURL })
     const receiver = await receiverContext.newPage()
     try {
+      // Catch the SharePlusSheet setup regression (KODY Sentry 7685051724):
+      // sync handle.update() before Remix wires scheduleUpdate.
+      await page.addInitScript(() => {
+        window.addEventListener('unhandledrejection', (event) => {
+          const msg =
+            event.reason instanceof Error ? event.reason.message : String(event.reason ?? '')
+          if (!msg.includes('scheduleUpdate')) return
+          const w = window as unknown as { __kodyScheduleUpdateErrors?: string[] }
+          ;(w.__kodyScheduleUpdateErrors ??= []).push(msg)
+        })
+      })
       await gotoHome(page)
       await unlockPlus(page)
       await page.goto('/about')
@@ -18,6 +29,12 @@ test.describe('Plus restore codes', () => {
       await expect(sheet).toBeVisible()
       const code = (await sheet.locator('.sync-code').innerText()).replace(/[^A-Z0-9]/g, '')
       expect(code).toHaveLength(6)
+      const scheduleUpdateErrors = await page.evaluate(
+        () =>
+          (window as unknown as { __kodyScheduleUpdateErrors?: string[] })
+            .__kodyScheduleUpdateErrors ?? [],
+      )
+      expect(scheduleUpdateErrors).toEqual([])
 
       await receiver.goto(`/unlocked?code=${code}`)
       await expect(receiver.getByRole('heading', { name: /Plus unlocked/ })).toBeVisible({


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sentry [7685051724](https://sentry.io/organizations/kent-c-dodds-tech-llc/issues/7685051724/) (`Error: scheduleUpdate not implemented`) fired on every open of **Use Plus on another device**.

Remix only wires `scheduleUpdate` after the first render commits (`setScheduleUpdate` runs after setup). `SharePlusSheet` kicked `load()` during setup and called `handle.update()` synchronously before any `await`, so the promise always rejected as an unhandledrejection. The sheet still worked afterward (post-await updates succeed), which is why e2e kept passing.

## Fix

- Skip the redundant busy paint on mount (initial state is already `busy=true`).
- Keep the busy paint for **Try again** once the component is connected.
- Unit regression (`createRoot` + unhandledrejection listener) and e2e assertion on the restore-code flow.

## Risk

Low — isolated sheet load path; no auth/billing/storage changes.

## Test plan

- [x] `npx vitest run src/components/share-plus-sheet.test.ts`
- [x] `npm run build` + full `npx vitest run` (480 tests)
- [x] `npx playwright test tests/e2e/restore.spec.ts`
- [x] `node scripts/manual-smoke.mjs` — 32/33 (unrelated flaky “export overlay shows encoded frames”)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0ab27739-0b7e-49fe-867f-f9b13b180d7e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0ab27739-0b7e-49fe-867f-f9b13b180d7e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

