### PR TITLE
Guard missing IndexedDB global on load-home (KODY-VIDEO-10)

### DIFF
--- a/src/lib/error-reporting.test.ts
+++ b/src/lib/error-reporting.test.ts
@@ -142,10 +142,18 @@ describe('isExpectedUserError / reportError', () => {
         new Error('UnknownError: Internal error opening backing store for indexedDB.open.'),
       ),
     ).toBe(true)
+    expect(isExpectedUserError(new ReferenceError('indexedDB is not defined'))).toBe(true)
+    expect(isExpectedUserError(new ReferenceError('foo is not defined'))).toBe(false)
   })
 
   it('reportError stays silent for IndexedDbUnavailableError', () => {
     expect(() => reportError(new IndexedDbUnavailableError(), 'load-home')).not.toThrow()
+  })
+
+  it('reportError stays silent for missing IndexedDB ReferenceError (KODY-VIDEO-10)', () => {
+    expect(() =>
+      reportError(new ReferenceError('indexedDB is not defined'), 'load-home'),
+    ).not.toThrow()
   })
 })
 
@@ -179,6 +187,33 @@ describe('isIndexedDbBackingStoreOpenEvent', () => {
         },
       }),
     ).toBe(true)
+  })
+
+  it('drops missing IndexedDB ReferenceError (KODY-VIDEO-10)', () => {
+    expect(
+      isIndexedDbBackingStoreOpenEvent({
+        exception: {
+          values: [
+            {
+              type: 'ReferenceError',
+              value: 'indexedDB is not defined',
+            },
+          ],
+        },
+      }),
+    ).toBe(true)
+    expect(
+      isIndexedDbBackingStoreOpenEvent({
+        exception: {
+          values: [
+            {
+              type: 'ReferenceError',
+              value: 'localStorage is not defined',
+            },
+          ],
+        },
+      }),
+    ).toBe(false)
   })
 
   it('drops UnknownError wrappers that only say opening backing store', () => {

--- a/src/lib/error-reporting.ts
+++ b/src/lib/error-reporting.ts
@@ -110,8 +110,10 @@ function isIndexedDbBackingStoreOpenText(
 
 /**
  * Environmental IndexedDB.open noise: Chromium cannot open the profile's
- * LevelDB backing store (disk/profile/AV). After one retry, storage throws
- * IndexedDbUnavailableError for in-app guidance — not a triage-worthy bug.
+ * LevelDB backing store (disk/profile/AV), or the IndexedDB global is
+ * absent (bots / non-browser shells — KODY-VIDEO-10). After one retry where
+ * applicable, storage throws IndexedDbUnavailableError for in-app guidance —
+ * not a triage-worthy bug.
  */
 export function isIndexedDbBackingStoreOpenEvent(
   event: FilterableSentryEvent,
@@ -120,11 +122,22 @@ export function isIndexedDbBackingStoreOpenEvent(
   for (const value of exceptionValues) {
     if (value.type === 'IndexedDbUnavailableError') return true
     if (isIndexedDbBackingStoreOpenText(value.type, value.value ?? '')) return true
+    if (isIndexedDbNotDefinedText(value.type, value.value ?? '')) return true
   }
   return (
     typeof event.message === 'string' &&
-    isIndexedDbBackingStoreOpenText(undefined, event.message)
+    (isIndexedDbBackingStoreOpenText(undefined, event.message) ||
+      isIndexedDbNotDefinedText(undefined, event.message))
   )
+}
+
+/** Missing IndexedDB global (ReferenceError from idb / raw indexedDB.open). */
+const IDB_NOT_DEFINED = /indexedDB is not defined/i
+
+function isIndexedDbNotDefinedText(type: string | undefined, text: string): boolean {
+  if (!IDB_NOT_DEFINED.test(text)) return false
+  // Prefer the ReferenceError type when present; still accept bare messages.
+  return type === undefined || type === 'ReferenceError' || type === 'Error'
 }
 
 /**
@@ -452,8 +465,8 @@ export function initErrorReporting(): void {
 
 /**
  * True for expected product gates / environmental storage failures that must
- * never become crash reports. Matched by `error.name` (and a narrow Chromium
- * IndexedDB.open signature) so this module stays free of a storage import
+ * never become crash reports. Matched by `error.name` (and narrow IndexedDB
+ * signatures) so this module stays free of a storage import
  * (storage pulls idb/OPFS; reportError is on the idle-deferred Sentry path).
  */
 export function isExpectedUserError(error: unknown): boolean {
@@ -461,7 +474,9 @@ export function isExpectedUserError(error: unknown): boolean {
   if (error.name === 'ProjectLimitError') return true
   if (error.name === 'IndexedDbUnavailableError') return true
   // Raw Chromium open failure if something reports before storage wraps it.
-  return isIndexedDbBackingStoreOpenText(error.name, error.message)
+  if (isIndexedDbBackingStoreOpenText(error.name, error.message)) return true
+  // Missing IndexedDB global (KODY-VIDEO-10) before storage wraps it.
+  return isIndexedDbNotDefinedText(error.name, error.message)
 }
 
 /**

--- a/src/lib/storage.test.ts
+++ b/src/lib/storage.test.ts
@@ -21,6 +21,8 @@ import {
   isRetriableIdbFailure,
   isStaleConnectionError,
   isIndexedDbBackingStoreOpenFailure,
+  isIndexedDbMissing,
+  isIndexedDbMissingError,
   IndexedDbUnavailableError,
   listProjects,
   moveClip,
@@ -156,6 +158,35 @@ describe('storage layer', () => {
     ).toBe(false)
     expect(isIndexedDbBackingStoreOpenFailure(new Error('Clip not found'))).toBe(false)
     expect(new IndexedDbUnavailableError().name).toBe('IndexedDbUnavailableError')
+  })
+
+  it('maps a missing IndexedDB global to IndexedDbUnavailableError (KODY-VIDEO-10)', async () => {
+    expect(isIndexedDbMissing()).toBe(false)
+    expect(isIndexedDbMissingError(new ReferenceError('indexedDB is not defined'))).toBe(true)
+    expect(isIndexedDbMissingError(new ReferenceError('foo is not defined'))).toBe(false)
+    expect(isIndexedDbMissingError(new Error('indexedDB is not defined'))).toBe(false)
+
+    // Clear any cached handle before removing the global — deleteDatabase needs it.
+    await __resetDbForTests()
+    const descriptor =
+      Object.getOwnPropertyDescriptor(globalThis, 'indexedDB') ??
+      Object.getOwnPropertyDescriptor(window, 'indexedDB')
+    Object.defineProperty(globalThis, 'indexedDB', {
+      configurable: true,
+      writable: true,
+      value: undefined,
+    })
+    try {
+      expect(isIndexedDbMissing()).toBe(true)
+      await expect(getDb()).rejects.toBeInstanceOf(IndexedDbUnavailableError)
+    } finally {
+      if (descriptor) {
+        Object.defineProperty(globalThis, 'indexedDB', descriptor)
+      } else {
+        delete (globalThis as { indexedDB?: IDBFactory }).indexedDB
+      }
+    }
+    expect(isIndexedDbMissing()).toBe(false)
   })
 
   it('heals a DB left empty by a version-less open (diag-style)', async () => {

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -126,6 +126,22 @@ export function isIndexedDbBackingStoreOpenFailure(error: unknown): boolean {
 }
 
 /**
+ * True when this JS realm has no IndexedDB binding (KODY-VIDEO-10). Bots,
+ * exotic shells, and non-browser hosts throw ReferenceError inside idb's
+ * openDB; typeof is safe even when the identifier is undeclared.
+ */
+export function isIndexedDbMissing(): boolean {
+  return typeof indexedDB === 'undefined'
+}
+
+/** True when idb (or raw indexedDB) threw because the global is absent. */
+export function isIndexedDbMissingError(error: unknown): boolean {
+  return (
+    error instanceof ReferenceError && /indexedDB is not defined/i.test(error.message)
+  )
+}
+
+/**
  * Soft storage-unavailable gate after IndexedDB.open fails environmentally.
  * Surfaced in-app as guidance; expected platform noise, never a crash report.
  */
@@ -169,6 +185,12 @@ function forgetCachedDb(closedDb?: IDBPDatabase<ClipsDB> | null): void {
 }
 
 function openTrackedDb(): Promise<IDBPDatabase<ClipsDB>> {
+  // idb's openDB reads the free `indexedDB` binding; missing globals throw
+  // ReferenceError (KODY-VIDEO-10). Fail closed with the soft unavailable
+  // gate so load-home shows guidance instead of a crash report.
+  if (isIndexedDbMissing()) {
+    return Promise.reject(new IndexedDbUnavailableError())
+  }
   // Capture this open's handle in terminated — activeDb may already point at
   // a newer reconnect by the time the close event runs.
   const tracked = openDB<ClipsDB>(DB_NAME, DB_VERSION, {
@@ -204,7 +226,8 @@ function discardStaleDb(stale: IDBPDatabase<ClipsDB> | null, pending: Promise<ID
  * out from under us. getDb() clears the cache on close and, if a caller still
  * holds a closing handle, probes and reopens once so getSettings/load-home
  * does not surface InvalidStateError. Chromium LevelDB open failures
- * (KODY-VIDEO-Y) get the same one-shot retry, then a clear IndexedDbUnavailableError.
+ * (KODY-VIDEO-Y) and a missing IndexedDB global (KODY-VIDEO-10) map to
+ * IndexedDbUnavailableError after any one-shot retry that applies.
  */
 export async function getDb(): Promise<IDBPDatabase<ClipsDB>> {
   for (let attempt = 0; attempt < 2; attempt += 1) {
@@ -222,6 +245,11 @@ export async function getDb(): Promise<IDBPDatabase<ClipsDB>> {
       db.transaction('meta')
       return db
     } catch (error) {
+      if (isIndexedDbMissingError(error) || error instanceof IndexedDbUnavailableError) {
+        throw error instanceof IndexedDbUnavailableError
+          ? error
+          : new IndexedDbUnavailableError()
+      }
       const retriable =
         isStaleConnectionError(error) || isIndexedDbBackingStoreOpenFailure(error)
       if (!retriable || attempt === 1) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sentry [KODY-VIDEO-10](https://sentry.io/organizations/kent-c-dodds-tech-llc/issues/7698329966/) (`ReferenceError: indexedDB is not defined`) fired twice from `load-home` → `openTrackedDb` → idb `openDB` when the IndexedDB global was absent (`app.browser`/`app.os` = other — likely a bot or non-browser shell).

## Fix

- Guard `openTrackedDb` with `typeof indexedDB === 'undefined'` and reject as `IndexedDbUnavailableError` (same soft gate as KODY-VIDEO-Y).
- Wrap residual `ReferenceError: indexedDB is not defined` in `getDb`.
- Drop that signature in `beforeSend` / `isExpectedUserError` so raw residuals never re-open triage.
- Unit coverage for the guard, classifier, and Sentry filter.

## Risk

Low — isolated storage/reporting path; no auth/billing/migration surface. Sibling unresolved issues (silent export audio, blob prepare UnknownError, export audio verify) do not share this root cause.

## Test plan

- [x] `npx vitest run src/lib/storage.test.ts src/lib/error-reporting.test.ts` — 100 passed
- [x] `npm run build` — passed
- [x] `node scripts/manual-smoke.mjs` — 32/33 (known flake: “export overlay shows encoded frames”; export still reaches ready; unrelated to this change)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-32ca6690-7952-4183-9e66-41f4d431d1c7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-32ca6690-7952-4183-9e66-41f4d431d1c7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling when IndexedDB is unavailable, providing a consistent storage-unavailable error instead of an unhandled failure.
  * Prevented expected IndexedDB availability errors from being reported as application errors.

* **Tests**
  * Added coverage for missing IndexedDB scenarios and unrelated reference errors.
  * Verified storage initialization and error-reporting behavior when IndexedDB is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->