### PR TITLE
Add a video quality setting to save recording space

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ simply lack the data and degrade gracefully.
 ### Recording quality
 
 - Phones prefer **hardware H.264** (`video/mp4`/`h264` MediaRecorder types) over software VP9 — software encoding is what makes previews and clips drop frames on Android.
-- Capture stays at **30fps** (no dropped-frame shortcuts). About → **Video quality** picks the size/bitrate for *new* clips: **High** is 1080p at about 10 Mbps, **Standard** is 720p (about half the space), **Saver** is 720p at a smaller bitrate. Already-saved clips are left alone. Bitrate still scales with the actual track size.
+- Capture stays at **30fps** (no dropped-frame shortcuts). About → **Video quality** picks the size/bitrate for *new* clips. Without Plus the default is **Standard** (720p). **High** (1080p, about 10 Mbps) is a Plus perk; **Saver** is 720p at a smaller bitrate. Already-saved clips are left alone. Bitrate still scales with the actual track size.
 - A live MediaRecorder is armed on the record screen so the hardware encoder is already past its ~170ms startup hole when the user presses; the take adopts that session and trims the pre-roll.
 - Clip duration is measured from the encoded media after stop (wall-clock time includes encoder startup latency and corrupts trim/export math).
 - The elapsed timer is a leaf component mutating its text node directly from a 10Hz boundary-aligned timer (a per-frame rAF loop would force 60 main-thread frames/s), so the ticking readout never re-renders the page during capture.
@@ -246,8 +246,9 @@ API is missing.
 
 The free plan includes one project, and exports carry a small Kody Video mark
 in the corner. Kody Video Plus — a one-time $0.99 Stripe Payment Link —
-removes the watermark, unlocks six project slots, background music,
-landscape projects, and sending a project to another device: the export
+removes the watermark, unlocks six project slots, 1080p High quality,
+background music, landscape projects, and sending a project to another
+device: the export
 sheet (or a locked home slot, the locked "Add music" button in the editor,
 or rotating an empty project sideways on the free plan) links to checkout,
 Stripe redirects back to `/unlocked?session_id=…`, and a single Cloudflare

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ simply lack the data and degrade gracefully.
 ### Recording quality
 
 - Phones prefer **hardware H.264** (`video/mp4`/`h264` MediaRecorder types) over software VP9 — software encoding is what makes previews and clips drop frames on Android.
-- Capture asks for **1080p at 30fps**; bitrate scales with the actual track size (about 10 Mbps at 1080×1920) instead of a flat 3.5 Mbps.
+- Capture stays at **30fps** (no dropped-frame shortcuts). About → **Video quality** picks the size/bitrate for *new* clips: **High** is 1080p at about 10 Mbps, **Standard** is 720p (about half the space), **Saver** is 720p at a smaller bitrate. Already-saved clips are left alone. Bitrate still scales with the actual track size.
 - A live MediaRecorder is armed on the record screen so the hardware encoder is already past its ~170ms startup hole when the user presses; the take adopts that session and trims the pre-roll.
 - Clip duration is measured from the encoded media after stop (wall-clock time includes encoder startup latency and corrupts trim/export math).
 - The elapsed timer is a leaf component mutating its text node directly from a 10Hz boundary-aligned timer (a per-frame rAF loop would force 60 main-thread frames/s), so the ticking readout never re-renders the page during capture.

--- a/src/components/clip-info-sheet.tsx
+++ b/src/components/clip-info-sheet.tsx
@@ -1,6 +1,7 @@
 import type { Handle } from 'remix/ui'
 import { on, ref } from 'remix/ui'
 import { canSplitClip, clipHasUnusedMedia } from '../lib/clip-edit'
+import { planClipQualityReduction } from '../lib/clip-quality'
 import { buildClipFacts } from '../lib/clip-facts'
 import { clipFit, clipMismatchesFilm } from '../lib/clip-fit'
 import { attachSheetModal } from '../lib/sheet-modal'
@@ -11,7 +12,7 @@ import {
   type ClipRecord,
   type ProjectOrientation,
 } from '../lib/types'
-import { IconCrop, IconDownload, IconLetterbox, IconSplit, IconTrim } from './icons'
+import { IconCompress, IconCrop, IconDownload, IconLetterbox, IconSplit, IconTrim } from './icons'
 
 interface ClipInfoSheetProps {
   clip: ClipRecord
@@ -21,17 +22,19 @@ interface ClipInfoSheetProps {
   filmOrientation: ProjectOrientation
   onSetFit: (fit: ClipFit) => Promise<void>
   onPermanentlyTrim: () => Promise<void>
+  onReduceQuality: () => Promise<void>
   onStartSplit: () => void
   onDownload: () => Promise<void>
   onClose: () => void
 }
 
-type BusyAction = 'trim' | 'download' | null
+type BusyAction = 'trim' | 'quality' | 'download' | null
+type ConfirmingAction = 'trim' | 'quality' | null
 
 /** Facts + destructive clip edits (permanent trim, split) and download. */
 export function ClipInfoSheet(handle: Handle<ClipInfoSheetProps>) {
   let busy: BusyAction = null
-  let confirmingTrim = false
+  let confirming: ConfirmingAction = null
   let error: string | null = null
 
   const run = async (action: Exclude<BusyAction, null>, work: () => Promise<void>) => {
@@ -61,6 +64,7 @@ export function ClipInfoSheet(handle: Handle<ClipInfoSheetProps>) {
     const photo = isImageClip(clip)
     const canTrim = clipHasUnusedMedia(clip)
     const canSplit = canSplitClip(clip)
+    const qualityPlan = photo ? null : planClipQualityReduction(clip)
     const working = busy !== null
 
     return (
@@ -123,15 +127,21 @@ export function ClipInfoSheet(handle: Handle<ClipInfoSheetProps>) {
 
           {error ? <p className="sheet-message is-error">{error}</p> : null}
 
-          {confirmingTrim ? (
+          {confirming === 'trim' ? (
             <p className="sheet-message">
               This deletes the unused start and end from the file. You cannot undo
               it.
             </p>
           ) : null}
+          {confirming === 'quality' && qualityPlan ? (
+            <p className="sheet-message">
+              This permanently replaces the clip with {qualityPlan.summary}. You cannot
+              undo it.
+            </p>
+          ) : null}
 
           <div className="clip-info-actions">
-            {photo ? null : confirmingTrim ? (
+            {photo ? null : confirming === 'trim' ? (
               <div className="sheet-actions">
                 <button
                   type="button"
@@ -139,7 +149,7 @@ export function ClipInfoSheet(handle: Handle<ClipInfoSheetProps>) {
                   disabled={working}
                   data-sheet-focus
                   mix={on('click', () => {
-                    confirmingTrim = false
+                    confirming = null
                     void handle.update()
                   })}
                 >
@@ -156,20 +166,60 @@ export function ClipInfoSheet(handle: Handle<ClipInfoSheetProps>) {
                   {busy === 'trim' ? 'Deleting…' : 'Delete unused parts'}
                 </button>
               </div>
+            ) : confirming === 'quality' ? (
+              <div className="sheet-actions">
+                <button
+                  type="button"
+                  className="btn btn-ghost"
+                  disabled={working}
+                  data-sheet-focus
+                  mix={on('click', () => {
+                    confirming = null
+                    void handle.update()
+                  })}
+                >
+                  Cancel
+                </button>
+                <button
+                  type="button"
+                  className="btn btn-primary confirm-sheet-danger"
+                  disabled={working}
+                  mix={on('click', () =>
+                    run('quality', () => handle.props.onReduceQuality()),
+                  )}
+                >
+                  {busy === 'quality' ? 'Replacing…' : 'Replace permanently'}
+                </button>
+              </div>
             ) : (
-              <button
-                type="button"
-                className="btn btn-ghost clip-info-action"
-                disabled={working || !canTrim}
-                mix={on('click', () => {
-                  if (!canTrim) return
-                  confirmingTrim = true
-                  void handle.update()
-                })}
-              >
-                <IconTrim size={18} />
-                Permanently trim
-              </button>
+              <>
+                <button
+                  type="button"
+                  className="btn btn-ghost clip-info-action"
+                  disabled={working || !canTrim}
+                  mix={on('click', () => {
+                    if (!canTrim) return
+                    confirming = 'trim'
+                    void handle.update()
+                  })}
+                >
+                  <IconTrim size={18} />
+                  Permanently trim
+                </button>
+                <button
+                  type="button"
+                  className="btn btn-ghost clip-info-action"
+                  disabled={working || !qualityPlan}
+                  mix={on('click', () => {
+                    if (!qualityPlan) return
+                    confirming = 'quality'
+                    void handle.update()
+                  })}
+                >
+                  <IconCompress size={18} />
+                  Reduce quality
+                </button>
+              </>
             )}
             {photo ? null : (
               <button
@@ -189,7 +239,7 @@ export function ClipInfoSheet(handle: Handle<ClipInfoSheetProps>) {
               type="button"
               className="btn btn-ghost clip-info-action"
               disabled={working}
-              data-sheet-focus={confirmingTrim ? undefined : true}
+              data-sheet-focus={confirming ? undefined : true}
               mix={on('click', () => run('download', () => handle.props.onDownload()))}
             >
               <IconDownload size={18} />
@@ -206,13 +256,20 @@ export function ClipInfoSheet(handle: Handle<ClipInfoSheetProps>) {
           </div>
           {photo ? (
             <p className="clip-info-hint muted">Photos can be downloaded; trim and split are for video clips.</p>
-          ) : confirmingTrim ? null : (
+          ) : confirming ? null : (
             <>
               {!canTrim ? (
                 <p className="clip-info-hint muted">
                   Trim the clip first, then permanently delete the unused parts.
                 </p>
               ) : null}
+              {!qualityPlan ? (
+                <p className="clip-info-hint muted">This clip is already a small file.</p>
+              ) : (
+                <p className="clip-info-hint muted">
+                  Reduce quality replaces the file with a smaller encode. That cannot be undone.
+                </p>
+              )}
               {canSplit ? (
                 <p className="clip-info-hint muted">
                   Split opens a handle on the filmstrip so you can choose the cut.

--- a/src/components/editor-screen.tsx
+++ b/src/components/editor-screen.tsx
@@ -7,6 +7,7 @@ import {
   importDeviceClips,
   moveSelectedClip,
   permanentlyTrimClip,
+  reduceClipQuality,
   removeClip,
   setAudioTrackSettings,
   setClipDuration,
@@ -769,6 +770,13 @@ export function EditorScreen(handle: Handle<EditorScreenProps>) {
               selectedClipId = updated.id
               await props.refresh()
               props.showToast('Unused parts deleted')
+            }}
+            onReduceQuality={async () => {
+              const updated = await reduceClipQuality(selected.id)
+              clipInfoOpen = false
+              selectedClipId = updated.id
+              await props.refresh()
+              props.showToast('Clip replaced with a smaller file')
             }}
             onStartSplit={() => {
               if (selected) openSplit(selected)

--- a/src/components/icons.tsx
+++ b/src/components/icons.tsx
@@ -139,6 +139,16 @@ export function IconDuplicate(handle: Handle<IconProps>) {
 }
 
 /** Bracket / I-beam handles that read as “trim”. */
+export function IconCompress(handle: Handle<IconProps>) {
+  return () => (
+    <svg {...baseProps(handle.props.size ?? 22)}>
+      <rect x="4" y="4" width="16" height="16" rx="2.5" />
+      <path d="M12 8v8" />
+      <path d="M8.5 13.5L12 17l3.5-3.5" />
+    </svg>
+  )
+}
+
 export function IconTrim(handle: Handle<IconProps>) {
   return () => (
     <svg {...baseProps(handle.props.size ?? 22)}>

--- a/src/components/storage-meter.tsx
+++ b/src/components/storage-meter.tsx
@@ -15,7 +15,9 @@ import { VideoQualityPicker } from './video-quality-picker'
 interface StorageMeterProps {
   storage: StorageSpace
   videoQuality: VideoQualityPreset
+  plus: boolean
   onVideoQualityChange: (next: VideoQualityPreset) => void
+  onUpsell: () => void
 }
 
 /**
@@ -76,7 +78,12 @@ export function StorageMeter(handle: Handle<StorageMeterProps>) {
           </span>
           <VideoQualityPicker
             compact
+            plus={handle.props.plus}
             value={handle.props.videoQuality}
+            onUpsell={() => {
+              setOpen(false)
+              handle.props.onUpsell()
+            }}
             onChange={(next) => {
               handle.props.onVideoQualityChange(next)
               void setVideoQuality(next).catch((err) => {

--- a/src/components/storage-meter.tsx
+++ b/src/components/storage-meter.tsx
@@ -7,9 +7,15 @@ import {
   storageSeverity,
   type StorageSpace,
 } from '../lib/storage-space'
+import { reportError } from '../lib/error-reporting'
+import { setVideoQuality } from '../lib/storage'
+import { VIDEO_QUALITY_PRESETS, type VideoQualityPreset } from '../lib/video-quality'
+import { VideoQualityPicker } from './video-quality-picker'
 
 interface StorageMeterProps {
   storage: StorageSpace
+  videoQuality: VideoQualityPreset
+  onVideoQualityChange: (next: VideoQualityPreset) => void
 }
 
 /**
@@ -64,6 +70,21 @@ export function StorageMeter(handle: Handle<StorageMeterProps>) {
         >
           <strong>Device storage {percent} full</strong>
           <span>{detail}</span>
+          <span>
+            New clips: {VIDEO_QUALITY_PRESETS[handle.props.videoQuality].label}. Lower quality
+            uses less space — 30 fps either way.
+          </span>
+          <VideoQualityPicker
+            compact
+            value={handle.props.videoQuality}
+            onChange={(next) => {
+              handle.props.onVideoQualityChange(next)
+              void setVideoQuality(next).catch((err) => {
+                reportError(err, 'video-quality')
+              })
+            }}
+          />
+          <a href="/about#video-quality">More on About</a>
         </div>
       </Popover.Context>
     )

--- a/src/components/storage-meter.tsx
+++ b/src/components/storage-meter.tsx
@@ -7,8 +7,6 @@ import {
   storageSeverity,
   type StorageSpace,
 } from '../lib/storage-space'
-import { reportError } from '../lib/error-reporting'
-import { setVideoQuality } from '../lib/storage'
 import { VIDEO_QUALITY_PRESETS, type VideoQualityPreset } from '../lib/video-quality'
 import { VideoQualityPicker } from './video-quality-picker'
 
@@ -84,12 +82,7 @@ export function StorageMeter(handle: Handle<StorageMeterProps>) {
               setOpen(false)
               handle.props.onUpsell()
             }}
-            onChange={(next) => {
-              handle.props.onVideoQualityChange(next)
-              void setVideoQuality(next).catch((err) => {
-                reportError(err, 'video-quality')
-              })
-            }}
+            onChange={handle.props.onVideoQualityChange}
           />
           <a href="/about#video-quality">More on About</a>
         </div>

--- a/src/components/upsell-sheet.tsx
+++ b/src/components/upsell-sheet.tsx
@@ -30,10 +30,11 @@ export function UpsellSheet(handle: Handle<UpsellSheetProps>) {
         >
           <h3>Kody Video Plus</h3>
           <p className="sheet-copy">
-            The free plan includes 1 project. Plus is a one-time $0.99 purchase that unlocks{' '}
-            {MAX_PROJECTS} project slots, background music, landscape projects, optional location
-            tagging, sending a project to another device, and removes the watermark from exports —
-            forever, on this device and any device you restore it on.
+            The free plan includes 1 project and records at 720p. Plus is a one-time $0.99 purchase
+            that unlocks {MAX_PROJECTS} project slots, 1080p High quality, background music,
+            landscape projects, optional location tagging, sending a project to another device, and
+            removes the watermark from exports — forever, on this device and any device you restore
+            it on.
           </p>
           <div className="sheet-actions">
             <button type="button" className="btn btn-ghost" mix={on('click', () => onClose())}>

--- a/src/components/video-quality-picker.tsx
+++ b/src/components/video-quality-picker.tsx
@@ -10,8 +10,10 @@ import { IconLock } from './icons'
 interface VideoQualityPickerProps {
   value: VideoQualityPreset
   onChange: (next: VideoQualityPreset) => void
-  /** High (1080p) is a Plus perk; free taps open the upsell. */
-  plus: boolean
+  /** High (1080p) is a Plus perk; free taps open the upsell. `null` means
+   * entitlement is still loading — High is not locked and nothing is
+   * tappable, so a Plus user never sees a false upsell on first paint. */
+  plus: boolean | null
   onUpsell: () => void
   /** Tighter chips for the home storage popover. */
   compact?: boolean
@@ -21,12 +23,18 @@ interface VideoQualityPickerProps {
 export function VideoQualityPicker(handle: Handle<VideoQualityPickerProps>) {
   return () => {
     const { value, onChange, plus, onUpsell, compact } = handle.props
+    const ready = plus !== null
     const selected = VIDEO_QUALITY_PRESETS[value]
     return (
       <div className={`video-quality-picker${compact ? ' is-compact' : ''}`}>
-        <div className="video-quality-options" role="radiogroup" aria-label="Video quality">
+        <div
+          className="video-quality-options"
+          role="radiogroup"
+          aria-label="Video quality"
+          aria-busy={!ready}
+        >
           {VIDEO_QUALITY_IDS.map((id) => {
-            const locked = id === 'high' && !plus
+            const locked = id === 'high' && plus === false
             return (
               <button
                 key={id}
@@ -34,8 +42,10 @@ export function VideoQualityPicker(handle: Handle<VideoQualityPickerProps>) {
                 role="radio"
                 aria-checked={value === id}
                 aria-label={locked ? 'High (Kody Video Plus)' : undefined}
+                disabled={!ready}
                 className={`video-quality-option${value === id ? ' is-active' : ''}${locked ? ' is-locked' : ''}`}
                 mix={on('click', () => {
+                  if (!ready) return
                   if (locked) {
                     onUpsell()
                     return

--- a/src/components/video-quality-picker.tsx
+++ b/src/components/video-quality-picker.tsx
@@ -1,0 +1,43 @@
+import type { Handle } from 'remix/ui'
+import { on } from 'remix/ui'
+import {
+  VIDEO_QUALITY_IDS,
+  VIDEO_QUALITY_PRESETS,
+  type VideoQualityPreset,
+} from '../lib/video-quality'
+
+interface VideoQualityPickerProps {
+  value: VideoQualityPreset
+  onChange: (next: VideoQualityPreset) => void
+  /** Tighter chips for the home storage popover. */
+  compact?: boolean
+}
+
+/** Segmented High / Standard / Saver control. 30fps in every option. */
+export function VideoQualityPicker(handle: Handle<VideoQualityPickerProps>) {
+  return () => {
+    const { value, onChange, compact } = handle.props
+    const selected = VIDEO_QUALITY_PRESETS[value]
+    return (
+      <div className={`video-quality-picker${compact ? ' is-compact' : ''}`}>
+        <div className="video-quality-options" role="radiogroup" aria-label="Video quality">
+          {VIDEO_QUALITY_IDS.map((id) => (
+            <button
+              key={id}
+              type="button"
+              role="radio"
+              aria-checked={value === id}
+              className={`video-quality-option${value === id ? ' is-active' : ''}`}
+              mix={on('click', () => {
+                if (id !== value) onChange(id)
+              })}
+            >
+              {VIDEO_QUALITY_PRESETS[id].label}
+            </button>
+          ))}
+        </div>
+        <p className="video-quality-hint">{selected.hint}</p>
+      </div>
+    )
+  }
+}

--- a/src/components/video-quality-picker.tsx
+++ b/src/components/video-quality-picker.tsx
@@ -5,10 +5,14 @@ import {
   VIDEO_QUALITY_PRESETS,
   type VideoQualityPreset,
 } from '../lib/video-quality'
+import { IconLock } from './icons'
 
 interface VideoQualityPickerProps {
   value: VideoQualityPreset
   onChange: (next: VideoQualityPreset) => void
+  /** High (1080p) is a Plus perk; free taps open the upsell. */
+  plus: boolean
+  onUpsell: () => void
   /** Tighter chips for the home storage popover. */
   compact?: boolean
 }
@@ -16,25 +20,38 @@ interface VideoQualityPickerProps {
 /** Segmented High / Standard / Saver control. 30fps in every option. */
 export function VideoQualityPicker(handle: Handle<VideoQualityPickerProps>) {
   return () => {
-    const { value, onChange, compact } = handle.props
+    const { value, onChange, plus, onUpsell, compact } = handle.props
     const selected = VIDEO_QUALITY_PRESETS[value]
     return (
       <div className={`video-quality-picker${compact ? ' is-compact' : ''}`}>
         <div className="video-quality-options" role="radiogroup" aria-label="Video quality">
-          {VIDEO_QUALITY_IDS.map((id) => (
-            <button
-              key={id}
-              type="button"
-              role="radio"
-              aria-checked={value === id}
-              className={`video-quality-option${value === id ? ' is-active' : ''}`}
-              mix={on('click', () => {
-                if (id !== value) onChange(id)
-              })}
-            >
-              {VIDEO_QUALITY_PRESETS[id].label}
-            </button>
-          ))}
+          {VIDEO_QUALITY_IDS.map((id) => {
+            const locked = id === 'high' && !plus
+            return (
+              <button
+                key={id}
+                type="button"
+                role="radio"
+                aria-checked={value === id}
+                aria-label={locked ? 'High (Kody Video Plus)' : undefined}
+                className={`video-quality-option${value === id ? ' is-active' : ''}${locked ? ' is-locked' : ''}`}
+                mix={on('click', () => {
+                  if (locked) {
+                    onUpsell()
+                    return
+                  }
+                  if (id !== value) onChange(id)
+                })}
+              >
+                {VIDEO_QUALITY_PRESETS[id].label}
+                {locked ? (
+                  <span className="video-quality-lock" aria-hidden="true">
+                    <IconLock size={12} />
+                  </span>
+                ) : null}
+              </button>
+            )
+          })}
         </div>
         <p className="video-quality-hint">{selected.hint}</p>
       </div>

--- a/src/lib/clip-media.test.ts
+++ b/src/lib/clip-media.test.ts
@@ -1,11 +1,12 @@
 import { beforeEach, describe, expect, it } from 'vitest'
-import { permanentlyTrimClip, splitSelectedClip } from './project-actions'
+import { permanentlyTrimClip, reduceClipQuality, splitSelectedClip } from './project-actions'
 import { __resetDbForTests, addClip, createProject, getClip, getClipsForProject, updateClipTrim } from './storage'
 import { makeLabeledClipBlob, makeTestClipBlob } from './testing/make-test-clip'
 import {
   outputMimeForClipMedia,
   probeVideoDisplaySize,
   probeVideoFileSize,
+  reduceClipMedia,
   sliceClipMedia,
 } from './clip-media'
 import { measureBlobDuration } from './media'
@@ -46,6 +47,25 @@ describe('sliceClipMedia', () => {
     expect(sliced.durationMs).toBeGreaterThanOrEqual(400)
     expect(sliced.durationMs).toBeLessThan(1000)
     await expect(measureBlobDuration(sliced.blob)).resolves.toBeGreaterThan(300)
+  })
+})
+
+describe('reduceClipMedia', () => {
+  it('re-encodes a 1080p clip down to 720p', async () => {
+    const source = await makeLabeledClipBlob(1080, 1920, 800)
+    const reduced = await reduceClipMedia(source, {
+      width: 720,
+      height: 1280,
+      bitrate: 800_000,
+    })
+    expect(reduced.blob.size).toBeGreaterThan(0)
+    expect(reduced.width).toBe(720)
+    expect(reduced.height).toBe(1280)
+    expect(reduced.durationMs).toBeGreaterThan(400)
+    await expect(probeVideoDisplaySize(reduced.blob)).resolves.toEqual({
+      width: 720,
+      height: 1280,
+    })
   })
 })
 
@@ -98,5 +118,38 @@ describe('permanentlyTrimClip / splitSelectedClip', () => {
     const ordered = await getClipsForProject(project.id)
     expect(ordered.map((item) => item.id)).toEqual([first.id, second.id])
     expect(await getClip(second.id)).toBeTruthy()
+  })
+
+  it('replaces a large clip with a 720p encode', async () => {
+    const project = await createProject('Shrink')
+    const blob = await makeLabeledClipBlob(1080, 1920, 800)
+    const original = await addClip({
+      projectId: project.id,
+      blob,
+      mimeType: 'video/webm',
+      durationMs: 800,
+      width: 1080,
+      height: 1920,
+    })
+
+    const updated = await reduceClipQuality(original.id)
+    expect(updated.width).toBe(720)
+    expect(updated.height).toBe(1280)
+    expect(updated.trimStartMs).toBe(0)
+    expect(updated.trimEndMs).toBe(updated.durationMs)
+  })
+
+  it('refuses to shrink an already-small clip', async () => {
+    const project = await createProject('Tiny')
+    const blob = await makeTestClipBlob(400)
+    const original = await addClip({
+      projectId: project.id,
+      blob,
+      mimeType: 'video/webm',
+      durationMs: 400,
+      width: 320,
+      height: 568,
+    })
+    await expect(reduceClipQuality(original.id)).rejects.toThrow(/already a small file/)
   })
 })

--- a/src/lib/clip-media.ts
+++ b/src/lib/clip-media.ts
@@ -75,6 +75,58 @@ export async function sliceClipMedia(
   }
 }
 
+/** Re-encode a clip at a smaller size/bitrate. Always transcodes. */
+export async function reduceClipMedia(
+  blob: Blob,
+  target: { width: number; height: number; bitrate: number },
+  mimeHint?: string,
+): Promise<SlicedClipMedia> {
+  const { ALL_FORMATS, BlobSource, BufferTarget, Conversion, Input, Mp4OutputFormat, Output, Quality, WebMOutputFormat } =
+    await import('mediabunny')
+
+  const input = new Input({ source: new BlobSource(blob), formats: ALL_FORMATS })
+  try {
+    const mimeType = outputMimeForClipMedia(blob.type || mimeHint || '')
+    const preferMp4 = mimeType === 'video/mp4'
+    const dest = new BufferTarget()
+    const output = new Output({
+      format: preferMp4 ? new Mp4OutputFormat({ fastStart: 'in-memory' }) : new WebMOutputFormat(),
+      target: dest,
+    })
+    const conversion = await Conversion.init({
+      input,
+      output,
+      video: {
+        width: target.width,
+        height: target.height,
+        fit: 'contain',
+        quality: new Quality({ bitrate: target.bitrate }),
+        forceTranscode: true,
+      },
+      showWarnings: false,
+    })
+    if (!conversion.isValid) {
+      throw new Error('Could not reduce that clip on this device')
+    }
+    await conversion.execute()
+    if (!dest.buffer || dest.buffer.byteLength <= 0) {
+      throw new Error('Reducing the clip produced no video')
+    }
+
+    const reduced = new Blob([dest.buffer], { type: mimeType })
+    const durationMs = await measureSlicedDuration(reduced, 0)
+    return {
+      blob: reduced,
+      mimeType,
+      durationMs: durationMs > 0 ? durationMs : 0,
+      width: target.width,
+      height: target.height,
+    }
+  } finally {
+    input.dispose()
+  }
+}
+
 async function measureSlicedDuration(blob: Blob, fallbackMs: number): Promise<number> {
   try {
     const measured = await measureBlobDuration(blob)

--- a/src/lib/clip-quality.test.ts
+++ b/src/lib/clip-quality.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest'
+import { planClipQualityReduction, scaleToLongEdge } from './clip-quality'
+import type { ClipRecord } from './types'
+
+function clip(overrides: Partial<ClipRecord> = {}): ClipRecord {
+  return {
+    id: 'clip_1',
+    projectId: 'proj_1',
+    mimeType: 'video/webm',
+    durationMs: 10_000,
+    trimStartMs: 0,
+    trimEndMs: 10_000,
+    createdAt: 1,
+    blob: new Blob([new Uint8Array(10 * 1024 * 1024)], { type: 'video/webm' }),
+    width: 1080,
+    height: 1920,
+    ...overrides,
+  }
+}
+
+describe('scaleToLongEdge', () => {
+  it('scales 1080×1920 to a 720p long edge and keeps dims even', () => {
+    expect(scaleToLongEdge(1080, 1920, 1280)).toEqual({ width: 720, height: 1280 })
+    expect(scaleToLongEdge(1920, 1080, 1280)).toEqual({ width: 1280, height: 720 })
+  })
+
+  it('does not upscale', () => {
+    expect(scaleToLongEdge(720, 1280, 1280)).toEqual({ width: 720, height: 1280 })
+  })
+})
+
+describe('planClipQualityReduction', () => {
+  it('plans 720p for a large 1080p file', () => {
+    const plan = planClipQualityReduction(clip())
+    expect(plan).not.toBeNull()
+    expect(plan?.width).toBe(720)
+    expect(plan?.height).toBe(1280)
+    expect(plan?.summary).toMatch(/720p/)
+    expect(plan?.bitrate).toBeGreaterThan(1_000_000)
+  })
+
+  it('plans a smaller bitrate for a fat 720p file', () => {
+    const plan = planClipQualityReduction(
+      clip({
+        width: 720,
+        height: 1280,
+        blob: new Blob([new Uint8Array(8 * 1024 * 1024)], { type: 'video/webm' }),
+      }),
+    )
+    expect(plan).not.toBeNull()
+    expect(plan?.width).toBe(720)
+    expect(plan?.height).toBe(1280)
+    expect(plan?.summary).toMatch(/smaller bitrate/)
+  })
+
+  it('skips photos and already-small files', () => {
+    expect(planClipQualityReduction(clip({ kind: 'image' }))).toBeNull()
+    expect(
+      planClipQualityReduction(
+        clip({
+          width: 720,
+          height: 1280,
+          durationMs: 10_000,
+          blob: new Blob([new Uint8Array(200_000)], { type: 'video/webm' }),
+        }),
+      ),
+    ).toBeNull()
+  })
+})

--- a/src/lib/clip-quality.ts
+++ b/src/lib/clip-quality.ts
@@ -1,0 +1,81 @@
+import { isImageClip, type ClipRecord } from './types'
+import { VIDEO_QUALITY_PRESETS, videoBitrateFor } from './video-quality'
+
+export interface ClipQualityReduction {
+  /** User-facing size/bitrate label for the confirm copy. */
+  summary: string
+  width: number
+  height: number
+  bitrate: number
+}
+
+const STANDARD_LONG_EDGE = VIDEO_QUALITY_PRESETS.standard.longEdge
+const SAVER_BPP = VIDEO_QUALITY_PRESETS.saver.captureBpp
+/** Leave headroom so a just-barely-richer file still shrinks. */
+const SHRINK_RATIO = 0.65
+const ALREADY_SMALL_RATIO = 0.9
+
+function even(n: number): number {
+  return Math.max(2, 2 * Math.round(n / 2))
+}
+
+export function scaleToLongEdge(
+  width: number,
+  height: number,
+  longEdge: number,
+): { width: number; height: number } {
+  const w = width > 0 ? width : longEdge
+  const h = height > 0 ? height : longEdge
+  const current = Math.max(w, h)
+  if (current <= longEdge) return { width: even(w), height: even(h) }
+  const scale = longEdge / current
+  return { width: even(w * scale), height: even(h * scale) }
+}
+
+export function estimatedClipBitsPerSecond(clip: Pick<ClipRecord, 'blob' | 'durationMs'>): number {
+  const durationSec = Math.max(0.2, clip.durationMs / 1000)
+  return (clip.blob.size * 8) / durationSec
+}
+
+/**
+ * Next smaller encode for an existing clip, or null when the file is
+ * already as small as Saver (or a photo). Never plans a larger bitrate
+ * than the clip already uses.
+ */
+export function planClipQualityReduction(
+  clip: Pick<ClipRecord, 'blob' | 'durationMs' | 'width' | 'height' | 'kind'>,
+): ClipQualityReduction | null {
+  if (isImageClip(clip)) return null
+  const width = clip.width ?? 0
+  const height = clip.height ?? 0
+  if (!(width > 0) || !(height > 0)) return null
+
+  const currentBps = estimatedClipBitsPerSecond(clip)
+  const longEdge = Math.max(width, height)
+
+  if (longEdge > STANDARD_LONG_EDGE) {
+    const size = scaleToLongEdge(width, height, STANDARD_LONG_EDGE)
+    const presetBps = videoBitrateFor(size.width, size.height, VIDEO_QUALITY_PRESETS.standard.captureBpp)
+    const bitrate = Math.round(Math.min(presetBps, currentBps * SHRINK_RATIO))
+    if (bitrate >= currentBps * ALREADY_SMALL_RATIO && size.width >= width && size.height >= height) {
+      return null
+    }
+    return {
+      summary: `${size.width}×${size.height} (720p)`,
+      width: size.width,
+      height: size.height,
+      bitrate,
+    }
+  }
+
+  const saverBps = videoBitrateFor(width, height, SAVER_BPP)
+  if (currentBps <= saverBps * 1.15) return null
+  const bitrate = Math.round(Math.min(saverBps, currentBps * SHRINK_RATIO))
+  if (bitrate >= currentBps * ALREADY_SMALL_RATIO) return null
+  return {
+    summary: 'the same size at a smaller bitrate',
+    width: even(width),
+    height: even(height),
+    bitrate,
+  }
+}

--- a/src/lib/media.ts
+++ b/src/lib/media.ts
@@ -1,7 +1,7 @@
 import { clipDownloadFilename } from './clip-facts'
 import { isMobileBrowser } from './platform'
 import type { ClipRecord } from './types'
-import { VIDEO_LONG_EDGE, VIDEO_SHORT_EDGE } from './video-quality'
+import { captureVideoConstraints } from './video-quality'
 
 export { isIosBrowser, isMobileBrowser } from './platform'
 
@@ -65,11 +65,7 @@ export async function openCameraStream(
         ? { deviceId: { exact: options.audioDeviceId } }
         : true
       : false
-  const baseConstraints: MediaTrackConstraints = {
-    width: { ideal: VIDEO_LONG_EDGE },
-    height: { ideal: VIDEO_SHORT_EDGE },
-    frameRate: { ideal: 30 },
-  }
+  const baseConstraints: MediaTrackConstraints = captureVideoConstraints()
 
   // A specific lens (e.g. the rear ultra-wide) is requested by device id;
   // stale ids (permission reset, OS updates) fall back to facing mode.

--- a/src/lib/project-actions.ts
+++ b/src/lib/project-actions.ts
@@ -36,6 +36,7 @@ import { heldDeviceOrientation } from './platform'
 import { probeAudioFile } from './audio-import'
 import { estimateExportCacheBytes } from './export/export-cache'
 import { estimateStorageSpace, type StorageSpace } from './storage-space'
+import { resolveVideoQuality } from './video-quality'
 import type { GeneratedThumbs } from './thumbs'
 import { canSplitClip, clipHasUnusedMedia, remapTrimToSlice, resolveSplitMs } from './clip-edit'
 import {
@@ -89,6 +90,8 @@ export interface HomeLoaderData {
   plus: boolean
   /** Home "Watch the tour" card dismissed (first-timer teaser). */
   tourCardDismissed: boolean
+  /** Capture quality for new recordings (missing = high). */
+  videoQuality: 'high' | 'standard' | 'saver'
 }
 
 export async function loadHomePage(): Promise<HomeLoaderData> {
@@ -104,6 +107,7 @@ export async function loadHomePage(): Promise<HomeLoaderData> {
     exportCacheBytes,
     plus: settings.watermarkRemoved === true,
     tourCardDismissed: settings.tourCardDismissed === true,
+    videoQuality: resolveVideoQuality(settings.videoQuality),
   }
 }
 

--- a/src/lib/project-actions.ts
+++ b/src/lib/project-actions.ts
@@ -107,7 +107,7 @@ export async function loadHomePage(): Promise<HomeLoaderData> {
     exportCacheBytes,
     plus: settings.watermarkRemoved === true,
     tourCardDismissed: settings.tourCardDismissed === true,
-    videoQuality: resolveVideoQuality(settings.videoQuality),
+    videoQuality: resolveVideoQuality(settings.videoQuality, settings.watermarkRemoved === true),
   }
 }
 

--- a/src/lib/project-actions.ts
+++ b/src/lib/project-actions.ts
@@ -360,6 +360,31 @@ export async function trimClip(
   await updateClipTrim(clipId, trimStartMs, trimEndMs)
 }
 
+/** Permanently replace a clip with a smaller encode. Cannot be undone. */
+export async function reduceClipQuality(clipId: ClipId): Promise<ClipRecord> {
+  const clip = await getClip(clipId)
+  if (!clip) throw new Error('Clip not found')
+  const { planClipQualityReduction } = await import('./clip-quality')
+  const plan = planClipQualityReduction(clip)
+  if (!plan) throw new Error('This clip is already a small file')
+
+  const { reduceClipMedia } = await import('./clip-media')
+  const reduced = await reduceClipMedia(clip.blob, plan, clip.mimeType)
+  const durationMs = reduced.durationMs > 0 ? reduced.durationMs : clip.durationMs
+  const scale = durationMs / Math.max(1, clip.durationMs)
+  const updated = await replaceClipMedia(clipId, {
+    blob: reduced.blob,
+    mimeType: reduced.mimeType,
+    durationMs,
+    trimStartMs: Math.round(clip.trimStartMs * scale),
+    trimEndMs: Math.round(clip.trimEndMs * scale),
+    width: reduced.width ?? plan.width,
+    height: reduced.height ?? plan.height,
+  })
+  await clearUndo(clip.projectId)
+  return decorateSlicedClip(updated)
+}
+
 /** Bake the saved trim into the file and drop the unused head/tail. */
 export async function permanentlyTrimClip(clipId: ClipId): Promise<ClipRecord> {
   const clip = await getClip(clipId)

--- a/src/lib/project-actions.ts
+++ b/src/lib/project-actions.ts
@@ -90,7 +90,7 @@ export interface HomeLoaderData {
   plus: boolean
   /** Home "Watch the tour" card dismissed (first-timer teaser). */
   tourCardDismissed: boolean
-  /** Capture quality for new recordings (missing = high). */
+  /** Capture quality for new recordings (missing follows Plus: high / standard). */
   videoQuality: 'high' | 'standard' | 'saver'
 }
 

--- a/src/lib/storage.test.ts
+++ b/src/lib/storage.test.ts
@@ -35,6 +35,7 @@ import {
   setProjectOrientation,
   setTourCardDismissed,
   setKeepWatermark,
+  setVideoQuality,
   toStoredBlob,
   undoDeleteLastClip,
   updateClipAudioPeak,
@@ -48,6 +49,7 @@ import {
   replaceClipMedia,
 } from './storage'
 import { markWatermarkRemoved } from './entitlement'
+import { activeVideoQuality, resetActiveVideoQualityForTests } from './video-quality'
 import {
   MAX_IMAGE_DURATION_MS,
   MAX_PROJECTS,
@@ -234,6 +236,24 @@ describe('storage layer', () => {
     expect(db.version).toBe(DB_VERSION)
     expect(db.objectStoreNames.contains('meta')).toBe(true)
     expect(db.objectStoreNames.contains('projects')).toBe(true)
+  })
+
+  it('defaults video quality to high and persists a lower preset', async () => {
+    expect((await getSettings()).videoQuality).toBeUndefined()
+    await setVideoQuality('standard')
+    expect((await getSettings()).videoQuality).toBe('standard')
+    await setVideoQuality('saver')
+    expect((await getSettings()).videoQuality).toBe('saver')
+    await setVideoQuality('high')
+    expect((await getSettings()).videoQuality).toBe('high')
+  })
+
+  it('hydrates the in-memory capture preset when settings are read', async () => {
+    await setVideoQuality('saver')
+    resetActiveVideoQualityForTests()
+    expect(activeVideoQuality()).toBe('high')
+    await getSettings()
+    expect(activeVideoQuality()).toBe('saver')
   })
 
   it('defaults keepWatermark off and persists the Plus opt-in', async () => {

--- a/src/lib/storage.test.ts
+++ b/src/lib/storage.test.ts
@@ -238,22 +238,37 @@ describe('storage layer', () => {
     expect(db.objectStoreNames.contains('projects')).toBe(true)
   })
 
-  it('defaults video quality to high and persists a lower preset', async () => {
+  it('defaults free video quality to standard and persists saver', async () => {
     expect((await getSettings()).videoQuality).toBeUndefined()
+    expect(activeVideoQuality()).toBe('standard')
     await setVideoQuality('standard')
     expect((await getSettings()).videoQuality).toBe('standard')
     await setVideoQuality('saver')
     expect((await getSettings()).videoQuality).toBe('saver')
+  })
+
+  it('gates high video quality behind Plus', async () => {
+    await expect(setVideoQuality('high')).rejects.toBeInstanceOf(PlusRequiredError)
+    await markWatermarkRemoved('cs_test_video_quality')
     await setVideoQuality('high')
     expect((await getSettings()).videoQuality).toBe('high')
+    expect(activeVideoQuality()).toBe('high')
   })
 
   it('hydrates the in-memory capture preset when settings are read', async () => {
     await setVideoQuality('saver')
     resetActiveVideoQualityForTests()
-    expect(activeVideoQuality()).toBe('high')
+    expect(activeVideoQuality()).toBe('standard')
     await getSettings()
     expect(activeVideoQuality()).toBe('saver')
+  })
+
+  it('hydrates Plus users to high when they have not picked a preset', async () => {
+    await markWatermarkRemoved('cs_test_video_quality_default')
+    resetActiveVideoQualityForTests()
+    expect(activeVideoQuality()).toBe('standard')
+    await getSettings()
+    expect(activeVideoQuality()).toBe('high')
   })
 
   it('defaults keepWatermark off and persists the Plus opt-in', async () => {

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -19,6 +19,12 @@ import {
   type ProjectId,
   type ProjectOrientation,
 } from './types'
+import {
+  resetActiveVideoQualityForTests,
+  resolveVideoQuality,
+  setActiveVideoQuality,
+  type VideoQualityPreset,
+} from './video-quality'
 
 interface ClipsDB extends DBSchema {
   projects: {
@@ -287,6 +293,7 @@ export async function __resetDbForTests(): Promise<void> {
     db?.close()
   }
   forgetCachedDb()
+  resetActiveVideoQualityForTests()
   await new Promise<void>((resolve, reject) => {
     const req = indexedDB.deleteDatabase(DB_NAME)
     req.onsuccess = () => resolve()
@@ -305,6 +312,7 @@ export async function getSettings(): Promise<AppMeta> {
       onboardingDismissed: false,
     }
     const settings = existing ? { ...defaults, ...existing } : defaults
+    setActiveVideoQuality(settings.videoQuality)
     if (!existing || existing.onboardingDismissed === undefined) {
       await db.put('meta', settings)
     }
@@ -350,6 +358,17 @@ function enqueueMetaWrite<T>(write: () => Promise<T>): Promise<T> {
     () => undefined,
   )
   return run
+}
+
+export async function setVideoQuality(videoQuality: VideoQualityPreset): Promise<VideoQualityPreset> {
+  const resolved = resolveVideoQuality(videoQuality)
+  await enqueueMetaWrite(async () => {
+    const db = await getDb()
+    const settings = await getSettings()
+    setActiveVideoQuality(resolved)
+    await db.put('meta', { ...settings, videoQuality: resolved })
+  })
+  return resolved
 }
 
 export async function setKeepWatermark(keepWatermark: boolean): Promise<void> {

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -312,7 +312,7 @@ export async function getSettings(): Promise<AppMeta> {
       onboardingDismissed: false,
     }
     const settings = existing ? { ...defaults, ...existing } : defaults
-    setActiveVideoQuality(settings.videoQuality)
+    setActiveVideoQuality(settings.videoQuality, settings.watermarkRemoved === true)
     if (!existing || existing.onboardingDismissed === undefined) {
       await db.put('meta', settings)
     }
@@ -361,14 +361,18 @@ function enqueueMetaWrite<T>(write: () => Promise<T>): Promise<T> {
 }
 
 export async function setVideoQuality(videoQuality: VideoQualityPreset): Promise<VideoQualityPreset> {
-  const resolved = resolveVideoQuality(videoQuality)
-  await enqueueMetaWrite(async () => {
+  return enqueueMetaWrite(async () => {
     const db = await getDb()
     const settings = await getSettings()
-    setActiveVideoQuality(resolved)
-    await db.put('meta', { ...settings, videoQuality: resolved })
+    const plus = settings.watermarkRemoved === true
+    if (videoQuality === 'high' && !plus) {
+      throw new PlusRequiredError('High video quality is a Kody Video Plus perk.')
+    }
+    const next = resolveVideoQuality(videoQuality, plus)
+    setActiveVideoQuality(next, plus)
+    await db.put('meta', { ...settings, videoQuality: next })
+    return next
   })
-  return resolved
 }
 
 export async function setKeepWatermark(keepWatermark: boolean): Promise<void> {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -225,6 +225,11 @@ export interface AppMeta {
   includeLocationInExports?: boolean
   /** Opt-in: tag new clips with device location. */
   locationTaggingEnabled?: boolean
+  /**
+   * Capture size/bitrate for new recordings. Missing/unknown = high (1080p).
+   * Does not rewrite already-saved clips. Frame rate stays 30 either way.
+   */
+  videoQuality?: 'high' | 'standard' | 'saver'
   /** The persisted last export (OPFS-backed), recoverable after the share
    * sheet is missed — and served instantly when nothing changed. */
   lastExport?: {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -226,7 +226,8 @@ export interface AppMeta {
   /** Opt-in: tag new clips with device location. */
   locationTaggingEnabled?: boolean
   /**
-   * Capture size/bitrate for new recordings. Missing/unknown = high (1080p).
+   * Capture size/bitrate for new recordings. Missing/unknown = standard
+   * (720p) without Plus, high (1080p) with Plus. High requires Plus.
    * Does not rewrite already-saved clips. Frame rate stays 30 either way.
    */
   videoQuality?: 'high' | 'standard' | 'saver'

--- a/src/lib/video-quality.test.ts
+++ b/src/lib/video-quality.test.ts
@@ -27,7 +27,9 @@ describe('videoBitrateFor', () => {
 })
 
 describe('recordingVideoBitsPerSecond', () => {
-  it('assumes 1080p when the track has not reported size yet', () => {
+  it('assumes the active preset size when the track has not reported yet', () => {
+    expect(recordingVideoBitsPerSecond()).toBe(videoBitrateFor(1280, 720, 0.16))
+    setActiveVideoQuality('high', true)
     expect(recordingVideoBitsPerSecond()).toBe(videoBitrateFor(1920, 1080, 0.16))
   })
 
@@ -52,10 +54,17 @@ describe('recordingVideoBitsPerSecond', () => {
 })
 
 describe('video quality presets', () => {
-  it('treats missing and unknown values as high', () => {
-    expect(resolveVideoQuality(undefined)).toBe('high')
-    expect(resolveVideoQuality('ultra')).toBe('high')
+  it('defaults free users to standard and Plus users to high', () => {
+    expect(resolveVideoQuality(undefined)).toBe('standard')
+    expect(resolveVideoQuality('ultra')).toBe('standard')
+    expect(resolveVideoQuality(undefined, true)).toBe('high')
     expect(resolveVideoQuality('saver')).toBe('saver')
+    expect(resolveVideoQuality('saver', true)).toBe('saver')
+  })
+
+  it('clamps a stored high preset back to standard without Plus', () => {
+    expect(resolveVideoQuality('high')).toBe('standard')
+    expect(resolveVideoQuality('high', true)).toBe('high')
   })
 
   it('keeps 30fps and only changes the capture size', () => {
@@ -74,10 +83,13 @@ describe('video quality presets', () => {
   })
 
   it('hydrates the in-memory capture preset used by camera and recorder', () => {
-    expect(activeVideoQuality()).toBe('high')
-    expect(setActiveVideoQuality('standard')).toBe('standard')
     expect(activeVideoQuality()).toBe('standard')
-    expect(captureVideoConstraints()).toEqual(captureVideoConstraints('standard'))
-    expect(recordingVideoBitsPerSecond()).toBe(recordingVideoBitsPerSecond(undefined, undefined, 'standard'))
+    expect(setActiveVideoQuality('high')).toBe('standard')
+    expect(setActiveVideoQuality('high', true)).toBe('high')
+    expect(activeVideoQuality()).toBe('high')
+    expect(captureVideoConstraints()).toEqual(captureVideoConstraints('high'))
+    expect(recordingVideoBitsPerSecond()).toBe(
+      recordingVideoBitsPerSecond(undefined, undefined, 'high'),
+    )
   })
 })

--- a/src/lib/video-quality.test.ts
+++ b/src/lib/video-quality.test.ts
@@ -1,5 +1,17 @@
-import { describe, expect, it } from 'vitest'
-import { recordingVideoBitsPerSecond, videoBitrateFor } from './video-quality'
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  activeVideoQuality,
+  captureVideoConstraints,
+  recordingVideoBitsPerSecond,
+  resetActiveVideoQualityForTests,
+  resolveVideoQuality,
+  setActiveVideoQuality,
+  videoBitrateFor,
+} from './video-quality'
+
+afterEach(() => {
+  resetActiveVideoQualityForTests()
+})
 
 describe('videoBitrateFor', () => {
   it('scales with pixels and stays in the 1080p band', () => {
@@ -21,5 +33,51 @@ describe('recordingVideoBitsPerSecond', () => {
 
   it('follows the live track size', () => {
     expect(recordingVideoBitsPerSecond(720, 1280)).toBe(videoBitrateFor(720, 1280, 0.16))
+  })
+
+  it('uses the saver bitrate without dropping below 30fps math', () => {
+    expect(recordingVideoBitsPerSecond(720, 1280, 'saver')).toBe(
+      videoBitrateFor(720, 1280, 0.08),
+    )
+    expect(recordingVideoBitsPerSecond(720, 1280, 'saver')).toBeLessThan(
+      recordingVideoBitsPerSecond(720, 1280, 'standard'),
+    )
+  })
+
+  it('assumes the preset frame size when the track is silent', () => {
+    expect(recordingVideoBitsPerSecond(undefined, undefined, 'standard')).toBe(
+      videoBitrateFor(1280, 720, 0.16),
+    )
+  })
+})
+
+describe('video quality presets', () => {
+  it('treats missing and unknown values as high', () => {
+    expect(resolveVideoQuality(undefined)).toBe('high')
+    expect(resolveVideoQuality('ultra')).toBe('high')
+    expect(resolveVideoQuality('saver')).toBe('saver')
+  })
+
+  it('keeps 30fps and only changes the capture size', () => {
+    expect(captureVideoConstraints('high')).toEqual({
+      width: { ideal: 1920 },
+      height: { ideal: 1080 },
+      frameRate: { ideal: 30 },
+    })
+    expect(captureVideoConstraints('standard')).toEqual({
+      width: { ideal: 1280 },
+      height: { ideal: 720 },
+      frameRate: { ideal: 30 },
+    })
+    expect(captureVideoConstraints('saver').frameRate).toEqual({ ideal: 30 })
+    expect(captureVideoConstraints('saver').width).toEqual({ ideal: 1280 })
+  })
+
+  it('hydrates the in-memory capture preset used by camera and recorder', () => {
+    expect(activeVideoQuality()).toBe('high')
+    expect(setActiveVideoQuality('standard')).toBe('standard')
+    expect(activeVideoQuality()).toBe('standard')
+    expect(captureVideoConstraints()).toEqual(captureVideoConstraints('standard'))
+    expect(recordingVideoBitsPerSecond()).toBe(recordingVideoBitsPerSecond(undefined, undefined, 'standard'))
   })
 })

--- a/src/lib/video-quality.test.ts
+++ b/src/lib/video-quality.test.ts
@@ -34,7 +34,19 @@ describe('recordingVideoBitsPerSecond', () => {
   })
 
   it('follows the live track size', () => {
-    expect(recordingVideoBitsPerSecond(720, 1280)).toBe(videoBitrateFor(720, 1280, 0.16))
+    expect(recordingVideoBitsPerSecond(720, 1280)).toBe(videoBitrateFor(1280, 720, 0.16))
+  })
+
+  it('does not bill a 1080p track at High bitrate on Standard or Saver', () => {
+    expect(recordingVideoBitsPerSecond(1080, 1920, 'standard')).toBe(
+      videoBitrateFor(1280, 720, 0.16),
+    )
+    expect(recordingVideoBitsPerSecond(1080, 1920, 'saver')).toBe(
+      videoBitrateFor(1280, 720, 0.08),
+    )
+    expect(recordingVideoBitsPerSecond(1080, 1920, 'standard')).toBeLessThan(
+      recordingVideoBitsPerSecond(1080, 1920, 'high'),
+    )
   })
 
   it('uses the saver bitrate without dropping below 30fps math', () => {

--- a/src/lib/video-quality.ts
+++ b/src/lib/video-quality.ts
@@ -121,9 +121,15 @@ export function recordingVideoBitsPerSecond(
   quality: VideoQualityPreset = activeQuality,
 ): number {
   const preset = VIDEO_QUALITY_PRESETS[quality]
+  // Cameras often ignore `ideal` size and hand back a 1080p (or larger)
+  // track. Bill at most the preset's frame so Standard/Saver still use
+  // less bits than High — do not add mandatory `max` constraints, which
+  // can fail getUserMedia or force a software scale.
+  const trackLong = Math.max(width ?? 0, height ?? 0)
+  const trackShort = Math.min(width ?? 0, height ?? 0)
   return videoBitrateFor(
-    width ?? preset.longEdge,
-    height ?? preset.shortEdge,
+    trackLong > 0 ? Math.min(trackLong, preset.longEdge) : preset.longEdge,
+    trackShort > 0 ? Math.min(trackShort, preset.shortEdge) : preset.shortEdge,
     preset.captureBpp,
   )
 }

--- a/src/lib/video-quality.ts
+++ b/src/lib/video-quality.ts
@@ -11,6 +11,91 @@ export const EXPORT_BPP = 0.16
 const BITRATE_MIN = 1_500_000
 const BITRATE_MAX = 12_000_000
 
+/** New recordings only. Always 30fps — quality only changes size and bitrate. */
+export type VideoQualityPreset = 'high' | 'standard' | 'saver'
+
+export const VIDEO_QUALITY_PRESETS: Record<
+  VideoQualityPreset,
+  {
+    id: VideoQualityPreset
+    label: string
+    /** One-line hint for the selected option. */
+    hint: string
+    longEdge: number
+    shortEdge: number
+    captureBpp: number
+  }
+> = {
+  high: {
+    id: 'high',
+    label: 'High',
+    hint: '1080p — sharpest new clips, largest files.',
+    longEdge: VIDEO_LONG_EDGE,
+    shortEdge: VIDEO_SHORT_EDGE,
+    captureBpp: CAPTURE_BPP,
+  },
+  standard: {
+    id: 'standard',
+    label: 'Standard',
+    hint: '720p — about half the space of High, still 30 fps.',
+    longEdge: 1280,
+    shortEdge: 720,
+    captureBpp: CAPTURE_BPP,
+  },
+  saver: {
+    id: 'saver',
+    label: 'Saver',
+    hint: '720p at a smaller bitrate — smallest files, still 30 fps.',
+    longEdge: 1280,
+    shortEdge: 720,
+    captureBpp: 0.08,
+  },
+}
+
+export const VIDEO_QUALITY_IDS = ['high', 'standard', 'saver'] as const satisfies readonly VideoQualityPreset[]
+
+const DEFAULT_VIDEO_QUALITY: VideoQualityPreset = 'high'
+
+let activeQuality: VideoQualityPreset = DEFAULT_VIDEO_QUALITY
+
+export function resolveVideoQuality(value: unknown): VideoQualityPreset {
+  if (value === 'high' || value === 'standard' || value === 'saver') return value
+  return DEFAULT_VIDEO_QUALITY
+}
+
+/** In-memory capture preset used by the camera and recorder (sync). Hydrated
+ * from settings on load so the first take already matches the user's choice. */
+export function setActiveVideoQuality(value: unknown): VideoQualityPreset {
+  activeQuality = resolveVideoQuality(value)
+  return activeQuality
+}
+
+export function activeVideoQuality(): VideoQualityPreset {
+  return activeQuality
+}
+
+export function resetActiveVideoQualityForTests(): void {
+  activeQuality = DEFAULT_VIDEO_QUALITY
+}
+
+export function videoQualityPreset(
+  quality: VideoQualityPreset = activeQuality,
+): (typeof VIDEO_QUALITY_PRESETS)[VideoQualityPreset] {
+  return VIDEO_QUALITY_PRESETS[quality]
+}
+
+/** getUserMedia hint for the active (or given) quality. Frame rate stays 30. */
+export function captureVideoConstraints(
+  quality: VideoQualityPreset = activeQuality,
+): MediaTrackConstraints {
+  const preset = VIDEO_QUALITY_PRESETS[quality]
+  return {
+    width: { ideal: preset.longEdge },
+    height: { ideal: preset.shortEdge },
+    frameRate: { ideal: VIDEO_FPS },
+  }
+}
+
 /** Hardware-AVC bitrate for a frame size: scales with pixels, floored so
  * tiny test/photo outputs stay cheap, capped so 1080p stays in the
  * 8–12 Mbps band instead of a flat 3.5 Mbps. */
@@ -26,6 +111,15 @@ export function videoBitrateFor(
   )
 }
 
-export function recordingVideoBitsPerSecond(width?: number, height?: number): number {
-  return videoBitrateFor(width ?? VIDEO_LONG_EDGE, height ?? VIDEO_SHORT_EDGE, CAPTURE_BPP)
+export function recordingVideoBitsPerSecond(
+  width?: number,
+  height?: number,
+  quality: VideoQualityPreset = activeQuality,
+): number {
+  const preset = VIDEO_QUALITY_PRESETS[quality]
+  return videoBitrateFor(
+    width ?? preset.longEdge,
+    height ?? preset.shortEdge,
+    preset.captureBpp,
+  )
 }

--- a/src/lib/video-quality.ts
+++ b/src/lib/video-quality.ts
@@ -29,7 +29,7 @@ export const VIDEO_QUALITY_PRESETS: Record<
   high: {
     id: 'high',
     label: 'High',
-    hint: '1080p — sharpest new clips, largest files.',
+    hint: '1080p — Plus. Sharpest new clips, largest files.',
     longEdge: VIDEO_LONG_EDGE,
     shortEdge: VIDEO_SHORT_EDGE,
     captureBpp: CAPTURE_BPP,
@@ -54,19 +54,23 @@ export const VIDEO_QUALITY_PRESETS: Record<
 
 export const VIDEO_QUALITY_IDS = ['high', 'standard', 'saver'] as const satisfies readonly VideoQualityPreset[]
 
-const DEFAULT_VIDEO_QUALITY: VideoQualityPreset = 'high'
+/** Free (and unknown-plus) default — 720p, still 30fps. */
+export const FREE_VIDEO_QUALITY: VideoQualityPreset = 'standard'
+/** Plus default when the user has not picked a preset — 1080p is the perk. */
+export const PLUS_DEFAULT_VIDEO_QUALITY: VideoQualityPreset = 'high'
 
-let activeQuality: VideoQualityPreset = DEFAULT_VIDEO_QUALITY
+let activeQuality: VideoQualityPreset = FREE_VIDEO_QUALITY
 
-export function resolveVideoQuality(value: unknown): VideoQualityPreset {
-  if (value === 'high' || value === 'standard' || value === 'saver') return value
-  return DEFAULT_VIDEO_QUALITY
+export function resolveVideoQuality(value: unknown, plus = false): VideoQualityPreset {
+  if (value === 'standard' || value === 'saver') return value
+  if (value === 'high') return plus ? 'high' : FREE_VIDEO_QUALITY
+  return plus ? PLUS_DEFAULT_VIDEO_QUALITY : FREE_VIDEO_QUALITY
 }
 
 /** In-memory capture preset used by the camera and recorder (sync). Hydrated
  * from settings on load so the first take already matches the user's choice. */
-export function setActiveVideoQuality(value: unknown): VideoQualityPreset {
-  activeQuality = resolveVideoQuality(value)
+export function setActiveVideoQuality(value: unknown, plus = false): VideoQualityPreset {
+  activeQuality = resolveVideoQuality(value, plus)
   return activeQuality
 }
 
@@ -75,7 +79,7 @@ export function activeVideoQuality(): VideoQualityPreset {
 }
 
 export function resetActiveVideoQualityForTests(): void {
-  activeQuality = DEFAULT_VIDEO_QUALITY
+  activeQuality = FREE_VIDEO_QUALITY
 }
 
 export function videoQualityPreset(

--- a/src/pages/about-page.tsx
+++ b/src/pages/about-page.tsx
@@ -77,9 +77,14 @@ function updateDiagnosticsReport(
 interface AboutData {
   storage: StorageSpace | null
   exportCacheBytes: number
-  plus: boolean
+  /** `null` until settings load so High is not locked on first paint. */
+  plus: boolean | null
   videoQuality: VideoQualityPreset
 }
+
+/** Last loaded About settings, kept across mounts so Plus/quality do not
+ * flash the free-plan picker when navigating back. */
+let lastAboutData: AboutData | null = null
 
 async function loadAboutData(): Promise<AboutData> {
   const [storage, exportCacheBytes, settings] = await Promise.all([
@@ -107,10 +112,10 @@ const UPDATE_STATUS_LABEL: Record<Exclude<UpdateStatus, 'idle'>, string> = {
 
 /** Credits, inspiration, and the open-source pointer. */
 export function AboutPage(handle: Handle) {
-  let data: AboutData = {
+  let data: AboutData = lastAboutData ?? {
     storage: null,
     exportCacheBytes: 0,
-    plus: false,
+    plus: null,
     videoQuality: 'standard',
   }
   let sharingPlus = false
@@ -127,12 +132,24 @@ export function AboutPage(handle: Handle) {
   let deployedCommit: string | null = null
   let deployedKnown = false
 
-  const refresh = async () => {
-    data = await loadAboutData()
-    if (handle.signal.aborted) return
-    void handle.update()
+  /** Same stale-load guard as home: an in-flight refresh must not overwrite
+   * a quality pick that landed while settings were still loading. */
+  let refreshVersion = 0
+  const refresh = () => {
+    const version = ++refreshVersion
+    void loadAboutData()
+      .then((loaded) => {
+        if (handle.signal.aborted || version !== refreshVersion) return
+        lastAboutData = loaded
+        data = loaded
+        void handle.update()
+      })
+      .catch((err) => {
+        if (handle.signal.aborted || version !== refreshVersion) return
+        reportError(err, 'load-about')
+      })
   }
-  void refresh()
+  refresh()
   let hashScrolled = false
   void fetchDeployedVersion().then((deployed) => {
     if (handle.signal.aborted) return
@@ -428,10 +445,12 @@ export function AboutPage(handle: Handle) {
               }}
               onChange={(next) => {
                 data = { ...data, videoQuality: next }
+                lastAboutData = data
+                refreshVersion += 1
                 void handle.update()
                 void setVideoQuality(next).catch((err) => {
                   reportError(err, 'video-quality')
-                  void refresh()
+                  refresh()
                 })
               }}
             />

--- a/src/pages/about-page.tsx
+++ b/src/pages/about-page.tsx
@@ -2,7 +2,9 @@ import type { Handle } from 'remix/ui'
 import { on } from 'remix/ui'
 import { IconBack } from '../components/icons'
 import { BrandMark } from '../components/brand-mark'
+import { RestoreSheet } from '../components/restore-sheet'
 import { SharePlusSheet } from '../components/share-plus-sheet'
+import { UpsellSheet } from '../components/upsell-sheet'
 import { VideoQualityPicker } from '../components/video-quality-picker'
 import {
   checkForUpdates,
@@ -89,7 +91,7 @@ async function loadAboutData(): Promise<AboutData> {
     storage,
     exportCacheBytes,
     plus: settings.watermarkRemoved === true,
-    videoQuality: resolveVideoQuality(settings.videoQuality),
+    videoQuality: resolveVideoQuality(settings.videoQuality, settings.watermarkRemoved === true),
   }
 }
 
@@ -109,9 +111,11 @@ export function AboutPage(handle: Handle) {
     storage: null,
     exportCacheBytes: 0,
     plus: false,
-    videoQuality: 'high',
+    videoQuality: 'standard',
   }
   let sharingPlus = false
+  let upselling = false
+  let restoring = false
   let updateStatus: UpdateStatus = 'idle'
   let cacheStatus: string | null = null
   let clearingCache = false
@@ -412,11 +416,16 @@ export function AboutPage(handle: Handle) {
             <h2>Video quality</h2>
             <p>
               New clips only — already-recorded takes stay as they are. Every option stays at 30
-              frames a second so recording does not drop frames or get janky. Lower settings ask
-              the camera for a smaller picture and a smaller file.
+              frames a second so recording does not drop frames or get janky. Without Plus, new
+              clips record at Standard (720p). High (1080p) is a Kody Video Plus perk.
             </p>
             <VideoQualityPicker
               value={videoQuality}
+              plus={plus}
+              onUpsell={() => {
+                upselling = true
+                void handle.update()
+              }}
               onChange={(next) => {
                 data = { ...data, videoQuality: next }
                 void handle.update()
@@ -580,6 +589,32 @@ export function AboutPage(handle: Handle) {
             onClose={() => {
               sharingPlus = false
               void handle.update()
+            }}
+          />
+        ) : null}
+        {upselling ? (
+          <UpsellSheet
+            onClose={() => {
+              upselling = false
+              void handle.update()
+            }}
+            onRestore={() => {
+              upselling = false
+              restoring = true
+              void handle.update()
+            }}
+          />
+        ) : null}
+        {restoring ? (
+          <RestoreSheet
+            onClose={() => {
+              restoring = false
+              void handle.update()
+            }}
+            onRestored={() => {
+              restoring = false
+              void handle.update()
+              void refresh()
             }}
           />
         ) : null}

--- a/src/pages/about-page.tsx
+++ b/src/pages/about-page.tsx
@@ -446,11 +446,11 @@ export function AboutPage(handle: Handle) {
               onChange={(next) => {
                 data = { ...data, videoQuality: next }
                 lastAboutData = data
-                refreshVersion += 1
+                const pickVersion = ++refreshVersion
                 void handle.update()
                 void setVideoQuality(next).catch((err) => {
                   reportError(err, 'video-quality')
-                  refresh()
+                  if (refreshVersion === pickVersion) refresh()
                 })
               }}
             />

--- a/src/pages/about-page.tsx
+++ b/src/pages/about-page.tsx
@@ -3,6 +3,7 @@ import { on } from 'remix/ui'
 import { IconBack } from '../components/icons'
 import { BrandMark } from '../components/brand-mark'
 import { SharePlusSheet } from '../components/share-plus-sheet'
+import { VideoQualityPicker } from '../components/video-quality-picker'
 import {
   checkForUpdates,
   fetchDeployedVersion,
@@ -17,7 +18,8 @@ import { clearExportCache, estimateExportCacheBytes } from '../lib/export/export
 import { listRearCameras } from '../lib/media'
 import { BackupFormatError, importKodyVideoBackupFile } from '../lib/project-transfer'
 import { estimateStorageSpace, formatBytes, type StorageSpace } from '../lib/storage-space'
-import { getSettings } from '../lib/storage'
+import { getSettings, setVideoQuality } from '../lib/storage'
+import { resolveVideoQuality, type VideoQualityPreset } from '../lib/video-quality'
 import { navigate } from '../router'
 
 /** Prefilled GitHub issue so bug reports arrive with device context attached. */
@@ -74,6 +76,7 @@ interface AboutData {
   storage: StorageSpace | null
   exportCacheBytes: number
   plus: boolean
+  videoQuality: VideoQualityPreset
 }
 
 async function loadAboutData(): Promise<AboutData> {
@@ -82,7 +85,12 @@ async function loadAboutData(): Promise<AboutData> {
     estimateExportCacheBytes(),
     getSettings(),
   ])
-  return { storage, exportCacheBytes, plus: settings.watermarkRemoved === true }
+  return {
+    storage,
+    exportCacheBytes,
+    plus: settings.watermarkRemoved === true,
+    videoQuality: resolveVideoQuality(settings.videoQuality),
+  }
 }
 
 type UpdateStatus = 'idle' | 'checking' | 'current' | 'updating' | 'downloading' | 'unavailable'
@@ -97,7 +105,12 @@ const UPDATE_STATUS_LABEL: Record<Exclude<UpdateStatus, 'idle'>, string> = {
 
 /** Credits, inspiration, and the open-source pointer. */
 export function AboutPage(handle: Handle) {
-  let data: AboutData = { storage: null, exportCacheBytes: 0, plus: false }
+  let data: AboutData = {
+    storage: null,
+    exportCacheBytes: 0,
+    plus: false,
+    videoQuality: 'high',
+  }
   let sharingPlus = false
   let updateStatus: UpdateStatus = 'idle'
   let cacheStatus: string | null = null
@@ -116,6 +129,7 @@ export function AboutPage(handle: Handle) {
     void handle.update()
   }
   void refresh()
+  let hashScrolled = false
   void fetchDeployedVersion().then((deployed) => {
     if (handle.signal.aborted) return
     deployedCommit = deployed?.commit ?? null
@@ -253,7 +267,13 @@ export function AboutPage(handle: Handle) {
   }
 
   return () => {
-    const { storage, exportCacheBytes, plus } = data
+    const { storage, exportCacheBytes, plus, videoQuality } = data
+    if (!hashScrolled && location.hash === '#video-quality') {
+      hashScrolled = true
+      queueMicrotask(() => {
+        document.getElementById('video-quality')?.scrollIntoView({ block: 'start' })
+      })
+    }
     const version = <code>{shortVersion()}</code>
     const versionUrl = commitUrl()
     const diagReport = updateDiagnosticsReport(deployedCommit, deployedKnown)
@@ -388,6 +408,26 @@ export function AboutPage(handle: Handle) {
             </p>
           </section>
 
+          <section className="about-section" id="video-quality">
+            <h2>Video quality</h2>
+            <p>
+              New clips only — already-recorded takes stay as they are. Every option stays at 30
+              frames a second so recording does not drop frames or get janky. Lower settings ask
+              the camera for a smaller picture and a smaller file.
+            </p>
+            <VideoQualityPicker
+              value={videoQuality}
+              onChange={(next) => {
+                data = { ...data, videoQuality: next }
+                void handle.update()
+                void setVideoQuality(next).catch((err) => {
+                  reportError(err, 'video-quality')
+                  void refresh()
+                })
+              }}
+            />
+          </section>
+
           <section className="about-section">
             <h2>Storage</h2>
             <p>
@@ -395,8 +435,9 @@ export function AboutPage(handle: Handle) {
                 ? `This app uses ${formatBytes(storage.usedBytes)} of the ${formatBytes(storage.quotaBytes)} the browser allows. `
                 : ''}
               Your recordings are the big consumer — delete old projects from the home screen
-              (⋯ → Delete) to free the most space. The app also keeps your latest export cached so
-              tapping Go on an unchanged project is instant.
+              (⋯ → Delete) to free the most space, or record new clips at a lower video quality
+              above. The app also keeps your latest export cached so tapping Go on an unchanged
+              project is instant.
             </p>
             <p>
               Cached export files: <strong>{formatBytes(exportCacheBytes)}</strong>

--- a/src/pages/home-page.tsx
+++ b/src/pages/home-page.tsx
@@ -211,7 +211,7 @@ export function HomePage(handle: Handle) {
       ) : null
     }
     const { projects, storage, exportCacheBytes, plus } = data
-    const videoQuality = data.videoQuality ?? 'high'
+    const videoQuality = data.videoQuality ?? 'standard'
     const installable = canPromptInstall()
 
     const slots = Array.from({ length: MAX_PROJECTS }, (_, index) => projects[index] ?? null)
@@ -523,9 +523,14 @@ export function HomePage(handle: Handle) {
               <StorageMeter
                 storage={storage}
                 videoQuality={videoQuality}
+                plus={plus}
                 onVideoQualityChange={(next) => {
                   data = { ...data!, videoQuality: next }
                   lastHomeData = data
+                  void handle.update()
+                }}
+                onUpsell={() => {
+                  upselling = true
                   void handle.update()
                 }}
               />

--- a/src/pages/home-page.tsx
+++ b/src/pages/home-page.tsx
@@ -29,6 +29,7 @@ import {
   getProjectAudio,
   renameProject,
   setTourCardDismissed,
+  setVideoQuality,
 } from '../lib/storage'
 import { clearExportCache } from '../lib/export/export-cache'
 import { reportError } from '../lib/error-reporting'
@@ -525,9 +526,18 @@ export function HomePage(handle: Handle) {
                 videoQuality={videoQuality}
                 plus={plus}
                 onVideoQualityChange={(next) => {
+                  // Invalidate the mount/revalidation load so it cannot land
+                  // after this pick and snap the control back to the stale
+                  // snapshot. Persist lives here so a failed write can
+                  // refresh from disk.
                   data = { ...data!, videoQuality: next }
                   lastHomeData = data
+                  refreshVersion += 1
                   void handle.update()
+                  void setVideoQuality(next).catch((err) => {
+                    reportError(err, 'video-quality')
+                    refresh()
+                  })
                 }}
                 onUpsell={() => {
                   upselling = true

--- a/src/pages/home-page.tsx
+++ b/src/pages/home-page.tsx
@@ -532,11 +532,11 @@ export function HomePage(handle: Handle) {
                   // refresh from disk.
                   data = { ...data!, videoQuality: next }
                   lastHomeData = data
-                  refreshVersion += 1
+                  const pickVersion = ++refreshVersion
                   void handle.update()
                   void setVideoQuality(next).catch((err) => {
                     reportError(err, 'video-quality')
-                    refresh()
+                    if (refreshVersion === pickVersion) refresh()
                   })
                 }}
                 onUpsell={() => {

--- a/src/pages/home-page.tsx
+++ b/src/pages/home-page.tsx
@@ -211,6 +211,7 @@ export function HomePage(handle: Handle) {
       ) : null
     }
     const { projects, storage, exportCacheBytes, plus } = data
+    const videoQuality = data.videoQuality ?? 'high'
     const installable = canPromptInstall()
 
     const slots = Array.from({ length: MAX_PROJECTS }, (_, index) => projects[index] ?? null)
@@ -380,7 +381,9 @@ export function HomePage(handle: Handle) {
                 {formatBytes(storage.usedBytes)} of {formatBytes(storage.quotaBytes)} used.
                 {oldestProject
                   ? ` Free space fast: delete an old project (⋯ on “${oldestProject.name}”, then Delete).`
-                  : ' Free space by clearing other site data or files on this device.'}
+                  : ' Free space by clearing other site data or files on this device.'}{' '}
+                New clips can also use less space — lower video quality below or on{' '}
+                <a href="/about#video-quality">About</a>.
               </span>
               {exportCacheBytes > 0 ? (
                 <button
@@ -516,7 +519,17 @@ export function HomePage(handle: Handle) {
               Clips stay on this phone until you share.{' '}
               <a href="/receive">Receive a project</a>
             </span>
-            {storage ? <StorageMeter storage={storage} /> : null}
+            {storage ? (
+              <StorageMeter
+                storage={storage}
+                videoQuality={videoQuality}
+                onVideoQualityChange={(next) => {
+                  data = { ...data!, videoQuality: next }
+                  lastHomeData = data
+                  void handle.update()
+                }}
+              />
+            ) : null}
           </p>
         </div>
 

--- a/src/pages/terms-page.tsx
+++ b/src/pages/terms-page.tsx
@@ -36,11 +36,11 @@ export function TermsPage() {
           <h2>Kody Video Plus</h2>
           <p>
             Kody Video Plus is a one-time $0.99 purchase that unlocks watermark-free exports,
-            optional location tagging, sending a project to another device, and up to six project
-            slots (the free plan includes one project) for the browser profile where it&rsquo;s
-            verified. You can restore the
-            purchase on another device with a short code or QR from the device that already has
-            Plus. Payments are handled by Stripe.
+            1080p High quality recording, optional location tagging, sending a project to another
+            device, and up to six project slots (the free plan includes one project and records at
+            720p) for the browser profile where it&rsquo;s verified. You can restore the purchase
+            on another device with a short code or QR from the device that already has Plus.
+            Payments are handled by Stripe.
             For refunds or purchase trouble, email{' '}
             <a href="mailto:team@kody.video">team@kody.video</a>.
           </p>

--- a/src/pages/unlocked-page.tsx
+++ b/src/pages/unlocked-page.tsx
@@ -52,9 +52,10 @@ export function UnlockedPage(handle: Handle) {
             <h1>Kody Video Plus unlocked! 🎉</h1>
             <p className="muted">
               Thank you for supporting Kody Video. Every export from this device is now
-              watermark-free, all six project slots are open, optional location tagging is
-              available, and you can send a project to another device. To unlock a second
-              phone or computer, tap Add another device and scan or type the short code.
+              watermark-free, all six project slots are open, 1080p High quality is available,
+              optional location tagging is available, and you can send a project to another device.
+              To unlock a second phone or computer, tap Add another device and scan or type the
+              short code.
             </p>
           </>
         ) : (

--- a/src/styles/home.css
+++ b/src/styles/home.css
@@ -722,6 +722,11 @@
   opacity: 0.75;
 }
 
+.video-quality-option:disabled {
+  opacity: 0.55;
+  pointer-events: none;
+}
+
 .video-quality-option.is-active {
   background: var(--accent);
   color: var(--ink-strong);

--- a/src/styles/home.css
+++ b/src/styles/home.css
@@ -446,8 +446,9 @@
   margin: 0;
   border: 1px solid var(--line);
   border-radius: 12px;
-  padding: 8px 12px;
-  gap: 1px;
+  padding: 10px 12px;
+  gap: 4px;
+  width: min(280px, calc(100vw - 24px));
   background: var(--toast-bg);
   color: var(--ink);
   font-family: var(--font-body);
@@ -469,6 +470,13 @@
 
 .storage-popover span {
   color: var(--ink-muted);
+}
+
+.storage-popover a {
+  color: var(--accent);
+  font-weight: 700;
+  text-decoration: underline;
+  text-underline-offset: 2px;
 }
 
 .home-notice {
@@ -608,6 +616,13 @@
   color: var(--ink-muted);
 }
 
+.storage-banner a {
+  color: var(--accent);
+  font-weight: 700;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
 .storage-banner.is-critical {
   background: color-mix(in srgb, var(--danger) 14%, transparent);
   border-color: color-mix(in srgb, var(--danger) 45%, transparent);
@@ -676,6 +691,51 @@
   color: var(--accent);
 }
 
+.video-quality-picker {
+  margin-top: 10px;
+}
+
+.video-quality-options {
+  display: flex;
+  gap: 6px;
+}
+
+.video-quality-option {
+  flex: 1;
+  min-height: var(--tap);
+  padding: 0 8px;
+  border-radius: 12px;
+  border: 1px solid var(--line);
+  font-weight: 700;
+  font-size: 0.88rem;
+  background: color-mix(in srgb, var(--ink) 6%, transparent);
+  color: var(--ink);
+}
+
+.video-quality-option.is-active {
+  background: var(--accent);
+  color: var(--ink-strong);
+  border-color: transparent;
+}
+
+.video-quality-hint {
+  margin: 8px 0 0;
+  color: var(--ink-muted);
+  font-size: 0.85rem;
+  line-height: 1.4;
+}
+
+.video-quality-picker.is-compact .video-quality-option {
+  min-height: 36px;
+  border-radius: 10px;
+  font-size: 0.78rem;
+}
+
+.video-quality-picker.is-compact .video-quality-hint {
+  margin-top: 6px;
+  font-size: 0.72rem;
+}
+
 .about-section {
   margin-top: 18px;
 }
@@ -690,6 +750,10 @@
   margin: 0;
   color: var(--ink-muted);
   line-height: 1.55;
+}
+
+.about-section .video-quality-hint {
+  margin-top: 8px;
 }
 
 .about-import {

--- a/src/styles/home.css
+++ b/src/styles/home.css
@@ -702,6 +702,10 @@
 
 .video-quality-option {
   flex: 1;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 5px;
   min-height: var(--tap);
   padding: 0 8px;
   border-radius: 12px;
@@ -710,6 +714,12 @@
   font-size: 0.88rem;
   background: color-mix(in srgb, var(--ink) 6%, transparent);
   color: var(--ink);
+}
+
+.video-quality-lock {
+  display: inline-flex;
+  line-height: 0;
+  opacity: 0.75;
 }
 
 .video-quality-option.is-active {

--- a/tests/e2e/clip-info.spec.ts
+++ b/tests/e2e/clip-info.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect, type Page } from '@playwright/test'
-import { openSeededProject } from './helpers'
+import { gotoHome, openSeededProject } from './helpers'
 
 async function openEditorWithClips(page: Page, clips: number, clipMs?: number): Promise<void> {
   await openSeededProject(page, { clips, clipMs, name: 'Facts' })
@@ -125,5 +125,46 @@ test.describe('clip info sheet', () => {
     expect(after.durationMs).toBeLessThan(1800)
     expect(after.trimStartMs).toBe(0)
     expect(after.trimEndMs).toBe(after.durationMs)
+  })
+
+  test('reduce quality permanently replaces a 1080p clip with 720p', async ({ page }) => {
+    await gotoHome(page)
+    const projectId = await page.evaluate(async () => {
+      const storage = await import('/src/lib/storage.ts')
+      const thumbs = await import('/src/lib/thumbs.ts')
+      const { makeLabeledClipBlob } = await import('/src/lib/testing/make-test-clip.ts')
+      const project = await storage.createProject('Shrink')
+      const blob = await makeLabeledClipBlob(1080, 1920, 800)
+      const clip = await storage.addClip({
+        projectId: project.id,
+        blob,
+        mimeType: 'video/webm',
+        durationMs: 800,
+        width: 1080,
+        height: 1920,
+      })
+      await thumbs.ensureClipThumbs(clip)
+      return project.id
+    })
+    await page.goto(`/project/${projectId}`)
+    await page.getByRole('button', { name: 'Open editor' }).click()
+    await expect(page.locator('.editor-screen')).toBeVisible()
+    await openClipInfo(page)
+
+    const sheet = page.locator('.clip-info-sheet')
+    await expect(sheet.getByText('1080 × 1920')).toBeVisible()
+    await sheet.getByRole('button', { name: 'Reduce quality' }).click()
+    await expect(sheet.getByText(/cannot undo/i)).toBeVisible()
+    await sheet.getByRole('button', { name: 'Replace permanently' }).click()
+    await expect(page.locator('.toast')).toContainText('smaller file', { timeout: 30_000 })
+
+    const after = await page.evaluate(async () => {
+      const storage = await import('/src/lib/storage.ts')
+      const projects = await storage.listProjects()
+      const clips = await storage.getClipMetasForProject(projects[0]!.id)
+      const clip = clips[0]!
+      return { width: clip.width, height: clip.height }
+    })
+    expect(after).toEqual({ width: 720, height: 1280 })
   })
 })

--- a/tests/e2e/storage.spec.ts
+++ b/tests/e2e/storage.spec.ts
@@ -98,9 +98,50 @@ test.describe('storage management', () => {
     await context.close()
   })
 
+  test('home storage popover keeps a quality pick after home revalidates', async ({
+    page,
+  }) => {
+    await gotoHome(page)
+    await page.locator('.storage-meter').click()
+    const popover = page.locator('.storage-popover')
+    await expect(popover).toBeVisible()
+    await popover.getByRole('radio', { name: 'Saver' }).click()
+    await expect(popover.getByRole('radio', { name: 'Saver' })).toHaveAttribute(
+      'aria-checked',
+      'true',
+    )
+    await expect
+      .poll(async () =>
+        page.evaluate(async () => {
+          const storage = await import('/src/lib/storage.ts')
+          return (await storage.getSettings()).videoQuality ?? null
+        }),
+      )
+      .toBe('saver')
+    // The mount/revalidation load must not snap the control back after persist.
+    await expect(popover.getByRole('radio', { name: 'Saver' })).toHaveAttribute(
+      'aria-checked',
+      'true',
+    )
+
+    await page.getByRole('link', { name: 'More on About' }).click()
+    await expect(page.locator('#video-quality').getByRole('radio', { name: 'Saver' })).toHaveAttribute(
+      'aria-checked',
+      'true',
+    )
+    await page.getByRole('link', { name: 'Back to projects' }).click()
+    await expect(page.locator('.project-slots')).toBeVisible()
+    await page.locator('.storage-meter').click()
+    await expect(page.locator('.storage-popover').getByRole('radio', { name: 'Saver' })).toHaveAttribute(
+      'aria-checked',
+      'true',
+    )
+  })
+
   test('about page defaults free quality to Standard and persists Saver', async ({ page }) => {
     await page.goto('/about')
     const section = page.locator('#video-quality')
+    await expect(section.getByRole('radio', { name: 'Standard' })).toBeEnabled()
     await expect(section.getByRole('radio', { name: 'Standard' })).toHaveAttribute(
       'aria-checked',
       'true',
@@ -135,10 +176,12 @@ test.describe('storage management', () => {
     await unlockPlus(page)
     await page.goto('/about')
     const section = page.locator('#video-quality')
+    await expect(section.getByRole('radio', { name: 'High' })).toBeEnabled()
     await expect(section.getByRole('radio', { name: 'High' })).toHaveAttribute(
       'aria-checked',
       'true',
     )
+    await expect(section.getByRole('radio', { name: 'High (Kody Video Plus)' })).toHaveCount(0)
     await section.getByRole('radio', { name: 'Standard' }).click()
     await expect(section.getByRole('radio', { name: 'Standard' })).toHaveAttribute(
       'aria-checked',

--- a/tests/e2e/storage.spec.ts
+++ b/tests/e2e/storage.spec.ts
@@ -131,6 +131,7 @@ test.describe('storage management', () => {
   })
 
   test('Plus can pick High video quality', async ({ page }) => {
+    await gotoHome(page)
     await unlockPlus(page)
     await page.goto('/about')
     const section = page.locator('#video-quality')

--- a/tests/e2e/storage.spec.ts
+++ b/tests/e2e/storage.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect, type Page } from '@playwright/test'
-import { gotoHome, seedProject } from './helpers'
+import { gotoHome, seedProject, unlockPlus } from './helpers'
 
 function listExportCache(page: Page): Promise<string[]> {
   return page.evaluate(async () => {
@@ -98,12 +98,19 @@ test.describe('storage management', () => {
     await context.close()
   })
 
-  test('about page persists a lower video quality', async ({ page }) => {
+  test('about page defaults free quality to Standard and persists Saver', async ({ page }) => {
     await page.goto('/about')
     const section = page.locator('#video-quality')
-    await expect(section.getByRole('radio', { name: 'High' })).toHaveAttribute('aria-checked', 'true')
-    await section.getByRole('radio', { name: 'Standard' }).click()
     await expect(section.getByRole('radio', { name: 'Standard' })).toHaveAttribute(
+      'aria-checked',
+      'true',
+    )
+    await section.getByRole('radio', { name: 'High (Kody Video Plus)' }).click()
+    await expect(page.getByRole('dialog', { name: 'Kody Video Plus' })).toBeVisible()
+    await page.getByRole('button', { name: 'Not now' }).click()
+
+    await section.getByRole('radio', { name: 'Saver' }).click()
+    await expect(section.getByRole('radio', { name: 'Saver' })).toHaveAttribute(
       'aria-checked',
       'true',
     )
@@ -114,14 +121,37 @@ test.describe('storage management', () => {
           return (await storage.getSettings()).videoQuality ?? null
         }),
       )
-      .toBe('standard')
+      .toBe('saver')
 
     await page.reload()
-    await expect(page.locator('#video-quality').getByRole('radio', { name: 'Standard' })).toHaveAttribute(
+    await expect(page.locator('#video-quality').getByRole('radio', { name: 'Saver' })).toHaveAttribute(
       'aria-checked',
       'true',
     )
-    await expect(page.locator('#video-quality')).toContainText('720p')
+  })
+
+  test('Plus can pick High video quality', async ({ page }) => {
+    await unlockPlus(page)
+    await page.goto('/about')
+    const section = page.locator('#video-quality')
+    await expect(section.getByRole('radio', { name: 'High' })).toHaveAttribute(
+      'aria-checked',
+      'true',
+    )
+    await section.getByRole('radio', { name: 'Standard' }).click()
+    await expect(section.getByRole('radio', { name: 'Standard' })).toHaveAttribute(
+      'aria-checked',
+      'true',
+    )
+    await section.getByRole('radio', { name: 'High' }).click()
+    await expect
+      .poll(async () =>
+        page.evaluate(async () => {
+          const storage = await import('/src/lib/storage.ts')
+          return (await storage.getSettings()).videoQuality ?? null
+        }),
+      )
+      .toBe('high')
   })
 
   test('about page shows cache size and clears it', async ({ page }) => {

--- a/tests/e2e/storage.spec.ts
+++ b/tests/e2e/storage.spec.ts
@@ -98,6 +98,32 @@ test.describe('storage management', () => {
     await context.close()
   })
 
+  test('about page persists a lower video quality', async ({ page }) => {
+    await page.goto('/about')
+    const section = page.locator('#video-quality')
+    await expect(section.getByRole('radio', { name: 'High' })).toHaveAttribute('aria-checked', 'true')
+    await section.getByRole('radio', { name: 'Standard' }).click()
+    await expect(section.getByRole('radio', { name: 'Standard' })).toHaveAttribute(
+      'aria-checked',
+      'true',
+    )
+    await expect
+      .poll(async () =>
+        page.evaluate(async () => {
+          const storage = await import('/src/lib/storage.ts')
+          return (await storage.getSettings()).videoQuality ?? null
+        }),
+      )
+      .toBe('standard')
+
+    await page.reload()
+    await expect(page.locator('#video-quality').getByRole('radio', { name: 'Standard' })).toHaveAttribute(
+      'aria-checked',
+      'true',
+    )
+    await expect(page.locator('#video-quality')).toContainText('720p')
+  })
+
   test('about page shows cache size and clears it', async ({ page }) => {
     await seedReferencedExportCache(page, 5 * 1024 * 1024)
     await page.goto('/about')


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The higher 1080p bitrate was filling on-device storage too quickly. This adds a **Video quality** preference for *new* clips, plus a way to shrink a clip you already recorded.

**Smoothness stays first.** Every capture option is still 30 fps, still hardware-encoded when the device can do it. Quality only changes the capture size and bitrate:

- **High** (Plus): 1080p, ~10 Mbps
- **Standard** (free default): 720p, about half the space
- **Saver** (everyone): 720p at a smaller bitrate

Without Plus, new clips record at Standard. Tapping High opens the Plus upsell. Plus devices default to High and can still drop to Standard or Saver.

Capture size is still an `ideal` hint (mandatory `max` can fail `getUserMedia` or force a software scale). If the camera still hands back 1080p, Standard and Saver bill at the 720p bitrate so they still use less space than High.

**Already-recorded clips:** Clip info → **Reduce quality** permanently replaces a large take with a smaller encode (1080p → 720p, or a fat 720p file at a smaller bitrate). A confirm step says this cannot be undone. Photos hide the action; already-small files keep a disabled control with “already a small file.”

The new-clip picker is on **About** and in the home storage popover.

## Testing
- Unit: preset math, free vs Plus defaults, High gated, 1080p track still bills Standard/Saver at 720p, reduction planner, 1080p→720p re-encode
- e2e: free About defaults to Standard; Plus can pick High; home popover keeps a pick after revalidation; clip info reduce quality
- Manual: About picker + clip info confirm

Follow-ups: a home/About quality tap no longer snaps back when an in-flight settings load lands, and High stays inert until Plus status is known.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4e0a4374-b546-4147-8293-1ce816316f98?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4e0a4374-b546-4147-8293-1ce816316f98&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Standard, High, and Saver quality options for new recordings.
  * Plus members can record in 1080p High quality; free plans default to 720p Standard.
  * Added video-quality controls in About and the storage menu, with settings saved across sessions.
  * Added a confirmed “Reduce quality” action to replace clips with smaller video files.
  * Added upgrade prompts when selecting Plus-only quality.
* **Documentation**
  * Updated Plus benefits, recording details, terms, and upgrade messaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->