### PR TITLE
Ease camera sinks during a take (preview stays live)

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ simply lack the data and degrade gracefully.
 - Phones prefer **hardware H.264** (`video/mp4`/`h264` MediaRecorder types) over software VP9 — software encoding is what makes previews and clips drop frames on Android.
 - Capture stays at **30fps** (no dropped-frame shortcuts). About → **Video quality** picks the size/bitrate for *new* clips. Without Plus the default is **Standard** (720p). **High** (1080p, about 10 Mbps) is a Plus perk; **Saver** is 720p at a smaller bitrate. Already-saved clips are left alone. Bitrate still scales with the actual track size.
 - A live MediaRecorder is armed on the record screen so the hardware encoder is already past its ~170ms startup hole when the user presses; the take adopts that session and trims the pre-roll.
+- During a take the live viewfinder stays on screen; the extra thumb-mirror `<video>` is attached only at lift so the hold has two video sinks (overlay + encoder clone), not three. Record clones get `contentHint: motion`, and the encoder is not sliced every 250ms.
 - Clip duration is measured from the encoded media after stop (wall-clock time includes encoder startup latency and corrupts trim/export math).
 - The elapsed timer is a leaf component mutating its text node directly from a 10Hz boundary-aligned timer (a per-frame rAF loop would force 60 main-thread frames/s), so the ticking readout never re-renders the page during capture.
 - A screen wake lock is held while recording.

--- a/src/components/record-screen.tsx
+++ b/src/components/record-screen.tsx
@@ -193,17 +193,17 @@ export function RecordScreen(handle: Handle<RecordScreenProps>) {
    * preview (readback kicks Android off the zero-copy overlay path —
    * the post-take black flash). The mirror is attached only at lift so
    * the hold itself has two video sinks (overlay + encoder clone), not
-   * three. Stop-grace usually covers the first-frame wait; flushNow
-   * (app hide) draws the on-screen element because the stream is about
-   * to die and the user is leaving.
+   * three. Stop-grace usually covers the first-frame wait. A miss leaves
+   * the clip without live thumbs (ensureClipThumbs later) instead of
+   * flashing the overlay. flushNow (app hide) is the one path that
+   * draws the on-screen element: the stream is about to die and the
+   * user is already leaving.
    */
   const captureTakeThumbs = (options?: { immediate?: boolean }) => {
     if (options?.immediate) {
       return captureLiveThumbs(camera.getVideoElement())
     }
-    return captureLiveThumbsFromStream(camera.getStream()).then(
-      (fromMirror) => fromMirror ?? captureLiveThumbs(camera.getVideoElement()),
-    )
+    return captureLiveThumbsFromStream(camera.getStream())
   }
 
   // Live zoom readout: updated imperatively (no component update) so
@@ -469,7 +469,9 @@ export function RecordScreen(handle: Handle<RecordScreenProps>) {
     // One end per take: stop() resolves asynchronously (duration is
     // measured), so a second caller (e.g. hide + return in quick
     // succession) waits for the in-flight flush instead of double-saving.
-    if (endInFlight) return endInFlight
+    // A successor take that started during that save must still flush
+    // now — waiting would let hide disarm/stop the camera unsaved.
+    if (endInFlight && !recorder.isRecording && !recording) return endInFlight
     if (!recorder.isRecording && !recording) {
       // Pointer released while mic grant was still in flight. Keep the
       // just-acquired mic warm — an aborted press is usually followed by
@@ -492,8 +494,8 @@ export function RecordScreen(handle: Handle<RecordScreenProps>) {
     // is about to kill the camera). Runs beside stop-grace.
     const capturedThumbs = captureTakeThumbs({ immediate: options?.flushNow }).catch(() => null)
     try {
-      // flushNow: skip the stop-grace tail. The hide handler awaits this
-      // so the encoder has flushed before camera tracks are stopped.
+      // flushNow: skip the stop-grace tail so MediaRecorder.stop() runs
+      // in this turn (hide then stops the tracks on the same turn).
       const result = await recorder.stop(options?.flushNow ? { graceMs: 0 } : undefined)
       if (!result) {
         props.showToast('Hold a bit longer')
@@ -700,17 +702,17 @@ export function RecordScreen(handle: Handle<RecordScreenProps>) {
       // returning starts fresh with a restarted camera (and mic, on iOS).
       micSilent = false
       void handle.update()
+      if (recorder.isRecording || recording) {
+        // flushNow makes MediaRecorder.stop() run in this turn (no
+        // stop-grace), so the encoder has been asked to flush before
+        // the tracks die below. The save itself continues in the
+        // background. Awaiting the full save here let a resume restart
+        // the camera, then this handler stopped it again.
+        void endRecord(undefined, { flushNow: true })
+      }
+      recorder.disarm()
+      camera.stop()
       cameraStoppedInBackground = true
-      void (async () => {
-        if (recorder.isRecording || recording) {
-          // Await the flush so the encoder (and lift-time thumbs) finish
-          // before the camera tracks are stopped. Same-turn camera.stop()
-          // used to race a deferred thumb mirror.
-          await endRecord(undefined, { flushNow: true })
-        }
-        recorder.disarm()
-        camera.stop()
-      })()
       return
     }
     // Coming back to the foreground: restart the camera unconditionally.

--- a/src/components/record-screen.tsx
+++ b/src/components/record-screen.tsx
@@ -19,7 +19,7 @@ import {
   type ScreenRecordingSession,
 } from '../lib/screen-recorder'
 import { setLocationTaggingEnabled } from '../lib/storage'
-import { captureLiveThumbs } from '../lib/thumbs'
+import { captureLiveThumbs, captureLiveThumbsFromStream } from '../lib/thumbs'
 import { formatZoomLabel, nearestZoomLevel, zoomChipLevels } from '../lib/zoom-chips'
 import {
   formatStoragePercent,
@@ -102,7 +102,7 @@ export function RecordScreen(handle: Handle<RecordScreenProps>) {
    * stray pointer events must not end the take or reset drag-zoom state. */
   let keyboardTake = false
   let beginInFlight = false
-  let endInFlight = false
+  let endInFlight: Promise<void> | null = null
   let countdownTimer = 0
   let wakeLock: WakeLockSentinel | null = null
   let wakeLockGen = 0
@@ -189,37 +189,21 @@ export function RecordScreen(handle: Handle<RecordScreenProps>) {
   }
 
   /**
-   * Thumbnail capture mirror: a DETACHED video element fed by the same
-   * camera stream for the take's duration. Post-take thumbs are drawn from
-   * it instead of the on-screen preview — reading back the on-screen
-   * element kicks it out of Android's zero-copy overlay compositing path
-   * for a frame, which is the post-take black flash. A detached element
-   * was never in the compositor, so its readback can't blink anything.
+   * Post-take thumbs come from a DETACHED video, never the on-screen
+   * preview (readback kicks Android off the zero-copy overlay path —
+   * the post-take black flash). The mirror is attached only at lift so
+   * the hold itself has two video sinks (overlay + encoder clone), not
+   * three. Stop-grace usually covers the first-frame wait; flushNow
+   * (app hide) draws the on-screen element because the stream is about
+   * to die and the user is leaving.
    */
-  let thumbMirror: HTMLVideoElement | null = null
-  const stopThumbMirror = () => {
-    const mirror = thumbMirror
-    thumbMirror = null
-    if (mirror) {
-      mirror.srcObject = null
+  const captureTakeThumbs = (options?: { immediate?: boolean }) => {
+    if (options?.immediate) {
+      return captureLiveThumbs(camera.getVideoElement())
     }
-  }
-  const startThumbMirror = (stream: MediaStream) => {
-    stopThumbMirror()
-    const mirror = document.createElement('video')
-    mirror.muted = true
-    mirror.playsInline = true
-    mirror.srcObject = stream
-    void mirror.play().catch(() => undefined)
-    thumbMirror = mirror
-  }
-  const captureTakeThumbs = async () => {
-    const mirror = thumbMirror
-    const fromMirror = mirror ? await captureLiveThumbs(mirror) : null
-    // Ultra-short takes can end before the mirror got its first frame —
-    // the on-screen element is the (blink-risking) fallback, still better
-    // than the loader decoding the fresh blob behind the live preview.
-    return fromMirror ?? captureLiveThumbs(camera.getVideoElement())
+    return captureLiveThumbsFromStream(camera.getStream()).then(
+      (fromMirror) => fromMirror ?? captureLiveThumbs(camera.getVideoElement()),
+    )
   }
 
   // Live zoom readout: updated imperatively (no component update) so
@@ -431,7 +415,6 @@ export function RecordScreen(handle: Handle<RecordScreenProps>) {
       if (props.plus && locationTagging) {
         pendingFix = getLocationFix()
       }
-      startThumbMirror(stream)
       acquireWakeLock()
       // Watch the live mic level: users must learn about a dead mic while
       // holding, not after sharing a silent video (Sentry: near-zero clip
@@ -485,8 +468,8 @@ export function RecordScreen(handle: Handle<RecordScreenProps>) {
     }
     // One end per take: stop() resolves asynchronously (duration is
     // measured), so a second caller (e.g. hide + return in quick
-    // succession) must not re-enter and double-save the clip.
-    if (endInFlight) return
+    // succession) waits for the in-flight flush instead of double-saving.
+    if (endInFlight) return endInFlight
     if (!recorder.isRecording && !recording) {
       // Pointer released while mic grant was still in flight. Keep the
       // just-acquired mic warm — an aborted press is usually followed by
@@ -496,7 +479,7 @@ export function RecordScreen(handle: Handle<RecordScreenProps>) {
       camera.releaseMic({ keepWarm: true })
       return
     }
-    endInFlight = true
+    const run = (async () => {
     pointerId = null
     keyboardTake = false
     recording = false
@@ -505,15 +488,12 @@ export function RecordScreen(handle: Handle<RecordScreenProps>) {
     // Detach this take's fix before any await so a quick next hold can own it.
     const pendingForThisTake = pendingFix
     pendingFix = null
-    // Grab the poster/thumb from the detached mirror NOW (synchronous
-    // draw at finger-lift) — decoding the recorded blob for thumbnails
-    // while the preview runs blanks it on many Androids, and reading
-    // back the on-screen element blinks its overlay path.
-    const capturedThumbs = captureTakeThumbs().catch(() => null)
+    // Lift-time detached mirror (or a sync on-screen draw when flushNow
+    // is about to kill the camera). Runs beside stop-grace.
+    const capturedThumbs = captureTakeThumbs({ immediate: options?.flushNow }).catch(() => null)
     try {
-      // flushNow: the caller is about to tear the camera (and the
-      // recorder's live mic track) down — the stop-grace tail must be
-      // skipped and the encoder flushed synchronously inside this call.
+      // flushNow: skip the stop-grace tail. The hide handler awaits this
+      // so the encoder has flushed before camera tracks are stopped.
       const result = await recorder.stop(options?.flushNow ? { graceMs: 0 } : undefined)
       if (!result) {
         props.showToast('Hold a bit longer')
@@ -544,7 +524,6 @@ export function RecordScreen(handle: Handle<RecordScreenProps>) {
       reportError(err, 'save-clip')
       props.showToast(err instanceof Error ? err.message : 'Save failed')
     } finally {
-      endInFlight = false
       // stop() resolves only after the blob's duration is measured, so a
       // quick next hold may already be recording (or acquiring the mic) by
       // now — never strip the mic, monitor, or wake lock from that newer
@@ -558,11 +537,15 @@ export function RecordScreen(handle: Handle<RecordScreenProps>) {
         // fresh acquisition's silent ramp-up at its head.
         camera.releaseMic({ keepWarm: true })
         releaseWakeLock()
-        // A quick next hold already replaced the mirror via
-        // startThumbMirror — only tear it down when this take is the last.
-        stopThumbMirror()
         armEncoderIfPossible()
       }
+    }
+    })()
+    endInFlight = run
+    try {
+      await run
+    } finally {
+      if (endInFlight === run) endInFlight = null
     }
   }
 
@@ -662,7 +645,6 @@ export function RecordScreen(handle: Handle<RecordScreenProps>) {
     micMonitor?.stop()
     micMonitor = null
     recorder.cancel()
-    stopThumbMirror()
     // Leaving the screen mustn't lose an active screen take — save it.
     void finishScreenRecord()
     releaseWakeLock()
@@ -718,16 +700,17 @@ export function RecordScreen(handle: Handle<RecordScreenProps>) {
       // returning starts fresh with a restarted camera (and mic, on iOS).
       micSilent = false
       void handle.update()
-      if (recorder.isRecording || recording) {
-        // flushNow makes MediaRecorder.stop() run synchronously inside
-        // endRecord (no stop-grace), so the encoder has flushed by the time
-        // the tracks are stopped below; the save itself continues in the
-        // background.
-        void endRecord(undefined, { flushNow: true })
-      }
-      recorder.disarm()
-      camera.stop()
       cameraStoppedInBackground = true
+      void (async () => {
+        if (recorder.isRecording || recording) {
+          // Await the flush so the encoder (and lift-time thumbs) finish
+          // before the camera tracks are stopped. Same-turn camera.stop()
+          // used to race a deferred thumb mirror.
+          await endRecord(undefined, { flushNow: true })
+        }
+        recorder.disarm()
+        camera.stop()
+      })()
       return
     }
     // Coming back to the foreground: restart the camera unconditionally.

--- a/src/components/record-screen.tsx
+++ b/src/components/record-screen.tsx
@@ -469,9 +469,12 @@ export function RecordScreen(handle: Handle<RecordScreenProps>) {
     // One end per take: stop() resolves asynchronously (duration is
     // measured), so a second caller (e.g. hide + return in quick
     // succession) waits for the in-flight flush instead of double-saving.
-    // A successor take that started during that save must still flush
-    // now — waiting would let hide disarm/stop the camera unsaved.
-    if (endInFlight && !recorder.isRecording && !recording) return endInFlight
+    // During stop-grace, `recording` is already false but the encoder is
+    // still live — must not start a second stop() (that overwrites
+    // onstop and loses the lift's takeWallMs). A successor take that
+    // started during the prior save has `recording` true again and
+    // still needs its own flush.
+    if (endInFlight && !recording) return endInFlight
     if (!recorder.isRecording && !recording) {
       // Pointer released while mic grant was still in flight. Keep the
       // just-acquired mic warm — an aborted press is usually followed by

--- a/src/lib/recorder.test.ts
+++ b/src/lib/recorder.test.ts
@@ -1,5 +1,23 @@
 import { describe, expect, it } from 'vitest'
-import { takeFallbackDurationMs, takeTrimEndMs, takeTrimStartMs } from './recorder'
+import {
+  hintVideoTrackMotion,
+  takeFallbackDurationMs,
+  takeTrimEndMs,
+  takeTrimStartMs,
+} from './recorder'
+
+describe('hintVideoTrackMotion', () => {
+  it('marks a video track as motion for the encoder', () => {
+    const canvas = document.createElement('canvas')
+    canvas.width = 16
+    canvas.height = 16
+    const track = canvas.captureStream(0).getVideoTracks()[0]
+    expect(track).toBeDefined()
+    hintVideoTrackMotion(track!)
+    expect(track!.contentHint).toBe('motion')
+    track!.stop()
+  })
+})
 
 describe('takeTrimEndMs', () => {
   it('walks the trim-out back by the real stop grace', () => {

--- a/src/lib/recorder.ts
+++ b/src/lib/recorder.ts
@@ -53,6 +53,12 @@ export function takeTrimStartMs(trimEndMs: number, takeWallMs: number): number {
   return Math.max(0, trimEndMs - takeWallMs)
 }
 
+/** Tell the encoder this clone is camera motion — not a slideshow —
+ * so it spends bits on movement instead of still-image sharpness. */
+export function hintVideoTrackMotion(track: MediaStreamTrack): void {
+  if ('contentHint' in track) track.contentHint = 'motion'
+}
+
 /** Blob length when media duration cannot be measured: encoder start →
  * stop (adopted pre-roll + hold + grace). Never shorter than the hold,
  * so a clock inversion cannot hide the take. */
@@ -196,6 +202,7 @@ export class HoldRecorder {
     if (!video || video.readyState !== 'live') return
     this.stopDummy()
     const clone = video.clone()
+    hintVideoTrackMotion(clone)
     const warmStream = new MediaStream([clone])
     try {
       const settings = video.getSettings()
@@ -211,7 +218,7 @@ export class HoldRecorder {
       recorder.onerror = () => {
         this.finishDummy(recorder)
       }
-      recorder.start(250)
+      recorder.start()
       window.setTimeout(() => {
         if (this.dummyRecorder === recorder && recorder.state !== 'inactive') {
           try {
@@ -476,7 +483,11 @@ export class HoldRecorder {
 
   private createSession(stream: MediaStream): RecordingSession | null {
     const settings = stream.getVideoTracks()[0]?.getSettings()
-    const clones = stream.getVideoTracks().map((track) => track.clone())
+    const clones = stream.getVideoTracks().map((track) => {
+      const clone = track.clone()
+      hintVideoTrackMotion(clone)
+      return clone
+    })
     const recordStream = new MediaStream([...clones, ...stream.getAudioTracks()])
 
     try {
@@ -495,7 +506,10 @@ export class HoldRecorder {
       recorder.ondataavailable = (event) => {
         if (event.data.size > 0) session.chunks.push(event.data)
       }
-      recorder.start(250)
+      // No timeslice: mid-take Blob events on the main thread are extra
+      // work during the hold. Clips and 1.5s warm sessions fit in memory;
+      // the muxed file arrives once, on stop.
+      recorder.start()
       return session
     } catch {
       // Constructor/start can throw (unsupported params, dead tracks) —

--- a/src/lib/thumbs.test.ts
+++ b/src/lib/thumbs.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest'
+import { captureLiveThumbsFromStream, waitForVideoFrame } from './thumbs'
+
+function paintCanvas(canvas: HTMLCanvasElement): void {
+  const ctx = canvas.getContext('2d')
+  if (!ctx) throw new Error('No 2d context')
+  ctx.fillStyle = '#1a7a4c'
+  ctx.fillRect(0, 0, canvas.width, canvas.height)
+}
+
+describe('waitForVideoFrame', () => {
+  it('resolves true once a canvas stream has a frame', async () => {
+    const canvas = document.createElement('canvas')
+    canvas.width = 64
+    canvas.height = 64
+    paintCanvas(canvas)
+    const video = document.createElement('video')
+    video.muted = true
+    video.playsInline = true
+    video.srcObject = canvas.captureStream(15)
+    const ready = await waitForVideoFrame(video, 1000)
+    expect(ready).toBe(true)
+    expect(video.videoWidth).toBeGreaterThan(0)
+    video.srcObject = null
+  })
+})
+
+describe('captureLiveThumbsFromStream', () => {
+  it('draws a poster from a live video track without using an on-screen element', async () => {
+    const canvas = document.createElement('canvas')
+    canvas.width = 128
+    canvas.height = 72
+    paintCanvas(canvas)
+    const timer = window.setInterval(() => paintCanvas(canvas), 30)
+    const stream = canvas.captureStream(15)
+    try {
+      const thumbs = await captureLiveThumbsFromStream(stream, 1000)
+      expect(thumbs).not.toBeNull()
+      expect(thumbs!.thumbs.length).toBe(1)
+      expect(thumbs!.poster.size).toBeGreaterThan(0)
+      expect(thumbs!.videoWidth).toBeGreaterThan(0)
+    } finally {
+      window.clearInterval(timer)
+      stream.getTracks().forEach((track) => {
+        track.stop()
+      })
+    }
+  })
+
+  it('returns null when the stream has no live video', async () => {
+    expect(await captureLiveThumbsFromStream(new MediaStream())).toBeNull()
+    expect(await captureLiveThumbsFromStream(null)).toBeNull()
+  })
+})

--- a/src/lib/thumbs.ts
+++ b/src/lib/thumbs.ts
@@ -142,6 +142,68 @@ export async function generateImageThumbs(blob: Blob): Promise<GeneratedThumbs> 
  * (the post-take black flash). The frame is drawn synchronously; only the
  * JPEG encode is async. Returns null when the preview has no frame to give.
  */
+/** How long a lift-time thumb mirror may wait for its first frame. */
+const LIVE_THUMB_FRAME_MS = 400
+
+/**
+ * Resolve once `video` has a paintable frame, or when `timeoutMs` elapses.
+ * Used by the lift-time thumb mirror so we never read back the on-screen
+ * preview (that blinks Android's overlay path).
+ */
+export function waitForVideoFrame(
+  video: HTMLVideoElement,
+  timeoutMs = LIVE_THUMB_FRAME_MS,
+): Promise<boolean> {
+  const hasFrame = () => video.readyState >= 2 && video.videoWidth > 0
+  if (hasFrame()) return Promise.resolve(true)
+  return new Promise((resolve) => {
+    let settled = false
+    const finish = (ok: boolean) => {
+      if (settled) return
+      settled = true
+      window.clearTimeout(timer)
+      video.removeEventListener('loadeddata', onReady)
+      video.removeEventListener('canplay', onReady)
+      resolve(ok)
+    }
+    const onReady = () => {
+      if (hasFrame()) finish(true)
+    }
+    const timer = window.setTimeout(() => finish(hasFrame()), timeoutMs)
+    video.addEventListener('loadeddata', onReady)
+    video.addEventListener('canplay', onReady)
+    if ('requestVideoFrameCallback' in video) {
+      video.requestVideoFrameCallback(() => finish(true))
+    }
+    void video.play().catch(() => undefined)
+  })
+}
+
+/**
+ * One detached <video> on the live camera, only for the stop beat.
+ * Keeping a mirror for the whole take added a third video sink beside
+ * the overlay preview and the MediaRecorder clone. Attach here, wait
+ * for a frame (the stop-grace window usually covers it), draw, detach.
+ */
+export async function captureLiveThumbsFromStream(
+  stream: MediaStream | null | undefined,
+  timeoutMs = LIVE_THUMB_FRAME_MS,
+): Promise<GeneratedThumbs | null> {
+  const track = stream?.getVideoTracks().find((item) => item.readyState === 'live')
+  if (!track) return null
+  const video = document.createElement('video')
+  video.muted = true
+  video.playsInline = true
+  video.srcObject = new MediaStream([track])
+  try {
+    const ready = await waitForVideoFrame(video, timeoutMs)
+    if (!ready) return null
+    return await captureLiveThumbs(video)
+  } finally {
+    video.srcObject = null
+  }
+}
+
 export async function captureLiveThumbs(
   video: HTMLVideoElement | null,
 ): Promise<GeneratedThumbs | null> {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

Recorded clips can still hitch. Moving `MediaRecorder` off-thread is not available for camera tracks and did not help when we measured it. This change eases the **camera sinks during a take** without touching the live viewfinder.

## What you should see

Nothing different while holding: live preview, REC pill, drag-to-zoom, filmstrip thumbs at lift (still a live frame, now from a short-lived detached video).

## What the original hold was doing

During a press the same 1080p/30 track had **three video sinks**: the on-screen overlay `<video>`, a detached thumb-mirror `<video>` for the whole take (so lift could `drawImage` without reading the overlay), and the `MediaRecorder` clone. The recorder also flushed a Blob onto the main thread every 250ms (`start(250)`). Record clones had no `contentHint`. Hide mid-take fired `endRecord({ flushNow })` without awaiting, then `camera.stop()` in the same turn.

## What changed

- **No thumb-mirror `<video>` for the whole take.** A detached element attaches only at lift (stop-grace usually covers the first frame). A miss leaves the clip without live thumbs (`ensureClipThumbs` later) instead of reading the overlay. Hide/background draws the on-screen element (user is leaving) and asks `MediaRecorder.stop()` in the same turn before `camera.stop()`; the save continues in the background.
- **Record clones get `contentHint: motion`** so the encoder spends bits on movement.
- **No 250ms MediaRecorder timeslice** on the live session — one muxed Blob on stop.
- Hide does not await the IndexedDB save (that race let a resume restart the camera, then the hidden handler stopped it again). A successor take that starts during a prior save can still flush. Hide during stop-grace waits for the in-flight `stop()` instead of starting a second one.

## Measurement (headless Chromium, fake camera, 3s holds, 4 counterbalanced trials)

- **Timeslice:** `start(250)` averaged 11 `dataavailable` events vs 1 without a timeslice. Decoded frames were the same (60 vs 60). This is less main-thread Blob work during the hold, not more recorded frames.
- **Sinks:** preview + recorder stayed at 60 decoded frames every trial. Adding a third live `<video>` (the old whole-take mirror) dropped to 36–47 frames (avg 42). Blob size and duration stayed about the same. Fake-camera, not a phone HAL — but the direction matches why the extra sink was costing us.

## Risk

Low/medium. Lift-time thumbs can miss a frame on a tiny tap (clip gets thumbs later). Hide-while-recording still saves; privacy dot drops in the same turn as hide.

## Test plan

- [x] `hintVideoTrackMotion` + lift-time thumb helpers (Vitest browser)
- [x] Counterbalanced sink/timeslice probe
- [x] Hide-restart race, overlay fallback, and grace double-stop addressed after Bugbot/CodeRabbit
- [ ] CI on this revision
- [ ] Preview deploy: hold-to-record, thumbs on the strip, hide mid-take still saves
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f2b8987b-704a-433e-a639-e41a539b2eeb?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f2b8987b-704a-433e-a639-e41a539b2eeb&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved thumbnail capture during and after recording, including more reliable captures when the app is backgrounded.
  - Recording video is optimized for motion to improve playback quality.
  - Recordings are finalized as a single file when stopping.

- **Bug Fixes**
  - Improved handling of overlapping stop actions and camera shutdown during backgrounding.
  - Reduced reliance on hidden preview elements during thumbnail generation.

- **Documentation**
  - Updated recording-quality guidance to reflect current viewfinder, mirroring, motion optimization, and file-finalization behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->