### PR TITLE
Fix ReceivePage scheduleUpdate rejection on deep-link receive

### DIFF
--- a/src/pages/receive-page.test.ts
+++ b/src/pages/receive-page.test.ts
@@ -1,0 +1,105 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { createElement, createRoot, type Handle } from 'remix/ui'
+
+/**
+ * Regression for Sentry 7700116197: Remix only wires scheduleUpdate after the
+ * first render commits. A sync handle.update() kicked from ReceivePage setup
+ * (deep-link code → receive() before any await) rejects with
+ * "scheduleUpdate not implemented".
+ *
+ * Mirrors ReceivePage's mount path: start in waiting with a code, skip the
+ * sync waiting paint, then update after the first await when connected.
+ */
+function ReceiveSetupWithCode(handle: Handle<{ code: string }>) {
+  const propCode = handle.props.code
+  let phase: 'waiting' | 'transferring' | 'done' = 'waiting'
+  let progress = ''
+  const abort = new AbortController()
+  handle.signal.addEventListener('abort', () => abort.abort(), { once: true })
+
+  const receive = (code: string) => {
+    const needsWaitingPaint = phase !== 'waiting' || progress !== ''
+    phase = 'waiting'
+    progress = ''
+    if (needsWaitingPaint) void handle.update()
+    void (async () => {
+      await Promise.resolve()
+      if (abort.signal.aborted) return
+      phase = 'transferring'
+      progress = `got:${code}`
+      void handle.update()
+      await Promise.resolve()
+      if (abort.signal.aborted) return
+      phase = 'done'
+      void handle.update()
+    })()
+  }
+
+  if (propCode) receive(propCode)
+
+  return () =>
+    createElement(
+      'div',
+      { 'data-phase': phase },
+      phase === 'waiting' ? 'Waiting for the sender.' : null,
+      progress ? createElement('p', { className: 'export-percent' }, progress) : null,
+      phase === 'done' ? 'Project received.' : null,
+    )
+}
+
+describe('ReceivePage setup receive', () => {
+  let dispose: (() => void) | undefined
+
+  afterEach(() => {
+    dispose?.()
+    dispose = undefined
+  })
+
+  it('does not reject scheduleUpdate when receive starts during setup', async () => {
+    const rejections: string[] = []
+    const onRejection = (event: PromiseRejectionEvent) => {
+      const msg =
+        event.reason instanceof Error ? event.reason.message : String(event.reason ?? '')
+      if (msg.includes('scheduleUpdate')) {
+        rejections.push(msg)
+        event.preventDefault()
+      }
+    }
+    window.addEventListener('unhandledrejection', onRejection)
+
+    const host = document.createElement('div')
+    document.body.appendChild(host)
+    const root = createRoot(host)
+    dispose = () => {
+      window.removeEventListener('unhandledrejection', onRejection)
+      root.dispose()
+      host.remove()
+    }
+
+    root.render(createElement(ReceiveSetupWithCode, { code: 'AB3K9Q' }))
+    root.flush()
+
+    await waitFor(() => {
+      root.flush()
+      expect(host.textContent).toContain('Project received.')
+      expect(host.querySelector('.export-percent')?.textContent).toBe('got:AB3K9Q')
+    })
+
+    expect(rejections).toEqual([])
+  })
+})
+
+async function waitFor(assert: () => void, timeoutMs = 2000): Promise<void> {
+  const start = Date.now()
+  let last: unknown
+  while (Date.now() - start < timeoutMs) {
+    try {
+      assert()
+      return
+    } catch (err) {
+      last = err
+    }
+    await new Promise((r) => setTimeout(r, 20))
+  }
+  throw last instanceof Error ? last : new Error(String(last))
+}

--- a/src/pages/receive-page.tsx
+++ b/src/pages/receive-page.tsx
@@ -42,9 +42,17 @@ function phaseCopy(phase: SyncPhase, error: string | null, hasCode: boolean): st
 
 /** Free: accept a Plus send and import it as a new project. */
 export function ReceivePage(handle: Handle<ReceivePageProps>) {
+  // Normalize once so mount can paint the right state without a sync
+  // handle.update() (Remix only wires scheduleUpdate after first commit).
+  const propCode = handle.props.code ? normalizeRoomCode(handle.props.code) : null
   let typed = handle.props.code ?? ''
-  let phase: SyncPhase = handle.props.code ? 'waiting' : 'creating'
-  let error: string | null = null
+  let phase: SyncPhase = propCode
+    ? 'waiting'
+    : handle.props.code
+      ? 'failed'
+      : 'creating'
+  let error: string | null =
+    handle.props.code && !propCode ? 'That is not a valid send code.' : null
   let progress = ''
   const abort = new AbortController()
 
@@ -74,10 +82,15 @@ export function ReceivePage(handle: Handle<ReceivePageProps>) {
       void handle.update()
       return
     }
+    // Remix wires scheduleUpdate only after the first render commits. Calling
+    // handle.update() synchronously from setup (before any await) rejects with
+    // "scheduleUpdate not implemented". Mount with a code already starts in
+    // waiting / clean error, so skip that paint; form submit still needs it.
+    const needsWaitingPaint = phase !== 'waiting' || error !== null || progress !== ''
     phase = 'waiting'
     error = null
     progress = ''
-    void handle.update()
+    if (needsWaitingPaint) void handle.update()
     void (async () => {
       try {
         const received = await receiveBackupFromPeer(
@@ -111,7 +124,7 @@ export function ReceivePage(handle: Handle<ReceivePageProps>) {
     })()
   }
 
-  if (handle.props.code) receive(handle.props.code)
+  if (propCode) receive(propCode)
 
   return () => (
     <div className="screen about-screen receive-screen">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sentry [7700116197](https://sentry.io/organizations/kent-c-dodds-tech-llc/issues/7700116197/) (`Error: scheduleUpdate not implemented`) fires when opening `/receive/:code`.

Same root class as #186 (SharePlusSheet): Remix only wires `scheduleUpdate` after the first render commits. `ReceivePage` called `receive(props.code)` during setup and sync `handle.update()` before any `await`, so the promise rejected as an unhandledrejection. Transfer still continued after awaits (post-await updates succeed).

## Fix

- Normalize the deep-link code up front so mount already starts in `waiting` (or `failed` for invalid codes) without a sync update.
- Skip the redundant waiting paint on mount; keep it for form submit once connected.
- Unit regression (`createRoot` + unhandledrejection listener), matching the SharePlusSheet pattern.

## Risk

Low — isolated receive-page mount path; no auth/billing/storage changes. Siblings (quota, export audio, IndexedDB blob) are unrelated.

## Test plan

- [x] `npx vitest run src/pages/receive-page.test.ts`
- [x] `npm run build` + full `npx vitest run` (503 tests)
- [x] `node scripts/manual-smoke.mjs` — 32/33 (unrelated flaky “export overlay shows encoded frames”, same as #186)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-09029e57-b48d-45b9-8576-e4102b823580?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-09029e57-b48d-45b9-8576-e4102b823580&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

