### PR TITLE
Treat QuotaExceededError as expected storage-full gate (KODY-VIDEO-12)

### DIFF
--- a/src/components/record-screen.tsx
+++ b/src/components/record-screen.tsx
@@ -539,8 +539,10 @@ export function RecordScreen(handle: Handle<RecordScreenProps>) {
       )
       props.refresh()
     } catch (err) {
-      // Real store failures (quota, bad blob) must still reach Sentry as
-      // handled exceptions — without the twin unhandled AbortError from tx.done.
+      // Store failures surface in-app (toast). Quota is an expected device
+      // gate (StorageQuotaExceededError / reportError no-op); other write
+      // failures still reach Sentry as handled exceptions — without the twin
+      // unhandled AbortError from tx.done.
       reportError(err, 'save-clip')
       props.showToast(err instanceof Error ? err.message : 'Save failed')
     } finally {

--- a/src/lib/error-reporting.test.ts
+++ b/src/lib/error-reporting.test.ts
@@ -8,13 +8,18 @@ import {
   isMonitoringSelfTestEvent,
   isProjectLimitEvent,
   isReportingHostname,
+  isStorageQuotaExceededEvent,
   isTranslatorDomMutationNoiseEvent,
   isViteCssPreloadError,
   isWebKitEmptyRangesNoiseEvent,
   reportComponentError,
   reportError,
 } from './error-reporting'
-import { IndexedDbUnavailableError, ProjectLimitError } from './storage'
+import {
+  IndexedDbUnavailableError,
+  ProjectLimitError,
+  StorageQuotaExceededError,
+} from './storage'
 
 describe('isMonitoringSelfTestEvent', () => {
   it('drops the setup-agent synthetic exception signature', () => {
@@ -114,6 +119,56 @@ describe('isProjectLimitEvent', () => {
   })
 })
 
+describe('isStorageQuotaExceededEvent (KODY-VIDEO-12)', () => {
+  it('drops bare QuotaExceededError even with an empty message', () => {
+    expect(
+      isStorageQuotaExceededEvent({
+        exception: {
+          values: [{ type: 'QuotaExceededError', value: '' }],
+        },
+      }),
+    ).toBe(true)
+    expect(
+      isStorageQuotaExceededEvent({
+        exception: {
+          values: [{ type: 'QuotaExceededError', value: 'No error message' }],
+        },
+      }),
+    ).toBe(true)
+  })
+
+  it('drops the wrapped StorageQuotaExceededError type', () => {
+    expect(
+      isStorageQuotaExceededEvent({
+        exception: {
+          values: [
+            {
+              type: 'StorageQuotaExceededError',
+              value:
+                'Device storage is full. Delete a project or clear cached exports, then try again.',
+            },
+          ],
+        },
+      }),
+    ).toBe(true)
+  })
+
+  it('keeps unrelated storage errors', () => {
+    expect(
+      isStorageQuotaExceededEvent({
+        exception: {
+          values: [
+            {
+              type: 'UnknownError',
+              value: 'Error preparing Blob/File data to be stored in object store',
+            },
+          ],
+        },
+      }),
+    ).toBe(false)
+  })
+})
+
 describe('isExpectedUserError / reportError', () => {
   it('recognizes ProjectLimitError instances', () => {
     expect(isExpectedUserError(new ProjectLimitError('capped'))).toBe(true)
@@ -153,6 +208,22 @@ describe('isExpectedUserError / reportError', () => {
   it('reportError stays silent for missing IndexedDB ReferenceError (KODY-VIDEO-10)', () => {
     expect(() =>
       reportError(new ReferenceError('indexedDB is not defined'), 'load-home'),
+    ).not.toThrow()
+  })
+
+  it('recognizes quota-full errors (KODY-VIDEO-12)', () => {
+    expect(isExpectedUserError(new StorageQuotaExceededError())).toBe(true)
+    expect(isExpectedUserError(new DOMException('', 'QuotaExceededError'))).toBe(true)
+    expect(isExpectedUserError(new DOMException('Quota exceeded', 'QuotaExceededError'))).toBe(
+      true,
+    )
+    expect(isExpectedUserError(new Error('Export failed'))).toBe(false)
+  })
+
+  it('reportError stays silent for StorageQuotaExceededError and raw QuotaExceededError', () => {
+    expect(() => reportError(new StorageQuotaExceededError(), 'import')).not.toThrow()
+    expect(() =>
+      reportError(new DOMException('', 'QuotaExceededError'), 'save-clip'),
     ).not.toThrow()
   })
 })

--- a/src/lib/error-reporting.ts
+++ b/src/lib/error-reporting.ts
@@ -87,6 +87,24 @@ export function isProjectLimitEvent(event: FilterableSentryEvent): boolean {
 }
 
 /**
+ * Device storage quota full (KODY-VIDEO-12). Expected environmental gate —
+ * in-app copy guides delete/clear; not a triage-worthy crash.
+ * Match by exception type only: message is often empty in Chromium.
+ */
+export function isStorageQuotaExceededEvent(event: FilterableSentryEvent): boolean {
+  const exceptionValues = event.exception?.values ?? []
+  for (const value of exceptionValues) {
+    if (
+      value.type === 'QuotaExceededError' ||
+      value.type === 'StorageQuotaExceededError'
+    ) {
+      return true
+    }
+  }
+  return false
+}
+
+/**
  * Chromium LevelDB open failure (KODY-VIDEO-Y). Keep in sync with
  * `isIndexedDbBackingStoreOpenFailure` in storage.ts — message-only here so
  * this module stays free of an idb import.
@@ -427,6 +445,7 @@ function loadSentry(): Promise<SentryLike> | null {
         if (isMonitoringSelfTestEvent(event)) return null
         if (isCloudflareInsightsBeaconEvent(event)) return null
         if (isProjectLimitEvent(event)) return null
+        if (isStorageQuotaExceededEvent(event)) return null
         if (isIndexedDbBackingStoreOpenEvent(event)) return null
         if (isBrowserExtensionHostObjectNoiseEvent(event)) return null
         if (isViteCssPreloadError(event)) return null
@@ -473,6 +492,9 @@ export function isExpectedUserError(error: unknown): boolean {
   if (!(error instanceof Error)) return false
   if (error.name === 'ProjectLimitError') return true
   if (error.name === 'IndexedDbUnavailableError') return true
+  // Device quota full (KODY-VIDEO-12) — wrapped or raw Chromium DOMException.
+  if (error.name === 'StorageQuotaExceededError') return true
+  if (error.name === 'QuotaExceededError') return true
   // Raw Chromium open failure if something reports before storage wraps it.
   if (isIndexedDbBackingStoreOpenText(error.name, error.message)) return true
   // Missing IndexedDB global (KODY-VIDEO-10) before storage wraps it.

--- a/src/lib/project-transfer.ts
+++ b/src/lib/project-transfer.ts
@@ -4,6 +4,7 @@ import {
   addProjectAudioTrack,
   createProject,
   deleteProject,
+  throwMappedStorageWriteError,
   updateClipTrim,
   updateProjectAudioTrack,
 } from './storage'
@@ -468,6 +469,8 @@ async function persistImportedProject(
   } catch (error) {
     // Never leave a half-imported project behind.
     await deleteProject(project.id).catch(() => undefined)
-    throw error
+    // arrayBuffer() / IDB puts can throw bare QuotaExceededError with an
+    // empty message (KODY-VIDEO-12) — remap before surfacing to the UI.
+    throwMappedStorageWriteError(error)
   }
 }

--- a/src/lib/storage.test.ts
+++ b/src/lib/storage.test.ts
@@ -36,6 +36,10 @@ import {
   setTourCardDismissed,
   setKeepWatermark,
   setVideoQuality,
+  STORAGE_QUOTA_MESSAGE,
+  StorageQuotaExceededError,
+  isQuotaExceededError,
+  throwMappedStorageWriteError,
   toStoredBlob,
   undoDeleteLastClip,
   updateClipAudioPeak,
@@ -137,6 +141,29 @@ describe('storage layer', () => {
       false,
     )
     expect(isStaleConnectionError(new Error('nope'))).toBe(false)
+  })
+
+  it('maps QuotaExceededError to StorageQuotaExceededError (KODY-VIDEO-12)', () => {
+    // Chromium often leaves the message empty — Sentry shows "No error message".
+    expect(isQuotaExceededError(new DOMException('', 'QuotaExceededError'))).toBe(true)
+    expect(isQuotaExceededError(new DOMException('Quota exceeded', 'QuotaExceededError'))).toBe(
+      true,
+    )
+    expect(isQuotaExceededError(new StorageQuotaExceededError())).toBe(true)
+    expect(isQuotaExceededError(new DOMException('nope', 'UnknownError'))).toBe(false)
+
+    expect(() =>
+      throwMappedStorageWriteError(new DOMException('', 'QuotaExceededError')),
+    ).toThrow(StorageQuotaExceededError)
+    try {
+      throwMappedStorageWriteError(new DOMException('', 'QuotaExceededError'))
+    } catch (error) {
+      expect(error).toBeInstanceOf(StorageQuotaExceededError)
+      expect((error as Error).message).toBe(STORAGE_QUOTA_MESSAGE)
+    }
+    expect(() => throwMappedStorageWriteError(new Error('Clip not found'))).toThrow(
+      'Clip not found',
+    )
   })
 
   it('recognizes Chromium IndexedDB backing-store open failures (KODY-VIDEO-Y)', () => {
@@ -1086,6 +1113,8 @@ describe('storage layer', () => {
     expect(isRetriableIdbFailure(new DOMException('Quota exceeded', 'QuotaExceededError'))).toBe(
       false,
     )
+    expect(isRetriableIdbFailure(new DOMException('', 'QuotaExceededError'))).toBe(false)
+    expect(isRetriableIdbFailure(new StorageQuotaExceededError())).toBe(false)
     expect(isRetriableIdbFailure(new Error('Clip not found'))).toBe(false)
   })
 

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -66,12 +66,19 @@ let activeDb: IDBPDatabase<ClipsDB> | null = null
  * `tx.done` together keeps that rejection in the same catch path (see
  * jakearchibald/idb#320). Otherwise Sentry sees `AbortError: AbortError`
  * via `unhandledrejection` as a twin of the real store error.
+ *
+ * QuotaExceededError (KODY-VIDEO-12) is remapped to StorageQuotaExceededError
+ * so callers get actionable copy even when the browser leaves message empty.
  */
 async function completeTransaction(
   ops: Array<Promise<unknown>>,
   tx: { done: Promise<void> },
 ): Promise<void> {
-  await Promise.all([...ops, tx.done])
+  try {
+    await Promise.all([...ops, tx.done])
+  } catch (error) {
+    throwMappedStorageWriteError(error)
+  }
 }
 
 /**
@@ -161,6 +168,40 @@ export class IndexedDbUnavailableError extends Error {
   }
 }
 
+/** Actionable copy when IndexedDB / Cache rejects a write for quota. */
+export const STORAGE_QUOTA_MESSAGE =
+  'Device storage is full. Delete a project or clear cached exports, then try again.'
+
+/**
+ * Soft storage-full gate (KODY-VIDEO-12). Browser QuotaExceededError often has
+ * an empty message ("No error message" in Sentry); wrap so in-app surfaces
+ * guide the user. Expected device constraint, never a crash report.
+ */
+export class StorageQuotaExceededError extends Error {
+  override readonly name = 'StorageQuotaExceededError'
+
+  constructor(message = STORAGE_QUOTA_MESSAGE) {
+    super(message)
+  }
+}
+
+/**
+ * True when the browser rejected a write because the origin quota is full.
+ * Match by `error.name` — Chromium often leaves `message` empty.
+ */
+export function isQuotaExceededError(error: unknown): boolean {
+  if (error instanceof StorageQuotaExceededError) return true
+  if (!(error instanceof DOMException) && !(error instanceof Error)) return false
+  return error.name === 'QuotaExceededError'
+}
+
+/** Remap raw quota DOMExceptions; rethrow everything else unchanged. */
+export function throwMappedStorageWriteError(error: unknown): never {
+  if (error instanceof StorageQuotaExceededError) throw error
+  if (isQuotaExceededError(error)) throw new StorageQuotaExceededError()
+  throw error
+}
+
 /**
  * True when an IndexedDB failure looks environmental — the connection or the
  * backing store gave out mid-operation (iOS Safari closing IDB under memory
@@ -172,6 +213,7 @@ export class IndexedDbUnavailableError extends Error {
 export function isRetriableIdbFailure(error: unknown): boolean {
   if (isStaleConnectionError(error)) return true
   if (isIndexedDbBackingStoreOpenFailure(error)) return true
+  if (isQuotaExceededError(error)) return false
   if (!(error instanceof DOMException)) return false
   return (
     error.name === 'AbortError' ||
@@ -450,7 +492,11 @@ export async function createProject(
   // caller-chosen name is meaningful and must never be auto-deleted.
   if (!chosenName) project.nameIsDefault = true
   if (options?.orientation === 'landscape') project.orientation = 'landscape'
-  await db.put('projects', project)
+  try {
+    await db.put('projects', project)
+  } catch (error) {
+    throwMappedStorageWriteError(error)
+  }
   await setLastOpenedProjectId(project.id)
   return project
 }

--- a/src/pages/receive-page.tsx
+++ b/src/pages/receive-page.tsx
@@ -4,7 +4,7 @@ import { IconBack } from '../components/icons'
 import { BrandMark } from '../components/brand-mark'
 import { reportError } from '../lib/error-reporting'
 import { BackupFormatError, importKodyVideoBackupFile } from '../lib/project-transfer'
-import { ProjectLimitError } from '../lib/storage'
+import { ProjectLimitError, StorageQuotaExceededError } from '../lib/storage'
 import { formatBytes } from '../lib/storage-space'
 import { formatRoomCode, normalizeRoomCode, type SyncPhase } from '../lib/sync-protocol'
 import { httpSyncSignaling, SyncSignalError } from '../lib/sync-signaling'
@@ -65,7 +65,8 @@ export function ReceivePage(handle: Handle<ReceivePageProps>) {
       !(err instanceof SyncSignalError) &&
       !(err instanceof SyncTransferError) &&
       !(err instanceof BackupFormatError) &&
-      !(err instanceof ProjectLimitError)
+      !(err instanceof ProjectLimitError) &&
+      !(err instanceof StorageQuotaExceededError)
     ) {
       reportError(err, 'sync-receive')
     }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sentry [KODY-VIDEO-12](https://kent-c-dodds-tech-llc.sentry.io/issues/7700119249/) reports `QuotaExceededError` with an empty message during backup import (`step: import`) on Chrome/macOS. That is a real device-quota constraint, not an app logic bug — but the empty Chromium message left users with a blank error and opened a triage issue.

## Fix

- Map `QuotaExceededError` → `StorageQuotaExceededError` with actionable copy at the IndexedDB write boundary (`completeTransaction`, `createProject`) and backup-import rollback path.
- Treat quota-full as an expected soft gate in `isExpectedUserError` / `beforeSend` (same class as project-cap and IndexedDB-unavailable), so it no longer opens Sentry issues.
- Unit coverage for the mapper, expected-error gate, and beforeSend filter.

## Risk

**Low** — wiring/filter + clear UX message; no auth/billing/migration surface. Intended to squash-merge after CI + Bugbot.

## Local verification

- `npx vitest run` — 509/509 passed
- `npm run build` — typecheck + production build OK
- `node scripts/manual-smoke.mjs` — 32/33 (pre-existing flake: `export overlay shows encoded frames`; export still completes; unrelated to this change)

## Test plan

- [x] Unit tests for quota mapping and Sentry filters
- [x] Full vitest + build
- [ ] CI green + Bugbot clear → squash-merge, resolve Sentry in commit
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-734735aa-be98-44bd-b843-2e950d0b9b43?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-734735aa-be98-44bd-b843-2e950d0b9b43&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

