### PR TITLE
Fix backup import, Plus share URLs, QR, and About back link

### DIFF
--- a/functions/lib/agent-markdown.ts
+++ b/functions/lib/agent-markdown.ts
@@ -220,7 +220,7 @@ Kody Video has **no accounts**.
 
 Plus is a one-time $0.99 [Stripe Payment Link](https://buy.stripe.com/00wfZi71ibU30rk9hU2Ry07). After checkout, Stripe redirects to \`/unlocked?session_id=<CHECKOUT_SESSION_ID>\`. \`/api/verify-purchase\` checks that session server-side; the entitlement is then stored on the device. 100%-off promotion codes use the same verification.
 
-Restore on another device from the device that already has Plus: About → **Use Plus on another device** shows a short code and QR. The new device types the code under **Already paid?** or opens \`/unlocked?code=\`. That mints a short-lived mapping to the same Stripe session — not a password. A checkout session id still works if you have one. Stripe receipt URLs do not include that session id.
+Restore on another device from the device that already has Plus: About → **Use Plus on another device** shows a short code and QR. The new device opens [kody.video/unlocked](/unlocked) (same path shape as [kody.video/receive](/receive)) and types or scans the code. Legacy \`/unlocked?code=\` links still work. That mints a short-lived mapping to the same Stripe session — not a password. A checkout session id still works if you have one. Stripe receipt URLs do not include that session id.
 
 ## Other network calls
 

--- a/public/_redirects
+++ b/public/_redirects
@@ -14,6 +14,7 @@
 # and Stripe's return to /unlocked when this was first attempted).
 /project/*    /app    200
 /unlocked     /app    200
+/unlocked/*   /app    200
 /about        /app    200
 /privacy      /app    200
 /terms        /app    200

--- a/public/auth.md
+++ b/public/auth.md
@@ -17,7 +17,7 @@ Kody Video has **no accounts**.
 
 Plus is a one-time $0.99 [Stripe Payment Link](https://buy.stripe.com/00wfZi71ibU30rk9hU2Ry07). After checkout, Stripe redirects to `/unlocked?session_id=<CHECKOUT_SESSION_ID>`. `/api/verify-purchase` checks that session server-side; the entitlement is then stored on the device. 100%-off promotion codes use the same verification.
 
-Restore on another device from the device that already has Plus: About → **Use Plus on another device** shows a short code and QR. The new device types the code under **Already paid?** or opens `/unlocked?code=`. That mints a short-lived mapping to the same Stripe session — not a password. A checkout session id still works if you have one. Stripe receipt URLs do not include that session id.
+Restore on another device from the device that already has Plus: About → **Use Plus on another device** shows a short code and QR. The new device opens `/unlocked` (same path shape as `/receive`) and types or scans the code — `/unlocked/ABC234`. Legacy `/unlocked?code=` links still work. That mints a short-lived mapping to the same Stripe session — not a password. A checkout session id still works if you have one. Stripe receipt URLs do not include that session id.
 
 ## Other network calls
 

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -65,6 +65,7 @@ export function App(handle: Handle) {
             <ProjectPage projectId={params.projectId ?? ''} />
           ),
           '/unlocked': () => <UnlockedPage />,
+          '/unlocked/:code': (params) => <UnlockedPage code={params.code ?? ''} />,
           '/about': () => <AboutPage />,
           '/privacy': () => <PrivacyPage />,
           '/terms': () => <TermsPage />,

--- a/src/components/backup-drop-overlay.tsx
+++ b/src/components/backup-drop-overlay.tsx
@@ -2,11 +2,13 @@ import type { Handle } from 'remix/ui'
 import { on } from 'remix/ui'
 import { reportError } from '../lib/error-reporting'
 import {
+  BackupCopyError,
   BackupFormatError,
   dataTransferHasFiles,
   importKodyVideoBackupFile,
   kodyVideoBackupFilesFromList,
 } from '../lib/project-transfer'
+import { ProjectLimitError, StorageQuotaExceededError } from '../lib/storage'
 import { navigate } from '../router'
 
 /**
@@ -46,7 +48,14 @@ export function BackupDropOverlay(handle: Handle) {
         })
         navigate(`/project/${project.id}`)
       } catch (err) {
-        if (!(err instanceof BackupFormatError)) reportError(err, 'import-drop')
+        if (
+          !(err instanceof BackupFormatError) &&
+          !(err instanceof BackupCopyError) &&
+          !(err instanceof StorageQuotaExceededError) &&
+          !(err instanceof ProjectLimitError)
+        ) {
+          reportError(err, 'import-drop')
+        }
         error = err instanceof Error ? err.message : 'Could not import that file'
       } finally {
         progress = null

--- a/src/components/restore-sheet.tsx
+++ b/src/components/restore-sheet.tsx
@@ -14,7 +14,7 @@ interface RestoreSheetProps {
 
 /**
  * Restore Kody Video Plus on a new device: paste a short code from the
- * device that already has Plus, scan its QR (opens /unlocked?code=), or
+ * device that already has Plus, scan its QR (opens /unlocked/:code), or
  * paste a checkout session id.
  */
 export function RestoreSheet(handle: Handle<RestoreSheetProps>) {

--- a/src/components/send-sheet.tsx
+++ b/src/components/send-sheet.tsx
@@ -7,6 +7,7 @@ import { createSyncRoom, httpSyncSignaling, SyncSignalError } from '../lib/sync-
 import { sendBackupToPeer, SyncTransferError } from '../lib/sync-peer'
 import { getClipsForProject, getProject, getProjectAudio } from '../lib/storage'
 import { projectBackupFilename, serializeProject } from '../lib/project-transfer'
+import { pairingHint, pairingHref } from '../lib/pairing-href'
 import { formatBytes } from '../lib/storage-space'
 import { SyncQr } from './sync-qr'
 
@@ -22,7 +23,7 @@ function phaseCopy(phase: SyncPhase, error: string | null): string {
     case 'creating':
       return 'Starting a send room…'
     case 'waiting':
-      return 'Open kody.video/receive on the other device and scan or type this code. Keep both screens open.'
+      return `Open ${pairingHint('receive')} on the other device and scan or type this code. Keep both screens open.`
     case 'connecting':
       return 'Connecting to the other device…'
     case 'transferring':
@@ -105,10 +106,7 @@ export function SendSheet(handle: Handle<SendSheetProps>) {
     }
   })()
 
-  const receiveHref = () => {
-    const origin = window.location.origin
-    return code ? `${origin}/receive/${code}` : `${origin}/receive`
-  }
+  const receiveHref = () => pairingHref('receive', code)
 
   return () => {
     const { projectName, onClose, onBackupInstead } = handle.props

--- a/src/components/share-plus-sheet.tsx
+++ b/src/components/share-plus-sheet.tsx
@@ -1,6 +1,7 @@
 import type { Handle } from 'remix/ui'
 import { on, ref } from 'remix/ui'
 import { attachSheetModal } from '../lib/sheet-modal'
+import { pairingHint, pairingHref } from '../lib/pairing-href'
 import { formatRoomCode } from '../lib/sync-protocol'
 import { getPurchaseSessionId, mintRestoreCode } from '../lib/entitlement'
 import { SyncQr } from './sync-qr'
@@ -49,10 +50,7 @@ export function SharePlusSheet(handle: Handle<SharePlusSheetProps>) {
 
   void load()
 
-  const unlockHref = () => {
-    const origin = window.location.origin
-    return code ? `${origin}/unlocked?code=${encodeURIComponent(code)}` : `${origin}/unlocked`
-  }
+  const unlockHref = () => pairingHref('unlocked', code)
 
   return () => {
     const { onClose } = handle.props
@@ -81,7 +79,7 @@ export function SharePlusSheet(handle: Handle<SharePlusSheetProps>) {
             {error ??
               (busy
                 ? 'Making a short code…'
-                : 'On the new device, open kody.video and tap Already paid? Type this code, or scan the QR. It expires in 30 minutes.')}
+                : `Open ${pairingHint('unlocked')} on the other device and scan or type this code. It expires in 30 minutes.`)}
           </p>
           {code ? (
             <div className="sync-code-block">

--- a/src/components/sync-qr.tsx
+++ b/src/components/sync-qr.tsx
@@ -1,6 +1,5 @@
 import type { Handle } from 'remix/ui'
-import { ref } from 'remix/ui'
-import { renderSVG } from 'uqr'
+import { qrSvgDataUrl } from '../lib/sync-qr-svg'
 
 interface SyncQrProps {
   href: string
@@ -10,20 +9,14 @@ interface SyncQrProps {
 /** QR for a pairing URL — scanned on the other device. */
 export function SyncQr(handle: Handle<SyncQrProps>) {
   return () => {
-    const svg = renderSVG(handle.props.href, {
-      ecc: 'M',
-      pixelSize: 8,
-      whiteColor: '#f3f5f4',
-      blackColor: '#1a2824',
-    })
+    const label = handle.props.label ?? 'QR code to receive this project'
     return (
-      <div
+      <img
         className="sync-qr"
-        role="img"
-        aria-label={handle.props.label ?? 'QR code to receive this project'}
-        mix={ref((node) => {
-          ;(node as HTMLElement).innerHTML = svg
-        })}
+        src={qrSvgDataUrl(handle.props.href)}
+        alt={label}
+        width={220}
+        height={220}
       />
     )
   }

--- a/src/lib/entitlement.test.ts
+++ b/src/lib/entitlement.test.ts
@@ -31,6 +31,18 @@ describe('extractRestoreToken', () => {
       kind: 'code',
       value: 'ABC234',
     })
+    expect(extractRestoreToken('https://kody.video/unlocked/ABC234')).toEqual({
+      kind: 'code',
+      value: 'ABC234',
+    })
+    expect(extractRestoreToken('https://kody.video/unlocked/ABC-234')).toEqual({
+      kind: 'code',
+      value: 'ABC234',
+    })
+    expect(extractRestoreToken('kody.video/unlocked/ABC234')).toEqual({
+      kind: 'code',
+      value: 'ABC234',
+    })
   })
 
   it('does not treat a Stripe receipt URL as a session id', () => {

--- a/src/lib/entitlement.ts
+++ b/src/lib/entitlement.ts
@@ -121,8 +121,18 @@ function extractCodeFromText(text: string): string | null {
     const url = new URL(trimmed)
     const fromQuery = normalizeRoomCode(url.searchParams.get('code') ?? '')
     if (fromQuery) return fromQuery
+    const pathMatch = url.pathname.match(/\/unlocked\/([A-Za-z0-9-]+)/i)
+    if (pathMatch?.[1]) {
+      const fromPath = normalizeRoomCode(pathMatch[1])
+      if (fromPath) return fromPath
+    }
   } catch {
     // Pasted text is often a bare code, not an absolute URL.
+  }
+  const pathMatch = trimmed.match(/\/unlocked\/([A-Za-z0-9-]+)(?:[/?#]|$)/i)
+  if (pathMatch?.[1]) {
+    const fromPath = normalizeRoomCode(pathMatch[1])
+    if (fromPath) return fromPath
   }
   const queryMatch = trimmed.match(/[?&]code=([A-Za-z0-9-]+)/i)
   if (queryMatch?.[1]) {

--- a/src/lib/error-reporting.test.ts
+++ b/src/lib/error-reporting.test.ts
@@ -220,6 +220,12 @@ describe('isExpectedUserError / reportError', () => {
     expect(isExpectedUserError(new Error('Export failed'))).toBe(false)
   })
 
+  it('recognizes BackupCopyError as expected import guidance', () => {
+    const error = new Error('The browser could not copy this backup')
+    error.name = 'BackupCopyError'
+    expect(isExpectedUserError(error)).toBe(true)
+  })
+
   it('reportError stays silent for StorageQuotaExceededError and raw QuotaExceededError', () => {
     expect(() => reportError(new StorageQuotaExceededError(), 'import')).not.toThrow()
     expect(() =>

--- a/src/lib/error-reporting.ts
+++ b/src/lib/error-reporting.ts
@@ -495,6 +495,8 @@ export function isExpectedUserError(error: unknown): boolean {
   // Device quota full (KODY-VIDEO-12) — wrapped or raw Chromium DOMException.
   if (error.name === 'StorageQuotaExceededError') return true
   if (error.name === 'QuotaExceededError') return true
+  // Large-file copy refused in RAM even though disk still has room.
+  if (error.name === 'BackupCopyError') return true
   // Raw Chromium open failure if something reports before storage wraps it.
   if (isIndexedDbBackingStoreOpenText(error.name, error.message)) return true
   // Missing IndexedDB global (KODY-VIDEO-10) before storage wraps it.

--- a/src/lib/pairing-href.test.ts
+++ b/src/lib/pairing-href.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest'
+import { pairingHint, pairingHref } from './pairing-href'
+
+describe('pairingHref', () => {
+  it('uses the same /kind and /kind/:code shape for receive and unlock', () => {
+    expect(pairingHref('receive', null, 'https://kody.video')).toBe('https://kody.video/receive')
+    expect(pairingHref('receive', 'AB3K9Q', 'https://kody.video')).toBe(
+      'https://kody.video/receive/AB3K9Q',
+    )
+    expect(pairingHref('unlocked', null, 'https://kody.video')).toBe('https://kody.video/unlocked')
+    expect(pairingHref('unlocked', 'ABC234', 'https://kody.video')).toBe(
+      'https://kody.video/unlocked/ABC234',
+    )
+  })
+})
+
+describe('pairingHint', () => {
+  it('prints the production host path', () => {
+    expect(pairingHint('receive')).toBe('kody.video/receive')
+    expect(pairingHint('unlocked')).toBe('kody.video/unlocked')
+  })
+})

--- a/src/lib/pairing-href.ts
+++ b/src/lib/pairing-href.ts
@@ -1,0 +1,17 @@
+/** Canonical pairing URLs — same path shape for receive and Plus unlock. */
+
+export type PairingKind = 'receive' | 'unlocked'
+
+export function pairingHref(
+  kind: PairingKind,
+  code?: string | null,
+  origin: string = typeof window !== 'undefined' ? window.location.origin : '',
+): string {
+  const base = `${origin}/${kind}`
+  return code ? `${base}/${code}` : base
+}
+
+/** Spoken/printed host path (always the production host, like the About copy). */
+export function pairingHint(kind: PairingKind): string {
+  return `kody.video/${kind}`
+}

--- a/src/lib/project-transfer.test.ts
+++ b/src/lib/project-transfer.test.ts
@@ -381,6 +381,7 @@ describe('project backup round trip', () => {
     try {
       await expect(assertBackupFitsStorage(50)).rejects.toBeInstanceOf(StorageQuotaExceededError)
       await expect(assertBackupFitsStorage(50)).rejects.toThrow(/free/i)
+      await expect(assertBackupFitsStorage(50)).rejects.toThrow(/imports need/i)
     } finally {
       Object.defineProperty(navigator.storage, 'estimate', {
         configurable: true,

--- a/src/lib/project-transfer.test.ts
+++ b/src/lib/project-transfer.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 import {
   __resetProjectTransferForTests,
+  assertBackupFitsStorage,
   BackupFormatError,
   dataTransferHasFiles,
   importKodyVideoBackupFile,
@@ -17,6 +18,7 @@ import {
   getProjectAudio,
   listProjects,
   ProjectLimitError,
+  StorageQuotaExceededError,
 } from './storage'
 import { markWatermarkRemoved } from './entitlement'
 import type { ClipRecord, Project, ProjectAudioRecord } from './types'
@@ -368,6 +370,23 @@ describe('project backup round trip', () => {
       false,
     )
     expect(dataTransferHasFiles(null)).toBe(false)
+  })
+
+  it('refuses an import when the remaining quota cannot hold the file', async () => {
+    const estimate = navigator.storage.estimate.bind(navigator.storage)
+    Object.defineProperty(navigator.storage, 'estimate', {
+      configurable: true,
+      value: async () => ({ usage: 90, quota: 100 }),
+    })
+    try {
+      await expect(assertBackupFitsStorage(50)).rejects.toBeInstanceOf(StorageQuotaExceededError)
+      await expect(assertBackupFitsStorage(50)).rejects.toThrow(/free/i)
+    } finally {
+      Object.defineProperty(navigator.storage, 'estimate', {
+        configurable: true,
+        value: estimate,
+      })
+    }
   })
 
   it('imports a backup file through the shared picker/drop helper', async () => {

--- a/src/lib/project-transfer.ts
+++ b/src/lib/project-transfer.ts
@@ -11,10 +11,9 @@ import {
   updateProjectAudioTrack,
 } from './storage'
 import {
-  availableBytes,
   backupFitsStorage,
+  backupTooLargeMessage,
   estimateStorageSpace,
-  formatBytes,
   requestPersistentStorage,
 } from './storage-space'
 import {
@@ -369,10 +368,7 @@ export async function assertBackupFitsStorage(backupBytes: number): Promise<void
   await requestPersistentStorage()
   const space = await estimateStorageSpace()
   if (backupFitsStorage(backupBytes, space)) return
-  const free = availableBytes(space)
-  throw new StorageQuotaExceededError(
-    `This backup is ${formatBytes(backupBytes)} and this device has ${formatBytes(free)} free. Delete a project or clear cached exports, then try again.`,
-  )
+  throw new StorageQuotaExceededError(backupTooLargeMessage(backupBytes, space))
 }
 
 /**
@@ -383,7 +379,7 @@ export async function assertBackupFitsStorage(backupBytes: number): Promise<void
 async function throwImportWriteError(error: unknown, backupBytes: number): Promise<never> {
   if (isQuotaExceededError(error) || error instanceof StorageQuotaExceededError) {
     const space = await estimateStorageSpace()
-    if (space && availableBytes(space) > backupBytes) {
+    if (space && backupFitsStorage(backupBytes, space)) {
       throw new BackupCopyError(
         'The browser could not copy this backup into on-device storage. Try again, or import on a computer (Chrome works best).',
       )

--- a/src/lib/project-transfer.ts
+++ b/src/lib/project-transfer.ts
@@ -4,11 +4,19 @@ import {
   addProjectAudioTrack,
   createProject,
   deleteProject,
+  isQuotaExceededError,
+  StorageQuotaExceededError,
   throwMappedStorageWriteError,
   updateClipTrim,
   updateProjectAudioTrack,
 } from './storage'
-import { requestPersistentStorage } from './storage-space'
+import {
+  availableBytes,
+  backupFitsStorage,
+  estimateStorageSpace,
+  formatBytes,
+  requestPersistentStorage,
+} from './storage-space'
 import {
   clampImageDurationMs,
   type ClipRecord,
@@ -354,17 +362,61 @@ function assertImportableClip(clip: ParsedBackup['clips'][number]): void {
 }
 
 /**
+ * Refuse an import when the remaining origin quota cannot hold the file.
+ * Missing estimates skip the gate (the write still has a quota catch).
+ */
+export async function assertBackupFitsStorage(backupBytes: number): Promise<void> {
+  await requestPersistentStorage()
+  const space = await estimateStorageSpace()
+  if (backupFitsStorage(backupBytes, space)) return
+  const free = availableBytes(space)
+  throw new StorageQuotaExceededError(
+    `This backup is ${formatBytes(backupBytes)} and this device has ${formatBytes(free)} free. Delete a project or clear cached exports, then try again.`,
+  )
+}
+
+/**
+ * QuotaExceededError during a giant File copy is often a RAM allocation
+ * refusal, not a full disk. If the estimate still shows room for the
+ * backup, say that instead of "Device storage is full".
+ */
+async function throwImportWriteError(error: unknown, backupBytes: number): Promise<never> {
+  if (isQuotaExceededError(error) || error instanceof StorageQuotaExceededError) {
+    const space = await estimateStorageSpace()
+    if (space && availableBytes(space) > backupBytes) {
+      throw new BackupCopyError(
+        'The browser could not copy this backup into on-device storage. Try again, or import on a computer (Chrome works best).',
+      )
+    }
+    if (error instanceof StorageQuotaExceededError) throw error
+    throw new StorageQuotaExceededError()
+  }
+  throwMappedStorageWriteError(error)
+}
+
+/**
+ * A write failed even though the disk estimate still has room — usually a
+ * huge in-memory copy the browser refused. Expected; not a crash report.
+ */
+export class BackupCopyError extends Error {
+  override readonly name = 'BackupCopyError'
+}
+
+/**
  * Parse a backup file and persist it as a new project. Requests persistent
- * storage on success (same as the About picker / drop import paths).
+ * storage first so a large write is less likely to hit a temporary quota.
  */
 export async function importKodyVideoBackupFile(
   file: File,
   onProgress?: (doneClips: number, totalClips: number) => void,
 ): Promise<Project> {
+  await assertBackupFitsStorage(file.size)
   const parsed = await parseProjectBackup(file)
-  const project = await importProjectBackup(parsed, onProgress)
-  requestPersistentStorage()
-  return project
+  try {
+    return await importProjectBackup(parsed, onProgress)
+  } catch (error) {
+    return await throwImportWriteError(error, file.size)
+  }
 }
 
 /** Create a fresh project (new ids) from a parsed backup. */
@@ -390,16 +442,13 @@ async function persistImportedProject(
     onProgress?.(0, parsed.clips.length)
     for (const clip of parsed.clips) {
       assertImportableClip(clip)
-      // CRITICAL: materialize the media bytes. The parsed blob is a lazy
-      // slice of the picked backup File; persisting that into IndexedDB
-      // stores a reference to the underlying file, which goes stale (esp.
-      // Android content URIs) and leaves clips unreadable. Reading it here
-      // both copies the bytes and proves the file is intact.
-      const bytes = await clip.blob.arrayBuffer()
+      // Pass the File.slice straight to addClip — toStoredBlob copies it
+      // in chunks so a ~1GB clip never needs one giant ArrayBuffer (that
+      // throw was remapped to "Device storage is full" even with room).
       const isImage = clip.kind === 'image'
       const added = await addClip({
         projectId: project.id,
-        blob: new Blob([bytes], { type: clip.mimeType }),
+        blob: clip.blob,
         mimeType: clip.mimeType,
         kind: clip.kind,
         // Photo durations re-clamp into the supported range on the way in.
@@ -436,10 +485,9 @@ async function persistImportedProject(
     // rollback below never leaves half the music behind.
     if (parsed.audio && plus) {
       for (const track of parsed.audio.tracks) {
-        const bytes = await track.blob.arrayBuffer()
         const record = await addProjectAudioTrack({
           projectId: project.id,
-          blob: new Blob([bytes], { type: track.mimeType }),
+          blob: track.blob,
           mimeType: track.mimeType,
           durationMs: track.durationMs,
           name: track.name,
@@ -469,8 +517,6 @@ async function persistImportedProject(
   } catch (error) {
     // Never leave a half-imported project behind.
     await deleteProject(project.id).catch(() => undefined)
-    // arrayBuffer() / IDB puts can throw bare QuotaExceededError with an
-    // empty message (KODY-VIDEO-12) — remap before surfacing to the UI.
-    throwMappedStorageWriteError(error)
+    throw error
   }
 }

--- a/src/lib/storage-space.test.ts
+++ b/src/lib/storage-space.test.ts
@@ -2,9 +2,11 @@ import { describe, expect, it } from 'vitest'
 import {
   availableBytes,
   backupFitsStorage,
+  backupTooLargeMessage,
   formatBytes,
   formatStoragePercent,
   IMPORT_SLACK_BYTES,
+  importNeedBytes,
   storageSeverity,
 } from './storage-space'
 
@@ -71,5 +73,14 @@ describe('availableBytes / backupFitsStorage', () => {
 
   it('skips the gate when the estimate is missing', () => {
     expect(backupFitsStorage(1e12, null)).toBe(true)
+  })
+
+  it('names both the file size and the room the import needs', () => {
+    const tight = { usedBytes: 90, quotaBytes: 100, ratio: 0.9 }
+    const message = backupTooLargeMessage(50, tight)
+    expect(message).toContain(formatBytes(50))
+    expect(message).toContain(formatBytes(availableBytes(tight)))
+    expect(message).toContain(formatBytes(importNeedBytes(50)))
+    expect(importNeedBytes(50)).toBe(50 + IMPORT_SLACK_BYTES)
   })
 })

--- a/src/lib/storage-space.test.ts
+++ b/src/lib/storage-space.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, it } from 'vitest'
-import { formatBytes, formatStoragePercent, storageSeverity } from './storage-space'
+import {
+  availableBytes,
+  backupFitsStorage,
+  formatBytes,
+  formatStoragePercent,
+  IMPORT_SLACK_BYTES,
+  storageSeverity,
+} from './storage-space'
 
 describe('storageSeverity', () => {
   it('is ok below 80%', () => {
@@ -39,5 +46,30 @@ describe('formatBytes', () => {
 describe('formatStoragePercent', () => {
   it('rounds to whole percent', () => {
     expect(formatStoragePercent(0.876)).toBe('88%')
+  })
+})
+
+describe('availableBytes / backupFitsStorage', () => {
+  const space = { usedBytes: 5 * 1024 * 1024, quotaBytes: 10 * 1024 * 1024 * 1024, ratio: 0 }
+
+  it('reports remaining quota', () => {
+    expect(availableBytes(space)).toBe(space.quotaBytes - space.usedBytes)
+    expect(availableBytes(null)).toBe(0)
+  })
+
+  it('lets a ~1GB backup through when 10GB is mostly free', () => {
+    expect(backupFitsStorage(918.7 * 1024 * 1024, space)).toBe(true)
+  })
+
+  it('refuses when the remaining quota cannot hold the file plus slack', () => {
+    const tight = { usedBytes: 90, quotaBytes: 100, ratio: 0.9 }
+    expect(backupFitsStorage(50, tight)).toBe(false)
+    expect(backupFitsStorage(1, { usedBytes: 0, quotaBytes: IMPORT_SLACK_BYTES + 2, ratio: 0 })).toBe(
+      true,
+    )
+  })
+
+  it('skips the gate when the estimate is missing', () => {
+    expect(backupFitsStorage(1e12, null)).toBe(true)
   })
 })

--- a/src/lib/storage-space.ts
+++ b/src/lib/storage-space.ts
@@ -37,6 +37,28 @@ export function formatBytes(bytes: number): string {
   return `${Math.max(1, Math.round(mb))} MB`
 }
 
+/** Bytes the origin can still write (0 when the estimate is missing). */
+export function availableBytes(space: StorageSpace | null | undefined): number {
+  if (!space) return 0
+  return Math.max(0, space.quotaBytes - space.usedBytes)
+}
+
+/**
+ * Headroom for IndexedDB overhead and generated thumbs so a backup that
+ * *just* fits the remaining quota does not fail midway.
+ */
+export const IMPORT_SLACK_BYTES = 32 * 1024 * 1024
+
+/** True when a backup of `backupBytes` should fit in the remaining quota. */
+export function backupFitsStorage(
+  backupBytes: number,
+  space: StorageSpace | null | undefined,
+): boolean {
+  if (!space) return true
+  if (!Number.isFinite(backupBytes) || backupBytes <= 0) return true
+  return availableBytes(space) >= backupBytes + IMPORT_SLACK_BYTES
+}
+
 export function formatStoragePercent(ratio: number): string {
   return `${Math.round(ratio * 100)}%`
 }
@@ -46,9 +68,9 @@ export function formatStoragePercent(ratio: number): string {
  * can't be silently evicted under storage pressure. Chromium grants it
  * without any prompt for engaged/installed origins; fire-and-forget.
  */
-export function requestPersistentStorage(): void {
+export async function requestPersistentStorage(): Promise<void> {
   try {
-    void navigator.storage?.persist?.().catch(() => undefined)
+    await navigator.storage?.persist?.()
   } catch {
     // Older browsers: nothing to do.
   }

--- a/src/lib/storage-space.ts
+++ b/src/lib/storage-space.ts
@@ -49,6 +49,12 @@ export function availableBytes(space: StorageSpace | null | undefined): number {
  */
 export const IMPORT_SLACK_BYTES = 32 * 1024 * 1024
 
+/** Bytes an import of this backup should leave free (file + thumbs slack). */
+export function importNeedBytes(backupBytes: number): number {
+  if (!Number.isFinite(backupBytes) || backupBytes <= 0) return IMPORT_SLACK_BYTES
+  return backupBytes + IMPORT_SLACK_BYTES
+}
+
 /** True when a backup of `backupBytes` should fit in the remaining quota. */
 export function backupFitsStorage(
   backupBytes: number,
@@ -56,7 +62,16 @@ export function backupFitsStorage(
 ): boolean {
   if (!space) return true
   if (!Number.isFinite(backupBytes) || backupBytes <= 0) return true
-  return availableBytes(space) >= backupBytes + IMPORT_SLACK_BYTES
+  return availableBytes(space) >= importNeedBytes(backupBytes)
+}
+
+/** User-facing copy when a backup does not fit the remaining quota. */
+export function backupTooLargeMessage(
+  backupBytes: number,
+  space: StorageSpace | null | undefined,
+): string {
+  const free = availableBytes(space)
+  return `This backup is ${formatBytes(backupBytes)} and this device has ${formatBytes(free)} free (imports need about ${formatBytes(importNeedBytes(backupBytes))}). Delete a project or clear cached exports, then try again.`
 }
 
 export function formatStoragePercent(ratio: number): string {

--- a/src/lib/storage.test.ts
+++ b/src/lib/storage.test.ts
@@ -40,6 +40,7 @@ import {
   StorageQuotaExceededError,
   isQuotaExceededError,
   throwMappedStorageWriteError,
+  copyBlobForStorage,
   toStoredBlob,
   undoDeleteLastClip,
   updateClipAudioPeak,
@@ -797,6 +798,16 @@ describe('storage layer', () => {
     expect(copy).not.toBe(original)
     expect(copy.type).toBe('video/webm')
     expect(await copy.text()).toBe('recorder-bytes')
+  })
+
+  it('copyBlobForStorage copies large blobs in chunks without losing bytes', async () => {
+    const payload = 'ABCDEFGHIJ'
+    const original = new Blob([payload], { type: 'video/mp4' })
+    const copy = await copyBlobForStorage(original, 'video/mp4', 3)
+    expect(copy).not.toBe(original)
+    expect(copy.type).toBe('video/mp4')
+    expect(copy.size).toBe(original.size)
+    expect(await copy.text()).toBe(payload)
   })
 
   it('toStoredBlob falls back to the clip mime when Blob.type is empty', async () => {

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -728,12 +728,37 @@ export function insertClipIdAfter(
  * with UnknownError ("Error preparing Blob/File data to be stored…") when
  * the original backing store is ephemeral or already released.
  *
+ * Large clips are copied in chunks: a single `arrayBuffer()` of a ~1GB
+ * File (or File.slice) throws QuotaExceededError on many phones even when
+ * disk quota is fine — the browser is refusing a giant RAM allocation, not
+ * reporting a full disk. Chunked reads keep peak allocation small.
+ *
  * Prefer `mimeType` when the source Blob's type is empty so Safari does not
  * later reject an `application/octet-stream` object URL at export.
  */
+export const STORED_BLOB_CHUNK_BYTES = 8 * 1024 * 1024
+
+export async function copyBlobForStorage(
+  blob: Blob,
+  mimeType?: string,
+  chunkBytes: number = STORED_BLOB_CHUNK_BYTES,
+): Promise<Blob> {
+  const type = blob.type || mimeType || 'application/octet-stream'
+  const size = chunkBytes > 0 ? chunkBytes : STORED_BLOB_CHUNK_BYTES
+  if (blob.size <= size) {
+    const buffer = await blob.arrayBuffer()
+    return new Blob([buffer], { type })
+  }
+  const parts: ArrayBuffer[] = []
+  for (let offset = 0; offset < blob.size; offset += size) {
+    const end = Math.min(offset + size, blob.size)
+    parts.push(await blob.slice(offset, end).arrayBuffer())
+  }
+  return new Blob(parts, { type })
+}
+
 export async function toStoredBlob(blob: Blob, mimeType?: string): Promise<Blob> {
-  const buffer = await blob.arrayBuffer()
-  return new Blob([buffer], { type: blob.type || mimeType || 'application/octet-stream' })
+  return copyBlobForStorage(blob, mimeType)
 }
 
 export async function addClip(input: AddClipInput): Promise<ClipRecord> {

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -749,10 +749,15 @@ export async function copyBlobForStorage(
     const buffer = await blob.arrayBuffer()
     return new Blob([buffer], { type })
   }
-  const parts: ArrayBuffer[] = []
+  // Read one chunk at a time and wrap it immediately. Holding every
+  // ArrayBuffer until the end would keep peak RAM at the full file size
+  // (the allocation that phones refuse). File.slice parts would not copy,
+  // so IndexedDB can still fail on ephemeral picker / MediaRecorder blobs.
+  const parts: Blob[] = []
   for (let offset = 0; offset < blob.size; offset += size) {
     const end = Math.min(offset + size, blob.size)
-    parts.push(await blob.slice(offset, end).arrayBuffer())
+    const buffer = await blob.slice(offset, end).arrayBuffer()
+    parts.push(new Blob([buffer]))
   }
   return new Blob(parts, { type })
 }

--- a/src/lib/sync-qr-svg.test.ts
+++ b/src/lib/sync-qr-svg.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest'
+import { qrSvgDataUrl, qrSvgMarkup } from './sync-qr-svg'
+
+describe('qrSvgMarkup', () => {
+  it('emits an SVG with a viewBox so it can scale in CSS', () => {
+    const svg = qrSvgMarkup('https://kody.video/receive/AB3K9Q')
+    expect(svg).toContain('<svg')
+    expect(svg).toMatch(/viewBox="/)
+    expect(svg).toContain('#1a2824')
+  })
+})
+
+describe('qrSvgDataUrl', () => {
+  it('is a usable image src', () => {
+    const src = qrSvgDataUrl('https://kody.video/unlocked/ABC234')
+    expect(src.startsWith('data:image/svg+xml;charset=utf-8,')).toBe(true)
+    expect(decodeURIComponent(src.slice('data:image/svg+xml;charset=utf-8,'.length))).toContain(
+      '<svg',
+    )
+  })
+})

--- a/src/lib/sync-qr-svg.ts
+++ b/src/lib/sync-qr-svg.ts
@@ -1,0 +1,23 @@
+import { renderSVG } from 'uqr'
+
+/** SVG QR for a pairing URL, with a viewBox so CSS can scale it reliably. */
+export function qrSvgMarkup(href: string): string {
+  let svg = renderSVG(href, {
+    ecc: 'M',
+    pixelSize: 8,
+    whiteColor: '#f3f5f4',
+    blackColor: '#1a2824',
+  })
+  if (!/viewBox=/.test(svg)) {
+    const width = svg.match(/\bwidth="(\d+(?:\.\d+)?)"/)?.[1]
+    const height = svg.match(/\bheight="(\d+(?:\.\d+)?)"/)?.[1]
+    if (width && height) {
+      svg = svg.replace('<svg', `<svg viewBox="0 0 ${width} ${height}"`)
+    }
+  }
+  return svg
+}
+
+export function qrSvgDataUrl(href: string): string {
+  return `data:image/svg+xml;charset=utf-8,${encodeURIComponent(qrSvgMarkup(href))}`
+}

--- a/src/pages/about-page.tsx
+++ b/src/pages/about-page.tsx
@@ -18,8 +18,19 @@ import { buildDateLabel, COMMIT_SHA, commitUrl, shortVersion } from '../lib/buil
 import { reportError } from '../lib/error-reporting'
 import { clearExportCache, estimateExportCacheBytes } from '../lib/export/export-cache'
 import { listRearCameras } from '../lib/media'
-import { BackupFormatError, importKodyVideoBackupFile } from '../lib/project-transfer'
-import { estimateStorageSpace, formatBytes, type StorageSpace } from '../lib/storage-space'
+import {
+  BackupCopyError,
+  BackupFormatError,
+  importKodyVideoBackupFile,
+} from '../lib/project-transfer'
+import {
+  availableBytes,
+  backupFitsStorage,
+  estimateStorageSpace,
+  formatBytes,
+  type StorageSpace,
+} from '../lib/storage-space'
+import { ProjectLimitError, StorageQuotaExceededError } from '../lib/storage'
 import { getSettings, setVideoQuality } from '../lib/storage'
 import { resolveVideoQuality, type VideoQualityPreset } from '../lib/video-quality'
 import { navigate } from '../router'
@@ -228,6 +239,12 @@ export function AboutPage(handle: Handle) {
 
   const importBackup = (file: File) => {
     void (async () => {
+      if (!backupFitsStorage(file.size, data.storage)) {
+        const free = availableBytes(data.storage)
+        importError = `This backup is ${formatBytes(file.size)} and this device has ${formatBytes(free)} free. Delete a project or clear cached exports, then try again.`
+        void handle.update()
+        return
+      }
       importing = true
       importError = null
       importProgress = 'Reading backup…'
@@ -240,8 +257,15 @@ export function AboutPage(handle: Handle) {
         // Land directly in the imported project — unambiguous success.
         navigate(`/project/${project.id}`)
       } catch (err) {
-        // Wrong/damaged file picked = expected user input, not a crash.
-        if (!(err instanceof BackupFormatError)) reportError(err, 'import')
+        // Wrong/damaged file, plan cap, or a full disk = expected guidance.
+        if (
+          !(err instanceof BackupFormatError) &&
+          !(err instanceof BackupCopyError) &&
+          !(err instanceof StorageQuotaExceededError) &&
+          !(err instanceof ProjectLimitError)
+        ) {
+          reportError(err, 'import')
+        }
         importError = err instanceof Error ? err.message : 'Could not import that file'
       } finally {
         importProgress = null
@@ -292,7 +316,16 @@ export function AboutPage(handle: Handle) {
     if (!hashScrolled && location.hash === '#video-quality') {
       hashScrolled = true
       queueMicrotask(() => {
-        document.getElementById('video-quality')?.scrollIntoView({ block: 'start' })
+        const section = document.getElementById('video-quality')
+        const scroller = document.querySelector('.about-screen .about-body')
+        if (section && scroller instanceof HTMLElement) {
+          const top =
+            section.getBoundingClientRect().top -
+            scroller.getBoundingClientRect().top +
+            scroller.scrollTop
+          scroller.scrollTo({ top: Math.max(0, top - 8) })
+        }
+        window.scrollTo(0, 0)
       })
     }
     const version = <code>{shortVersion()}</code>
@@ -321,7 +354,9 @@ export function AboutPage(handle: Handle) {
               <h2>Kody Video Plus</h2>
               <p>
                 This device is unlocked. To use Plus on a second phone or computer, show a short
-                code and QR the new device can type or scan — no Stripe receipt required.
+                code and QR — the other device opens{' '}
+                <a href="/unlocked">kody.video/unlocked</a> (same idea as{' '}
+                <a href="/receive">kody.video/receive</a>). No Stripe receipt required.
               </p>
               <button
                 type="button"
@@ -500,21 +535,28 @@ export function AboutPage(handle: Handle) {
               <a href="/receive">kody.video/receive</a>). Restore a backup here, or drop the file
               anywhere in the app:
             </p>
-            <label className={`btn btn-ghost about-import${importing ? ' is-disabled' : ''}`}>
-              Import a backup
-              <input
-                type="file"
-                accept=".kodyvideo,application/octet-stream"
-                className="visually-hidden"
-                disabled={importing}
-                mix={on('change', (event) => {
-                  const input = event.currentTarget as HTMLInputElement
-                  const file = input.files?.[0]
-                  input.value = ''
-                  if (file) importBackup(file)
-                })}
-              />
-            </label>
+            <div className="about-import-row">
+              <label className={`btn btn-ghost about-import${importing ? ' is-disabled' : ''}`}>
+                Import a backup
+                <input
+                  type="file"
+                  accept=".kodyvideo,application/octet-stream"
+                  className="visually-hidden"
+                  disabled={importing}
+                  mix={on('change', (event) => {
+                    const input = event.currentTarget as HTMLInputElement
+                    const file = input.files?.[0]
+                    input.value = ''
+                    if (file) importBackup(file)
+                  })}
+                />
+              </label>
+              {storage ? (
+                <p className="about-import-space">
+                  {formatBytes(availableBytes(storage))} available
+                </p>
+              ) : null}
+            </div>
             {importProgress ? (
               <p role="status" aria-live="polite">
                 {importProgress} Keep this tab open.

--- a/src/pages/about-page.tsx
+++ b/src/pages/about-page.tsx
@@ -25,7 +25,6 @@ import {
 } from '../lib/project-transfer'
 import {
   availableBytes,
-  backupFitsStorage,
   estimateStorageSpace,
   formatBytes,
   type StorageSpace,
@@ -239,12 +238,6 @@ export function AboutPage(handle: Handle) {
 
   const importBackup = (file: File) => {
     void (async () => {
-      if (!backupFitsStorage(file.size, data.storage)) {
-        const free = availableBytes(data.storage)
-        importError = `This backup is ${formatBytes(file.size)} and this device has ${formatBytes(free)} free. Delete a project or clear cached exports, then try again.`
-        void handle.update()
-        return
-      }
       importing = true
       importError = null
       importProgress = 'Reading backup…'

--- a/src/pages/unlocked-page.tsx
+++ b/src/pages/unlocked-page.tsx
@@ -8,15 +8,20 @@ import {
   type VerifyResult,
 } from '../lib/entitlement'
 
+interface UnlockedPageProps {
+  /** Path segment from /unlocked/:code — same shape as /receive/:code. */
+  code?: string
+}
+
 /**
  * Stripe's Payment Link redirects here after checkout with
  * ?session_id={CHECKOUT_SESSION_ID}. A Plus device can also mint a short
- * code whose QR opens ?code=ABC123. Setup verifies server-side and
- * persists the entitlement before rendering the result.
+ * code whose QR opens /unlocked/ABC123 (legacy ?code= still works). Setup
+ * verifies server-side and persists the entitlement before rendering.
  */
-async function verifyFromLocation(): Promise<VerifyResult> {
+async function verifyFromLocation(pathCode?: string): Promise<VerifyResult> {
   const params = new URL(window.location.href).searchParams
-  const raw = params.get('session_id') ?? params.get('code') ?? ''
+  const raw = params.get('session_id') ?? params.get('code') ?? pathCode ?? ''
   const token = extractRestoreToken(raw)
   if (!token) {
     return {
@@ -27,11 +32,11 @@ async function verifyFromLocation(): Promise<VerifyResult> {
   return verifyPurchase(token)
 }
 
-export function UnlockedPage(handle: Handle) {
+export function UnlockedPage(handle: Handle<UnlockedPageProps>) {
   let result: VerifyResult | null = null
   let sharing = false
 
-  void verifyFromLocation().then((verified) => {
+  void verifyFromLocation(handle.props.code).then((verified) => {
     if (handle.signal.aborted) return
     result = verified
     void handle.update()

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -668,17 +668,14 @@ a {
 }
 
 .sync-qr {
+  display: block;
   width: min(220px, 70vw);
+  height: auto;
   aspect-ratio: 1;
   padding: 10px;
   border-radius: 16px;
   background: #f3f5f4;
-}
-
-.sync-qr svg {
-  display: block;
-  width: 100%;
-  height: 100%;
+  object-fit: contain;
 }
 
 .receive-form {

--- a/src/styles/home.css
+++ b/src/styles/home.css
@@ -654,6 +654,11 @@
   justify-content: space-between;
   gap: 12px;
   margin-bottom: 4px;
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background: var(--bg);
+  padding-bottom: 8px;
 }
 
 .about-top strong {
@@ -771,9 +776,27 @@
   margin-top: 8px;
 }
 
-.about-import {
+.about-import-row {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 10px 14px;
   margin-top: 10px;
+}
+
+.about-import {
+  margin-top: 0;
   cursor: pointer;
+}
+
+.about-import-space {
+  margin: 0;
+  color: var(--ink-muted);
+  font-size: 0.88rem;
+}
+
+#video-quality {
+  scroll-margin-top: 8px;
 }
 
 .about-import.is-disabled {

--- a/tests/e2e/restore.spec.ts
+++ b/tests/e2e/restore.spec.ts
@@ -36,7 +36,12 @@ test.describe('Plus restore codes', () => {
       )
       expect(scheduleUpdateErrors).toEqual([])
 
-      await receiver.goto(`/unlocked?code=${code}`)
+      await expect(sheet.getByText(/kody\.video\/unlocked/)).toBeVisible()
+      await expect(sheet.locator('img.sync-qr')).toBeVisible()
+      const qrSrc = await sheet.locator('img.sync-qr').getAttribute('src')
+      expect(qrSrc ?? '').toMatch(/^data:image\/svg\+xml/)
+
+      await receiver.goto(`/unlocked/${code}`)
       await expect(receiver.getByRole('heading', { name: /Plus unlocked/ })).toBeVisible({
         timeout: 15_000,
       })

--- a/tests/e2e/storage.spec.ts
+++ b/tests/e2e/storage.spec.ts
@@ -125,6 +125,7 @@ test.describe('storage management', () => {
     )
 
     await page.getByRole('link', { name: 'More on About' }).click()
+    await expect(page.getByRole('link', { name: 'Back to projects' })).toBeInViewport()
     await expect(page.locator('#video-quality').getByRole('radio', { name: 'Saver' })).toHaveAttribute(
       'aria-checked',
       'true',
@@ -201,6 +202,8 @@ test.describe('storage management', () => {
   test('about page shows cache size and clears it', async ({ page }) => {
     await seedReferencedExportCache(page, 5 * 1024 * 1024)
     await page.goto('/about')
+    const backups = page.locator('.about-section', { hasText: 'Import a backup' })
+    await expect(backups.locator('.about-import-space')).toContainText(/available/)
     const section = page.locator('.about-section', { hasText: 'Cached export files' })
     await expect(section).toContainText('5 MB')
     await section.getByRole('button', { name: 'Clear' }).click()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Importing a large `.kodyvideo` backup (≈900 MB) failed with **Device storage is full** even when the origin still had gigabytes free. The write path loaded each clip with a single giant `arrayBuffer()`, which many browsers report as `QuotaExceededError` (a RAM allocation refusal, not a full disk). That error was remapped to the storage-full banner.

Related UX gaps:

- No remaining-space hint next to **Import a backup**, so people only learned they were short after picking a file.
- Sharing Plus did not name a URL the way **Send to device** names `kody.video/receive`, and the unlock link used `?code=` instead of a path.
- The pairing QR was injected with `innerHTML` via a Remix `ref`, so it could disappear or fail to scale after a re-render.
- **More on About** jumped to `#video-quality` with `scrollIntoView`, which could scroll the whole screen and hide the back control.

## Changes

- Copy large blobs in 8 MB chunks before IndexedDB (wrap each chunk in a Blob immediately so peak RAM is one chunk, not the whole file), and skip the extra whole-clip `arrayBuffer()` on import.
- Preflight remaining quota (file + slack) before import starts; if a write still throws quota but the estimate still has room, show a copy-failed message instead of “storage is full”.
- Show **N available** next to **Import a backup**.
- Use `/unlocked/:code` (same shape as `/receive/:code`), keep `?code=` / `?session_id=` working, and tell people to open `kody.video/unlocked`.
- Render pairing QR as a viewBox SVG data-URL `<img>`.
- Scroll only `.about-body` for `#video-quality` and keep the About header sticky so **Back to projects** stays on screen.

## Testing

- Unit: chunked blob copy, storage preflight, pairing hrefs, QR SVG, unlock path tokens, expected-error filter.
- E2E: About available-space label, back link stays in viewport after **More on About**, Plus share sheet URL + QR, redeem via `/unlocked/:code`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-aff64b49-4abd-410d-9da0-065f98d0d44c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-aff64b49-4abd-410d-9da0-065f98d0d44c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Plus restoration supports `/unlocked/<code>` links, with legacy links remaining compatible.
  * QR pairing codes now use improved, scalable images.
  * Backup imports show available storage and clearer space requirements.
* **Bug Fixes**
  * Improved handling of large backups to reduce memory usage and incomplete imports.
  * Expected backup and storage errors no longer generate unnecessary error reports.
* **Documentation**
  * Updated Plus restoration instructions for the new link and code-entry flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->