### PR TITLE
Let people type a Plus code on /unlocked

### DIFF
--- a/src/pages/unlocked-page.tsx
+++ b/src/pages/unlocked-page.tsx
@@ -1,57 +1,117 @@
 import type { Handle } from 'remix/ui'
-import { on } from 'remix/ui'
+import { on, ref } from 'remix/ui'
+import { IconBack } from '../components/icons'
 import { BrandMark } from '../components/brand-mark'
 import { SharePlusSheet } from '../components/share-plus-sheet'
 import {
   extractRestoreToken,
+  looksLikeStripeReceipt,
   verifyPurchase,
   type VerifyResult,
 } from '../lib/entitlement'
+import { formatRoomCode } from '../lib/sync-protocol'
 
 interface UnlockedPageProps {
   /** Path segment from /unlocked/:code — same shape as /receive/:code. */
   code?: string
 }
 
+type UnlockPhase = 'enter' | 'checking' | 'unlocked' | 'failed'
+
+function rawTokenFromLocation(pathCode?: string): string {
+  const params = new URL(window.location.href).searchParams
+  return params.get('session_id') ?? params.get('code') ?? pathCode ?? ''
+}
+
+function missingTokenMessage(raw: string): string {
+  if (looksLikeStripeReceipt(raw)) {
+    return 'Stripe receipt links do not include a restore handle. On the device that already has Plus, open About and tap Use Plus on another device.'
+  }
+  return 'Enter the short code from the other device, or a checkout session id starting with “cs_”.'
+}
+
+function phaseCopy(phase: UnlockPhase, error: string | null, hasDeepLink: boolean): string {
+  switch (phase) {
+    case 'enter':
+      return hasDeepLink
+        ? 'That is not a valid unlock code.'
+        : 'Type the code from the other device, or open the link / QR it showed.'
+    case 'checking':
+      return 'Checking your purchase…'
+    case 'unlocked':
+      return 'Purchase verified'
+    case 'failed':
+      return error ?? 'Could not verify this purchase.'
+    default: {
+      const exhaustive: never = phase
+      return exhaustive
+    }
+  }
+}
+
 /**
  * Stripe's Payment Link redirects here after checkout with
  * ?session_id={CHECKOUT_SESSION_ID}. A Plus device can also mint a short
- * code whose QR opens /unlocked/ABC123 (legacy ?code= still works). Setup
- * verifies server-side and persists the entitlement before rendering.
+ * code whose QR opens /unlocked/ABC123 (legacy ?code= still works). Bare
+ * /unlocked shows a form so people can type the code — same idea as
+ * /receive. Setup verifies server-side and persists the entitlement.
  */
-async function verifyFromLocation(pathCode?: string): Promise<VerifyResult> {
-  const params = new URL(window.location.href).searchParams
-  const raw = params.get('session_id') ?? params.get('code') ?? pathCode ?? ''
-  const token = extractRestoreToken(raw)
-  if (!token) {
-    return {
-      unlocked: false,
-      error: 'Missing checkout session or restore code. Use the code from the other device.',
-    }
-  }
-  return verifyPurchase(token)
-}
-
 export function UnlockedPage(handle: Handle<UnlockedPageProps>) {
-  let result: VerifyResult | null = null
+  const initialRaw = rawTokenFromLocation(handle.props.code)
+  const initialToken = extractRestoreToken(initialRaw)
+  let typed = handle.props.code ?? ''
+  let phase: UnlockPhase = initialToken ? 'checking' : 'enter'
+  let result: VerifyResult | null = initialToken
+    ? null
+    : initialRaw
+      ? { unlocked: false, error: missingTokenMessage(initialRaw) }
+      : null
   let sharing = false
 
-  void verifyFromLocation(handle.props.code).then((verified) => {
-    if (handle.signal.aborted) return
-    result = verified
-    void handle.update()
-  })
+  const verify = (raw: string) => {
+    const token = extractRestoreToken(raw)
+    if (!token) {
+      result = { unlocked: false, error: missingTokenMessage(raw) }
+      phase = 'failed'
+      void handle.update()
+      return
+    }
+    // Remix wires scheduleUpdate only after the first render commits. Calling
+    // handle.update() synchronously from setup (before any await) rejects with
+    // "scheduleUpdate not implemented". Mount with a token already starts in
+    // checking, so skip that paint; form submit still needs it.
+    const needsCheckingPaint = phase !== 'checking' || result !== null
+    phase = 'checking'
+    result = null
+    if (needsCheckingPaint) void handle.update()
+    void verifyPurchase(token).then((verified) => {
+      if (handle.signal.aborted) return
+      result = verified
+      phase = verified.unlocked ? 'unlocked' : 'failed'
+      void handle.update()
+    })
+  }
+
+  if (initialToken) verify(initialRaw)
 
   return () => (
-    <div className="screen unlocked-screen">
-      <div className="unlocked-card">
-        <BrandMark size={110} className="export-celebrate-art" variant="share" />
-        {result === null ? (
-          <>
-            <p className="eyebrow">Checking your purchase…</p>
-            <h1>One moment</h1>
-          </>
-        ) : result.unlocked ? (
+    <div className="screen about-screen receive-screen">
+      <div className="about-top">
+        <a href="/" className="btn-icon" aria-label="Back to projects">
+          <IconBack />
+        </a>
+        <strong>Unlock Plus</strong>
+        <span className="about-top-spacer" aria-hidden="true" />
+      </div>
+      <div className="about-body">
+        <div className="about-hero" aria-hidden="true">
+          <BrandMark
+            size={96}
+            className={phase === 'unlocked' ? 'export-celebrate-art' : 'brand-hero-art'}
+            variant={phase === 'unlocked' ? 'share' : 'icon'}
+          />
+        </div>
+        {phase === 'unlocked' ? (
           <>
             <p className="eyebrow">Purchase verified</p>
             <h1>Kody Video Plus unlocked! 🎉</h1>
@@ -65,17 +125,57 @@ export function UnlockedPage(handle: Handle<UnlockedPageProps>) {
           </>
         ) : (
           <>
-            <p className="eyebrow">Verification failed</p>
-            <h1>Hmm, that didn’t check out</h1>
+            <h1>{phase === 'checking' ? 'One moment' : 'Unlock Plus'}</h1>
             <p className="muted">
-              {result.error ?? 'Could not verify this purchase.'} If you paid and keep seeing
-              this, restore from the device that already has Plus (About → Use Plus on another
-              device).
+              {phaseCopy(phase, result?.error ?? null, Boolean(handle.props.code))}
             </p>
           </>
         )}
-        {result === null ? null : result.unlocked ? (
-          <div className="sheet-actions">
+        {handle.props.code && phase === 'checking' ? (
+          <p className="sync-code receive-code">{formatRoomCode(handle.props.code)}</p>
+        ) : null}
+        {phase === 'enter' || phase === 'failed' ? (
+          <form
+            className="receive-form"
+            mix={on('submit', (event) => {
+              event.preventDefault()
+              verify(typed)
+            })}
+          >
+            <div className="field">
+              <label htmlFor="unlock-code">Plus code</label>
+              <input
+                id="unlock-code"
+                type="text"
+                inputMode="text"
+                autoCapitalize="characters"
+                autoCorrect="off"
+                spellCheck={false}
+                autoComplete="off"
+                placeholder="ABC-234"
+                value={typed}
+                mix={[
+                  ref((node) => {
+                    if (phase === 'enter') (node as HTMLInputElement).focus()
+                  }),
+                  on('input', (event) => {
+                    typed = (event.currentTarget as HTMLInputElement).value
+                    void handle.update()
+                  }),
+                ]}
+              />
+            </div>
+            <button
+              type="submit"
+              className="btn btn-primary"
+              disabled={!extractRestoreToken(typed)}
+            >
+              Unlock
+            </button>
+          </form>
+        ) : null}
+        {phase === 'unlocked' ? (
+          <div className="sheet-actions receive-actions">
             <button
               type="button"
               className="btn btn-ghost"
@@ -90,11 +190,7 @@ export function UnlockedPage(handle: Handle<UnlockedPageProps>) {
               Start creating
             </a>
           </div>
-        ) : (
-          <a className="btn btn-primary" href="/">
-            Back to Kody Video
-          </a>
-        )}
+        ) : null}
       </div>
       {sharing ? (
         <SharePlusSheet

--- a/src/pages/unlocked-page.tsx
+++ b/src/pages/unlocked-page.tsx
@@ -30,12 +30,10 @@ function missingTokenMessage(raw: string): string {
   return 'Enter the short code from the other device, or a checkout session id starting with “cs_”.'
 }
 
-function phaseCopy(phase: UnlockPhase, error: string | null, hasDeepLink: boolean): string {
+function phaseCopy(phase: UnlockPhase, error: string | null): string {
   switch (phase) {
     case 'enter':
-      return hasDeepLink
-        ? 'That is not a valid unlock code.'
-        : 'Type the code from the other device, or open the link / QR it showed.'
+      return 'Type the code from the other device, or open the link / QR it showed.'
     case 'checking':
       return 'Checking your purchase…'
     case 'unlocked':
@@ -60,7 +58,7 @@ export function UnlockedPage(handle: Handle<UnlockedPageProps>) {
   const initialRaw = rawTokenFromLocation(handle.props.code)
   const initialToken = extractRestoreToken(initialRaw)
   let typed = handle.props.code ?? ''
-  let phase: UnlockPhase = initialToken ? 'checking' : 'enter'
+  let phase: UnlockPhase = initialToken ? 'checking' : initialRaw ? 'failed' : 'enter'
   let result: VerifyResult | null = initialToken
     ? null
     : initialRaw
@@ -127,7 +125,7 @@ export function UnlockedPage(handle: Handle<UnlockedPageProps>) {
           <>
             <h1>{phase === 'checking' ? 'One moment' : 'Unlock Plus'}</h1>
             <p className="muted">
-              {phaseCopy(phase, result?.error ?? null, Boolean(handle.props.code))}
+              {phaseCopy(phase, result?.error ?? null)}
             </p>
           </>
         )}

--- a/tests/e2e/home.spec.ts
+++ b/tests/e2e/home.spec.ts
@@ -329,6 +329,9 @@ test.describe('home & app shell', () => {
     await expect(page.getByRole('heading', { name: 'Terms', exact: true })).toBeVisible()
     await page.goto('/receive')
     await expect(page.getByRole('heading', { name: 'Receive a project' })).toBeVisible()
+    await page.goto('/unlocked')
+    await expect(page.getByRole('heading', { name: 'Unlock Plus' })).toBeVisible()
+    await expect(page.getByLabel('Plus code')).toBeVisible()
   })
 })
 

--- a/tests/e2e/restore.spec.ts
+++ b/tests/e2e/restore.spec.ts
@@ -58,6 +58,14 @@ test.describe('Plus restore codes', () => {
     }
   })
 
+  test('an invalid /unlocked path still offers the code form', async ({ page }) => {
+    await page.goto('/unlocked/nope')
+    await expect(page.getByRole('heading', { name: 'Unlock Plus' })).toBeVisible()
+    await expect(page.getByText(/Enter the short code from the other device/)).toBeVisible()
+    await expect(page.getByLabel('Plus code')).toBeVisible()
+    await expect(page.getByRole('button', { name: 'Unlock' })).toBeVisible()
+  })
+
   test('a QR / path code still redeems on /unlocked/:code', async ({ page, browser, baseURL }) => {
     const receiverContext = await browser.newContext({ baseURL })
     const receiver = await receiverContext.newPage()

--- a/tests/e2e/restore.spec.ts
+++ b/tests/e2e/restore.spec.ts
@@ -1,47 +1,49 @@
-import { test, expect } from '@playwright/test'
+import { test, expect, type Page } from '@playwright/test'
 import { gotoHome, unlockPlus } from './helpers'
 
+async function mintPlusRestoreCode(page: Page): Promise<string> {
+  await page.addInitScript(() => {
+    window.addEventListener('unhandledrejection', (event) => {
+      const msg =
+        event.reason instanceof Error ? event.reason.message : String(event.reason ?? '')
+      if (!msg.includes('scheduleUpdate')) return
+      const w = window as unknown as { __kodyScheduleUpdateErrors?: string[] }
+      ;(w.__kodyScheduleUpdateErrors ??= []).push(msg)
+    })
+  })
+  await gotoHome(page)
+  await unlockPlus(page)
+  await page.goto('/about')
+  await page.getByRole('button', { name: 'Use Plus on another device' }).click()
+  const sheet = page.getByRole('dialog', { name: 'Use Plus on another device' })
+  await expect(sheet).toBeVisible()
+  const code = (await sheet.locator('.sync-code').innerText()).replace(/[^A-Z0-9]/g, '')
+  expect(code).toHaveLength(6)
+  const scheduleUpdateErrors = await page.evaluate(
+    () =>
+      (window as unknown as { __kodyScheduleUpdateErrors?: string[] }).__kodyScheduleUpdateErrors ??
+      [],
+  )
+  expect(scheduleUpdateErrors).toEqual([])
+  await expect(sheet.getByText(/kody\.video\/unlocked/)).toBeVisible()
+  return code
+}
+
 test.describe('Plus restore codes', () => {
-  test('the Plus device shows a code the other browser can redeem', async ({
-    page,
-    browser,
-    baseURL,
-  }) => {
+  test('the other device can type the code on /unlocked', async ({ page, browser, baseURL }) => {
     const receiverContext = await browser.newContext({ baseURL })
     const receiver = await receiverContext.newPage()
     try {
-      // Catch the SharePlusSheet setup regression (KODY Sentry 7685051724):
-      // sync handle.update() before Remix wires scheduleUpdate.
-      await page.addInitScript(() => {
-        window.addEventListener('unhandledrejection', (event) => {
-          const msg =
-            event.reason instanceof Error ? event.reason.message : String(event.reason ?? '')
-          if (!msg.includes('scheduleUpdate')) return
-          const w = window as unknown as { __kodyScheduleUpdateErrors?: string[] }
-          ;(w.__kodyScheduleUpdateErrors ??= []).push(msg)
-        })
-      })
-      await gotoHome(page)
-      await unlockPlus(page)
-      await page.goto('/about')
-      await page.getByRole('button', { name: 'Use Plus on another device' }).click()
-      const sheet = page.getByRole('dialog', { name: 'Use Plus on another device' })
-      await expect(sheet).toBeVisible()
-      const code = (await sheet.locator('.sync-code').innerText()).replace(/[^A-Z0-9]/g, '')
-      expect(code).toHaveLength(6)
-      const scheduleUpdateErrors = await page.evaluate(
-        () =>
-          (window as unknown as { __kodyScheduleUpdateErrors?: string[] })
-            .__kodyScheduleUpdateErrors ?? [],
-      )
-      expect(scheduleUpdateErrors).toEqual([])
-
-      await expect(sheet.getByText(/kody\.video\/unlocked/)).toBeVisible()
-      await expect(sheet.locator('img.sync-qr')).toBeVisible()
-      const qrSrc = await sheet.locator('img.sync-qr').getAttribute('src')
+      const code = await mintPlusRestoreCode(page)
+      await expect(page.locator('img.sync-qr')).toBeVisible()
+      const qrSrc = await page.locator('img.sync-qr').getAttribute('src')
       expect(qrSrc ?? '').toMatch(/^data:image\/svg\+xml/)
 
-      await receiver.goto(`/unlocked/${code}`)
+      await receiver.goto('/unlocked')
+      await expect(receiver.getByRole('heading', { name: 'Unlock Plus' })).toBeVisible()
+      await expect(receiver.getByRole('link', { name: 'Back to projects' })).toBeVisible()
+      await receiver.getByLabel('Plus code').fill(code)
+      await receiver.getByRole('button', { name: 'Unlock' }).click()
       await expect(receiver.getByRole('heading', { name: /Plus unlocked/ })).toBeVisible({
         timeout: 15_000,
       })
@@ -51,6 +53,20 @@ test.describe('Plus restore codes', () => {
         return settings.watermarkRemoved === true
       })
       expect(unlocked).toBe(true)
+    } finally {
+      await receiverContext.close()
+    }
+  })
+
+  test('a QR / path code still redeems on /unlocked/:code', async ({ page, browser, baseURL }) => {
+    const receiverContext = await browser.newContext({ baseURL })
+    const receiver = await receiverContext.newPage()
+    try {
+      const code = await mintPlusRestoreCode(page)
+      await receiver.goto(`/unlocked/${code}`)
+      await expect(receiver.getByRole('heading', { name: /Plus unlocked/ })).toBeVisible({
+        timeout: 15_000,
+      })
     } finally {
       await receiverContext.close()
     }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Sharing Plus tells the other device to open `kody.video/unlocked`, but landing on that path with no code immediately failed (“Missing checkout session or restore code”) instead of offering a place to type the code the way `kody.video/receive` does.

## Changes

- Bare `/unlocked` shows a receive-style page: back control, **Plus code** field, **Unlock**.
- Path (`/unlocked/:code`) and query (`?code=` / `?session_id=`) still verify on arrival.
- A failed check or an invalid path segment keeps the form so you can try another code.

## Testing

- E2E: type a minted code on `/unlocked`; `/unlocked/:code` still redeems; `/unlocked/nope` still shows the form.
- Home smoke: `/unlocked` renders the heading and code field.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-aff64b49-4abd-410d-9da0-065f98d0d44c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-aff64b49-4abd-410d-9da0-065f98d0d44c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a Plus code entry form on the unlock page.
  - Codes can be redeemed by entering them manually or opening a direct unlock link.
  - Added clear progress, success, and failure states during verification.
  - Codes are automatically formatted for easier entry.
  - Success actions now include adding another device or starting creation.
  - Added tailored messaging for invalid or unsupported unlock links.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->