### PR TITLE
Blend the Receive/About header into the page gradient

### DIFF
--- a/src/styles/home.css
+++ b/src/styles/home.css
@@ -648,16 +648,15 @@
   }
 }
 
+/* Lives above `.about-body` (the scroller), so it already stays put.
+   Do not paint a solid `--bg` slab — the page sits on body's gradient,
+   and a flat fill reads as a mismatched bar on Receive / Unlock / About. */
 .about-top {
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 12px;
   margin-bottom: 4px;
-  position: sticky;
-  top: 0;
-  z-index: 2;
-  background: var(--bg);
   padding-bottom: 8px;
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The shared `.about-top` bar (Receive, Unlock Plus, About, Privacy, Terms) painted a solid `--bg` rectangle. That sat on the page’s radial/linear gradient and read as a mismatched slab in dark and light, and on short pages like Receive.

## Changes

Remove the sticky solid fill. The header already lives above `.about-body` (the scroller), so it stays put without a painted bar.

## Testing

- Browser: Receive, Unlock, About (including `#video-quality`), light scheme.
- Existing e2e still asserts the About back control stays in viewport after **More on About**.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-aff64b49-4abd-410d-9da0-065f98d0d44c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-aff64b49-4abd-410d-9da0-065f98d0d44c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the About page layout so the top section remains in place without a solid background.
  * The page’s gradient now shows through for a more seamless visual appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->