### PR TITLE
Route Bugbot triggers through kody:@kentcdodds/bugbot

### DIFF
--- a/.cursor/skills/ship-pr/SKILL.md
+++ b/.cursor/skills/ship-pr/SKILL.md
@@ -25,7 +25,15 @@ rate-limits do not block. High-risk work, or an explicit pause, still waits.
 ## AI reviewers
 
 Prefer **Cursor Bugbot** (`Cursor Bugbot` check / `cursor[bot]` review comments).
-Trigger with `bugbot run` or `@cursor review` on the PR if it has not started.
+Never comment `bugbot run` or `cursor review` yourself, including via `gh` or
+GitHub `request` as kody-bot. Trigger with `kody:@kentcdodds/bugbot` using
+`{ prUrl }` or `{ owner, repo, prNumber }`. Do not pass a GitHub account.
+
+```javascript
+import triggerBugbot from 'kody:@kentcdodds/bugbot'
+
+await triggerBugbot({ prUrl })
+```
 
 **CodeRabbit:** if it is rate-limited, errored, or otherwise unavailable, **do not
 wait** on it for low/medium risk — proceed with Bugbot + CI. Only wait on


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
kody-bot is not authorized to trigger Cursor BugBot. A `bugbot run` comment from kody-bot is skipped with “Skipping Bugbot: Unable to authenticate your request.”

This updates the `ship-pr` skill so agents trigger BugBot via `kody:@kentcdodds/bugbot`, which always posts the comment as kentcdodds. Agents must not comment `bugbot run` or `cursor review` themselves (including via `gh` or GitHub request as kody-bot).

CodeRabbit guidance, the ship-when-ready default, the loop, and merge policy are unchanged.

Do not merge.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ef6b6a18-9329-4e10-9f0e-312b36cd947b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ef6b6a18-9329-4e10-9f0e-312b36cd947b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the AI review workflow to automatically trigger Cursor Bugbot through the Kody integration using pull request or repository details.

* **Improvements**
  * Replaced manual Bugbot commands and review mentions with a streamlined automated process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->